### PR TITLE
Fix waitForParticipant

### DIFF
--- a/agents/src/job.ts
+++ b/agents/src/job.ts
@@ -105,8 +105,6 @@ export class JobContext {
       throw new Error('room is not connected');
     }
 
-    console.log(this.#room.remoteParticipants.values());
-
     for (const p of this.#room.remoteParticipants.values()) {
       if ((!identity || p.identity === identity) && p.info.kind != ParticipantKind.AGENT) {
         return p;


### PR DESCRIPTION
Two bugs:

1. it hangs indefinitely if the participant was already in the room but you didn't pass a specific identity
2. it doesn't apply the identity check in the event callback when waiting is required