### PR TITLE
fix(multimodal): crash on reconnect to same room

### DIFF
--- a/.changeset/clean-lies-grow.md
+++ b/.changeset/clean-lies-grow.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(multimodal): crash on reconnect to same room


### PR DESCRIPTION
removed the janky half-implementation of cancellations that didn't work and caused the agent to error out when reconnecting to the same room.

fixes #214