### PR TITLE
fix(stream): allow DeferredReadableStream to be reused after detachSource

### DIFF
--- a/agents/src/stream/deferred_stream.ts
+++ b/agents/src/stream/deferred_stream.ts
@@ -37,6 +37,7 @@ export class DeferredReadableStream<T> {
   private transform: IdentityTransform<T>;
   private writer: WritableStreamDefaultWriter<T>;
   private sourceReader?: ReadableStreamDefaultReader<T>;
+  private writerClosed: boolean = false;
 
   constructor() {
     this.transform = new IdentityTransform<T>();
@@ -53,10 +54,18 @@ export class DeferredReadableStream<T> {
 
   /**
    * Call once the actual source is ready.
+   * Can be called again after detachSource() to attach a new source.
    */
   setSource(source: ReadableStream<T>) {
     if (this.isSourceSet) {
       throw new Error('Stream source already set');
+    }
+
+    // If writer was closed from a previous source, recreate the transform
+    if (this.writerClosed) {
+      this.transform = new IdentityTransform<T>();
+      this.writer = this.transform.writable.getWriter();
+      this.writerClosed = false;
     }
 
     this.sourceReader = source.getReader();
@@ -65,18 +74,26 @@ export class DeferredReadableStream<T> {
 
   private async pump() {
     let sourceError: unknown;
+    let detached = false;
 
     try {
       while (true) {
-        const { done, value } = await this.sourceReader!.read();
+        // Check if source was detached (sourceReader set to undefined)
+        if (!this.sourceReader) {
+          detached = true;
+          break;
+        }
+        const { done, value } = await this.sourceReader.read();
         if (done) break;
         await this.writer.write(value);
       }
     } catch (e) {
-      // skip stream cleanup related errors
-      if (isStreamReaderReleaseError(e)) return;
-
-      sourceError = e;
+      // Skip stream cleanup related errors (happens when detachSource is called)
+      if (isStreamReaderReleaseError(e)) {
+        detached = true;
+      } else {
+        sourceError = e;
+      }
     } finally {
       // any other error from source will be propagated to the consumer
       if (sourceError) {
@@ -85,6 +102,7 @@ export class DeferredReadableStream<T> {
         } catch (e) {
           // ignore if writer is already closed
         }
+        this.writerClosed = true;
         return;
       }
 
@@ -98,6 +116,7 @@ export class DeferredReadableStream<T> {
       // we only close the writable stream after done
       try {
         await this.transform.writable.close();
+        this.writerClosed = true;
         // NOTE: we do not cancel this.transform.readable as there might be access to
         // this.transform.readable.getReader() outside that blocks this cancellation
         // hence, user is responsible for canceling reader on their own
@@ -105,12 +124,14 @@ export class DeferredReadableStream<T> {
         // ignore TypeError: Invalid state: WritableStream is closed
         // in case stream reader is already closed, this will throw
         // but we ignore it as we are closing the stream anyway
+        this.writerClosed = true;
       }
     }
   }
 
   /**
    * Detach the source stream and clean up resources.
+   * After calling this, setSource() can be called again with a new source.
    */
   async detachSource() {
     if (!this.isSourceSet) {
@@ -123,5 +144,9 @@ export class DeferredReadableStream<T> {
     // using isStreamReaderReleaseError
     // this will unblock any pending read() inside the async for loop
     this.sourceReader!.releaseLock();
+
+    // Reset sourceReader so isSourceSet returns false
+    // This allows setSource() to be called again on reconnection
+    this.sourceReader = undefined;
   }
 }


### PR DESCRIPTION
## Description
Fix `DeferredReadableStream` to allow `setSource()` to be called again after `detachSource()`, enabling stream reuse during participant reconnection scenarios.

When a participant's connection is interrupted and restored (e.g., browser reload, network interruption, or user canceling the "Leave site?" confirmation dialog), the SDK's `ParticipantAudioInputStream` attempts to reattach the audio track via `onTrackSubscribed`. This triggers:

1. `closeStream()` → calls `deferredStream.detachSource()`
2. Then `deferredStream.setSource(newAudioStream)` to attach the new track

However, `setSource()` throws **"Stream source already set"** because:

1. `detachSource()` releases the reader lock but doesn't reset `sourceReader` to `undefined`
2. `isSourceSet` (which checks `!!this.sourceReader`) still returns `true`
3. Even if that were fixed, the `writer` may already be closed from the previous session

This makes it impossible to reuse the agent session after any participant reconnection event.

## Changes Made
- Reset `sourceReader = undefined` in `detachSource()` so `isSourceSet` returns `false`
- Added `writerClosed` state tracking to detect when transform needs recreation
- Recreate the internal transform stream in `setSource()` if writer was previously closed
- Added check for `!this.sourceReader` before read in `pump()` to handle race condition where `detachSource()` is called while pump is running

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title
- [ ] **Video demo**: N/A - This is an internal stream management fix, not user-facing UI. The fix enables reconnection scenarios that previously crashed.

## Testing
- [x] Automated tests added/updated (if applicable) - All 25 existing tests in `deferred_stream.test.ts` pass
- [x] All tests pass - `pnpm build:agents` and `pnpm test` pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly - N/A for this internal stream fix

**Manual Testing Performed:**
- Verified fix in production with browser tab close/cancel reconnection scenario
- Verified fix with network interruption simulation
- Confirmed agent session remains functional after participant reconnects

## Additional Notes
This bug affects any scenario where a participant disconnects and reconnects to the same room session. Without this fix, the agent becomes unresponsive after reconnection because audio input cannot be reattached.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.