### PR TITLE
fix(tts): add instructions parameter to updateOptions method

### DIFF
--- a/plugins/openai/src/tts.ts
+++ b/plugins/openai/src/tts.ts
@@ -55,7 +55,7 @@ export class TTS extends tts.TTS {
       });
   }
 
-  updateOptions(opts: { model?: TTSModels | string; voice?: TTSVoices; speed?: number }) {
+  updateOptions(opts: { model?: TTSModels | string; voice?: TTSVoices; speed?: number, instructions?: string }) {
     this.#opts = { ...this.#opts, ...opts };
   }
 


### PR DESCRIPTION
I forgot to add the instruction params for the updateOptions method. This isn't a breaking issue as you can currently do the workaround of expecting a type error eg, // @ts-expect-error. It's just not ideal to have in a production code base.