### PR TITLE
build(openai): paths mapping and composite

### DIFF
--- a/plugins/openai/package.json
+++ b/plugins/openai/package.json
@@ -7,7 +7,7 @@
   "author": "LiveKit",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b tsconfig.json",
     "clean": "rm -rf dist",
     "clean:build": "pnpm clean && pnpm build",
     "lint": "eslint -f unix \"src/**/*.{ts,js}\"",

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { AsyncIterableQueue, Future, Queue } from '@livekit/agents';
-import { llm, log, multimodal } from '@livekit/agents';
+import { AsyncIterableQueue, Future, Queue, llm, log, multimodal } from '@livekit/agents';
 import { AudioFrame } from '@livekit/rtc-node';
 import { once } from 'events';
 import { WebSocket } from 'ws';

--- a/plugins/openai/tsconfig.json
+++ b/plugins/openai/tsconfig.json
@@ -11,5 +11,6 @@
     "name": "plugins/agents-plugin-openai",
     "entryPointStrategy": "resolve",
     "entryPoints": ["src/index.ts"]
-  }
+  },
+  "references": [{ "path": "../../agents/tsconfig.json" }]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "composite": true
   },
   "typedocOptions": {
     "entryPoints": ["agents", "plugins/*"],
@@ -22,5 +23,11 @@
     "includeVersion": true,
     "out": "docs",
     "theme": "default"
+  },
+  "rootDir": ".",
+  "baseUrl": ".",
+  "paths": {
+    "@livekit/agents": ["agents/src"],
+    "@livekit/agents-plugin-openai": ["plugins/openai/src"]
   }
 }


### PR DESCRIPTION
This PR resolves type errors below.

```sh
$ pnpm build

> @livekit/agents-plugin-openai@0.3.2 build /Users/ocean/contrib/agents-js/plugins/openai
> tsc

src/realtime/realtime_model.ts:4:73 - error TS2307: Cannot find module '@livekit/agents' or its corresponding type declarations.

4 import { AsyncIterableQueue, Future, Queue, llm, log, multimodal } from '@livekit/agents';
                                                                          ~~~~~~~~~~~~~~~~~

src/realtime/realtime_model.ts:425:24 - error TS18046: 'func' is of type 'unknown'.

425           description: func.description,
                           ~~~~

src/realtime/realtime_model.ts:426:37 - error TS18046: 'func' is of type 'unknown'.

426           parameters: llm.oaiParams(func.parameters),
                                        ~~~~

src/realtime/realtime_model.ts:621:10 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

621     this.emit('input_speech_committed', {
             ~~~~

src/realtime/realtime_model.ts:633:10 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

633     this.emit('input_speech_started', {
             ~~~~

src/realtime/realtime_model.ts:642:10 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

642     this.emit('input_speech_stopped');
             ~~~~

src/realtime/realtime_model.ts:652:10 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

652     this.emit('input_speech_transcription_completed', {
             ~~~~

src/realtime/realtime_model.ts:663:10 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

663     this.emit('input_speech_transcription_failed', {
             ~~~~

src/realtime/realtime_model.ts:686:10 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

686     this.emit('response_created', newResponse);
             ~~~~

src/realtime/realtime_model.ts:697:10 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

697     this.emit('response_done', response);
             ~~~~

src/realtime/realtime_model.ts:726:10 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

726     this.emit('response_output_added', newOutput);
             ~~~~

src/realtime/realtime_model.ts:747:12 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

747       this.emit('function_call_started', {
               ~~~~

src/realtime/realtime_model.ts:758:10 - error TS7006: Parameter 'content' implicitly has an 'any' type.

758         (content) => {
             ~~~~~~~

src/realtime/realtime_model.ts:760:16 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

760           this.emit('function_call_completed', {
                   ~~~~

src/realtime/realtime_model.ts:773:10 - error TS7006: Parameter 'error' implicitly has an 'any' type.

773         (error) => {
             ~~~~~

src/realtime/realtime_model.ts:776:16 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

776           this.emit('function_call_failed', {
                   ~~~~

src/realtime/realtime_model.ts:784:10 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

784     this.emit('response_output_done', output);
             ~~~~

src/realtime/realtime_model.ts:808:10 - error TS2339: Property 'emit' does not exist on type 'RealtimeSession'.

808     this.emit('response_content_added', newContent);
```
