### PR TITLE
fix: added itemId for final transcription

### DIFF
--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -532,6 +532,7 @@ export class AgentActivity implements RecognitionHooks {
       createUserInputTranscribedEvent({
         transcript: ev.transcript,
         isFinal: ev.isFinal,
+        itemId: ev.isFinal ? ev.itemId : null,
       }),
     );
 

--- a/agents/src/voice/events.ts
+++ b/agents/src/voice/events.ts
@@ -80,6 +80,7 @@ export type UserInputTranscribedEvent = {
   type: 'user_input_transcribed';
   transcript: string;
   isFinal: boolean;
+  itemId: string | null;
   // TODO(AJS-106): add multi participant support
   /** Not supported yet. Always null by default. */
   speakerId: string | null;
@@ -92,12 +93,14 @@ export const createUserInputTranscribedEvent = ({
   isFinal,
   speakerId = null,
   language = null,
+  itemId = null,
   createdAt = Date.now(),
 }: {
   transcript: string;
   isFinal: boolean;
   speakerId?: string | null;
   language?: string | null;
+  itemId?: string | null;
   createdAt?: number;
 }): UserInputTranscribedEvent => ({
   type: 'user_input_transcribed',
@@ -106,6 +109,7 @@ export const createUserInputTranscribedEvent = ({
   speakerId,
   language,
   createdAt,
+  itemId,
 });
 
 export type MetricsCollectedEvent = {


### PR DESCRIPTION
## Description

Expose the itemId for the chat message that will be used. This is useful do to async modifications to the chat context.

## Changes Made
- Exposed the message itemId in the userInputTranscribed event if the transcript is final

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.