### PR TITLE
fix(pipeline): don't mark segment end if cancelled

### DIFF
--- a/.changeset/lazy-wolves-give.md
+++ b/.changeset/lazy-wolves-give.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(pipeline): don't mark segment end if cancelled

--- a/agents/src/pipeline/agent_output.ts
+++ b/agents/src/pipeline/agent_output.ts
@@ -202,7 +202,9 @@ const streamSynthesisTask = (
       handle.synchronizer.pushText(text);
       ttsStream.pushText(text);
     }
-    handle.synchronizer.markTextSegmentEnd();
+    if (!cancelled) {
+      handle.synchronizer.markTextSegmentEnd();
+    }
 
     // end the audio queue early if there is no actual text to turn into speech
     if (!fullText || fullText.trim().length === 0) {


### PR DESCRIPTION
fix #311 