### PR TITLE
ci: split into multiple jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: agents CI
+name: Build
 on:
   push:
     branches: [main]
@@ -10,13 +10,17 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    name: Test and build
+  reuse:
+    name: REUSE-3.2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: REUSE-3.2 compliance check
-        uses: fsfe/reuse-action@v4
+      - uses: fsfe/reuse-action@v4
+  lint:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - name: Setup node
         uses: actions/setup-node@v4
@@ -29,5 +33,18 @@ jobs:
         run: pnpm lint
       - name: Prettier
         run: pnpm format:check
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
       - name: Build
         run: pnpm build

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ $ pnpm build
 Your output will be in the `dist/` directory.
 
 ## License
-This project is licensed under `Apache-2.0`, and is [REUSE-3.0](https://reuse.software) compliant. Refer to [the license](LICENSES/Apache-2.0.txt) for details.
+This project is licensed under `Apache-2.0`, and is [REUSE-3.2](https://reuse.software) compliant. Refer to [the license](LICENSES/Apache-2.0.txt) for details.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -21,6 +21,6 @@ SPDX-License-Identifier = "Apache-2.0"
 
 # project configuration files
 [[annotations]]
-path = ["packages/livekit-rtc/.npmignore", ".prettierrc", ".prettierignore", ".eslintrc", "**.json"]
+path = [".prettierrc", ".prettierignore", ".eslintrc", "**.json"]
 SPDX-FileCopyrightText = "2024 LiveKit, Inc."
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
slower and more redundant, but gives us clearer messages in PR page rather than just "agents CI / Test and build: failing".