### PR TITLE
fix: resolve race condition in TextAudioSynchronizer closure

### DIFF
--- a/.changeset/fix-synchronizer-race.md
+++ b/.changeset/fix-synchronizer-race.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix: fix race condition in TextAudioSynchronizer causing "TextAudioSynchronizer is closed" errors in AgentPlayout

--- a/agents/src/multimodal/agent_playout.ts
+++ b/agents/src/multimodal/agent_playout.ts
@@ -233,15 +233,14 @@ export class AgentPlayout extends EventEmitter {
               await gracefullyCancel(captureTask);
             }
 
+            if (!readTextTask.isCancelled) {
+              await gracefullyCancel(readTextTask);
+            }
+
             handle.totalPlayedTime = handle.pushedDuration - this.#audioSource.queuedDuration;
 
             if (handle.interrupted || captureTask.error) {
-              await handle.synchronizer.close(true);
               this.#audioSource.clearQueue(); // make sure to remove any queued frames
-            }
-
-            if (!readTextTask.isCancelled) {
-              await gracefullyCancel(readTextTask);
             }
 
             if (!firstFrame) {
@@ -249,7 +248,9 @@ export class AgentPlayout extends EventEmitter {
             }
 
             handle.doneFut.resolve();
-            await handle.synchronizer.close(false);
+
+            const isInterrupted = handle.interrupted || !!captureTask.error;
+            await handle.synchronizer.close(isInterrupted);
           }
 
           resolve();


### PR DESCRIPTION
## Description

The race condition occurs because the `TextAudioSynchronizer` is closed before the readText task is cancelled. When the readText task continues running and calls methods on the already-closed synchronizer, it triggers the "TextAudioSynchronizer is closed" error. This fix ensures all tasks are properly cancelled before closing the synchronizer.