### PR TITLE
fix: support ElevenLabs non legacy voices

### DIFF
--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -458,7 +458,7 @@ class Connection {
           if (result.done || this.#closed) break;
 
           const data = result.value;
-          const contextId = data.contextId as string | undefined;
+          const contextId = (data.contextId ?? data.context_id) as string | undefined;
           const ctx = contextId ? this.#contextData.get(contextId) : undefined;
 
           if (data.error) {


### PR DESCRIPTION
## Description
The current LiveKit ElevenLabs plugin only supports legacy voices.
When I tried to use it with a default ElevenLabs voice, it didn't play the audio.
I realized that with this simple fix it would work with non legacy voices.

**Root cause:** The ElevenLabs WebSocket API can return the context id as `context_id` (snake_case) instead of `contextId` (camelCase). The plugin only read `data.contextId`, so when the API sent `context_id` the lookup failed and messages were dropped (no audio).

## Changes Made
- In `src/tts.ts`, read context id from both `data.contextId` and `data.context_id` when handling WebSocket messages (`contextId = data.contextId ?? data.context_id`).

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable)

## Testing
- [ ] Automated tests added/updated (if applicable)
- [x] All tests pass
- [x] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

Tested with a non-legacy default ElevenLabs voice; TTS audio now plays. Legacy voices still work.