### PR TITLE
Move github banners to assets directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "turbo lint -- --fix",
     "test": "vitest run",
     "test:watch": "vitest",
-    "doc": "typedoc && mkdir docs/.github && cp .github/*.png docs/.github/",
+    "doc": "typedoc && mkdir -p docs/assets/github && cp .github/*.png docs/assets/github/ && find docs -name '*.html' -type f -exec sed -i.bak 's|=\"/.github/|=\"assets/github/|g' {} + && find docs -name '*.bak' -delete",
     "examples:minimal": "pnpm exec tsx examples/src/minimal_assistant.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
Unfortunately #116  didn't work both due to a leading slash in the img tag (which means relative to the host not the current path) and due to the .github/ folder not being exposed from S3/cloudfront. Instead of making changes in readme manager, I changed the doc gen script to also rewrite the image url and move the images into assets where they belong.