### PR TITLE
Patch Rime TTS Plugin

### DIFF
--- a/.changeset/young-dryers-give.md
+++ b/.changeset/young-dryers-give.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-rime': patch
+---
+
+Add Rime TTS plugin for LiveKit agents

--- a/plugins/rime/README.md
+++ b/plugins/rime/README.md
@@ -10,6 +10,7 @@ participants that run on servers. Use it to create conversational, multi-modal
 voice agents that can see, hear, and understand.
 
 This package contains the Rime plugin, which provides high-quality text-to-speech (TTS) capabilities for voice synthesis. Refer to the
-[documentation](https://docs.livekit.io/agents/overview/) for information on how
+[documentation](https://docs.livekit.io/agents/overview/) for information on how to use it,
+or browse the [API reference](https://docs.livekit.io/agents-js/modules/plugins_agents_plugin_rime.html).
 See the [repository](https://github.com/livekit/agents-js) for more information
 about the framework as a whole.


### PR DESCRIPTION
1.0.0 was marked as deprecated before so release CI failed when attempting to publish the same version. Unblock the release by making it start with 1.0.1