### PR TITLE
Keyterm fix for nova-3-general

### DIFF
--- a/plugins/deepgram/src/stt.ts
+++ b/plugins/deepgram/src/stt.ts
@@ -137,7 +137,8 @@ export class SpeechStream extends stt.SpeechStream {
         channels: this.#opts.numChannels,
         endpointing: this.#opts.endpointing || false,
         filler_words: this.#opts.fillerWords,
-        keywords: this.#opts.keywords.map((x) => x.join(':')),
+        keywords: this.#opts.model === 'nova-3-general' ? undefined : this.#opts.keywords.map((x) => x.join(':')),
+        keyterm: this.#opts.model === 'nova-3-general' ? this.#opts.keywords.map((x) => x[0]) : undefined,
         profanity_filter: this.#opts.profanityFilter,
         language: this.#opts.language,
       };
@@ -146,7 +147,7 @@ export class SpeechStream extends stt.SpeechStream {
           if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
             streamURL.searchParams.append(k, encodeURIComponent(v));
           } else {
-            v.forEach((x) => streamURL.searchParams.append('keywords', encodeURIComponent(x)));
+            v.forEach((x) => streamURL.searchParams.append(k, encodeURIComponent(x)));
           }
         }
       });

--- a/plugins/deepgram/src/stt.ts
+++ b/plugins/deepgram/src/stt.ts
@@ -137,8 +137,12 @@ export class SpeechStream extends stt.SpeechStream {
         channels: this.#opts.numChannels,
         endpointing: this.#opts.endpointing || false,
         filler_words: this.#opts.fillerWords,
-        keywords: this.#opts.model === 'nova-3-general' ? undefined : this.#opts.keywords.map((x) => x.join(':')),
-        keyterm: this.#opts.model === 'nova-3-general' ? this.#opts.keywords.map((x) => x[0]) : undefined,
+        keywords:
+          this.#opts.model === 'nova-3-general'
+            ? undefined
+            : this.#opts.keywords.map((x) => x.join(':')),
+        keyterm:
+          this.#opts.model === 'nova-3-general' ? this.#opts.keywords.map((x) => x[0]) : undefined,
         profanity_filter: this.#opts.profanityFilter,
         language: this.#opts.language,
       };


### PR DESCRIPTION
The `keywords` isn't supported by nova-3-general, it has been changed to `keyterm` which is quite similar, it's just missing the multiplier at on the words. I believe it's best to abstract this away and make it work as I lost hours trying to upgrade to nova-3-general. A lot of people use `keywords` and the error messages aren't good when it fails from deepgram.