### PR TITLE
Allow Community PR to run Tests Workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 
 # Tests run for all PRs including community contributions from forks.
 # Note: Current tests don't require secrets. If plugin tests are re-enabled,
-# consider using workflow_run pattern for privileged operations.
+# we would need to use workflow_run pattern for privileged operations.
 
 name: Test
 on:


### PR DESCRIPTION
Removes the restriction that blocked tests from running on community PRs from forks.