### PR TITLE
only throw WebSocket errors for non-audio events

### DIFF
--- a/plugins/openai/src/voice_assistant/index.ts
+++ b/plugins/openai/src/voice_assistant/index.ts
@@ -224,12 +224,14 @@ export class VoiceAssistant {
   }
 
   private sendClientCommand(command: proto.ClientEvent): void {
+    const isAudio = command.event === proto.ClientEventType.ADD_USER_AUDIO;
+
     if (!this.connected || !this.ws) {
-      this.logger.error('WebSocket is not connected');
+      if (!isAudio) this.logger.error('WebSocket is not connected');
       return;
     }
 
-    if (command.event !== proto.ClientEventType.ADD_USER_AUDIO) {
+    if (!isAudio) {
       this.logger.debug(`-> ${JSON.stringify(this.loggableEvent(command))}`);
     }
     this.ws.send(JSON.stringify(command));


### PR DESCRIPTION
we start receiving data immediately, this just returns gracefully when attempting to send audio data to a closed websocket.