### PR TITLE
Fix old references to minimal_assistant.ts in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Your main file for an agent is built of two parts:
 - The code that is exported when this file is imported into Agents, to be ran on all jobs (which
   includes your entrypoint function, and an optional prewarm function)
 
-Refer to the [minimal voice assistant](/examples/src/minimal_assistant.ts) example to understand
+Refer to the [minimal voice assistant](/examples/src/examples/src/multimodal_agent.ts) example to understand
 how to build a simple voice assistant with function calling using OpenAI's model.
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Your main file for an agent is built of two parts:
 - The code that is exported when this file is imported into Agents, to be ran on all jobs (which
   includes your entrypoint function, and an optional prewarm function)
 
-Refer to the [minimal voice assistant](/examples/src/examples/src/multimodal_agent.ts) example to understand
+Refer to the [minimal voice assistant](/examples/src/multimodal_agent.ts) example to understand
 how to build a simple voice assistant with function calling using OpenAI's model.
 
 ## Running

--- a/examples/package.json
+++ b/examples/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf dist",
     "clean:build": "pnpm clean && pnpm build",
     "lint": "eslint -f unix \"src/**/*.ts\"",
-    "minimal": "pnpm exec tsx src/minimal_assistant.ts"
+    "minimal": "pnpm exec tsx src/multimodal_agent.ts"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "doc": "typedoc && mkdir -p docs/assets/github && cp .github/*.png docs/assets/github/ && find docs -name '*.html' -type f -exec sed -i.bak 's|=\"/.github/|=\"assets/github/|g' {} + && find docs -name '*.bak' -delete",
-    "examples:minimal": "pnpm exec tsx examples/src/minimal_assistant.ts"
+    "examples:minimal": "pnpm exec tsx examples/src/multimodal_agent.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",


### PR DESCRIPTION
The file `minimal_assistant.ts` was renamed to `multimodal_agent.ts` in #138, but there were still references to the old name.
