### PR TITLE
log unhandled promise rejections

### DIFF
--- a/.changeset/eight-dolls-change.md
+++ b/.changeset/eight-dolls-change.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+log unhandled promise rejections

--- a/agents/src/ipc/job_proc_lazy_main.ts
+++ b/agents/src/ipc/job_proc_lazy_main.ts
@@ -150,6 +150,10 @@ const startJob = (
     const proc = new JobProcess();
     let logger = log().child({ pid: proc.pid });
 
+    process.on('unhandledRejection', (reason) => {
+      logger.error(reason);
+    });
+
     logger.debug('initializing job runner');
     agent.prewarm(proc);
     logger.debug('job runner initialized');


### PR DESCRIPTION
this way whole processes don't exit whenever something errored, instead attempting to continue