### PR TITLE
Update llm.ts

### DIFF
--- a/plugins/openai/src/llm.ts
+++ b/plugins/openai/src/llm.ts
@@ -118,7 +118,7 @@ export class LLM extends llm.LLM {
       temperature?: number;
     } = defaultAzureLLMOptions,
   ): LLM {
-    opts = { ...defaultLLMOptions, ...opts };
+    opts = { ...defaultAzureLLMOptions, ...opts };
     if (opts.apiKey === undefined) {
       throw new Error('Azure API key is required, whether as an argument or as $AZURE_API_KEY');
     }


### PR DESCRIPTION
Seems to be a incorrect selection of default options
WithAzure should use azure default options and not openAi default options.
- Use AZURE_API_KEY
- Not OPENAI_API_KEY