### PR TITLE
fix(agent): ensure safe access of conversation content

### DIFF
--- a/.changeset/calm-wolves-mate.md
+++ b/.changeset/calm-wolves-mate.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Ensure llm string conversation safely accesses content

--- a/agents/src/pipeline/pipeline_agent.ts
+++ b/agents/src/pipeline/pipeline_agent.ts
@@ -827,7 +827,7 @@ async function* llmStreamToStringIterable(
   const startTime = Date.now();
   let firstFrame = true;
   for await (const chunk of stream) {
-    const content = chunk.choices[0].delta.content;
+    const content = chunk.choices[0]?.delta.content;
     if (!content) continue;
 
     if (firstFrame) {


### PR DESCRIPTION
When converting the LLM stream response to string, `choices[0]` could potentially be `undefined`

### Changes
* Add in optional chain check on `choices[0]`

### Reproduction
* ***Note*** Was testing on a local agent
* Respond to agent via voice
* When a response was returned from the LLM, `choices[0]` was undefined


### Extra
* Enabling [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) would prevent this issue moving forward