### PR TITLE
Add noise cancellation support to VoicePipelineAgent and MultimodalAgent

### DIFF
--- a/.changeset/noise-cancellation.md
+++ b/.changeset/noise-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+add inbound noise cancellation support

--- a/agents/package.json
+++ b/agents/package.json
@@ -49,6 +49,6 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@livekit/rtc-node": "^0.13.4"
+    "@livekit/rtc-node": "^0.13.11"
   }
 }

--- a/agents/package.json
+++ b/agents/package.json
@@ -30,7 +30,7 @@
     "api:update": "api-extractor run --local --typescript-compiler-folder ../node_modules/typescript --verbose"
   },
   "devDependencies": {
-    "@livekit/rtc-node": "^0.13.4",
+    "@livekit/rtc-node": "^0.13.11",
     "@microsoft/api-extractor": "^7.35.0",
     "@types/node": "^22.5.5",
     "@types/ws": "^8.5.10",

--- a/agents/src/multimodal/multimodal_agent.ts
+++ b/agents/src/multimodal/multimodal_agent.ts
@@ -462,11 +462,9 @@ export class MultimodalAgent extends EventEmitter {
       const audioStreamOptions = {
         sampleRate: this.model.sampleRate,
         numChannels: this.model.numChannels,
-        ...(this.#noiseCancellation ? { noiseCancellation: this.#noiseCancellation } : {})
+        ...(this.#noiseCancellation ? { noiseCancellation: this.#noiseCancellation } : {}),
       };
-      readAudioStreamTask(new AudioStream(track, audioStreamOptions))
-        .then(resolve)
-        .catch(reject);
+      readAudioStreamTask(new AudioStream(track, audioStreamOptions)).then(resolve).catch(reject);
     });
   }
 

--- a/agents/src/multimodal/multimodal_agent.ts
+++ b/agents/src/multimodal/multimodal_agent.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type {
   LocalTrackPublication,
+  NoiseCancellationOptions,
   RemoteAudioTrack,
   RemoteParticipant,
   RemoteTrack,
@@ -72,17 +73,20 @@ export class MultimodalAgent extends EventEmitter {
     chatCtx,
     fncCtx,
     maxTextResponseRetries = 5,
+    noiseCancellation,
   }: {
     model: RealtimeModel;
     chatCtx?: llm.ChatContext;
     fncCtx?: llm.FunctionContext;
     maxTextResponseRetries?: number;
+    noiseCancellation?: NoiseCancellationOptions;
   }) {
     super();
     this.model = model;
     this.#chatCtx = chatCtx;
     this.#fncCtx = fncCtx;
     this.#maxTextResponseRetries = maxTextResponseRetries;
+    this.#noiseCancellation = noiseCancellation;
   }
 
   #participant: RemoteParticipant | string | null = null;
@@ -95,6 +99,7 @@ export class MultimodalAgent extends EventEmitter {
   #session: RealtimeSession | null = null;
   #fncCtx: llm.FunctionContext | undefined = undefined;
   #chatCtx: llm.ChatContext | undefined = undefined;
+  #noiseCancellation: NoiseCancellationOptions | undefined = undefined;
 
   #_started: boolean = false;
   #_pendingFunctionCalls: Set<string> = new Set();
@@ -454,7 +459,12 @@ export class MultimodalAgent extends EventEmitter {
     this.subscribedTrack = track;
 
     this.readMicroTask = new Promise<void>((resolve, reject) => {
-      readAudioStreamTask(new AudioStream(track, this.model.sampleRate, this.model.numChannels))
+      const audioStreamOptions = {
+        sampleRate: this.model.sampleRate,
+        numChannels: this.model.numChannels,
+        ...(this.#noiseCancellation ? { noiseCancellation: this.#noiseCancellation } : {})
+      };
+      readAudioStreamTask(new AudioStream(track, audioStreamOptions))
         .then(resolve)
         .catch(reject);
     });

--- a/agents/src/pipeline/human_input.ts
+++ b/agents/src/pipeline/human_input.ts
@@ -52,7 +52,7 @@ export class HumanInput extends (EventEmitter as new () => TypedEmitter<HumanInp
     vad: VAD,
     stt: STT,
     participant: RemoteParticipant,
-    noiseCancellation?: NoiseCancellationOptions
+    noiseCancellation?: NoiseCancellationOptions,
   ) {
     super();
     this.#room = room;
@@ -105,7 +105,7 @@ export class HumanInput extends (EventEmitter as new () => TypedEmitter<HumanInp
       const audioStreamOptions = {
         sampleRate: 16000,
         numChannels: 1,
-        ...(this.#noiseCancellation ? { noiseCancellation: this.#noiseCancellation } : {})
+        ...(this.#noiseCancellation ? { noiseCancellation: this.#noiseCancellation } : {}),
       };
       const audioStream = new AudioStream(track, audioStreamOptions);
 

--- a/agents/src/pipeline/human_input.ts
+++ b/agents/src/pipeline/human_input.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type {
+  NoiseCancellationOptions,
   RemoteAudioTrack,
   RemoteParticipant,
   RemoteTrackPublication,
@@ -44,13 +45,21 @@ export class HumanInput extends (EventEmitter as new () => TypedEmitter<HumanInp
   #speaking = false;
   #speechProbability = 0;
   #logger = log();
+  #noiseCancellation?: NoiseCancellationOptions;
 
-  constructor(room: Room, vad: VAD, stt: STT, participant: RemoteParticipant) {
+  constructor(
+    room: Room,
+    vad: VAD,
+    stt: STT,
+    participant: RemoteParticipant,
+    noiseCancellation?: NoiseCancellationOptions
+  ) {
     super();
     this.#room = room;
     this.#vad = vad;
     this.#stt = stt;
     this.#participant = participant;
+    this.#noiseCancellation = noiseCancellation;
 
     this.#room.on(RoomEvent.TrackPublished, this.#subscribeToMicrophone.bind(this));
     this.#room.on(RoomEvent.TrackSubscribed, this.#subscribeToMicrophone.bind(this));
@@ -93,7 +102,12 @@ export class HumanInput extends (EventEmitter as new () => TypedEmitter<HumanInp
         this.#recognizeTask.cancel();
       }
 
-      const audioStream = new AudioStream(track, 16000);
+      const audioStreamOptions = {
+        sampleRate: 16000,
+        numChannels: 1,
+        ...(this.#noiseCancellation ? { noiseCancellation: this.#noiseCancellation } : {})
+      };
+      const audioStream = new AudioStream(track, audioStreamOptions);
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       this.#recognizeTask = new CancellablePromise(async (resolve, _, onCancel) => {

--- a/agents/src/pipeline/pipeline_agent.ts
+++ b/agents/src/pipeline/pipeline_agent.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { LocalTrackPublication, RemoteParticipant, Room } from '@livekit/rtc-node';
+import type { LocalTrackPublication, NoiseCancellationOptions, RemoteParticipant, Room } from '@livekit/rtc-node';
 import {
   AudioSource,
   LocalAudioTrack,
@@ -216,6 +216,8 @@ export interface VPAOptions {
   transcription: AgentTranscriptionOptions;
   /** Turn detection model to use. */
   turnDetector?: TurnDetector;
+  /** Noise cancellation options. */
+  noiseCancellation?: NoiseCancellationOptions;
 }
 
 const defaultVPAOptions: VPAOptions = {
@@ -474,7 +476,13 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
       return;
     }
 
-    this.#humanInput = new HumanInput(this.#room, this.#vad, this.#stt, this.#participant);
+    this.#humanInput = new HumanInput(
+      this.#room,
+      this.#vad,
+      this.#stt,
+      this.#participant,
+      this.#opts.noiseCancellation
+    );
     this.#humanInput.on(HumanInputEvent.START_OF_SPEECH, (event) => {
       this.emit(VPAEvent.USER_STARTED_SPEAKING);
       this.#deferredValidation.onHumanStartOfSpeech(event);

--- a/agents/src/pipeline/pipeline_agent.ts
+++ b/agents/src/pipeline/pipeline_agent.ts
@@ -1,7 +1,12 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { LocalTrackPublication, NoiseCancellationOptions, RemoteParticipant, Room } from '@livekit/rtc-node';
+import type {
+  LocalTrackPublication,
+  NoiseCancellationOptions,
+  RemoteParticipant,
+  Room,
+} from '@livekit/rtc-node';
 import {
   AudioSource,
   LocalAudioTrack,
@@ -481,7 +486,7 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
       this.#vad,
       this.#stt,
       this.#participant,
-      this.#opts.noiseCancellation
+      this.#opts.noiseCancellation,
     );
     this.#humanInput.on(HumanInputEvent.START_OF_SPEECH, (event) => {
       this.emit(VPAEvent.USER_STARTED_SPEAKING);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 1.13.3(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n:
         specifier: ^16.6.2
         version: 16.6.2(eslint@8.57.0)
@@ -106,8 +106,8 @@ importers:
         version: 3.23.8
     devDependencies:
       '@livekit/rtc-node':
-        specifier: ^0.13.4
-        version: 0.13.4
+        specifier: ^0.13.11
+        version: 0.13.11
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@22.5.5)
@@ -1179,10 +1179,22 @@ packages:
   '@livekit/protocol@1.29.1':
     resolution: {integrity: sha512-OhxXTZlyM5f4ydnAq1p5azzzOtKWmIoCSVtyVj9rgE42zQI5JM1rR9pubVRZovouGSvEDSJx9yL4Js2IlIyM1Q==}
 
+  '@livekit/rtc-node-darwin-arm64@0.13.11':
+    resolution: {integrity: sha512-XqbVUW5rVrRdVzxUI3+f8K6A1bnzAXytbCmPx7YiGOXVNRCV1kC84R7fap7OgrgN/rAtObhyYK882xdJVG/BYA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@livekit/rtc-node-darwin-arm64@0.13.4':
     resolution: {integrity: sha512-CYEpfls1/KTGCwjXTbr0WYYizVzbLYzeuGp43kG9zOxQRr3Y0KWAFeGglafupyvwib21nxe7+1ubzpXQMsYVOg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@livekit/rtc-node-darwin-x64@0.13.11':
+    resolution: {integrity: sha512-UFe9Lp+7Z8UZcJq2oOH8+6nCKWlX0PVorB4jeCRZuVa4QL2PL1CcGvo9/kNNw5aA25AkPUgDjMXj2WbfEPNMKA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
     os: [darwin]
 
   '@livekit/rtc-node-darwin-x64@0.13.4':
@@ -1191,10 +1203,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@livekit/rtc-node-linux-arm64-gnu@0.13.11':
+    resolution: {integrity: sha512-GuJtl1nJhJnFEMI9plJqlIJ0BJCWuynJzbhhD7Yd/Zuw/NYzzzIf+wQ2mIZ0Zk9/EUV4oMYJqacJiZXvOvUQ3A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@livekit/rtc-node-linux-arm64-gnu@0.13.4':
     resolution: {integrity: sha512-CAvvwpFt5dXyEIkkkLKspN7lReKk9t0sKoahqw1jN9boeDFgvbBYMJ5rtJwUA55keFN0yixfRyyYIRO/hPU8bw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
+    os: [linux]
+
+  '@livekit/rtc-node-linux-x64-gnu@0.13.11':
+    resolution: {integrity: sha512-Zi7Elg29JSmDzikxL2Q9YAAka2Khi7GwYHYBv69W6XXHqz3MN4wtnUGShclmqC7aITkHF0tVNLHdexFmMc3trA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
     os: [linux]
 
   '@livekit/rtc-node-linux-x64-gnu@0.13.4':
@@ -1203,11 +1227,21 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@livekit/rtc-node-win32-x64-msvc@0.13.11':
+    resolution: {integrity: sha512-NYemYGbc271SFv+ttYaNvEKLWmwkJqn988xOasq+lWd31kuhj0krR2cThM07HKhgoQwOfdyIcSV87b0mjPzb/A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@livekit/rtc-node-win32-x64-msvc@0.13.4':
     resolution: {integrity: sha512-/mv9A+ZA6ZKwXupoG7vs2b1G9CfcEdyY7DcWqacTR5WjE2nuO256q6aPnNd7A4dNOPepMZKc3eLX+RuVj4M9FQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@livekit/rtc-node@0.13.11':
+    resolution: {integrity: sha512-yq9uNRK+cdee0W6w0HPMSjTHovUteY4t4ZFrTdmpNt7fg/VxaJkdpXaG7cg8t+RX0pBT/NHskSQ4WFrqumezZg==}
+    engines: {node: '>= 18'}
 
   '@livekit/rtc-node@0.13.4':
     resolution: {integrity: sha512-wqhzqRtB6zC5yxL8cQTP2xAwCEhyXezjWp0FzJhOYNtH3dwJXChCKvcCpoaMKIOZI/nLTTYe5LWgC/2snLCnmA==}
@@ -4785,20 +4819,49 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 
+  '@livekit/rtc-node-darwin-arm64@0.13.11':
+    optional: true
+
   '@livekit/rtc-node-darwin-arm64@0.13.4':
+    optional: true
+
+  '@livekit/rtc-node-darwin-x64@0.13.11':
     optional: true
 
   '@livekit/rtc-node-darwin-x64@0.13.4':
     optional: true
 
+  '@livekit/rtc-node-linux-arm64-gnu@0.13.11':
+    optional: true
+
   '@livekit/rtc-node-linux-arm64-gnu@0.13.4':
+    optional: true
+
+  '@livekit/rtc-node-linux-x64-gnu@0.13.11':
     optional: true
 
   '@livekit/rtc-node-linux-x64-gnu@0.13.4':
     optional: true
 
+  '@livekit/rtc-node-win32-x64-msvc@0.13.11':
+    optional: true
+
   '@livekit/rtc-node-win32-x64-msvc@0.13.4':
     optional: true
+
+  '@livekit/rtc-node@0.13.11':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@livekit/mutex': 1.1.1
+      '@livekit/typed-emitter': 3.0.0
+      pino: 9.6.0
+      pino-pretty: 13.0.0
+    optionalDependencies:
+      '@livekit/rtc-node-darwin-arm64': 0.13.11
+      '@livekit/rtc-node-darwin-x64': 0.13.11
+      '@livekit/rtc-node-linux-arm64-gnu': 0.13.11
+      '@livekit/rtc-node-linux-x64-gnu': 0.13.11
+      '@livekit/rtc-node-win32-x64-msvc': 0.13.11
 
   '@livekit/rtc-node@0.13.4':
     dependencies:
@@ -5888,8 +5951,8 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -5906,7 +5969,7 @@ snapshots:
   eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 16.6.2(eslint@8.57.0)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)
 
@@ -5923,13 +5986,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -5940,14 +6003,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5958,7 +6021,7 @@ snapshots:
       eslint: 8.57.0
       eslint-compat-utils: 0.5.0(eslint@8.57.0)
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -5968,7 +6031,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3


### PR DESCRIPTION
  - For VoicePipelineAgent: Added to VPAOptions interface
  - For MultimodalAgent: Added as constructor parameter

Regarding the implementation for MultimodalAgent, I've currently added an extra parameter to the constructor, but I believe this isn't the best approach. Similar to how we added `AudioStreamOptions` to `AudioStream`, I think it would be better to create a parameter that consolidates options.
However, since I lack context on this project, I'd appreciate your opinion on how to best structure this.

