### PR TITLE
feat(silero): update options for Silero VAD

### DIFF
--- a/.changeset/late-buckets-draw.md
+++ b/.changeset/late-buckets-draw.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-silero": patch
+---
+
+support updating options

--- a/plugins/silero/src/vad.ts
+++ b/plugins/silero/src/vad.ts
@@ -377,9 +377,9 @@ export class VADStream extends baseStream {
   /**
    * Update the VAD options
    *
-   * This method allows you to update the VAD options after the VAD object has been created
-   *
    * @param opts - Partial options object containing the values to update
+   * @remarks
+   * This method allows you to update the VAD options after the VAD object has been created
    */
   updateOptions(opts: Partial<VADOptions>) {
     const oldMaxBufferedSpeech = this.#opts.maxBufferedSpeech;

--- a/plugins/silero/src/vad.ts
+++ b/plugins/silero/src/vad.ts
@@ -167,10 +167,10 @@ export class VADStream extends baseStream {
           this.#prefixPaddingSamples = Math.trunc(
             (this.#opts.prefixPaddingDuration * this.#inputSampleRate) / 1000,
           );
-
-          this.#speechBuffer = new Int16Array(
-            this.#opts.maxBufferedSpeech * this.#inputSampleRate + this.#prefixPaddingSamples,
-          );
+          const bufferSize =
+            Math.trunc((this.#opts.maxBufferedSpeech * this.#inputSampleRate) / 1000) +
+            this.#prefixPaddingSamples;
+          this.#speechBuffer = new Int16Array(bufferSize);
 
           if (this.#opts.sampleRate !== this.#inputSampleRate) {
             // resampling needed: the input sample rate isn't the same as the model's
@@ -394,7 +394,7 @@ export class VADStream extends baseStream {
         (this.#opts.prefixPaddingDuration * this.#inputSampleRate) / 1000,
       );
       const bufferSize =
-        Math.floor(this.#opts.maxBufferedSpeech * this.#inputSampleRate) +
+        Math.trunc((this.#opts.maxBufferedSpeech * this.#inputSampleRate) / 1000) +
         this.#prefixPaddingSamples;
       const resizedBuffer = new Int16Array(bufferSize);
       resizedBuffer.set(


### PR DESCRIPTION
Implementation of `updateOptions` function on Silero VAD (Issue #268).

I Took heavy inspiration for this from the [python implementation](https://github.com/livekit/agents/blob/695f7b567d0b7fffa6a18f14c74e50421434a0aa/livekit-plugins/livekit-plugins-silero/livekit/plugins/silero/vad.py#L217), though I did not look too deep at the differences between `#task` and `_main_task`, so there may be implications I am not aware of.
