### PR TITLE
fix(multimodal): never feed a negative audio end

### DIFF
--- a/.changeset/sixty-tips-nail.md
+++ b/.changeset/sixty-tips-nail.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(multimodal): never feed a negative audio end (hacky fix)

--- a/agents/src/multimodal/multimodal_agent.ts
+++ b/agents/src/multimodal/multimodal_agent.ts
@@ -335,7 +335,7 @@ export class MultimodalAgent extends EventEmitter {
           this.#session!.conversation.item.truncate(
             this.#playingHandle.itemId,
             this.#playingHandle.contentIndex,
-            Math.floor((this.#playingHandle.audioSamples / 24000) * 1000),
+            Math.max(0, Math.floor((this.#playingHandle.audioSamples / 24000) * 1000)),
           );
 
           this.#playingHandle = undefined;


### PR DESCRIPTION
this is a patchy fix to get stuff to not break as fast as possible, but we should look into why the length can be negative in the first place.