### PR TITLE
fix(proc): clearer errors on crash

### DIFF
--- a/.changeset/afraid-camels-listen.md
+++ b/.changeset/afraid-camels-listen.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(proc): clearer errors on crash

--- a/agents/src/ipc/proc_job_executor.ts
+++ b/agents/src/ipc/proc_job_executor.ts
@@ -94,9 +94,9 @@ export class ProcJobExecutor extends JobExecutor {
       }
     };
     this.#proc!.on('message', listener);
-    this.#proc!.on('error', (err) => {
+    this.#proc!.on('error', () => {
       if (this.#closing) return;
-      this.#logger.child({ err }).warn('job process exited unexpectedly');
+      this.#logger.warn('job process exited unexpectedly');
       clearTimeout(this.#pongTimeout);
       clearInterval(this.#pingInterval);
       this.#join.resolve();

--- a/agents/src/ipc/proc_job_executor.ts
+++ b/agents/src/ipc/proc_job_executor.ts
@@ -94,9 +94,9 @@ export class ProcJobExecutor extends JobExecutor {
       }
     };
     this.#proc!.on('message', listener);
-    this.#proc!.on('error', () => {
+    this.#proc!.on('error', (err) => {
       if (this.#closing) return;
-      this.#logger.warn('job process exited unexpectedly');
+      this.#logger.child({ err }).warn('job process exited unexpectedly; this likely means the error above caused a crash');
       clearTimeout(this.#pongTimeout);
       clearInterval(this.#pingInterval);
       this.#join.resolve();


### PR DESCRIPTION
we see a lot of bug reports focusing on ERR_IPC_CHANNEL_CLOSED, because it is the *big scary exception*, when in reality the actual error gets logged a few lines up. this gets rid of the useless log and should hopefully lead to more useful bug reports