### PR TITLE
brianyin/ajs-223-tts-stt-llm-provider-run-out-of-quota-but-no-error-log-shown

### DIFF
--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -193,6 +193,11 @@ export class SynthesizeStream extends tts.SynthesizeStream {
         headers: { [AUTHORIZATION_HEADER]: this.#opts.apiKey },
       });
 
+      ws.on('error', (error) => {
+        this.abortController.abort();
+        this.#logger.error({ error }, 'Error connecting to ElevenLabs');
+      });
+
       try {
         await new Promise((resolve, reject) => {
           ws.on('open', resolve);


### PR DESCRIPTION
This change help retrying 11lab TTS when connection raises error