### PR TITLE
support arrays in function call schema

### DIFF
--- a/.changeset/breezy-pandas-compare.md
+++ b/.changeset/breezy-pandas-compare.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Subscribe to published mic track for linked participant only

--- a/.changeset/pink-swans-approve.md
+++ b/.changeset/pink-swans-approve.md
@@ -1,0 +1,6 @@
+---
+'@livekit/agents': patch
+'@livekit/agents-plugin-openai': patch
+---
+
+support arrays in OpenAI function calling schema

--- a/agents/CHANGELOG.md
+++ b/agents/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @livekit/agents
 
+## 0.3.5
+
+### Patch Changes
+
+- support arrays in function call schema
+
 ## 0.3.4
 
 ### Patch Changes

--- a/agents/package.json
+++ b/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/agents",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "LiveKit Agents - Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agents/src/llm/function_context.test.ts
+++ b/agents/src/llm/function_context.test.ts
@@ -24,7 +24,7 @@ describe('function_context', () => {
             description: 'The user age',
           },
         },
-        required_properties: ['name', 'age'],
+        required: ['name', 'age'],
       });
     });
 
@@ -44,7 +44,7 @@ describe('function_context', () => {
             enum: ['red', 'blue', 'green'],
           },
         },
-        required_properties: ['color'],
+        required: ['color'],
       });
     });
 
@@ -66,7 +66,7 @@ describe('function_context', () => {
             },
           },
         },
-        required_properties: ['tags'],
+        required: ['tags'],
       });
     });
 
@@ -89,7 +89,7 @@ describe('function_context', () => {
             },
           },
         },
-        required_properties: ['colors'],
+        required: ['colors'],
       });
     });
 
@@ -113,7 +113,7 @@ describe('function_context', () => {
             description: 'The user age',
           },
         },
-        required_properties: ['name'], // age should not be required
+        required: ['name'], // age should not be required
       });
     });
 
@@ -137,7 +137,7 @@ describe('function_context', () => {
             description: undefined,
           },
         },
-        required_properties: ['name', 'age'],
+        required: ['name', 'age'],
       });
     });
   });
@@ -182,6 +182,59 @@ describe('function_context', () => {
 
       expect(result).toBe(100);
       expect(duration).toBeGreaterThanOrEqual(95); // Allow for small timing variations
+    });
+
+    describe('array support', () => {
+      it('should handle array fields', () => {
+        const schema = z.object({
+          items: z.array(
+            z.object({
+              name: z.string().describe('the item name'),
+              modifiers: z.array(
+                z.object({
+                  modifier_name: z.string(),
+                  modifier_value: z.string(),
+                }),
+              ).describe('list of the modifiers applied on this item, such as size'),
+            }),
+          ),
+        });
+        const result = oaiParams(schema);
+        expect(result).toEqual({
+          type: 'object',
+          properties: {
+            items: {
+              type: 'array',
+              description: undefined,
+              items: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                    description: 'the item name',
+                  },
+                  modifiers: {
+                    type: 'array',
+                    description: 'list of the modifiers applied on this item, such as size',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        modifier_name: {
+                          type: 'string',
+                        },
+                        modifier_value: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          required: ['items'],
+        });
+      });
     });
   });
 });

--- a/agents/src/llm/function_context.test.ts
+++ b/agents/src/llm/function_context.test.ts
@@ -84,7 +84,7 @@ describe('function_context', () => {
             type: 'array',
             description: 'List of colors',
             items: {
-              type: 'enum',
+              type: 'string',
               enum: ['red', 'blue', 'green'],
             },
           },
@@ -190,12 +190,14 @@ describe('function_context', () => {
           items: z.array(
             z.object({
               name: z.string().describe('the item name'),
-              modifiers: z.array(
-                z.object({
-                  modifier_name: z.string(),
-                  modifier_value: z.string(),
-                }),
-              ).describe('list of the modifiers applied on this item, such as size'),
+              modifiers: z
+                .array(
+                  z.object({
+                    modifier_name: z.string(),
+                    modifier_value: z.string(),
+                  }),
+                )
+                .describe('list of the modifiers applied on this item, such as size'),
             }),
           ),
         });
@@ -226,9 +228,11 @@ describe('function_context', () => {
                           type: 'string',
                         },
                       },
+                      required: ['modifier_name', 'modifier_value'],
                     },
                   },
                 },
+                required: ['name', 'modifiers'],
               },
             },
           },

--- a/agents/src/llm/function_context.test.ts
+++ b/agents/src/llm/function_context.test.ts
@@ -184,8 +184,8 @@ describe('function_context', () => {
       expect(duration).toBeGreaterThanOrEqual(95); // Allow for small timing variations
     });
 
-    describe('array support', () => {
-      it('should handle array fields', () => {
+    describe('nested array support', () => {
+      it('should handle nested array fields', () => {
         const schema = z.object({
           items: z.array(
             z.object({

--- a/agents/src/llm/function_context.ts
+++ b/agents/src/llm/function_context.ts
@@ -31,26 +31,26 @@ export const oaiParams = (p: z.AnyZodObject) => {
   const processZodType = (field: z.ZodTypeAny): any => {
     const isOptional = field instanceof z.ZodOptional;
     const nestedField = isOptional ? field._def.innerType : field;
-    const description = field._def.description || undefined;
+    const description = field._def.description;
 
     if (nestedField instanceof z.ZodEnum) {
       return {
         type: typeof nestedField._def.values[0],
-        description,
+        ...(description && { description }),
         enum: nestedField._def.values,
       };
     } else if (nestedField instanceof z.ZodArray) {
       const elementType = nestedField._def.type;
       return {
         type: 'array',
-        description,
+        ...(description && { description }),
         items: processZodType(elementType),
       };
     } else if (nestedField instanceof z.ZodObject) {
       const { properties, required } = oaiParams(nestedField);
       return {
         type: 'object',
-        description,
+        ...(description && { description }),
         properties,
         required,
       };
@@ -59,7 +59,7 @@ export const oaiParams = (p: z.AnyZodObject) => {
       type = type.includes('zod') ? type.substring(3) : type;
       return {
         type,
-        description,
+        ...(description && { description }),
       };
     }
   };

--- a/agents/src/llm/function_context.ts
+++ b/agents/src/llm/function_context.ts
@@ -74,7 +74,7 @@ export const oaiParams = (p: z.AnyZodObject) => {
   }
 
   return {
-    type: 'object',
+    type: 'object' as const,
     properties,
     required: required_properties,
   };

--- a/agents/src/multimodal/multimodal_agent.ts
+++ b/agents/src/multimodal/multimodal_agent.ts
@@ -143,10 +143,19 @@ export class MultimodalAgent extends EventEmitter {
         }
         this.#linkParticipant(participant.identity);
       });
-      room.on(RoomEvent.TrackPublished, () => {
-        // in case we are connected before the participant has published, we'd need to re-subscribe
-        this.#subscribeToMicrophone();
-      });
+      room.on(
+        RoomEvent.TrackPublished,
+        (trackPublication: RemoteTrackPublication, participant: RemoteParticipant) => {
+          if (
+            this.linkedParticipant &&
+            participant.identity === this.linkedParticipant.identity &&
+            trackPublication.source === TrackSource.SOURCE_MICROPHONE &&
+            !trackPublication.subscribed
+          ) {
+            trackPublication.setSubscribed(true);
+          }
+        },
+      );
       room.on(RoomEvent.TrackSubscribed, this.#handleTrackSubscription.bind(this));
 
       this.room = room;

--- a/examples/src/minimal_assistant.ts
+++ b/examples/src/minimal_assistant.ts
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { type JobContext, WorkerOptions, cli, defineAgent, multimodal } from '@livekit/agents';
+import {
+  type JobContext,
+  WorkerOptions,
+  cli,
+  defineAgent,
+  type llm,
+  multimodal,
+} from '@livekit/agents';
 import * as openai from '@livekit/agents-plugin-openai';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
@@ -30,22 +37,27 @@ export default defineAgent({
       });
     }
 
-    const agent = new multimodal.MultimodalAgent({
-      model,
-      fncCtx: {
-        weather: {
-          description: 'Get the weather in a location',
-          parameters: z.object({
-            location: z.string().describe('The location to get the weather for'),
-          }),
-          execute: async ({ location }) => {
-            console.debug(`executing weather function for ${location}`);
-            return await fetch(`https://wttr.in/${location}?format=%C+%t`)
-              .then((data) => data.text())
-              .then((data) => `The weather in ${location} right now is ${data}.`);
-          },
+    const fncCtx: llm.FunctionContext = {
+      weather: {
+        description: 'Get the weather in a location',
+        parameters: z.object({
+          location: z.string().describe('The location to get the weather for'),
+        }),
+        execute: async ({ location }) => {
+          console.debug(`executing weather function for ${location}`);
+          const response = await fetch(`https://wttr.in/${location}?format=%C+%t`);
+          if (!response.ok) {
+            throw new Error(`Weather API returned status: ${response.status}`);
+          }
+          const weather = await response.text();
+          return `The weather in ${location} right now is ${weather}.`;
         },
       },
+    };
+
+    const agent = new multimodal.MultimodalAgent({
+      model,
+      fncCtx,
     });
 
     const session = await agent

--- a/plugins/openai/src/realtime/api_proto.ts
+++ b/plugins/openai/src/realtime/api_proto.ts
@@ -79,7 +79,7 @@ export interface Tool {
         [prop: string]: any;
       };
     };
-    required_properties: string[];
+    required: string[];
   };
 }
 


### PR DESCRIPTION
this PR
* updates `oaiParams` to include the `items` property in arrays to match  openAI's function call schema requirements (fixes issue #124)
* updates  `oaiParams`  to omit optional fields from the `required` section of the generated openAI function call schema
* adds unit tests for `oaiParams`