### PR TITLE
fix(multimodal): ensure audio samples is never smaller than 0

### DIFF
--- a/.changeset/gentle-jokes-refuse.md
+++ b/.changeset/gentle-jokes-refuse.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(multimodal): ensure audio samples is never smaller than 0

--- a/agents/src/multimodal/agent_playout.ts
+++ b/agents/src/multimodal/agent_playout.ts
@@ -57,8 +57,11 @@ export class PlayoutHandle extends EventEmitter {
       return Math.floor(this.totalPlayedTime * this.#sampleRate);
     }
 
-    return Math.floor(
-      (this.pushedDuration - this.#audioSource.queuedDuration) * (this.#sampleRate / 1000),
+    return Math.max(
+      0,
+      Math.floor(
+        (this.pushedDuration - this.#audioSource.queuedDuration) * (this.#sampleRate / 1000),
+      ),
     );
   }
 


### PR DESCRIPTION
replaces https://github.com/livekit/agents-js/pull/317

when `queuedDuration` is bigger than `pushedDuration`, audioSamples can become negative