### PR TITLE
Fix await call that is never resolved in agent_output.ts — causes TTS to hang

### DIFF
--- a/agents/src/pipeline/agent_output.ts
+++ b/agents/src/pipeline/agent_output.ts
@@ -186,7 +186,7 @@ const streamSynthesisTask = (
       cancelled = true;
       handle.queue.put(SynthesisHandle.FLUSH_SENTINEL);
     }
-    
+
     ttsStream.flush();
     ttsStream.endInput();
 

--- a/agents/src/pipeline/agent_output.ts
+++ b/agents/src/pipeline/agent_output.ts
@@ -180,6 +180,13 @@ const streamSynthesisTask = (
       if (cancelled) break;
       ttsStream.pushText(text);
     }
+
+    // end the audio queue early if there is no actual text to turn into speech
+    if (!fullText || fullText.trim().length === 0) {
+      cancelled = true;
+      handle.queue.put(SynthesisHandle.FLUSH_SENTINEL);
+    }
+    
     ttsStream.flush();
     ttsStream.endInput();
 


### PR DESCRIPTION
1. In some cases, an LLM plugin can generate a blank ("") string when outputting a response. One example of this is when the OpenAI LLM plugin generates a tool function execution request.
2. If there is no text, some streaming TTS plugins, the Cartesia plugin for example, will not generate any audio.
3. If no audio is generated, then the for await call in the `readGeneratedAudio` function in `agent_output.ts` will never loop and the `handle.queue.put(SynthesisHandle.FLUSH_SENTINEL);` function will never be called. In this case the pipeline agent will go into an infinite wait loop because it is awaiting for a signal that the audio queue can be flushed, but it never happens.
4. We fix this by explicitly calling `handle.queue.put(SynthesisHandle.FLUSH_SENTINEL);` in cases where the string is missing or blank.

Note: it may also be recommended to find out why LLM plugins seem to generate blank text in the first place, but it felt like it was worth it to fix it here to guard against blanks strings generated for any reason.

Edit: the specific loop in pipeline_agent.ts that would never end because of this bug is here https://github.com/livekit/agents-js/blob/a383de1ab82ade8b78bb6eaf31dc14b29f30f92f/agents/src/pipeline/pipeline_agent.ts#L684-L692