### PR TITLE
Fix frame size from TTS output and bug where we don't queue frames

### DIFF
--- a/.changeset/good-papayas-crash.md
+++ b/.changeset/good-papayas-crash.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+bugfix: don't wait to queue audio frames before they are sent to the room

--- a/agents/src/audio.ts
+++ b/agents/src/audio.ts
@@ -17,7 +17,7 @@ export class AudioByteStream {
     this.#numChannels = numChannels;
 
     if (samplesPerChannel === null) {
-      samplesPerChannel = Math.floor(sampleRate / 50); // 20ms by default
+      samplesPerChannel = Math.floor(sampleRate / 10); // 100ms by default
     }
 
     this.#bytesPerFrame = numChannels * samplesPerChannel * 2; // 2 bytes per sample (Int16)

--- a/agents/src/pipeline/agent_playout.ts
+++ b/agents/src/pipeline/agent_playout.ts
@@ -167,7 +167,6 @@ export class AgentPlayout extends (EventEmitter as new () => TypedEmitter<AgentP
           }
           handle.pushedDuration += (frame.samplesPerChannel / frame.sampleRate) * 1000;
           handle.synchronizer.pushAudio(frame);
-          console.log('captureFrame with frame duration (ms)', frame.samplesPerChannel / frame.sampleRate * 1000);
           await this.#audioSource.captureFrame(frame);
         }
 

--- a/agents/src/pipeline/agent_playout.ts
+++ b/agents/src/pipeline/agent_playout.ts
@@ -167,16 +167,12 @@ export class AgentPlayout extends (EventEmitter as new () => TypedEmitter<AgentP
           }
           handle.pushedDuration += (frame.samplesPerChannel / frame.sampleRate) * 1000;
           handle.synchronizer.pushAudio(frame);
+          console.log('captureFrame with frame duration (ms)', frame.samplesPerChannel / frame.sampleRate * 1000);
           await this.#audioSource.captureFrame(frame);
-          await this.#audioSource.waitForPlayout();
         }
 
-        // XXX(nbsp): line 161 waits instead of this. this is not the case on python agents,
-        //            but for some reason too many TTS frames can gunk up the buffer and lead to
-        //            FFI errors. this works 🤷‍♀️
-        // if (this.#audioSource.queuedDuration > 0) {
-        //   await this.#audioSource.waitForPlayout();
-        // }
+        await this.#audioSource.waitForPlayout();
+
 
         handle.synchronizer.close(false);
         resolve();


### PR DESCRIPTION
Allow the agent playout to be buffered. Previously we were waiting every Frame to be acknowledged by the FFiclient before we queued the next one. 