### PR TITLE
fix(openai): set apiKey to bypass default check in LLM constructor

### DIFF
--- a/.changeset/short-pears-do.md
+++ b/.changeset/short-pears-do.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+When using the `LLM.withAzure` method, the `apiKey` is redundant, but we need to set it to bypass the LLM's default apiKey check

--- a/plugins/openai/src/llm.ts
+++ b/plugins/openai/src/llm.ts
@@ -100,6 +100,7 @@ export class LLM extends llm.LLM {
     return new LLM({
       temperature: opts.temperature,
       user: opts.user,
+      apiKey: opts.apiKey, // this is redundant, but we need to set it to bypass the LLM's default apiKey check
       client: new AzureOpenAI(opts),
     });
   }


### PR DESCRIPTION
Seems like the OpenAI Realtime version is using a default `isAzure` parameter. Anyways, this bypasses the `apiKey` check when using the withAzure static function to return a new LLM instance.