### PR TITLE
fix(vpa): correct state attribute name

### DIFF
--- a/.changeset/slimy-hounds-decide.md
+++ b/.changeset/slimy-hounds-decide.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+correct pipeline agent state attribute name

--- a/.changeset/swift-mails-beg.md
+++ b/.changeset/swift-mails-beg.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix: correct pipeline agent state attribute name

--- a/agents/src/pipeline/pipeline_agent.ts
+++ b/agents/src/pipeline/pipeline_agent.ts
@@ -38,6 +38,7 @@ import { HumanInput, HumanInputEvent } from './human_input.js';
 import { SpeechHandle } from './speech_handle.js';
 
 export type AgentState = 'initializing' | 'thinking' | 'listening' | 'speaking';
+export const AGENT_STATE_ATTRIBUTE = 'lk.agent.state';
 
 export type BeforeLLMCallback = (
   agent: VoicePipelineAgent,
@@ -361,7 +362,7 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
         await new Promise((resolve) => setTimeout(resolve, delay));
         if (this.#room?.isConnected) {
           if (!cancelled) {
-            await this.#room.localParticipant?.setAttributes({ ATTRIBUTE_AGENT_STATE: state });
+            await this.#room.localParticipant?.setAttributes({ [AGENT_STATE_ATTRIBUTE]: state });
           }
         }
         resolve();


### PR DESCRIPTION
The voice pipeline agent's state attribute is called `"ATTRIBUTE_AGENT_STATE"`. Other LiveKit SDKs (e.g. [JS SDK multimodal agent](https://github.com/livekit/agents-js/blob/9734c34ba3d4b6961042cdeee25be3680a548f4f/agents/src/multimodal/multimodal_agent.ts#L55), [Python agents SDK](https://github.com/livekit/agents/blob/70b4e87f592d34785ebc7b4cc6badefce5291197/livekit-agents/livekit/agents/types.py#L5), [React SDK](https://github.com/livekit/components-js/blob/92e2c1733f91b218e0a7a95da6934f97d981bee5/packages/react/src/hooks/useVoiceAssistant.ts#L33)) expect the attribute to be called `"lk.agent.state"`, meaning that the agent state is not picked up correctly by other LiveKit clients, such as my frontend.

This PR defines the correct attribute name as a constant, and sets the agent state on the local participant accordingly. This eliminates the need for workarounds when attempting to access the attribute value.

Note: This may be considered a breaking change if clients are depending on the incorrect attribute name, but I marked it as a patch since this the SDK is still in developer preview. If this is a mistake or if any other changes are required, I'm happy to fix it.