### PR TITLE
fix(deepgram): missing speakers for STT when diarization enabled

### DIFF
--- a/plugins/deepgram/src/stt.ts
+++ b/plugins/deepgram/src/stt.ts
@@ -320,11 +320,21 @@ const liveTranscriptionToSpeechData = (
 ): stt.SpeechData[] => {
   const alts: any[] = data['channel']['alternatives'];
 
-  return alts.map((alt) => ({
-    language,
-    startTime: alt['words'].length ? alt['words'][0]['start'] : 0,
-    endTime: alt['words'].length ? alt['words'][alt['words'].length - 1]['end'] : 0,
-    confidence: alt['confidence'],
-    text: alt['transcript'],
-  }));
+  return alts.map((alt) => {
+    // Check if words array exists and has speaker information
+    const hasSpeaker = alt['words']?.length > 0 && 'speaker' in alt['words'][0];
+
+    // Get the speaker if available (all words in the same alternative have the same speaker)
+    const speaker = hasSpeaker ? alt['words'][0].speaker : undefined;
+
+    return {
+      language,
+      startTime: alt['words']?.length ? alt['words'][0]['start'] : 0,
+      endTime: alt['words']?.length ? alt['words'][alt['words'].length - 1]['end'] : 0,
+      confidence: alt['confidence'],
+      text: alt['transcript'],
+      ...(speaker !== undefined && { speaker }),
+    };
+  });
 };
+


### PR DESCRIPTION
Deepgram provides every speaker a number
It should be returned on the final payload when available

Docs: [https://developers.deepgram.com/reference/speech-to-text-api/listen-streaming#request.query.diarize](https://developers.deepgram.com/reference/speech-to-text-api/listen-streaming#request.query.diarize)