### PR TITLE
Fix agent-js to be patch bump

### DIFF
--- a/.changeset/yellow-wombats-wait.md
+++ b/.changeset/yellow-wombats-wait.md
@@ -1,5 +1,5 @@
 ---
-'@livekit/agents': minor
+'@livekit/agents': patch
 '@livekit/agents-plugin-openai': patch
 ---
 


### PR DESCRIPTION
This PR should fix the changeset of accidentally bumping all plugins to major version
```
% npx changeset status --verbose
🦋  info Packages to be bumped at patch
🦋  - @livekit/agents-plugin-openai 1.0.7
🦋    - .changeset/every-moons-search.md
🦋    - .changeset/yellow-wombats-wait.md
🦋  - @livekit/agents 1.0.7
🦋    - .changeset/yellow-wombats-wait.md
🦋  - @livekit/agents-plugin-cartesia 1.0.7
🦋  - @livekit/agents-plugin-elevenlabs 1.0.7
🦋  - @livekit/agents-plugin-google 1.0.7
🦋  - @livekit/agents-plugin-neuphonic 1.0.7
🦋  - @livekit/agents-plugin-deepgram 1.0.7
🦋  - @livekit/agents-plugin-livekit 1.0.7
🦋  - @livekit/agents-plugin-resemble 1.0.7
🦋  - @livekit/agents-plugin-silero 1.0.7
🦋  - @livekit/agents-plugins-test 1.0.7
🦋  ---
🦋  info Running release would release NO packages as a minor
🦋  ---
🦋  info Packages to be bumped at major
🦋  - @livekit/agents-plugin-rime 1.0.0
🦋    - .changeset/late-eels-wait.md
```