### PR TITLE
Fix race condition in clean:build task for monorepo packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "turbo run build",
     "clean": "turbo run clean",
-    "clean:build": "turbo run clean:build",
+    "clean:build": "turbo run clean && turbo run build",
     "build:agents": "turbo run build --filter=@livekit/agents...",
     "build:plugins": "turbo run build --filter=@livekit/agents-plugin-*...",
     "ci:publish": "pnpm build && changeset publish",

--- a/turbo.json
+++ b/turbo.json
@@ -35,10 +35,6 @@
       "dependsOn": ["^clean"],
       "outputs": [""]
     },
-    "clean:build": {
-      "dependsOn": ["^clean:build"],
-      "outputs": ["dist/**"]
-    },
     "lint": {
       "outputs": []
     },


### PR DESCRIPTION
## Problem

When running `pnpm clean:build`, the build process would fail due to race conditions between interdependent packages, while `pnpm build` worked correctly. This occurred because the combined `clean:build` task would attempt to clean and rebuild packages simultaneously, causing plugins to try building before their dependencies (like the core `agents` package) had completed rebuilding.

### Error logs (before fix)

```
@livekit/agents-plugin-openai:build: error TS2307: Cannot find module '@livekit/agents' or its corresponding type declarations.
@livekit/agents-plugin-silero:build: error TS2307: Cannot find module '@livekit/agents/dist/types' or its corresponding type declarations.
```

## Solution

Modified the scripts to run clean and build sequentially rather than as a combined task. This ensures all packages are fully cleaned before any builds start.
