### PR TITLE
feat(openai): introducing `KnownRealtimeResponse`

### DIFF
--- a/plugins/openai/src/realtime/api_proto.ts
+++ b/plugins/openai/src/realtime/api_proto.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { ExtractStrict } from "../utility-types";
+
 export const SAMPLE_RATE = 24000;
 export const NUM_CHANNELS = 1;
 export const IN_FRAME_SIZE = 2400; // 100ms
@@ -18,13 +20,13 @@ export type InputTranscriptionModel = 'whisper-1' | string; // Open-ended, for f
 export type Modality = 'text' | 'audio';
 export type ToolChoice = 'auto' | 'none' | 'required' | string;
 export type State = 'initializing' | 'listening' | 'thinking' | 'speaking' | string;
-export type ResponseStatus =
+export type KnownResponseStatus =
   | 'in_progress'
   | 'completed'
   | 'incomplete'
   | 'cancelled'
-  | 'failed'
-  | string;
+  | 'failed';
+export type ResponseStatus = KnownResponseStatus | string;
 export type ClientEventType =
   | 'session.update'
   | 'input_audio_buffer.append'
@@ -191,22 +193,28 @@ export interface ConversationResource {
   object: 'realtime.conversation';
 }
 
+export interface IncompleteResponseStatusDetails {
+  type: ExtractStrict<KnownResponseStatus, 'incomplete'>;
+  reason: 'max_output_tokens' | 'content_filter' | string;
+}
+
+export interface FailedResponseStatusDetails {
+  type: ExtractStrict<KnownResponseStatus, 'failed'>;
+  error?: {
+    code: 'server_error' | 'rate_limit_exceeded' | string;
+    message: string;
+  };
+}
+
+export interface CancelledResponseStatusDetails {
+  type: ExtractStrict<KnownResponseStatus, 'cancelled'>;
+  reason: 'turn_detected' | 'client_cancelled' | string;
+}
+
 export type ResponseStatusDetails =
-  | {
-      type: 'incomplete';
-      reason: 'max_output_tokens' | 'content_filter' | string;
-    }
-  | {
-      type: 'failed';
-      error?: {
-        code: 'server_error' | 'rate_limit_exceeded' | string;
-        message: string;
-      };
-    }
-  | {
-      type: 'cancelled';
-      reason: 'turn_detected' | 'client_cancelled' | string;
-    };
+  | IncompleteResponseStatusDetails
+  | FailedResponseStatusDetails
+  | CancelledResponseStatusDetails;
 
 export interface ResponseResource {
   id: string;

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -6,6 +6,7 @@ import { llm, log, multimodal } from '@livekit/agents';
 import { AudioFrame } from '@livekit/rtc-node';
 import { once } from 'events';
 import { WebSocket } from 'ws';
+import { ExtractStrict } from '../utility-types.js';
 import * as api_proto from './api_proto.js';
 
 interface ModelOptions {
@@ -23,13 +24,37 @@ interface ModelOptions {
   baseURL: string;
 }
 
-export interface RealtimeResponse {
+interface RealtimeResponseBase {
   id: string;
   status: api_proto.ResponseStatus;
   statusDetails: api_proto.ResponseStatusDetails | null;
   output: RealtimeOutput[];
   doneFut: Future;
 }
+
+interface KnownRealtimeResponseBase<T extends api_proto.ResponseStatusDetails>
+  extends RealtimeResponseBase {
+  status: T['type'];
+  statusDetails: T;
+}
+
+export interface UnknownRealtimeResponse extends RealtimeResponseBase {
+  status: string;
+  statusDetails: null;
+}
+
+export type IncompleteRealtimeResponse =
+  KnownRealtimeResponseBase<api_proto.IncompleteResponseStatusDetails>;
+export type FailedRealtimeResponse =
+  KnownRealtimeResponseBase<api_proto.FailedResponseStatusDetails>;
+export type CancelledRealtimeResponse =
+  KnownRealtimeResponseBase<api_proto.CancelledResponseStatusDetails>;
+export type KnownRealtimeResponse =
+  | IncompleteRealtimeResponse
+  | FailedRealtimeResponse
+  | CancelledRealtimeResponse;
+
+export type RealtimeResponse = KnownRealtimeResponse | UnknownRealtimeResponse;
 
 export interface RealtimeOutput {
   responseId: string;

--- a/plugins/openai/src/utility-types.ts
+++ b/plugins/openai/src/utility-types.ts
@@ -1,0 +1,1 @@
+export type ExtractStrict<T, U extends T> = T extends U ? T : never;


### PR DESCRIPTION
Hi!

Type inference is not made smartly when using the type `RealtimeResponse`.

Let's take this snippet as a usage.

https://github.com/livekit-examples/realtime-playground/blob/989a7cb0edb517e4915e21305a041fa7da2aac37/agent/playground_agent.ts#L172-L209
  
<img width="340" alt="스크린샷 2024-10-09 오후 3 14 35" src="https://github.com/user-attachments/assets/4ff4330a-dbb8-4ac7-8281-cfef27f33087">

For example, when `response.status === "incomplete"`, `response.statusDetails.reason` should be asserted to `'turn_detected' | 'client_cancelled' | string;`. But as you can see, it's not.

The error message is like this.
<img width="531" alt="스크린샷 2024-10-09 오후 3 14 55" src="https://github.com/user-attachments/assets/19127dc9-29a3-4506-aa61-b1d0de5f55f3">

The same applies to other statuses such as `"failed"`.

This PR exports new types including `KnownRealtimeResponse`, which resolves the issue