### PR TITLE
chore: move to node:stream/web from homegrown API

### DIFF
--- a/agents/src/pipeline/agent_playout.ts
+++ b/agents/src/pipeline/agent_playout.ts
@@ -4,6 +4,7 @@
 import type { AudioFrame, AudioSource } from '@livekit/rtc-node';
 import type { TypedEventEmitter as TypedEmitter } from '@livekit/typed-emitter';
 import EventEmitter from 'node:events';
+import type { ReadableStream } from 'node:stream/web';
 import { log } from '../log.js';
 import { CancellablePromise, Future, gracefullyCancel } from '../utils.js';
 import { SynthesisHandle } from './agent_output.js';
@@ -21,7 +22,7 @@ export type AgentPlayoutCallbacks = {
 export class PlayoutHandle {
   #speechId: string;
   #audioSource: AudioSource;
-  playoutSource: AsyncIterable<AudioFrame | typeof SynthesisHandle.FLUSH_SENTINEL>;
+  playoutSource: ReadableStream<AudioFrame | typeof SynthesisHandle.FLUSH_SENTINEL>;
   totalPlayedTime?: number;
   #interrupted = false;
   pushedDuration = 0;
@@ -31,7 +32,7 @@ export class PlayoutHandle {
   constructor(
     speechId: string,
     audioSource: AudioSource,
-    playoutSource: AsyncIterable<AudioFrame | typeof SynthesisHandle.FLUSH_SENTINEL>,
+    playoutSource: ReadableStream<AudioFrame | typeof SynthesisHandle.FLUSH_SENTINEL>,
   ) {
     this.#speechId = speechId;
     this.#audioSource = audioSource;
@@ -90,7 +91,7 @@ export class AgentPlayout extends (EventEmitter as new () => TypedEmitter<AgentP
 
   play(
     speechId: string,
-    playoutSource: AsyncIterable<AudioFrame | typeof SynthesisHandle.FLUSH_SENTINEL>,
+    playoutSource: ReadableStream<AudioFrame | typeof SynthesisHandle.FLUSH_SENTINEL>,
   ): PlayoutHandle {
     if (this.#closed) {
       throw new Error('source closed');

--- a/agents/src/pipeline/pipeline_agent.ts
+++ b/agents/src/pipeline/pipeline_agent.ts
@@ -11,6 +11,7 @@ import {
 } from '@livekit/rtc-node';
 import type { TypedEventEmitter as TypedEmitter } from '@livekit/typed-emitter';
 import EventEmitter from 'node:events';
+import { TransformStream } from 'node:stream/web';
 import type {
   CallableFunctionResult,
   FunctionCallInfo,
@@ -30,7 +31,7 @@ import {
 import type { SentenceTokenizer, WordTokenizer } from '../tokenize/tokenizer.js';
 import type { TTS } from '../tts/index.js';
 import { TTSEvent, StreamAdapter as TTSStreamAdapter } from '../tts/index.js';
-import { AsyncIterableQueue, CancellablePromise, Future, gracefullyCancel } from '../utils.js';
+import { CancellablePromise, Future, gracefullyCancel } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { SpeechSource, SynthesisHandle } from './agent_output.js';
 import { AgentOutput } from './agent_output.js';
@@ -232,7 +233,10 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
   #transcribedText = '';
   #transcribedInterimText = '';
   #speechQueueOpen = new Future();
-  #speechQueue = new AsyncIterableQueue<SpeechHandle | typeof VoicePipelineAgent.FLUSH_SENTINEL>();
+  #speechQueue = new TransformStream<
+    SpeechHandle | typeof VoicePipelineAgent.FLUSH_SENTINEL,
+    SpeechHandle | typeof VoicePipelineAgent.FLUSH_SENTINEL
+  >();
   #updateStateTask?: CancellablePromise<void>;
   #started = false;
   #room?: Room;
@@ -497,7 +501,7 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
 
     while (true) {
       await this.#speechQueueOpen.await;
-      for await (const speech of this.#speechQueue) {
+      for await (const speech of this.#speechQueue.readable) {
         if (speech === VoicePipelineAgent.FLUSH_SENTINEL) break;
         this.#playingSpeech = speech;
         await this.#playSpeech(speech);
@@ -793,7 +797,7 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
     // in some bad timimg, we could end up with two pushed agent replies inside the speech queue.
     // so make sure we directly interrupt every reply when validating a new one
     if (this.#speechQueueOpen.done) {
-      for await (const speech of this.#speechQueue) {
+      for await (const speech of this.#speechQueue.readable) {
         if (speech === VoicePipelineAgent.FLUSH_SENTINEL) break;
         if (!speech.isReply) continue;
         if (speech.allowInterruptions) speech.interrupt();
@@ -845,8 +849,9 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
   }
 
   #addSpeechForPlayout(handle: SpeechHandle) {
-    this.#speechQueue.put(handle);
-    this.#speechQueue.put(VoicePipelineAgent.FLUSH_SENTINEL);
+    const writer = this.#speechQueue.writable.getWriter();
+    writer.write(handle);
+    writer.write(VoicePipelineAgent.FLUSH_SENTINEL);
     this.#speechQueueOpen.resolve();
   }
 

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -225,44 +225,6 @@ export async function gracefullyCancel<T>(promise: CancellablePromise<T>): Promi
 }
 
 /** @internal */
-export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
-  private static readonly CLOSE_SENTINEL = Symbol('CLOSE_SENTINEL');
-  #queue = new Queue<T | typeof AsyncIterableQueue.CLOSE_SENTINEL>();
-  #closed = false;
-
-  get closed(): boolean {
-    return this.#closed;
-  }
-
-  put(item: T): void {
-    if (this.#closed) {
-      throw new Error('Queue is closed');
-    }
-    this.#queue.put(item);
-  }
-
-  close(): void {
-    this.#closed = true;
-    this.#queue.put(AsyncIterableQueue.CLOSE_SENTINEL);
-  }
-
-  async next(): Promise<IteratorResult<T>> {
-    if (this.#closed && this.#queue.items.length === 0) {
-      return { value: undefined, done: true };
-    }
-    const item = await this.#queue.get();
-    if (item === AsyncIterableQueue.CLOSE_SENTINEL && this.#closed) {
-      return { value: undefined, done: true };
-    }
-    return { value: item as T, done: false };
-  }
-
-  [Symbol.asyncIterator](): AsyncIterableQueue<T> {
-    return this;
-  }
-}
-
-/** @internal */
 export class ExpFilter {
   #alpha: number;
   #max?: number;

--- a/agents/src/vad.ts
+++ b/agents/src/vad.ts
@@ -4,8 +4,9 @@
 import type { AudioFrame } from '@livekit/rtc-node';
 import type { TypedEventEmitter as TypedEmitter } from '@livekit/typed-emitter';
 import { EventEmitter } from 'node:events';
+import type { ReadableStream } from 'node:stream/web';
+import { TransformStream } from 'node:stream/web';
 import type { VADMetrics } from './metrics/base.js';
-import { AsyncIterableQueue } from './utils.js';
 
 export enum VADEventType {
   START_OF_SPEECH,
@@ -77,24 +78,28 @@ export abstract class VAD extends (EventEmitter as new () => TypedEmitter<VADCal
 
 export abstract class VADStream implements AsyncIterableIterator<VADEvent> {
   protected static readonly FLUSH_SENTINEL = Symbol('FLUSH_SENTINEL');
-  protected input = new AsyncIterableQueue<AudioFrame | typeof VADStream.FLUSH_SENTINEL>();
-  protected queue = new AsyncIterableQueue<VADEvent>();
-  protected output = new AsyncIterableQueue<VADEvent>();
+  protected input = new TransformStream<
+    AudioFrame | typeof VADStream.FLUSH_SENTINEL,
+    AudioFrame | typeof VADStream.FLUSH_SENTINEL
+  >();
+  protected output = new TransformStream<VADEvent, VADEvent>();
   protected closed = false;
   #vad: VAD;
   #lastActivityTime = BigInt(0);
+  #outputReadable: ReadableStream<VADEvent>;
 
   constructor(vad: VAD) {
     this.#vad = vad;
-    this.monitorMetrics();
+    const [r1, r2] = this.output.readable.tee();
+    this.#outputReadable = r1;
+    this.monitorMetrics(r2);
   }
 
-  protected async monitorMetrics() {
+  protected async monitorMetrics(readable: ReadableStream<VADEvent>) {
     let inferenceDurationTotal = 0;
     let inferenceCount = 0;
 
-    for await (const event of this.queue) {
-      this.output.put(event);
+    for await (const event of readable) {
       switch (event.type) {
         case VADEventType.START_OF_SPEECH:
           inferenceCount++;
@@ -119,47 +124,54 @@ export abstract class VADStream implements AsyncIterableIterator<VADEvent> {
           break;
       }
     }
-    this.output.close();
   }
 
   pushFrame(frame: AudioFrame) {
-    if (this.input.closed) {
-      throw new Error('Input is closed');
-    }
+    // if (this.input.closed) {
+    //   throw new Error('Input is closed');
+    // }
     if (this.closed) {
       throw new Error('Stream is closed');
     }
-    this.input.put(frame);
+    this.input.writable.getWriter().write(frame);
   }
 
   flush() {
-    if (this.input.closed) {
-      throw new Error('Input is closed');
-    }
+    // if (this.input.closed) {
+    //   throw new Error('Input is closed');
+    // }
     if (this.closed) {
       throw new Error('Stream is closed');
     }
-    this.input.put(VADStream.FLUSH_SENTINEL);
+    this.input.writable.getWriter().write(VADStream.FLUSH_SENTINEL);
   }
 
   endInput() {
-    if (this.input.closed) {
-      throw new Error('Input is closed');
-    }
+    // if (this.input.closed) {
+    //   throw new Error('Input is closed');
+    // }
     if (this.closed) {
       throw new Error('Stream is closed');
     }
-    this.input.close();
+    this.input.writable.close();
   }
 
-  next(): Promise<IteratorResult<VADEvent>> {
-    return this.output.next();
+  async next(): Promise<IteratorResult<VADEvent>> {
+    return this.#outputReadable
+      .getReader()
+      .read()
+      .then(({ value }) => {
+        if (value) {
+          return { value, done: false };
+        } else {
+          return { value: undefined, done: true };
+        }
+      });
   }
 
   close() {
-    this.input.close();
-    this.queue.close();
-    this.output.close();
+    this.input.writable.close();
+    this.output.writable.close();
     this.closed = true;
   }
 


### PR DESCRIPTION
this PR gets rid of our homegrown `AsyncIterableQueue` implementation in favour of WHATWG's Streams API.

- [ ] go over plugins
- [ ] implement locking
- [ ] figure out how to check whether a writer is closed