### PR TITLE
Add GPT-5.4 to OpenAI plugin

### DIFF
--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -17,7 +17,6 @@ import { type AnyString, createAccessToken } from './utils.js';
 const DEFAULT_BASE_URL = 'https://agent-gateway.livekit.cloud/v1';
 
 export type OpenAIModels =
-  | 'openai/gpt-5.4'
   | 'openai/gpt-5.2'
   | 'openai/gpt-5.2-chat-latest'
   | 'openai/gpt-5.1'


### PR DESCRIPTION
## Summary
- Add `gpt-5.4` to `ChatModels` type in OpenAI plugin
- Add `gpt-5.4` to `supportsReasoningEffort()`
- Backfill missing `gpt-5.1`, `gpt-5.1-chat-latest`, `gpt-5.2`, `gpt-5.2-chat-latest` in `ChatModels`