### PR TITLE
include name, arguments, result & error (as applicable) in function_call_XXX events so they are much more useful

### DIFF
--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -1101,11 +1101,13 @@ export class RealtimeSession extends multimodal.RealtimeSession {
         return;
       }
 
-      this.emit('function_call_started', {
-        callId: item.call_id,
-      });
-
       const parsedArgs = JSON.parse(item.arguments);
+
+      this.emit('function_call_started', {
+        name: item.name,
+        callId: item.call_id,
+        arguments: parsedArgs,
+      });
 
       this.#logger.debug(
         `[Function Call ${item.call_id}] Executing ${item.name} with arguments ${parsedArgs}`,
@@ -1115,7 +1117,10 @@ export class RealtimeSession extends multimodal.RealtimeSession {
         (content) => {
           this.#logger.debug(`[Function Call ${item.call_id}] ${item.name} returned ${content}`);
           this.emit('function_call_completed', {
+            name: item.name,
             callId: item.call_id,
+            arguments: parsedArgs,
+            result: content,
           });
           this.conversation.item.create(
             llm.ChatMessage.createToolFromFunctionResult({
@@ -1131,7 +1136,10 @@ export class RealtimeSession extends multimodal.RealtimeSession {
           this.#logger.error(`[Function Call ${item.call_id}] ${item.name} failed with ${error}`);
           // TODO: send it back up as failed?
           this.emit('function_call_failed', {
+            name: item.name,
             callId: item.call_id,
+            arguments: parsedArgs,
+            error: error,
           });
         },
       );


### PR DESCRIPTION
These events are perfect for observing when a function is called, completes or throws an error so that additional steps can be taken by the agent that cannot normally run directly within the function context (such as taking some additional action before hanging up or transferring a call). But the events as coded unfortunately did not included any context about the function in the event payload. Adding that!