### PR TITLE
[feat] Add support for language code on 11labs TTS

### DIFF
--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -41,6 +41,7 @@ export interface TTSOptions {
   apiKey?: string;
   voice: Voice;
   modelID: TTSModels | string;
+  languageCode?: string;
   baseURL: string;
   encoding: TTSEncoding;
   streamingLatency: number;
@@ -134,6 +135,7 @@ export class SynthesizeStream extends tts.SynthesizeStream {
       output_format: opts.encoding,
       optimize_streaming_latency: `${opts.streamingLatency}`,
       enable_ssml_parsing: `${opts.enableSsmlParsing}`,
+      ...(opts.languageCode && { language_code: opts.languageCode }),
     };
     Object.entries(params).forEach(([k, v]) => this.streamURL.searchParams.append(k, v));
     this.streamURL.protocol = this.streamURL.protocol.replace('http', 'ws');


### PR DESCRIPTION
The [11Labs TTS API](https://elevenlabs.io/docs/api-reference/text-to-speech/websockets#request.query.language_code) has support for supplying a `language_code` parameter on some models, steering the model toward the right accent and pronunciation for given text.
The proposed changes make it possible to supply this parameter over Livekit.