### PR TITLE
Publish transcriptions additionally via text stream APIs

### DIFF
--- a/.changeset/heavy-cats-unite.md
+++ b/.changeset/heavy-cats-unite.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Publish transcriptions additionally via text stream APIs

--- a/agents/src/constants.ts
+++ b/agents/src/constants.ts
@@ -1,0 +1,4 @@
+export const ATTRIBUTE_TRANSCRIPTION_TRACK_ID = 'lk.transcribed_track_id';
+export const ATTRIBUTE_TRANSCRIPTION_FINAL = 'lk.transcription_final';
+export const TOPIC_TRANSCRIPTION = 'lk.transcription';
+export const TOPIC_CHAT = 'lk.chat';

--- a/agents/src/constants.ts
+++ b/agents/src/constants.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
 export const ATTRIBUTE_TRANSCRIPTION_TRACK_ID = 'lk.transcribed_track_id';
 export const ATTRIBUTE_TRANSCRIPTION_FINAL = 'lk.transcription_final';
 export const TOPIC_TRANSCRIPTION = 'lk.transcription';

--- a/agents/src/multimodal/multimodal_agent.ts
+++ b/agents/src/multimodal/multimodal_agent.ts
@@ -19,9 +19,11 @@ import {
 } from '@livekit/rtc-node';
 import { EventEmitter } from 'node:events';
 import { AudioByteStream } from '../audio.js';
-import { TOPIC_TRANSCRIPTION } from '../constants.js';
-import { ATTRIBUTE_TRANSCRIPTION_FINAL } from '../constants.js';
-import { ATTRIBUTE_TRANSCRIPTION_TRACK_ID } from '../constants.js';
+import {
+  ATTRIBUTE_TRANSCRIPTION_FINAL,
+  ATTRIBUTE_TRANSCRIPTION_TRACK_ID,
+  TOPIC_TRANSCRIPTION,
+} from '../constants.js';
 import * as llm from '../llm/index.js';
 import { log } from '../log.js';
 import type { MultimodalLLMMetrics } from '../metrics/base.js';

--- a/agents/src/pipeline/pipeline_agent.ts
+++ b/agents/src/pipeline/pipeline_agent.ts
@@ -12,9 +12,11 @@ import {
 import type { TypedEventEmitter as TypedEmitter } from '@livekit/typed-emitter';
 import { randomUUID } from 'node:crypto';
 import EventEmitter from 'node:events';
-import { TOPIC_TRANSCRIPTION } from '../constants.js';
-import { ATTRIBUTE_TRANSCRIPTION_TRACK_ID } from '../constants.js';
-import { ATTRIBUTE_TRANSCRIPTION_FINAL } from '../constants.js';
+import {
+  ATTRIBUTE_TRANSCRIPTION_FINAL,
+  ATTRIBUTE_TRANSCRIPTION_TRACK_ID,
+  TOPIC_TRANSCRIPTION,
+} from '../constants.js';
 import type {
   CallableFunctionResult,
   FunctionCallInfo,


### PR DESCRIPTION
depends on https://github.com/livekit/node-sdks/pull/447

add support for text stream based transcriptions while trying to leave things as they are otherwise. 

The whole synchronizer logic (esp. wrt to deltas) should get an overhaul for 1.0 as a bunch of things changed on the python side.