### PR TITLE
Add pronunciation_dict_id in Cartesia plugin

### DIFF
--- a/plugins/cartesia/src/tts.ts
+++ b/plugins/cartesia/src/tts.ts
@@ -60,6 +60,8 @@ export interface TTSOptions {
    * @defaultValue true
    */
   wordTimestamps?: boolean;
+
+  pronunciationDictId?: string;
 }
 
 const defaultTTSOptions: TTSOptions = {
@@ -513,6 +515,7 @@ const toCartesiaOptions = (
       sample_rate: opts.sampleRate,
     },
     language: opts.language,
+    pronunciation_dict_id: opts.pronunciationDictId,
   };
 
   if (streaming && opts.wordTimestamps !== false) {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->

Added `pronunciationDictId` property for using the [custom pronunciations](https://docs.cartesia.ai/build-with-cartesia/sonic-3/custom-pronunciations) feature in Cartesia plugin

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- Added `pronunciationDictId` option to TTS opts
- Added `pronunciation_dict_id` to `toCartesiaOptions`

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.