### PR TITLE
Fix: Default to floating `gpt-4o-realtime-preview` model tag

### DIFF
--- a/plugins/openai/src/realtime/api_proto.ts
+++ b/plugins/openai/src/realtime/api_proto.ts
@@ -9,7 +9,7 @@ export const OUT_FRAME_SIZE = 1200; // 50ms
 
 export const BASE_URL = 'wss://api.openai.com/v1';
 
-export type Model = 'gpt-4o-realtime-preview-2024-10-01' | string; // Open-ended, for future models
+export type Model = 'gpt-4o-realtime-preview' | string; // Open-ended, for future models
 export type Voice =
   | 'alloy'
   | 'shimmer'


### PR DESCRIPTION
Updates the default model for the realtime plugin from the specific snapshot `gpt-4o-realtime-preview-2024-10-01` to the floating tag `gpt-4o-realtime-preview`.

By using the `gpt-4o-realtime-preview` tag, the plugin will automatically default to the latest realtime model snapshot (in this case 2024-12-17). This eliminates the need for manual code updates each time a new snapshot is released and ensures users benefit from the most recent model improvements by default.

This also aligns it with the python version [here](https://github.com/livekit/agents/blob/0d608925d3981f9c3734b922ea8053063e6b35ef/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py#L168) and [here](https://github.com/livekit/agents/blob/0d608925d3981f9c3734b922ea8053063e6b35ef/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py#L199).