### PR TITLE
fix(metrics): fix MultimodalLLMError typescript

### DIFF
--- a/.changeset/clean-garlics-cross.md
+++ b/.changeset/clean-garlics-cross.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(metrics): remove ErrorOptions from MultimodalError

--- a/agents/src/ipc/proc_job_executor.ts
+++ b/agents/src/ipc/proc_job_executor.ts
@@ -96,7 +96,9 @@ export class ProcJobExecutor extends JobExecutor {
     this.#proc!.on('message', listener);
     this.#proc!.on('error', (err) => {
       if (this.#closing) return;
-      this.#logger.child({ err }).warn('job process exited unexpectedly; this likely means the error above caused a crash');
+      this.#logger
+        .child({ err })
+        .warn('job process exited unexpectedly; this likely means the error above caused a crash');
       clearTimeout(this.#pongTimeout);
       clearInterval(this.#pingInterval);
       this.#join.resolve();

--- a/agents/src/metrics/base.ts
+++ b/agents/src/metrics/base.ts
@@ -93,9 +93,8 @@ export class MultimodalLLMError extends Error {
       code,
       message,
     }: { type?: string; reason?: string; code?: string; message?: string } = {},
-    options?: ErrorOptions,
   ) {
-    super(message, options);
+    super(message);
     this.type = type;
     this.reason = reason;
     this.code = code;

--- a/agents/src/metrics/base.ts
+++ b/agents/src/metrics/base.ts
@@ -86,14 +86,12 @@ export class MultimodalLLMError extends Error {
   type?: string;
   reason?: string;
   code?: string;
-  constructor(
-    {
-      type,
-      reason,
-      code,
-      message,
-    }: { type?: string; reason?: string; code?: string; message?: string } = {},
-  ) {
+  constructor({
+    type,
+    reason,
+    code,
+    message,
+  }: { type?: string; reason?: string; code?: string; message?: string } = {}) {
     super(message);
     this.type = type;
     this.reason = reason;


### PR DESCRIPTION
we don't use ErrorOptions in any of our other `extends Error`s, and this causes a misbuild on some targets, presumably because of TS targets and modules.