### PR TITLE
Shubhra/ajs 76 memory leak in node process

### DIFF
--- a/.changeset/heavy-weeks-beam.md
+++ b/.changeset/heavy-weeks-beam.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix memory leak when job completed

--- a/agents/src/ipc/job_proc_lazy_main.ts
+++ b/agents/src/ipc/job_proc_lazy_main.ts
@@ -222,6 +222,6 @@ const startJob = (
     await join.await;
 
     logger.info('Job process shutdown');
-    return process.exitCode;
+    process.exit(0);
   }
 })();


### PR DESCRIPTION
`job_proc_lazy_main.ts` completes its shutdown logic but doesn't explicitly call `process.exit()`. It just returns from the main async function, but the Node.js process can stay alive if there are still active resources like:
- WebSocket connections (in this case a Deepgram connection that was not cleaned up properly)
- Timers or intervals
- Open file handles
- Other event loop references


Ideally we can just `return` from the main async function and clean up all running async functions, this is something we can debate for 1.0 changes. For now we should just hard exit to make sure there is not memory leak. 