### PR TITLE
chore(agents): explicitly unsupport CommonJS

### DIFF
--- a/.changeset/plenty-fans-kiss.md
+++ b/.changeset/plenty-fans-kiss.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+throw an error when using CommonJS with tsx

--- a/agents/src/index.ts
+++ b/agents/src/index.ts
@@ -15,6 +15,19 @@ import * as multimodal from './multimodal/index.js';
 import * as stt from './stt/index.js';
 import * as tts from './tts/index.js';
 
+const isCommonJS = (): boolean => {
+  try {
+    return !!require;
+  } catch {
+    return false;
+  }
+};
+if (isCommonJS()) {
+  throw new ReferenceError(
+    '@livekit/agents cannot be used in a CommonJS environment. Please set your project to use ES modules.',
+  );
+}
+
 export * from './vad.js';
 export * from './plugin.js';
 export * from './version.js';

--- a/agents/src/index.ts
+++ b/agents/src/index.ts
@@ -24,7 +24,7 @@ const isCommonJS = (): boolean => {
 };
 if (isCommonJS()) {
   throw new ReferenceError(
-    '@livekit/agents cannot be used in a CommonJS environment. Please set your project to use ES modules.',
+    '@livekit/agents cannot be used in a CommonJS environment. Please set `"type": "module"` in package.json.',
   );
 }
 


### PR DESCRIPTION
there's a weird edge-case with `tsx` where if `module` is unset in package.json but the typescript file still uses module imports, it will still run, but as CommonJS, without checking for inconsistencies. this doesn't immediately break agents, instead erroring on `job_main.js`, without throwing a useful error.

we do not support and have not supported CommonJS, this PR just throws an error for this specific usecase which has thrown a few folks for a loop.

for reference, compiling to JavaScript and then running with those settings throws an explicit error on Node's side before ever reaching index.js.