### PR TITLE
ci: change changelogs main branch to stable

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,7 @@
   "ignore": ["livekit-agents-examples"],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "stable",
   "updateInternalDependencies": "patch",
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true


### PR DESCRIPTION
after this is merged, new branch `stable` will be created, and `main` will be renamed `next`. all development will take place on `next`, with occasional cherry-picks of relevant commits in PRs to `stable`, after which we cut new releases.

https://www.notion.so/livekit/the-stable-next-repository-model-14d3c4901a428099bc7cccfda8e1fa8b?pvs=4