### PR TITLE
Add link to wiki in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ SPDX-License-Identifier: Apache-2.0
 
 This is a Node port of the [LiveKit Agents framework](https://livekit.io/agents), originally written in Python.
 
+## Usage
+
+The wiki includes a [guide](https://github.com/livekit/agents-js/wiki/Getting-started) on setting up Node Agents and writing a small program using the framework.
+
 ## Building
 
 This project depends on [`@livekit/rtc-node`](https://npmjs.com/package/@livekit/rtc-node), which itself depends on `libstdc++` version 6 being in PATH.


### PR DESCRIPTION
moved the getting started gist to a wiki
https://github.com/livekit/agents-js/wiki/Getting-started