### PR TITLE
Send `lk.segment_id` attribute in transcription events so non final transcriptions can be deduplicated client side

### DIFF
--- a/.changeset/heavy-cherries-yell.md
+++ b/.changeset/heavy-cherries-yell.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+add `lk.segment_id` to all generated trancription events

--- a/agents/src/constants.ts
+++ b/agents/src/constants.ts
@@ -4,4 +4,5 @@
 export const ATTRIBUTE_TRANSCRIPTION_TRACK_ID = 'lk.transcribed_track_id';
 export const ATTRIBUTE_TRANSCRIPTION_FINAL = 'lk.transcription_final';
 export const TOPIC_TRANSCRIPTION = 'lk.transcription';
+export const ATTRIBUTE_SEGMENT_ID = 'lk.segment_id';
 export const TOPIC_CHAT = 'lk.chat';

--- a/agents/src/multimodal/multimodal_agent.ts
+++ b/agents/src/multimodal/multimodal_agent.ts
@@ -21,6 +21,7 @@ import {
 import { EventEmitter } from 'node:events';
 import { AudioByteStream } from '../audio.js';
 import {
+  ATTRIBUTE_SEGMENT_ID,
   ATTRIBUTE_TRANSCRIPTION_FINAL,
   ATTRIBUTE_TRANSCRIPTION_TRACK_ID,
   TOPIC_TRANSCRIPTION,
@@ -492,6 +493,7 @@ export class MultimodalAgent extends EventEmitter {
     text: string,
     isFinal: boolean,
     id: string,
+    segmentId: string,
   ): Promise<void> {
     this.#logger.debug(
       `Publishing transcription ${participantIdentity} ${trackSid} ${text} ${isFinal} ${id}`,
@@ -522,6 +524,7 @@ export class MultimodalAgent extends EventEmitter {
       attributes: {
         [ATTRIBUTE_TRANSCRIPTION_TRACK_ID]: trackSid,
         [ATTRIBUTE_TRANSCRIPTION_FINAL]: isFinal.toString(),
+        [ATTRIBUTE_SEGMENT_ID]: segmentId,
       },
     });
     await stream.write(text);

--- a/agents/src/multimodal/multimodal_agent.ts
+++ b/agents/src/multimodal/multimodal_agent.ts
@@ -18,6 +18,7 @@ import {
   TrackPublishOptions,
   TrackSource,
 } from '@livekit/rtc-node';
+import { randomUUID } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import { AudioByteStream } from '../audio.js';
 import {
@@ -73,6 +74,7 @@ export class MultimodalAgent extends EventEmitter {
 
   #textResponseRetries = 0;
   #maxTextResponseRetries: number;
+  #transcriptionId?: string;
 
   constructor({
     model,
@@ -258,13 +260,20 @@ export class MultimodalAgent extends EventEmitter {
 
         const synchronizer = new TextAudioSynchronizer(defaultTextSyncOptions);
         synchronizer.on('textUpdated', async (text) => {
+          if (!this.#transcriptionId) {
+            this.#transcriptionId = randomUUID();
+          }
           await this.#publishTranscription(
             this.room!.localParticipant!.identity!,
             this.#getLocalTrackSid()!,
             text.text,
             text.final,
             text.id,
+            this.#transcriptionId,
           );
+          if (text.final) {
+            this.#transcriptionId = undefined;
+          }
         });
 
         const handle = this.#agentPlayout?.play(
@@ -313,7 +322,17 @@ export class MultimodalAgent extends EventEmitter {
         const participantIdentity = this.linkedParticipant?.identity;
         const trackSid = this.subscribedTrack?.sid;
         if (participantIdentity && trackSid) {
-          await this.#publishTranscription(participantIdentity, trackSid, '…', false, ev.itemId);
+          if (!this.#transcriptionId) {
+            this.#transcriptionId = randomUUID();
+          }
+          await this.#publishTranscription(
+            participantIdentity,
+            trackSid,
+            '…',
+            false,
+            ev.itemId,
+            this.#transcriptionId,
+          );
         } else {
           this.#logger.error('Participant or track not set');
         }
@@ -326,13 +345,18 @@ export class MultimodalAgent extends EventEmitter {
         const participantIdentity = this.linkedParticipant?.identity;
         const trackSid = this.subscribedTrack?.sid;
         if (participantIdentity && trackSid) {
+          if (!this.#transcriptionId) {
+            this.#transcriptionId = randomUUID();
+          }
           await this.#publishTranscription(
             participantIdentity,
             trackSid,
             transcription,
             true,
             ev.itemId,
+            this.#transcriptionId,
           );
+          this.#transcriptionId = undefined;
         } else {
           this.#logger.error('Participant or track not set');
         }
@@ -361,7 +385,17 @@ export class MultimodalAgent extends EventEmitter {
         const participantIdentity = this.linkedParticipant?.identity;
         const trackSid = this.subscribedTrack?.sid;
         if (participantIdentity && trackSid) {
-          await this.#publishTranscription(participantIdentity, trackSid, '…', false, ev.itemId);
+          if (!this.#transcriptionId) {
+            this.#transcriptionId = randomUUID();
+          }
+          await this.#publishTranscription(
+            participantIdentity,
+            trackSid,
+            '…',
+            false,
+            ev.itemId,
+            this.#transcriptionId,
+          );
         }
       });
 

--- a/agents/src/pipeline/pipeline_agent.ts
+++ b/agents/src/pipeline/pipeline_agent.ts
@@ -18,6 +18,7 @@ import type { TypedEventEmitter as TypedEmitter } from '@livekit/typed-emitter';
 import { randomUUID } from 'node:crypto';
 import EventEmitter from 'node:events';
 import {
+  ATTRIBUTE_SEGMENT_ID,
   ATTRIBUTE_TRANSCRIPTION_FINAL,
   ATTRIBUTE_TRANSCRIPTION_TRACK_ID,
   TOPIC_TRANSCRIPTION,
@@ -895,6 +896,7 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
     text: string,
     isFinal: boolean,
     id: string,
+    segmentId: string,
   ) {
     this.#room!.localParticipant!.publishTranscription({
       participantIdentity: participantIdentity,
@@ -916,6 +918,7 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
       attributes: {
         [ATTRIBUTE_TRANSCRIPTION_TRACK_ID]: trackSid,
         [ATTRIBUTE_TRANSCRIPTION_FINAL]: isFinal.toString(),
+        [ATTRIBUTE_SEGMENT_ID]: segmentId,
       },
     });
     await stream.write(text);

--- a/agents/src/pipeline/pipeline_agent.ts
+++ b/agents/src/pipeline/pipeline_agent.ts
@@ -538,6 +538,7 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
         this.#transcribedInterimText,
         false,
         this.#transcriptionId,
+        this.#transcriptionId,
       );
     });
     this.#humanInput.on(HumanInputEvent.FINAL_TRANSCRIPT, async (event) => {
@@ -556,6 +557,7 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
         this.#humanInput!.subscribedTrack!.sid!,
         this.transcribedText,
         true,
+        this.#transcriptionId,
         this.#transcriptionId,
       );
 
@@ -933,13 +935,20 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
     // TODO: where possible we would want to use deltas instead of full text segments, esp for LLM streams over the streamText API
     synchronizer.on('textUpdated', async (text) => {
       this.#agentTranscribedText = text.text;
+      if (!this.#transcriptionId) {
+        this.#transcriptionId = randomUUID();
+      }
       await this.#publishTranscription(
         this.#room!.localParticipant!.identity!,
         this.#agentPublication?.sid ?? '',
         text.text,
         text.final,
         text.id,
+        this.#transcriptionId,
       );
+      if (text.final) {
+        this.#transcriptionId = undefined;
+      }
     });
 
     if (!this.#agentOutput) {


### PR DESCRIPTION
The python agents sdk includes a `lk.segment_id` attribute in all transcription events, which clients ([js sdk example](https://github.com/livekit/components-js/blob/6f02e9f9b3e7737863d256b26a26ade914a5066a/packages/core/src/components/textStream.ts#L79-L85)) can use to deduplicate non finalized events into a list of renderable transcription messages.

However, the agents-js sdk doesn't include this field, and because the `id` field for human-generated transcriptions isn't always the same for transcriptions that represent the same speech, there's no way for that deduplication to occur, which at least in [agents-starter-react](https://github.com/livekit-examples/agent-starter-react) results in rendering each partial transcription distinctly in lists, which is bad:

<img width="1428" height="1542" alt="image" src="https://github.com/user-attachments/assets/9af6b4fc-4a8d-4e50-a009-fe0e85b4be2c" />


So, to address this, this change does a few things:
- Extends the `transcriptionId` field to be used for tracking human-generated transcriptions as well as agent-generated transcriptions
- Adds the `lk.segment_id` attribute with similar semantics as the python agents sdk (ie, two transcriptions representing the same speech at different times = same segment id), which fixed the above [agents-starter-react](https://github.com/livekit-examples/agent-starter-react) issue
- Extends the `transcriptionId` pattern to the multimodal agent as well (tested my changes with [multimodal-agent-node](https://github.com/livekit-examples/multimodal-agent-node)!)