### PR TITLE
Subscribe to published mic track for linked participant only

### DIFF
--- a/.changeset/breezy-pandas-compare.md
+++ b/.changeset/breezy-pandas-compare.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Subscribe to published mic track for linked participant only

--- a/agents/src/multimodal/multimodal_agent.ts
+++ b/agents/src/multimodal/multimodal_agent.ts
@@ -143,10 +143,19 @@ export class MultimodalAgent extends EventEmitter {
         }
         this.#linkParticipant(participant.identity);
       });
-      room.on(RoomEvent.TrackPublished, () => {
-        // in case we are connected before the participant has published, we'd need to re-subscribe
-        this.#subscribeToMicrophone();
-      });
+      room.on(
+        RoomEvent.TrackPublished,
+        (trackPublication: RemoteTrackPublication, participant: RemoteParticipant) => {
+          if (
+            this.linkedParticipant &&
+            participant.identity === this.linkedParticipant.identity &&
+            trackPublication.source === TrackSource.SOURCE_MICROPHONE &&
+            !trackPublication.subscribed
+          ) {
+            trackPublication.setSubscribed(true);
+          }
+        },
+      );
       room.on(RoomEvent.TrackSubscribed, this.#handleTrackSubscription.bind(this));
 
       this.room = room;


### PR DESCRIPTION
There's an error in the console every time about "Participant is not set" when this runs before the participant gets linked. The whole thing is unnecessary - we don't need to lookup the publications again, we just need to subscribe to mic tracks if the linked participant publishes one.