### PR TITLE
Add support for away timeout

### DIFF
--- a/.changeset/long-cameras-throw.md
+++ b/.changeset/long-cameras-throw.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Emit away events for User

--- a/agents/src/voice/room_io/room_io.ts
+++ b/agents/src/voice/room_io/room_io.ts
@@ -369,6 +369,10 @@ export class RoomIO {
     return this.transcriptionSynchronizer.textOutput;
   }
 
+  get isParticipantAvailable(): boolean {
+    return this.participantAvailableFuture.done;
+  }
+
   /** Switch to a different participant */
   setParticipant(participantIdentity: string | null) {
     this.logger.debug({ participantIdentity }, 'setting participant');

--- a/examples/src/idle_user_timeout_example.ts
+++ b/examples/src/idle_user_timeout_example.ts
@@ -13,6 +13,7 @@ import {
   WorkerOptions,
   cli,
   defineAgent,
+  delay,
   log,
   voice,
 } from '@livekit/agents';
@@ -51,17 +52,11 @@ export default defineAgent({
 
         await reply.waitForPlayout();
 
-        await new Promise<void>((resolve) => {
-          const timeout = setTimeout(resolve, 10000);
-          controller.signal.addEventListener(
-            'abort',
-            () => {
-              clearTimeout(timeout);
-              resolve();
-            },
-            { once: true },
-          );
-        });
+        try {
+          await delay(10000, { signal: controller.signal });
+        } catch {
+          return;
+        }
       }
 
       if (!controller.signal.aborted) {

--- a/examples/src/idle_user_timeout_example.ts
+++ b/examples/src/idle_user_timeout_example.ts
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Minimal example demonstrating idle user timeout functionality.
+ * Direct port of: https://github.com/livekit/agents/blob/main/examples/voice_agents/inactive_user.py
+ */
+import {
+  type JobContext,
+  type JobProcess,
+  WorkerOptions,
+  cli,
+  defineAgent,
+  log,
+  voice,
+} from '@livekit/agents';
+import * as openai from '@livekit/agents-plugin-openai';
+import * as silero from '@livekit/agents-plugin-silero';
+import { fileURLToPath } from 'node:url';
+
+export default defineAgent({
+  prewarm: async (proc: JobProcess) => {
+    proc.userData.vad = await silero.VAD.load();
+  },
+  entry: async (ctx: JobContext) => {
+    const logger = log();
+    const vad = ctx.proc.userData.vad! as silero.VAD;
+
+    const session = new voice.AgentSession({
+      vad,
+      llm: new openai.LLM({ model: 'gpt-4o-mini' }),
+      stt: 'assemblyai/universal-streaming:en',
+      tts: 'cartesia/sonic-2:9626c31c-bec5-4cca-baa8-f8ba9e84c8bc',
+
+      voiceOptions: {
+        userAwayTimeout: 12.5,
+      },
+    });
+
+    let inactivityController: AbortController | null = null;
+
+    const userPresenceTask = async (signal: AbortSignal): Promise<void> => {
+      try {
+        for (let i = 0; i < 3; i++) {
+          if (signal.aborted) return;
+
+          const reply = await session.generateReply({
+            instructions:
+              'The user has been inactive. Politely check if the user is still present.',
+          });
+
+          await reply.waitForPlayout();
+
+          await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(resolve, 10000);
+            signal.addEventListener('abort', () => {
+              clearTimeout(timeout);
+              reject(new Error('Aborted'));
+            });
+          });
+        }
+
+        if (!signal.aborted) {
+          await session.close();
+        }
+      } catch (error) {
+        if (error instanceof Error && error.message === 'Aborted') {
+          logger.info({ error }, 'User presence task aborted');
+          // Task was cancelled, which is expected
+          return;
+        }
+        throw error;
+      }
+    };
+
+    session.on(voice.AgentSessionEventTypes.UserStateChanged, (event) => {
+      logger.info({ event }, 'User state changed');
+      if (event.newState === 'away') {
+        if (inactivityController) {
+          inactivityController.abort();
+        }
+
+        // Start new task with fresh controller
+        inactivityController = new AbortController();
+        userPresenceTask(inactivityController.signal);
+        return;
+      }
+
+      if (inactivityController) {
+        inactivityController.abort();
+        inactivityController = null;
+      }
+    });
+
+    const agent = new voice.Agent({
+      instructions: 'You are a helpful assistant.',
+    });
+
+    await session.start({ agent, room: ctx.room });
+  },
+});
+
+cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->
The framework didn't support the away state, so this PR adds support for this. I've done my best to document the logical paths of python ensuring to match verbatim here. 


## Changes Made


| **Condition/Trigger** | **Python Logic** | **JavaScript Implementation** | **Status** | **Notes** |
|----------------------|------------------|-------------------------------|------------|-----------|
| **Timer Initialization** |
| `user_away_timeout` is `None` | Return early, no timer set | ✅ Check `null \|\| undefined`, return early | ✅ **COMPLETE** | Exact match |
| `room_io.subscribed_fut.done()` is `False` | Skip timer (user hasn't joined) | ✅ Check `!this.roomIO.isParticipantAvailable` | ✅ **COMPLETE** | Matches Python logic |
| Valid timeout + participant available | Set timer with `loop.call_later(timeout, callback)` | ✅ Use `setTimeout(callback, timeout * 1000)` | ✅ **COMPLETE** | Platform-appropriate equivalent |
| **User State Transitions** |
| User → 'speaking' | Cancel timer via `_cancel_user_away_timer()` | ✅ Cancel in `_updateUserState()` | ✅ **COMPLETE** | Exact logic match |
| User → 'listening' + Agent 'listening' | Set timer via `_set_user_away_timer()` | ✅ Set in `_updateUserState()` | ✅ **COMPLETE** | Exact logic match |
| User → 'away' | Cancel timer | ✅ Cancel in `_updateUserState()` | ✅ **COMPLETE** | Exact logic match |
| **Agent State Transitions** |
| Agent → 'speaking' | Cancel timer | ✅ Cancel in `_updateAgentState()` | ✅ **COMPLETE** | Exact logic match |
| Agent → 'listening' + User 'listening' | Set timer | ✅ Set in `_updateAgentState()` | ✅ **COMPLETE** | Exact logic match |
| Agent → other states | Cancel timer | ✅ Cancel in `_updateAgentState()` | ✅ **COMPLETE** | Exact logic match |
| **User Activity Detection** |
| `_user_input_transcribed()` called with `is_final=True` | Reset from 'away' to 'listening' | ✅ Reset in `_onUserInputTranscribed()` with `isFinal` | ✅ **COMPLETE** | Exact logic match |
| `_user_input_transcribed()` called with `is_final=False` | No state change | ✅ Only act on `isFinal` | ✅ **COMPLETE** | Exact logic match |
| **Session Lifecycle** |
| `aclose()` called | Cancel timer in `_aclose_impl()` | ✅ Cancel in `closeImpl()` | ✅ **COMPLETE** | Proper cleanup |
| **Timer Management** |
| `_set_user_away_timer()` called multiple times | Cancel existing, set new | ✅ `_cancelUserAwayTimer()` then set new | ✅ **COMPLETE** | Prevents multiple timers |
| `_cancel_user_away_timer()` called when no timer | No-op | ✅ Check `!== null` before clearing | ✅ **COMPLETE** | Safe operation |
| **Error Conditions** |
| Timer callback execution | Call `_update_user_state('away')` | ✅ Call `_updateUserState('away')` | ✅ **COMPLETE** | Exact match |
| **Edge Cases** |
| Session closed while timer active | Timer cancelled in cleanup | ✅ Timer cancelled in `closeImpl()` | ✅ **COMPLETE** | Memory leak prevention |
| Multiple rapid state changes | Each change cancels/sets timer appropriately | ✅ Each state change handles timer correctly | ✅ **COMPLETE** | Race condition safe |
| User speaks immediately after going away | State reset to 'listening' | ✅ State reset in `_onUserInputTranscribed()` | ✅ **COMPLETE** | Immediate recovery |

 
https://github.com/user-attachments/assets/88bea626-12cc-4f9c-8967-592ef38c91e6



## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)



## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

Notably the following shows up in my demo, but is related to the inference STT
```
(node:13823) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. MaxListeners is 10. Use events.setMaxListeners() to increase limit
    at [kNewListener] (node:internal/event_target:566:17)
    at [kNewListener] (node:internal/abort_controller:240:24)
    at EventTarget.addEventListener (node:internal/event_target:679:23)
    at waitForAbort (.../agents-js/agents/src/utils.ts:828:10)
    at recv (.../agents-js/agents/src/inference/stt.ts:332:55)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Task.fn (.../agents-js/agents/src/inference/stt.ts:369:11)
    at async run (.../agents-js/agents/src/utils.ts:433:14)
```


---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.