### PR TITLE
add fully defined ModelUsage type

### DIFF
--- a/plugins/openai/src/realtime/api_proto.ts
+++ b/plugins/openai/src/realtime/api_proto.ts
@@ -208,17 +208,32 @@ export type ResponseStatusDetails =
       reason: 'turn_detected' | 'client_cancelled' | string;
     };
 
+export interface ModelUsage {
+  total_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+  input_token_details: {
+    text_tokens: number;
+    audio_tokens: number;
+    cached_tokens: number;
+    cached_tokens_details: {
+      text_tokens: number;
+      audio_tokens: number;
+    };
+  };
+  output_token_details: {
+    text_tokens: number;
+    audio_tokens: number;
+  };
+}
+
 export interface ResponseResource {
   id: string;
   object: 'realtime.response';
   status: ResponseStatus;
   status_details: ResponseStatusDetails;
   output: ItemResource[];
-  usage?: {
-    total_tokens: number;
-    input_tokens: number;
-    output_tokens: number;
-  };
+  usage?: ModelUsage;
 }
 
 // Client Events

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -37,7 +37,7 @@ export interface RealtimeResponse {
   id: string;
   status: api_proto.ResponseStatus;
   statusDetails: api_proto.ResponseStatusDetails | null;
-  usage: api_proto.ResponseResource['usage'] | null;
+  usage: api_proto.ModelUsage | null;
   output: RealtimeOutput[];
   doneFut: Future;
 }
@@ -939,7 +939,7 @@ export class RealtimeSession extends multimodal.RealtimeSession {
     const response = this.#pendingResponses[responseId];
     response.status = responseData.status;
     response.statusDetails = responseData.status_details;
-    response.usage = responseData.usage;
+    response.usage = responseData.usage ?? null;
     this.#pendingResponses[responseId] = response;
     response.doneFut.resolve();
     this.emit('response_done', response);


### PR DESCRIPTION
Improve the `usage` attribute of `ResponseUsage`, now defined in its own type `ModelUsage`.  

With OpenAI Realtime API, there are 6 different token types, all with different prices.  The data is already present at runtime but not expressed in livekit's typings.