### PR TITLE
fix(openai-realtime): remove buggy resolveGeneration method that used wrong key lookup

### DIFF
--- a/.changeset/red-flowers-retire.md
+++ b/.changeset/red-flowers-retire.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+remove buggy resolveGeneration method that used wrong key lookup in openai realtime model

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -1169,16 +1169,11 @@ export class RealtimeSession extends llm.RealtimeSession {
       throw new Error('item.type is not set');
     }
 
-    if (!event.response_id) {
-      throw new Error('response_id is not set');
-    }
-
     const itemType = event.item.type;
-    const responseId = event.response_id;
 
     if (itemType !== 'message') {
-      // emit immediately if it's not a message, otherwise wait response.content_part.added
-      this.resolveGeneration(responseId);
+      // non-message items (e.g. function calls) don't need additional handling here
+      // the generation event was already emitted in handleResponseCreated
       this.textModeRecoveryRetries = 0;
       return;
     }
@@ -1597,30 +1592,6 @@ export class RealtimeSession extends llm.RealtimeSession {
     });
 
     return handle;
-  }
-
-  private resolveGeneration(responseId: string): void {
-    if (!this.currentGeneration) {
-      throw new Error('currentGeneration is not set');
-    }
-
-    const generation_ev = {
-      messageStream: this.currentGeneration.messageChannel.stream(),
-      functionStream: this.currentGeneration.functionChannel.stream(),
-      userInitiated: false,
-      responseId,
-    } as llm.GenerationCreatedEvent;
-
-    const handle = this.responseCreatedFutures[responseId];
-    if (handle) {
-      delete this.responseCreatedFutures[responseId];
-      generation_ev.userInitiated = true;
-      if (handle.doneFut.done) {
-        this.#logger.warn({ responseId }, 'response received after timeout');
-      } else {
-        handle.doneFut.resolve(generation_ev);
-      }
-    }
   }
 }
 

--- a/plugins/openai/src/realtime/realtime_model_beta.ts
+++ b/plugins/openai/src/realtime/realtime_model_beta.ts
@@ -1090,16 +1090,11 @@ export class RealtimeSession extends llm.RealtimeSession {
       throw new Error('item.type is not set');
     }
 
-    if (!event.response_id) {
-      throw new Error('response_id is not set');
-    }
-
     const itemType = event.item.type;
-    const responseId = event.response_id;
 
     if (itemType !== 'message') {
-      // emit immediately if it's not a message, otherwise wait response.content_part.added
-      this.resolveGeneration(responseId);
+      // non-message items (e.g. function calls) don't need additional handling here
+      // the generation event was already emitted in handleResponseCreated
       this.textModeRecoveryRetries = 0;
       return;
     }
@@ -1517,30 +1512,6 @@ export class RealtimeSession extends llm.RealtimeSession {
     });
 
     return handle;
-  }
-
-  private resolveGeneration(responseId: string): void {
-    if (!this.currentGeneration) {
-      throw new Error('currentGeneration is not set');
-    }
-
-    const generation_ev = {
-      messageStream: this.currentGeneration.messageChannel.stream(),
-      functionStream: this.currentGeneration.functionChannel.stream(),
-      userInitiated: false,
-      responseId,
-    } as llm.GenerationCreatedEvent;
-
-    const handle = this.responseCreatedFutures[responseId];
-    if (handle) {
-      delete this.responseCreatedFutures[responseId];
-      generation_ev.userInitiated = true;
-      if (handle.doneFut.done) {
-        this.#logger.warn({ responseId }, 'response received after timeout');
-      } else {
-        handle.doneFut.resolve(generation_ev);
-      }
-    }
   }
 }
 


### PR DESCRIPTION
- Fixes #968
- Removes the `resolveGeneration` method which incorrectly looked up futures using `responseId` (server-generated) instead of `eventId` (client-generated)
- Aligns with the Python implementation which does not have a `resolveGeneration` method

## Problem

When `generateReply()` was called and the AI returned a function call (non-message item), `handleResponseOutputItemAdded` called `resolveGeneration(responseId)`. This method tried to look up `responseCreatedFutures[responseId]`, but futures were stored with `eventId` (client-generated), causing the lookup to fail.

The future was already correctly resolved in `handleResponseCreated` using `client_event_id` from response metadata, making `resolveGeneration` both redundant and buggy.