### PR TITLE
feat(openai): allow raw JSON function parameters

### DIFF
--- a/.changeset/two-shirts-cover.md
+++ b/.changeset/two-shirts-cover.md
@@ -1,0 +1,6 @@
+---
+"@livekit/agents": patch
+"@livekit/agents-plugin-openai": patch
+---
+
+feat(openai): allow raw JSON function parameters

--- a/agents/src/llm/function_context.ts
+++ b/agents/src/llm/function_context.ts
@@ -11,10 +11,18 @@ import { z } from 'zod';
 /** Type reinforcement for the callable function's execute parameters. */
 export type inferParameters<P extends z.ZodTypeAny> = z.infer<P>;
 
+/** Raw OpenAI-adherent function parameters. */
+export type OpenAIFunctionParameters = {
+  type: 'object';
+  properties: { [id: string]: any };
+  required: string[];
+  additionalProperties: boolean;
+};
+
 /** A definition for a function callable by the LLM. */
 export interface CallableFunction<P extends z.ZodTypeAny = any, R = any> {
   description: string;
-  parameters: P;
+  parameters: OpenAIFunctionParameters | P;
   execute: (args: inferParameters<P>) => PromiseLike<R>;
 }
 

--- a/plugins/openai/src/llm.ts
+++ b/plugins/openai/src/llm.ts
@@ -438,7 +438,11 @@ export class LLMStream extends llm.LLMStream {
           function: {
             name,
             description: func.description,
-            parameters: llm.oaiParams(func.parameters),
+            // don't format parameters if they are raw openai params
+            parameters:
+              func.parameters.type == ('object' as const)
+                ? func.parameters
+                : llm.oaiParams(func.parameters),
           },
         }))
       : undefined;

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -630,7 +630,11 @@ export class RealtimeSession extends multimodal.RealtimeSession {
           type: 'function' as const,
           name,
           description: func.description,
-          parameters: llm.oaiParams(func.parameters),
+          parameters:
+            // don't format parameters if they are raw openai params
+            func.parameters.type == ('object' as const)
+              ? func.parameters
+              : llm.oaiParams(func.parameters),
         }))
       : [];
 


### PR DESCRIPTION
this is less brittle (in case openai updates its schema for parameters, you can edit without waiting for us to fix), but doesn't supply the type reinforcements with Zod.