### PR TITLE
fix(inworld): exclude test files from declaration build

### DIFF
--- a/plugins/inworld/tsconfig.json
+++ b/plugins/inworld/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src"],
+  "exclude": ["./src/**/*.test.ts"],
   "compilerOptions": {
     // match output dir to input dir. e.g. dist/index instead of dist/src/index
     "rootDir": "./src",


### PR DESCRIPTION
- Exclude `*.test.ts` files from tsconfig to fix build failures caused by parallel build race conditions

## Details
Inworld's test file imports from `@livekit/agents-plugin-openai`, which may not be built yet during parallel turborepo builds. This caused `TS2307: Cannot find module` errors when tsc tried to generate type declarations.

Other plugins don't have this issue because their test files don't import from other plugins.