### PR TITLE
brianyin/ajs-306-fix-commonjs-entrypoint-to-resolve-files-from-dist

### DIFF
--- a/.changeset/olive-roses-brush.md
+++ b/.changeset/olive-roses-brush.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+- Fix CommonJS entrypoint to resolve files from `dist`

--- a/agents/package.json
+++ b/agents/package.json
@@ -11,8 +11,8 @@
       "default": "./dist/index.js"
     },
     "require": {
-      "types": "./index.d.cts",
-      "default": "./index.cjs"
+      "types": "./dist/index.d.cts",
+      "default": "./dist/index.cjs"
     }
   },
   "author": "LiveKit",


### PR DESCRIPTION
### Summary
Fix the CommonJS export map so `require('@livekit/agents')` resolves to the built files in `dist`.

### Background
In Node 22+ the package export map is authoritative for `require`. Our export map still pointed at `./index.cjs`, which doesn’t exist in the published package, so `require('@livekit/agents')` failed with `MODULE_NOT_FOUND` (it was looking for `node_modules/@livekit/agents/index.cjs`). Updating the export map to `./dist/index.cjs`/`./dist/index.d.cts` fixes the regression.

### Testing
- `node -p "require('./packages/agents/dist').version"`