### PR TITLE
Allow Not Specify OPENAI_API_KEY when using Inference Gateway

### DIFF
--- a/.changeset/dry-states-smile.md
+++ b/.changeset/dry-states-smile.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Fix inference gateway LLM to allow not passing OPENAI_API_KEY

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -135,6 +135,7 @@ export class LLM extends llm.LLM {
 
     this.client = new OpenAI({
       baseURL: this.opts.baseURL,
+      apiKey: '', // leave a temporary empty string to avoid OpenAI complain about missing key
       timeout: 15000,
     });
   }


### PR DESCRIPTION
Add a temporary placeholder key in OpenAI client SDK, preventing it to complain when using inference gateway