### PR TITLE
Fixes infinte await in agent_output.ts

### DIFF
--- a/.changeset/lazy-horses-divide.md
+++ b/.changeset/lazy-horses-divide.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+skip TTS on empty LLM output

--- a/agents/src/pipeline/agent_output.ts
+++ b/agents/src/pipeline/agent_output.ts
@@ -180,6 +180,12 @@ const streamSynthesisTask = (
       if (cancelled) break;
       ttsStream.pushText(text);
     }
+
+    // end the audio queue early if there is no actual text to turn into speech
+    if (!fullText || fullText.trim().length === 0) {
+      cancelled = true;
+      handle.queue.put(SynthesisHandle.FLUSH_SENTINEL);
+    }
     ttsStream.flush();
     ttsStream.endInput();
 


### PR DESCRIPTION
1. In some cases, an LLM plugin can generate a blank ("") string when outputting a response. One example of this is when the OpenAI LLM plugin generates a tool function execution request.
2. If there is no text, some streaming TTS plugins, the Cartesia plugin for example, will not generate any audio.
3. If no audio is generated, then the for await call in the readGeneratedAudio function in agent_output.ts will never loop and the handle.queue.put(SynthesisHandle.FLUSH_SENTINEL); function will never be called. In this case the pipeline agent will go into an infinite wait loop because it is awaiting for a signal that the audio queue can be flushed, but it never happens.
4. We fix this by explicitly calling handle.queue.put(SynthesisHandle.FLUSH_SENTINEL); in cases where the string is missing or blank.

Note: it may also be recommended to find out why LLM plugins seem to generate blank text in the first place, but it felt like it was worth it to fix it here to guard against blanks strings generated for any reason.

Edit: the specific loop in pipeline_agent.ts that would never end because of this bug is here https://github.com/livekit/agents-js/blob/a383de1ab82ade8b78bb6eaf31dc14b29f30f92f/agents/src/pipeline/pipeline_agent.ts#L684-L692

The issue described above can be replicated with the following Agent:

```typescript
const agent = new pipeline.VoicePipelineAgent(
            vad,
            new deepgram.STT({
                model: "nova-2-general",
                apiKey: Config.DEEPGRAM_API_KEY
            }),
            new openai.LLM({
                apiKey: Config.OPEN_AI_API_KEY,
            }),
            new cartesia.TTS({
                apiKey: Config.CARTESIA_API_KEY,
                emotion: ["curiosity:high", "positivity:high"]
            }),
            {
                // initial ChatContext with system prompt
                chatCtx: initialContext,
                fncCtx: { 
                    my_function: {
                        description: "Get order status",
                        parameters: z.object({
                            orderNumber: z.string()
                        }),
                        execute: async (any) => {
                            console.log("this will never execute")
                        }
                    }
                },
                // whether the agent can be interrupted
                allowInterruptions: true,
                // sensitivity of when to interrupt
                interruptSpeechDuration: 500,
                interruptMinWords: 0,
                preemptiveSynthesis: true,
                // minimal silence duration to consider end-of-turn
                minEndpointingDelay: 500
            },
        );
```
In this case, none of the functions defined in fncCtx will ever be executed because the pipeline agent will wait forever for a TTS sound that will never be played.