### PR TITLE
fix(agent): ensure token stream flushes

### DIFF
--- a/.changeset/itchy-sheep-smash.md
+++ b/.changeset/itchy-sheep-smash.md
@@ -1,0 +1,6 @@
+---
+"@livekit/agents": patch
+"@livekit/agents-plugin-elevenlabs": patch
+---
+
+Ensure token stream flushes

--- a/agents/src/tokenize/token_stream.ts
+++ b/agents/src/tokenize/token_stream.ts
@@ -100,7 +100,7 @@ export class BufferedTokenStream implements AsyncIterableIterator<TokenData> {
       throw new Error('Stream is closed');
     }
     this.flush();
-    this.closed = true;
+    this.close();
   }
 
   next(): Promise<IteratorResult<TokenData>> {
@@ -156,8 +156,15 @@ export class BufferedWordStream extends WordStream {
     this.#stream.pushText(text);
   }
 
+  flush() {
+    this.#stream.flush();
+  }
+
+  endInput() {
+    this.#stream.endInput();
+  }
+
   close() {
-    super.close();
     this.#stream.close();
   }
 

--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -143,9 +143,7 @@ export class SynthesizeStream extends tts.SynthesizeStream {
       let stream: tokenize.WordStream | null = null;
       for await (const text of this.input) {
         if (text === SynthesizeStream.FLUSH_SENTINEL) {
-          if (stream) {
-            stream.close();
-          }
+          stream?.endInput();
           stream = null;
         } else {
           if (!stream) {


### PR DESCRIPTION
Was noticing the last word for TTS was not being outputted (Websocket, ElevenLabs).
The input stream was not being flushed, and therefore, the remaining token was not being sent upstream.

### Changes
* Ensure `BufferedTokenStream` ends the input and is flushed before closing
* Implement missing wrapping methods for `BufferedWordStream` so the underlying `WordStream` implementations isn't used

### Reproduction
* Use voice agent pipeline with ElevenLabs
* Every spoken prompt would be missing the last word

### Notes
* `WordStream` can probably be converted to an interface since the underlying implementation is technically not needed
