### PR TITLE
chore(ci): enable LFS in publish script

### DIFF
--- a/.changeset/small-roses-flow.md
+++ b/.changeset/small-roses-flow.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-silero": patch
+---
+
+enable LFS in publish script

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: pnpm/action-setup@v4
       - name: Use Node.js 20
         uses: actions/setup-node@v4


### PR DESCRIPTION
silero vad is broken currently on npm because the LFS file wasn't pulled