### PR TITLE
Test suite verification

### DIFF
--- a/plugins/openai/src/realtime/index.ts
+++ b/plugins/openai/src/realtime/index.ts
@@ -2,4 +2,4 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 export * from './api_proto.js';
-export * from './realtime_model_beta_1.js';
+export * from './realtime_model.js';


### PR DESCRIPTION
## Description
Fixes a TypeScript build error (TS2307) in the OpenAI plugin that was causing `build:types` and CI tests to fail. The error stemmed from an incorrect module export path.

## Changes Made
- Updated `plugins/openai/src/realtime/index.ts` to export `realtime_model.js` instead of the non-existent `realtime_model_beta_1.js`.

## Pre-Review Checklist
- [ ] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [ ] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
- [x] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
The root cause was `plugins/openai/src/realtime/index.ts` exporting `./realtime_model_beta_1.js`, but no corresponding source file existed, leading to a `TS2307: Cannot find module` error during `tsc --emitDeclarationOnly`. The fix points the export to the correct `realtime_model.js` module.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.

---
<a href="https://cursor.com/background-agent?bcId=bc-e087bfbe-adaf-4fa6-b0f3-06879ca199b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e087bfbe-adaf-4fa6-b0f3-06879ca199b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

