### PR TITLE
chore(ci): remove "fixed" from changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,6 @@
     }
   ],
   "commit": false,
-  "fixed": [["@livekit/agents", "@livekit/agents-plugin-*"]],
   "ignore": ["livekit-agents-examples"],
   "linked": [],
   "access": "public",


### PR DESCRIPTION
this should stop packages from all keeping the same version number and updating all when one plugin is bumped