### PR TITLE
fix(openai): skip apiKey check when client is provided in LLM constructor

### DIFF
--- a/.changeset/fix-llm-azure-apikey.md
+++ b/.changeset/fix-llm-azure-apikey.md
@@ -1,0 +1,7 @@
+---
+"@livekit/agents-plugin-openai": patch
+---
+
+fix(openai): skip apiKey check when client is provided in LLM and TTS constructors
+
+When using `LLM.withAzure()` or passing a custom client to `TTS`, the constructors were incorrectly requiring `OPENAI_API_KEY` even though a client was already provided. This fix skips the apiKey validation when a custom client is passed, matching the behavior fixed in RealtimeModel (PR #339).

--- a/plugins/openai/src/llm.ts
+++ b/plugins/openai/src/llm.ts
@@ -66,7 +66,7 @@ export class LLM extends llm.LLM {
 
     this.#opts = { ...defaultLLMOptions, ...opts };
     this.#providerFmt = providerFmt;
-    if (this.#opts.apiKey === undefined) {
+    if (this.#opts.apiKey === undefined && !this.#opts.client) {
       throw new Error('OpenAI API key is required, whether as an argument or as $OPENAI_API_KEY');
     }
 

--- a/plugins/openai/src/tts.ts
+++ b/plugins/openai/src/tts.ts
@@ -43,7 +43,7 @@ export class TTS extends tts.TTS {
     super(OPENAI_TTS_SAMPLE_RATE, OPENAI_TTS_CHANNELS, { streaming: false });
 
     this.#opts = { ...defaultTTSOptions, ...opts };
-    if (this.#opts.apiKey === undefined) {
+    if (this.#opts.apiKey === undefined && !this.#opts.client) {
       throw new Error('OpenAI API key is required, whether as an argument or as $OPENAI_API_KEY');
     }
 


### PR DESCRIPTION
## Description

When using `LLM.withAzure()` or passing a custom client to `TTS`, the constructors were incorrectly requiring `OPENAI_API_KEY` environment variable even though a client was already provided via the `client` option.

This is the same issue that was fixed for `RealtimeModel` in PR #339, but the fix was not applied to the `LLM` and `TTS` classes.

## Changes Made

- Modified `plugins/openai/src/llm.ts` to skip `apiKey` validation when a custom `client` is provided
- Modified `plugins/openai/src/tts.ts` to skip `apiKey` validation when a custom `client` is provided
- Added changeset for patch release

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: N/A - This is a bug fix for constructor validation, no UI changes

## Testing

- [x] Verified that `LLM.withAzure()` no longer throws when `OPENAI_API_KEY` is not set
- [x] Verified that `new TTS({ client: azureClient })` no longer throws when `OPENAI_API_KEY` is not set
- [x] Verified that regular `new LLM()` and `new TTS()` still require `apiKey` when no client is provided

## Additional Notes

**Problem:**
\`\`\`typescript
// LLM: This throws "OpenAI API key is required" even though Azure uses its own auth
const llm = openai.LLM.withAzure({
  model: "gpt-4o",
  apiKey: process.env.AZURE_API_KEY,
  azureEndpoint: "https://my-endpoint.openai.azure.com",
});

// TTS: Same issue when passing a custom client
const tts = new openai.TTS({
  client: new AzureOpenAI({ ... }),
});
\`\`\`

**Root cause:**
- \`withAzure()\` creates an \`AzureOpenAI\` client and passes it to \`new LLM({ client: azureClient })\`
- But \`withAzure()\` doesn't pass \`apiKey\` to the \`LLM\` constructor
- The constructors check \`if (this.#opts.apiKey === undefined)\` and throw, even though a client is already provided

**Solution:**
Skip the \`apiKey\` check when a custom \`client\` is provided:
\`\`\`typescript
if (this.#opts.apiKey === undefined && !this.#opts.client) {
  throw new Error('OpenAI API key is required...');
}
\`\`\`

**Related:**
- Fixes the same issue as #333 but for \`LLM\` and \`TTS\` classes (not just \`RealtimeModel\`)
- Similar fix was applied in #339 for \`RealtimeModel\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * External OpenAI clients can now be used with LLM and TTS without requiring separate API key configuration. API key validation is skipped when a custom client is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->