### PR TITLE
fix: early return after agent handoff in realtime pipeline

### DIFF
--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2183,6 +2183,10 @@ export class AgentActivity implements RecognitionHooks {
     if (!ignoreTaskSwitch && newAgentTask !== null) {
       this.agentSession.updateAgent(newAgentTask);
       draining = true;
+      // Skip chat context update and reply creation - the new agent will handle this.
+      // The old realtime session is being closed by updateAgent(), so we cannot
+      // continue using this.realtimeSession after this point.
+      return;
     }
 
     if (functionToolsExecutedEvent.functionCallOutputs.length > 0) {


### PR DESCRIPTION
## Summary

- After `updateAgent()` triggers activity transition in the realtime tool output handler, the old code continued using `this.realtimeSession` for chat context updates and reply generation. Since `updateAgent()` calls `drain()` and `close()` on the old activity (including its realtime session), this caused errors and broken agent transfers (e.g. transferring back from a specialist agent to the main agent would fail silently).
- Added early `return` to skip post-handoff processing in the realtime pipeline, matching the equivalent fix in the Python agents SDK (livekit/agents#4746).

## Context

The bug manifests when using multi-agent handoff with Gemini Realtime models:

1. A handoff tool returns `llm.handoff({ agent })`, triggering `updateAgent()`
2. `updateAgent()` starts `updateActivity()` which calls `drain()` and `close()` on the old `AgentActivity`
3. But the realtime tool output handler continues past the handoff, trying to call `this.realtimeSession.updateChatCtx()` on the closing session
4. This causes the transfer to hang or error out

The STT-LLM-TTS pipeline (`agent_activity.ts:1691`) is **not affected** — it uses a local `chatCtx` variable and creates a new `pipelineReplyTask`, never touching `this.realtimeSession`.

## Test plan

- [ ] Verify bidirectional agent transfer works with Gemini realtime (main → specialist → main)
- [ ] Verify single-agent Gemini realtime sessions work normally (no regression)
- [ ] Verify STT-LLM-TTS pipeline agent transfer is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent handoff behavior to prevent the current agent from continuing to process after transitioning to a successor agent, ensuring more reliable multi-agent interactions in realtime sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->