### PR TITLE
improve logging for server connection issues

### DIFF
--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -403,7 +403,8 @@ export class AgentServer {
           const delay = Math.min(retries * 2, 10);
 
           this.#logger.warn(
-            e, `failed to connect to LiveKit server (${this.#opts.wsURL}), retrying in ${delay} seconds: (${retries}/${this.#opts.maxRetry})`,
+            e,
+            `failed to connect to LiveKit server (${this.#opts.wsURL}), retrying in ${delay} seconds: (${retries}/${this.#opts.maxRetry})`,
           );
 
           await new Promise((resolve) => setTimeout(resolve, delay * 1000));


### PR DESCRIPTION
## Description

This PR adds the LiveKit server URL to the failure log messages.  This is useful to see when there is an error connecting.  In particular, it's useful when the `LIVEKIT_URL` environment variable isn't set at all.  When not set, the current error message displays:

```
[11:12:38.280] INFO (36295): starting worker
[11:12:38.288] INFO (36295): Server is listening on port 59170
[11:12:38.290] WARN (36295): failed to connect to LiveKit server, retrying in 2 seconds:  (1/10)
```

which doesn't tell you the problem since the `${e}` is blank.  

In addition, I tried to improve the error logging so it's easier for customers to see what is causing the problem.

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- Improve error messages when the worker has trouble connecting to the LiveKit server

## Pre-Review Checklist
- [ ] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [ ] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.