### PR TITLE
brian/fix-cartesia-tts-chunk-timeout

### DIFF
--- a/.changeset/whole-wings-find.md
+++ b/.changeset/whole-wings-find.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-cartesia': patch
+---
+
+Fix cartesia TTS segment stream timeout

--- a/plugins/cartesia/src/tts.ts
+++ b/plugins/cartesia/src/tts.ts
@@ -29,6 +29,11 @@ export interface TTSOptions {
   apiKey?: string;
   language: string;
   baseUrl: string;
+
+  /**
+   * The timeout for the next chunk to be received from the Cartesia API.
+   */
+  chunkTimeout: number;
 }
 
 const defaultTTSOptions: TTSOptions = {
@@ -39,6 +44,7 @@ const defaultTTSOptions: TTSOptions = {
   apiKey: process.env.CARTESIA_API_KEY,
   language: 'en',
   baseUrl: 'https://api.cartesia.ai',
+  chunkTimeout: 5000,
 };
 
 export class TTS extends tts.TTS {
@@ -227,6 +233,15 @@ export class SynthesizeStream extends tts.SynthesizeStream {
         }
       };
 
+      let timeout: NodeJS.Timeout | null = null;
+
+      const clearTTSChunkTimeout = () => {
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = null;
+        }
+      };
+
       while (!this.closed && !this.abortController.signal.aborted && !shouldExit) {
         try {
           await new Promise<RawData | null>((resolve, reject) => {
@@ -254,6 +269,17 @@ export class SynthesizeStream extends tts.SynthesizeStream {
                 sendLastFrame(segmentId, false);
                 lastFrame = frame;
               }
+
+              // IMPORTANT: close WS if TTS chunk stream been stuck too long
+              // this allows unblock the current "broken" TTS node so that any future TTS nodes
+              // can continue to process the stream without been blocked by the stuck node
+              clearTTSChunkTimeout();
+              timeout = setTimeout(() => {
+                this.#logger.error(
+                  `Cartesia WebSocket STT chunk stream timeout after ${this.#opts.chunkTimeout}ms`,
+                );
+                ws.close();
+              }, this.#opts.chunkTimeout);
             } else if ('done' in json) {
               finalReceived = true;
               for (const frame of bstream.flush()) {
@@ -268,6 +294,7 @@ export class SynthesizeStream extends tts.SynthesizeStream {
               if (segmentId === requestId) {
                 closing = true;
                 shouldExit = true;
+                clearTTSChunkTimeout();
                 ws.close();
               }
             }

--- a/plugins/cartesia/src/tts.ts
+++ b/plugins/cartesia/src/tts.ts
@@ -304,6 +304,7 @@ export class SynthesizeStream extends tts.SynthesizeStream {
           if (err instanceof Error && !err.message.includes('WebSocket closed')) {
             this.#logger.error({ err }, 'Error in recvTask from Cartesia WebSocket');
           }
+          clearTTSChunkTimeout();
           break;
         }
       }


### PR DESCRIPTION
Bug fix on Cartesia TTS. Sometimes when there are too many user <-> agent interaction that consumes too much TTS requests, it will hit rate limit. But instead of returning an error from websocket, cartesia API just streams part of STT chunks message without emitting the final one where `done` is `true`. This makes TTS been stuck and any future speech will be stuck into speech queue as well since the current speech cannot finish due to the cartesia's rate limiting behavior.

This change allows unblock the broken TTS node by adding a chunk timeout, so the WS will automatically closed if the next in-progress chunk did not arrive within bounded time.