### PR TITLE
fix(job_main): import using URLs, not paths

### DIFF
--- a/.changeset/ten-donkeys-happen.md
+++ b/.changeset/ten-donkeys-happen.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix usage on Windows by importing using URLs, not paths

--- a/agents/src/ipc/job_main.ts
+++ b/agents/src/ipc/job_main.ts
@@ -6,7 +6,7 @@ import type { ChildProcess } from 'child_process';
 import { fork } from 'child_process';
 import { EventEmitter, once } from 'events';
 import type { Logger } from 'pino';
-import { fileURLToPath } from 'url';
+import { pathToFileURL } from 'url';
 import { type Agent, isAgent } from '../generator.js';
 import type { RunningJobInfo } from '../job.js';
 import { JobContext } from '../job.js';
@@ -28,7 +28,7 @@ type JobTask = {
 };
 
 export const runProcess = (args: StartArgs): ChildProcess => {
-  return fork(fileURLToPath(import.meta.url), [args.agentFile]);
+  return fork(new URL(import.meta.url), [args.agentFile]);
 };
 
 const startJob = (
@@ -94,7 +94,7 @@ if (process.send) {
   //   [1] import.meta.filename
   //   [2] import.meta.filename of function containing entry file
   const moduleFile = process.argv[2];
-  const agent: Agent = await import(moduleFile).then((module) => {
+  const agent: Agent = await import(pathToFileURL(moduleFile).href).then((module) => {
     const agent = module.default;
     if (agent === undefined || !isAgent(agent)) {
       throw new Error(`Unable to load agent: Missing or invalid default export in ${moduleFile}`);


### PR DESCRIPTION
fixes the usage on windows where importing with paths doesn't automatically map it on top of a URL

closes #94 