### PR TITLE
Use #opts.apiVersion

### DIFF
--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -731,7 +731,7 @@ export class RealtimeSession extends multimodal.RealtimeSession {
       // Construct query parameters
       const queryParams: Record<string, string> = {};
       if (this.#opts.isAzure) {
-        queryParams['api-version'] = '2024-10-01-preview';
+        queryParams['api-version'] = this.#opts.apiVersion ?? '2024-10-01-preview';
         queryParams['deployment'] = this.#opts.model;
       } else {
         queryParams['model'] = this.#opts.model;


### PR DESCRIPTION
It's using `2024-10-01-preview` hardcoded value without chance to change apiVersion.

In [Azure document](https://learn.microsoft.com/en-us/azure/ai-services/openai/realtime-audio-quickstart?tabs=keyless%2Clinux&pivots=programming-language-typescript), it is stated that: "Use the latest `2024-12-17` model version".