### PR TITLE
fix(elevenlabs): override with defaults if opts are provided

### DIFF
--- a/.changeset/fifty-apes-whisper.md
+++ b/.changeset/fifty-apes-whisper.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-elevenlabs": patch
+---
+
+Override with defaults if opts are provided

--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -65,17 +65,21 @@ const defaultTTSOptions: TTSOptions = {
 export class TTS extends tts.TTS {
   #opts: TTSOptions;
 
-  constructor(opts: Partial<TTSOptions> = defaultTTSOptions) {
+  constructor(opts: Partial<TTSOptions> = {}) {
     super(sampleRateFromFormat(opts.encoding || defaultTTSOptions.encoding), 1, {
       streaming: true,
     });
-    if (opts.apiKey === undefined) {
+
+    this.#opts = {
+      ...defaultTTSOptions,
+      ...opts,
+    };
+
+    if (this.#opts.apiKey === undefined) {
       throw new Error(
         'ElevenLabs API key is required, whether as an argument or as $ELEVEN_API_KEY',
       );
     }
-
-    this.#opts = { ...defaultTTSOptions, ...opts };
   }
 
   async listVoices(): Promise<Voice[]> {


### PR DESCRIPTION
Providing any `opts` to `elevenlabs.TTS` without the `apiKey` will result in an error since we are only merging the `opts` with the defaults after the check
ex.
```ts
// Will throw an error since an apiKey isn't provided and the defaults with the env variable isn't provided
elevenlabs.TTS({}) 
```

### Changes
* Set and merge `#opts` with defaults before `apiKey` check
* Remove defaulting `opts` argument to `defaultTTSOptions` since its technically not needed