### PR TITLE
fix: Update form to import `*.cjs` extension

### DIFF
--- a/.changeset/shy-terms-rule.md
+++ b/.changeset/shy-terms-rule.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Fork files with cjs extension when running cjs file

--- a/agents/src/ipc/inference_proc_executor.ts
+++ b/agents/src/ipc/inference_proc_executor.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ChildProcess } from 'node:child_process';
 import { fork } from 'node:child_process';
+import { extname } from 'node:path';
 import { log } from '../log.js';
 import { shortuuid } from '../utils.js';
 import type { InferenceExecutor } from './inference_executor.js';
@@ -17,6 +18,8 @@ class PendingInference {
     arg;
   }
 }
+
+const currentFileExtension = extname(import.meta.url);
 
 export class InferenceProcExecutor extends SupervisedProc implements InferenceExecutor {
   #runners: { [id: string]: string };
@@ -55,7 +58,7 @@ export class InferenceProcExecutor extends SupervisedProc implements InferenceEx
   }
 
   createProcess(): ChildProcess {
-    return fork(new URL('./inference_proc_lazy_main.js', import.meta.url), [
+    return fork(new URL(`./inference_proc_lazy_main${currentFileExtension}`, import.meta.url), [
       JSON.stringify(this.#runners),
     ]);
   }

--- a/agents/src/ipc/job_proc_executor.ts
+++ b/agents/src/ipc/job_proc_executor.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ChildProcess } from 'node:child_process';
 import { fork } from 'node:child_process';
+import { extname } from 'node:path';
 import type { RunningJobInfo } from '../job.js';
 import { log } from '../log.js';
 import type { InferenceExecutor } from './inference_executor.js';
@@ -10,6 +11,8 @@ import type { JobExecutor } from './job_executor.js';
 import { JobStatus } from './job_executor.js';
 import type { IPCMessage } from './message.js';
 import { SupervisedProc } from './supervised_proc.js';
+
+const currentFileExtension = extname(import.meta.url);
 
 export class JobProcExecutor extends SupervisedProc implements JobExecutor {
   #userArgs?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -64,7 +67,9 @@ export class JobProcExecutor extends SupervisedProc implements JobExecutor {
   }
 
   createProcess(): ChildProcess {
-    return fork(new URL('./job_proc_lazy_main.js', import.meta.url), [this.#agent]);
+    return fork(new URL(`./job_proc_lazy_main${currentFileExtension}`, import.meta.url), [
+      this.#agent,
+    ]);
   }
 
   async mainTask(proc: ChildProcess) {

--- a/plugins/livekit/src/turn_detector/index.ts
+++ b/plugins/livekit/src/turn_detector/index.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { InferenceRunner } from '@livekit/agents';
+import { extname } from 'node:path';
 import { INFERENCE_METHOD_EN } from './english.js';
 import { INFERENCE_METHOD_MULTILINGUAL } from './multilingual.js';
 
@@ -10,12 +11,14 @@ export { EnglishModel } from './english.js';
 export { MultilingualModel } from './multilingual.js';
 export { getUnicodeCategory, normalizeText } from './utils.js';
 
+const currentFileExtension = extname(import.meta.url);
+
 InferenceRunner.registerRunner(
   INFERENCE_METHOD_EN,
-  new URL('./english.js', import.meta.url).toString(),
+  new URL(`./english${currentFileExtension}`, import.meta.url).toString(),
 );
 
 InferenceRunner.registerRunner(
   INFERENCE_METHOD_MULTILINGUAL,
-  new URL('./multilingual.js', import.meta.url).toString(),
+  new URL(`./multilingual${currentFileExtension}`, import.meta.url).toString(),
 );

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -24,6 +24,7 @@ const defaultOptions: Options = {
       // require('../path') → require('../path.cjs') in `.cjs` files
       // from './path' → from './path.cjs' in `.cjs` files
       // from '../path' → from '../path.cjs' in `.cjs` files
+      // (0, import_node_child_process.fork)(new URL("./path.js" → (0, import_node_child_process.fork)(new URL("./path.cjs" in `.cjs` files
       name: 'fix-cjs-imports',
       renderChunk(code) {
         if (this.format === 'cjs') {


### PR DESCRIPTION
## Description

Updates `fork(...)` to use file with `*.cjs` when running in `cjs`.

## Changes Made
-  Replace `fork(new URL('./path.js')` with `fork(new URL('./path.cjs')`.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [x] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [x] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.