### PR TITLE
feat(openai): emit Realtime API response text delta and done

### DIFF
--- a/.changeset/seven-dryers-repeat.md
+++ b/.changeset/seven-dryers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-openai": minor
+---
+
+Emit events for response text delta and done

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -1061,11 +1061,13 @@ export class RealtimeSession extends multimodal.RealtimeSession {
     this.emit('response_content_done', content);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  #handleResponseTextDelta(event: api_proto.ResponseTextDeltaEvent): void {}
+  #handleResponseTextDelta(event: api_proto.ResponseTextDeltaEvent): void {
+    this.emit('response_text_delta', event);
+  }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  #handleResponseTextDone(event: api_proto.ResponseTextDoneEvent): void {}
+  #handleResponseTextDone(event: api_proto.ResponseTextDoneEvent): void {
+    this.emit('response_text_done', event);
+  }
 
   #handleResponseAudioTranscriptDelta(event: api_proto.ResponseAudioTranscriptDeltaEvent): void {
     const content = this.#getContent(event);


### PR DESCRIPTION
This adds simple support for reading the responses of a text-only Realtime API Model. I found no way currently to get the responses as transcriptions don't seem to be created when only the "text" modality is chosen. 

In our case, we patched these changes and forwarded the text to the agent's publication track so our client handles audio and text transcriptions the same way.