### PR TITLE
docs: Add Bey plugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Currently, only the following plugins are supported:
 | [@livekit/agents-plugin-silero](https://www.npmjs.com/package/@livekit/agents-plugin-silero)         | VAD           |
 | [@livekit/agents-plugin-livekit](https://www.npmjs.com/package/@livekit/agents-plugin-livekit)       | EOU           |
 | [@livekit/agents-plugin-anam](https://www.npmjs.com/package/@livekit/agents-plugin-anam)             | Avatar        |
+| [@livekit/agents-plugin-bey](https://www.npmjs.com/package/@livekit/agents-plugin-bey)               | Avatar        |
 
 ## Docs and guides
 


### PR DESCRIPTION
This pull request updates the documentation to reflect support for an additional plugin. The change ensures that users are aware of all currently supported plugins.

Documentation update:

* Added `@livekit/agents-plugin-bey` to the list of supported plugins in the `README.md`, indicating its type as "Avatar".