### PR TITLE
Pull up `TextOutput` and `AudioOutput` into abstract classes users can inherit. 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,11 +17,17 @@
   "rules": {
     "tsdoc/syntax": "warn",
     "space-before-function-parens": 0,
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_"
+      }
+    ],
     "import/export": 0,
     "@typescript-eslint/ban-ts-comment": "warn",
     "@typescript-eslint/no-empty-interface": "warn",
     "@typescript-eslint/consistent-type-imports": "warn",
     "@typescript-eslint/no-explicit-any": "warn",
+    
   },
 }

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -16,7 +16,7 @@ import type { Agent } from './agent.js';
 import { AgentActivity } from './agent_activity.js';
 import type { _TurnDetector } from './audio_recognition.js';
 import type { UserState } from './events.js';
-import type { ParticipantAudioOutput, TextOutput } from './room_io/index.js';
+import type { AudioOutput, TextOutput } from './io.js';
 import { RoomIO } from './room_io/index.js';
 
 export type AgentState = 'initializing' | 'thinking' | 'listening' | 'speaking';
@@ -79,7 +79,7 @@ export class AgentSession extends (EventEmitter as new () => TypedEmitter<AgentS
   /** @internal */
   audioInput?: ReadableStream<AudioFrame>;
   /** @internal */
-  audioOutput?: ParticipantAudioOutput;
+  audioOutput?: AudioOutput;
   /** @internal */
   _transcriptionOutput?: TextOutput;
 

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -8,8 +8,7 @@ import type { ChatContext } from '../llm/chat_context.js';
 import type { ChatChunk } from '../llm/llm.js';
 import { IdentityTransform } from '../stream/identity_transform.js';
 import { Future, Task } from '../utils.js';
-import type { LLMNode, TTSNode } from './io.js';
-import type { ParticipantAudioOutput, TextOutput } from './room_io/index.js';
+import type { AudioOutput, LLMNode, TTSNode, TextOutput } from './io.js';
 
 /* @internal */
 export class _LLMGenerationData {
@@ -194,7 +193,7 @@ export interface _AudioOut {
 
 async function forwardAudio(
   ttsStream: ReadableStream<AudioFrame>,
-  audioOuput: ParticipantAudioOutput,
+  audioOuput: AudioOutput,
   out: _AudioOut,
   signal?: AbortSignal,
 ): Promise<void> {
@@ -228,7 +227,7 @@ async function forwardAudio(
 
 export function performAudioForwarding(
   ttsStream: ReadableStream<AudioFrame>,
-  audioOutput: ParticipantAudioOutput,
+  audioOutput: AudioOutput,
   controller: AbortController,
 ): [Task<void>, _AudioOut] {
   const out = {

--- a/agents/src/voice/io.ts
+++ b/agents/src/voice/io.ts
@@ -6,6 +6,7 @@ import type { ReadableStream } from 'node:stream/web';
 import type { ChatContext } from '../llm/chat_context.js';
 import type { ChatChunk } from '../llm/llm.js';
 import type { SpeechEvent } from '../stt/stt.js';
+import { Future } from '../utils.js';
 
 export type STTNode = (
   audio: ReadableStream<AudioFrame>,
@@ -21,3 +22,80 @@ export type TTSNode = (
   text: ReadableStream<string>,
   modelSettings: any, // TODO(AJS-59): add type
 ) => Promise<ReadableStream<AudioFrame> | null>;
+export abstract class AudioOutput {
+  private playbackFinishedFuture: Future<void> = new Future();
+  private capturing: boolean = false;
+  private playbackFinishedCount: number = 0;
+  private playbackSegmentsCount: number = 0;
+  private lastPlaybackEvent: PlaybackFinishedEvent = {
+    playbackPosition: 0,
+    interrupted: false,
+  };
+
+  constructor(protected readonly sampleRate?: number) {}
+
+  /**
+   * Capture an audio frame for playback, frames can be pushed faster than real-time
+   */
+  async captureFrame(_frame: AudioFrame): Promise<void> {
+    if (!this.capturing) {
+      this.capturing = true;
+      this.playbackSegmentsCount++;
+    }
+  }
+
+  /**
+   * Wait for the past audio segments to finish playing out.
+   *
+   * @returns The event that was emitted when the audio finished playing out (only the last segment information)
+   */
+  async waitForPlayout(): Promise<PlaybackFinishedEvent> {
+    const target = this.playbackSegmentsCount;
+
+    while (this.playbackFinishedCount < target) {
+      await this.playbackFinishedFuture.await;
+      this.playbackFinishedFuture = new Future();
+    }
+
+    return this.lastPlaybackEvent;
+  }
+
+  /**
+   * Developers building audio sinks must call this method when a playback/segment is finished.
+   * Segments are segmented by calls to flush() or clearBuffer()
+   */
+  onPlaybackFinished(event: PlaybackFinishedEvent) {
+    this.lastPlaybackEvent = event;
+    this.playbackFinishedCount++;
+    this.playbackFinishedFuture.resolve();
+  }
+
+  flush(): void {
+    this.capturing = false;
+  }
+
+  /**
+   * Clear the buffer, stopping playback immediately
+   */
+  abstract clearBuffer(): void;
+}
+export interface PlaybackFinishedEvent {
+  // How much of the audio was played back
+  playbackPosition: number;
+  // Interrupted is True if playback was interrupted (clearBuffer() was called)
+  interrupted: boolean;
+  // Transcript synced with playback; may be partial if the audio was interrupted
+  // When null, the transcript is not synchronized with the playback
+  synchronizedTranscript?: string;
+}
+export abstract class TextOutput {
+  /**
+   * Capture a text segment (Used by the output of LLM nodes)
+   */
+  abstract captureText(text: string): Promise<void>;
+
+  /**
+   * Mark the current text segment as complete (e.g LLM generation is complete)
+   */
+  abstract flush(): void;
+}


### PR DESCRIPTION
Pulling up `TextOutput` and `AudioOutput` into public interfaces users can inherit. This will also make Future PRs easier to read since we already define the base classes.


**There are not functional changes in this PR**