### PR TITLE
Fix TTS Hanging when Receiving empty text stream

### DIFF
--- a/agents/src/utils.test.ts
+++ b/agents/src/utils.test.ts
@@ -3,9 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import { delay } from '@std/async';
 import { describe, expect, it } from 'vitest';
+import { initializeLogger } from '../src/log.js';
 import { TASK_TIMEOUT_ERROR, Task, TaskResult } from '../src/utils.js';
 
 describe('AbortableTask', () => {
+  // initialize logger
+  initializeLogger({ pretty: true, level: 'debug' });
+
   describe('AbortableTask.from', () => {
     it('should execute task successfully and return result', async () => {
       const expectedResult = 'task completed';

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -14,6 +14,7 @@ import {
   type LLM,
   type ToolContext,
 } from '../llm/index.js';
+import { log } from '../log.js';
 import type { STT, SpeechEvent } from '../stt/index.js';
 import { StreamAdapter as STTStreamAdapter } from '../stt/index.js';
 import { SentenceTokenizer as BasicSentenceTokenizer } from '../tokenize/basic/index.js';
@@ -242,6 +243,7 @@ export class Agent<UserData = any> {
         async start(controller) {
           for await (const chunk of stream) {
             if (chunk === SynthesizeStream.END_OF_STREAM) {
+              log().debug('ttsNode: END_OF_STREAM');
               break;
             }
             controller.enqueue(chunk.frame);

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -14,7 +14,6 @@ import {
   type LLM,
   type ToolContext,
 } from '../llm/index.js';
-import { log } from '../log.js';
 import type { STT, SpeechEvent } from '../stt/index.js';
 import { StreamAdapter as STTStreamAdapter } from '../stt/index.js';
 import { SentenceTokenizer as BasicSentenceTokenizer } from '../tokenize/basic/index.js';
@@ -243,7 +242,6 @@ export class Agent<UserData = any> {
         async start(controller) {
           for await (const chunk of stream) {
             if (chunk === SynthesizeStream.END_OF_STREAM) {
-              log().debug('ttsNode: END_OF_STREAM');
               break;
             }
             controller.enqueue(chunk.frame);

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -578,7 +578,12 @@ export class AgentActivity implements RecognitionHooks {
       tasks.push(ttsTask);
     }
 
+    this.logger.debug(
+      { speech_id: speechHandle.id },
+      'waitIfNotInterrupted: waiting for authorization',
+    );
     await speechHandle.waitIfNotInterrupted([speechHandle.waitForAuthorization()]);
+    this.logger.debug({ speech_id: speechHandle.id }, 'waitIfNotInterrupted: authorization done');
     if (speechHandle.interrupted) {
       replyAbortController.abort();
       await Promise.allSettled(
@@ -631,10 +636,17 @@ export class AgentActivity implements RecognitionHooks {
     });
     tasks.push(executeToolsTask);
 
+    this.logger.debug({ speech_id: speechHandle.id }, 'waitIfNotInterrupted: waiting for tasks');
     await speechHandle.waitIfNotInterrupted(tasks.map((task) => task.result));
+    this.logger.debug({ speech_id: speechHandle.id }, 'waitIfNotInterrupted: tasks done');
 
     if (audioOutput) {
+      this.logger.debug(
+        { speech_id: speechHandle.id },
+        'waitIfNotInterrupted: waiting for audio output',
+      );
       await speechHandle.waitIfNotInterrupted([audioOutput.waitForPlayout()]);
+      this.logger.debug({ speech_id: speechHandle.id }, 'waitIfNotInterrupted: audio output done');
     }
 
     // add the tools messages that triggers this reply to the chat context

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -578,12 +578,7 @@ export class AgentActivity implements RecognitionHooks {
       tasks.push(ttsTask);
     }
 
-    this.logger.debug(
-      { speech_id: speechHandle.id },
-      'waitIfNotInterrupted: waiting for authorization',
-    );
     await speechHandle.waitIfNotInterrupted([speechHandle.waitForAuthorization()]);
-    this.logger.debug({ speech_id: speechHandle.id }, 'waitIfNotInterrupted: authorization done');
     if (speechHandle.interrupted) {
       replyAbortController.abort();
       await Promise.allSettled(
@@ -636,17 +631,10 @@ export class AgentActivity implements RecognitionHooks {
     });
     tasks.push(executeToolsTask);
 
-    this.logger.debug({ speech_id: speechHandle.id }, 'waitIfNotInterrupted: waiting for tasks');
     await speechHandle.waitIfNotInterrupted(tasks.map((task) => task.result));
-    this.logger.debug({ speech_id: speechHandle.id }, 'waitIfNotInterrupted: tasks done');
 
     if (audioOutput) {
-      this.logger.debug(
-        { speech_id: speechHandle.id },
-        'waitIfNotInterrupted: waiting for audio output',
-      );
       await speechHandle.waitIfNotInterrupted([audioOutput.waitForPlayout()]);
-      this.logger.debug({ speech_id: speechHandle.id }, 'waitIfNotInterrupted: audio output done');
     }
 
     // add the tools messages that triggers this reply to the chat context

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -628,6 +628,7 @@ export class AgentActivity implements RecognitionHooks {
       toolCtx,
       toolChoice,
       toolCallStream: llmGenData.toolCallStream,
+      controller: replyAbortController,
     });
     tasks.push(executeToolsTask);
 

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -217,7 +217,10 @@ export function performLLMInference(
     }
   };
 
-  return [Task.from((controller) => inferenceTask(controller.signal), controller), data];
+  return [
+    Task.from((controller) => inferenceTask(controller.signal), controller, 'performLLMInference'),
+    data,
+  ];
 }
 
 export function performTTSInference(
@@ -266,7 +269,7 @@ export function performTTSInference(
   };
 
   return [
-    Task.from((controller) => inferenceTask(controller.signal), controller),
+    Task.from((controller) => inferenceTask(controller.signal), controller, 'performTTSInference'),
     audioOutputStream,
   ];
 }
@@ -314,7 +317,11 @@ export function performTextForwarding(
     firstTextFut: new Future(),
   };
   return [
-    Task.from((controller) => forwardText(source, out, controller.signal, textOutput), controller),
+    Task.from(
+      (controller) => forwardText(source, out, controller.signal, textOutput),
+      controller,
+      'performTextForwarding',
+    ),
     out,
   ];
 }
@@ -371,6 +378,7 @@ export function performAudioForwarding(
     Task.from(
       (controller) => forwardAudio(ttsStream, audioOutput, out, controller.signal),
       controller,
+      'performAudioForwarding',
     ),
     out,
   ];
@@ -515,7 +523,7 @@ export function performToolExecutions({
     }
   };
 
-  return [Task.from(executeToolsTask), toolOutput];
+  return [Task.from(executeToolsTask, undefined, 'performToolExecutions'), toolOutput];
 }
 
 type Aborted<T> =

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -390,12 +390,14 @@ export function performToolExecutions({
   toolCtx,
   toolChoice,
   toolCallStream,
+  controller,
 }: {
   session: AgentSession;
   speechHandle: SpeechHandle;
   toolCtx: ToolContext;
   toolChoice: ToolChoice;
   toolCallStream: ReadableStream<FunctionCall>;
+  controller: AbortController;
 }): [Task<void>, _ToolOutput] {
   const logger = log();
   const toolOutput = new _ToolOutput();
@@ -523,7 +525,7 @@ export function performToolExecutions({
     }
   };
 
-  return [Task.from(executeToolsTask, undefined, 'performToolExecutions'), toolOutput];
+  return [Task.from(executeToolsTask, controller, 'performToolExecutions'), toolOutput];
 }
 
 type Aborted<T> =

--- a/examples/src/basic_tool_call_agent.ts
+++ b/examples/src/basic_tool_call_agent.ts
@@ -34,9 +34,9 @@ export default defineAgent({
         location: z.string().describe('The location to get the weather for'),
       }),
       execute: async ({ location }) => {
-        if (Math.random() < 0.5) {
-          throw new llm.ToolError('Internal server error, please try again later.');
-        }
+        // if (Math.random() < 0.5) {
+        //   throw new llm.ToolError('Internal server error, please try again later.');
+        // }
         return `The weather in ${location} is sunny today.`;
       },
     });

--- a/examples/src/basic_tool_call_agent.ts
+++ b/examples/src/basic_tool_call_agent.ts
@@ -104,6 +104,7 @@ export default defineAgent({
       userData: { number: 0 },
     });
     session.start(agent, ctx.room);
+    session.say("Hello, I'm a powerful LiveKit agent. I can help you with your tasks.");
   },
 });
 

--- a/examples/src/basic_tool_call_agent.ts
+++ b/examples/src/basic_tool_call_agent.ts
@@ -103,7 +103,7 @@ export default defineAgent({
       tts: new elevenlabs.TTS(),
       userData: { number: 0 },
     });
-    session.start(agent, ctx.room);
+    await session.start(agent, ctx.room);
     session.say("Hello, I'm a powerful LiveKit agent. I can help you with your tasks.");
   },
 });

--- a/examples/src/push_to_talk.ts
+++ b/examples/src/push_to_talk.ts
@@ -35,6 +35,7 @@ export default defineAgent({
       stt: new deepgram.STT(),
       llm: new openai.LLM(),
       tts: new elevenlabs.TTS(),
+      turnDetection: 'manual',
     });
 
     if (!ctx.room.localParticipant) {


### PR DESCRIPTION
Issue is that when perform tool calling, the text stream will be a empty stream. This won't trigger `pushText` method in ts's `SynthesizeStream` object. However, pushText lazily starts `monitorMetrics` task, which controlling the close lifecycle stage of the tts stream. Without any text chunk, we cannot start `monitorMetrics` which make the TTS stream unable to close so it become hanging. 

This PR separate the close outside of monitorMetric task so it call `this.output.close()` as soon as the main task finishes