### PR TITLE
Stabilize test environment

### DIFF
--- a/agents/src/index.ts
+++ b/agents/src/index.ts
@@ -9,34 +9,31 @@
  * @see {@link https://docs.livekit.io/agents/overview | LiveKit Agents documentation}
  * @packageDocumentation
  */
-import * as beta from './beta/index.js';
-import * as cli from './cli.js';
-import * as inference from './inference/index.js';
-import * as ipc from './ipc/index.js';
-import * as llm from './llm/index.js';
-import * as metrics from './metrics/index.js';
-import * as stream from './stream/index.js';
-import * as stt from './stt/index.js';
-import * as telemetry from './telemetry/index.js';
-import * as tokenize from './tokenize/index.js';
-import * as tts from './tts/index.js';
-import * as voice from './voice/index.js';
-
 export * from './_exceptions.js';
 export * from './audio.js';
+export * as beta from './beta/index.js';
+export * as cli from './cli.js';
 export * from './connection_pool.js';
 export * from './generator.js';
+export * as inference from './inference/index.js';
 export * from './inference_runner.js';
+export * as ipc from './ipc/index.js';
 export * from './job.js';
 export * from './language.js';
+export * as llm from './llm/index.js';
 export * from './log.js';
+export * as metrics from './metrics/index.js';
 export * from './plugin.js';
+export * as stream from './stream/index.js';
+export * as stt from './stt/index.js';
+export * as telemetry from './telemetry/index.js';
+export * as tokenize from './tokenize/index.js';
 export * from './transcription.js';
+export * as tts from './tts/index.js';
 export * from './types.js';
 export * from './utils.js';
 export * from './vad.js';
 export * from './version.js';
+export * as voice from './voice/index.js';
 export { createTimedString, isTimedString, type TimedString } from './voice/io.js';
 export * from './worker.js';
-
-export { beta, cli, inference, ipc, llm, metrics, stream, stt, telemetry, tokenize, tts, voice };

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -6,10 +6,14 @@ import {
   APIConnectionError,
   APIStatusError,
   APITimeoutError,
+} from '../_exceptions.js';
+import {
   DEFAULT_API_CONNECT_OPTIONS,
+} from '../types.js';
+import {
   type Expand,
   toError,
-} from '../index.js';
+} from '../utils.js';
 import * as llm from '../llm/index.js';
 import type { APIConnectOptions } from '../types.js';
 import { type AnyString, createAccessToken } from './utils.js';

--- a/agents/src/inference/utils.ts
+++ b/agents/src/inference/utils.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { AccessToken } from 'livekit-server-sdk';
 import { WebSocket } from 'ws';
-import { APIConnectionError, APIStatusError } from '../index.js';
+import { APIConnectionError, APIStatusError } from '../_exceptions.js';
 
 export type AnyString = string & NonNullable<unknown>;
 

--- a/plugins/baseten/src/llm.test.ts
+++ b/plugins/baseten/src/llm.test.ts
@@ -2,15 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { llm } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { LLM } from './llm.js';
 
-describe('Baseten', async () => {
-  await llm(
-    new LLM({
-      model: 'openai/gpt-4o-mini',
-      temperature: 0,
-    }),
-    false,
-  );
-});
+const hasBasetenApiKey = Boolean(process.env.BASETEN_API_KEY);
+
+if (hasBasetenApiKey) {
+  describe('Baseten', async () => {
+    await llm(
+      new LLM({
+        model: 'openai/gpt-4o-mini',
+        temperature: 0,
+      }),
+      false,
+    );
+  });
+} else {
+  describe('Baseten', () => {
+    it.skip('requires BASETEN_API_KEY', () => {});
+  });
+}

--- a/plugins/baseten/src/stt.test.ts
+++ b/plugins/baseten/src/stt.test.ts
@@ -3,9 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 import { VAD } from '@livekit/agents-plugin-silero';
 import { stt } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { STT } from './stt.js';
 
-describe('Baseten', async () => {
-  await stt(new STT(), await VAD.load(), { streaming: true });
-});
+const hasBasetenStreamingConfig = Boolean(
+  process.env.BASETEN_API_KEY &&
+    (process.env.BASETEN_MODEL_ENDPOINT || process.env.BASETEN_STT_MODEL_ID),
+);
+
+if (hasBasetenStreamingConfig) {
+  describe('Baseten', async () => {
+    await stt(new STT(), await VAD.load(), { streaming: true });
+  });
+} else {
+  describe('Baseten', () => {
+    it.skip('requires Baseten streaming credentials/config', () => {});
+  });
+}

--- a/plugins/baseten/src/tts.test.ts
+++ b/plugins/baseten/src/tts.test.ts
@@ -2,10 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { tts } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { STT } from './stt.js';
 import { TTS } from './tts.js';
 
-describe('Baseten', async () => {
-  await tts(new TTS(), new STT(), { streaming: false });
-});
+const hasBasetenStreamingConfig = Boolean(
+  process.env.BASETEN_API_KEY && process.env.BASETEN_MODEL_ENDPOINT,
+);
+
+if (hasBasetenStreamingConfig) {
+  describe('Baseten', async () => {
+    await tts(new TTS(), new STT(), { streaming: false });
+  });
+} else {
+  describe('Baseten', () => {
+    it.skip('requires Baseten streaming credentials/config', () => {});
+  });
+}

--- a/plugins/cartesia/src/tts.test.ts
+++ b/plugins/cartesia/src/tts.test.ts
@@ -3,9 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { TTS } from './tts.js';
 
-describe('Cartesia', async () => {
-  await tts(new TTS(), new STT());
-});
+const hasCartesiaConfig = Boolean(process.env.CARTESIA_API_KEY && process.env.OPENAI_API_KEY);
+
+if (hasCartesiaConfig) {
+  describe('Cartesia', async () => {
+    await tts(new TTS(), new STT());
+  });
+} else {
+  describe('Cartesia', () => {
+    it.skip('requires CARTESIA_API_KEY and OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/deepgram/package.json
+++ b/plugins/deepgram/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@livekit/agents": "workspace:*",
+    "@livekit/agents-plugin-openai": "workspace:^",
     "@livekit/agents-plugin-silero": "workspace:*",
     "@livekit/agents-plugins-test": "workspace:*",
     "@livekit/rtc-node": "catalog:",

--- a/plugins/deepgram/src/stt.test.ts
+++ b/plugins/deepgram/src/stt.test.ts
@@ -1,13 +1,19 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { initializeLogger } from '@livekit/agents';
 import { VAD } from '@livekit/agents-plugin-silero';
 import { stt } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { STT } from './stt.js';
 
-describe('Deepgram', async () => {
-  initializeLogger({ pretty: false });
-  await stt(new STT(), await VAD.load(), { nonStreaming: false });
-});
+const hasDeepgramApiKey = Boolean(process.env.DEEPGRAM_API_KEY);
+
+if (hasDeepgramApiKey) {
+  describe('Deepgram', async () => {
+    await stt(new STT(), await VAD.load(), { nonStreaming: false });
+  });
+} else {
+  describe('Deepgram', () => {
+    it.skip('requires DEEPGRAM_API_KEY', () => {});
+  });
+}

--- a/plugins/deepgram/src/stt_v2.test.ts
+++ b/plugins/deepgram/src/stt_v2.test.ts
@@ -1,13 +1,19 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { initializeLogger } from '@livekit/agents';
 import { VAD } from '@livekit/agents-plugin-silero';
 import { stt } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { STTv2 } from './stt_v2.js';
 
-describe('Deepgram STTv2 (Flux)', async () => {
-  initializeLogger({ pretty: false });
-  await stt(new STTv2(), await VAD.load(), { nonStreaming: false });
-});
+const hasDeepgramApiKey = Boolean(process.env.DEEPGRAM_API_KEY);
+
+if (hasDeepgramApiKey) {
+  describe('Deepgram STTv2 (Flux)', async () => {
+    await stt(new STTv2(), await VAD.load(), { nonStreaming: false });
+  });
+} else {
+  describe('Deepgram STTv2 (Flux)', () => {
+    it.skip('requires DEEPGRAM_API_KEY', () => {});
+  });
+}

--- a/plugins/deepgram/src/tts.test.ts
+++ b/plugins/deepgram/src/tts.test.ts
@@ -1,11 +1,19 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { STT } from '@livekit/agents-plugin-deepgram';
 import { tts } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
+import { STT } from '@livekit/agents-plugin-openai';
 import { TTS } from './tts.js';
 
-describe('Deepgram', async () => {
-  await tts(new TTS(), new STT());
-});
+const hasDeepgramTtsConfig = Boolean(process.env.DEEPGRAM_API_KEY && process.env.OPENAI_API_KEY);
+
+if (hasDeepgramTtsConfig) {
+  describe('Deepgram', async () => {
+    await tts(new TTS(), new STT());
+  });
+} else {
+  describe('Deepgram', () => {
+    it.skip('requires DEEPGRAM_API_KEY and OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/elevenlabs/src/tts.test.ts
+++ b/plugins/elevenlabs/src/tts.test.ts
@@ -3,9 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { TTS } from './tts.js';
 
-describe('ElevenLabs', async () => {
-  await tts(new TTS(), new STT());
-});
+const hasElevenlabsConfig = Boolean(process.env.ELEVEN_API_KEY && process.env.OPENAI_API_KEY);
+
+if (hasElevenlabsConfig) {
+  describe('ElevenLabs', async () => {
+    await tts(new TTS(), new STT());
+  });
+} else {
+  describe('ElevenLabs', () => {
+    it.skip('requires ELEVEN_API_KEY and OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/google/src/llm.test.ts
+++ b/plugins/google/src/llm.test.ts
@@ -2,15 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { llm } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { LLM } from './llm.js';
 
-describe('Google', async () => {
-  await llm(
-    new LLM({
-      model: 'gemini-2.5-flash',
-      temperature: 0,
-    }),
-    true,
-  );
-});
+const hasGoogleApiKey = Boolean(process.env.GOOGLE_API_KEY);
+
+if (hasGoogleApiKey) {
+  describe('Google', async () => {
+    await llm(
+      new LLM({
+        model: 'gemini-2.5-flash',
+        temperature: 0,
+      }),
+      true,
+    );
+  });
+} else {
+  describe('Google', () => {
+    it.skip('requires GOOGLE_API_KEY', () => {});
+  });
+}

--- a/plugins/inworld/src/tts.test.ts
+++ b/plugins/inworld/src/tts.test.ts
@@ -3,9 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { TTS } from './tts.js';
 
-describe('Inworld', async () => {
-  await tts(new TTS(), new STT());
-});
+const hasInworldConfig = Boolean(process.env.INWORLD_API_KEY && process.env.OPENAI_API_KEY);
+
+if (hasInworldConfig) {
+  describe('Inworld', async () => {
+    await tts(new TTS(), new STT());
+  });
+} else {
+  describe('Inworld', () => {
+    it.skip('requires INWORLD_API_KEY and OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/neuphonic/src/tts.test.ts
+++ b/plugins/neuphonic/src/tts.test.ts
@@ -3,9 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { TTS } from './tts.js';
 
-describe('Neuphonic', async () => {
-  await tts(new TTS(), new STT());
-});
+const hasNeuphonicConfig = Boolean(process.env.NEUPHONIC_API_KEY && process.env.OPENAI_API_KEY);
+
+if (hasNeuphonicConfig) {
+  describe('Neuphonic', async () => {
+    await tts(new TTS(), new STT());
+  });
+} else {
+  describe('Neuphonic', () => {
+    it.skip('requires NEUPHONIC_API_KEY and OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/openai/src/llm.test.ts
+++ b/plugins/openai/src/llm.test.ts
@@ -2,23 +2,37 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { llm, llmStrict } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { LLM } from './llm.js';
 
-describe('OpenAI', async () => {
-  await llm(
-    new LLM({
-      temperature: 0,
-    }),
-    false,
-  );
-});
+const hasOpenAIApiKey = Boolean(process.env.OPENAI_API_KEY);
 
-describe('OpenAI strict tool schema', async () => {
-  await llmStrict(
-    new LLM({
-      temperature: 0,
-      strictToolSchema: true,
-    }),
-  );
-});
+if (hasOpenAIApiKey) {
+  describe('OpenAI', async () => {
+    await llm(
+      new LLM({
+        temperature: 0,
+      }),
+      false,
+    );
+  });
+} else {
+  describe('OpenAI', () => {
+    it.skip('requires OPENAI_API_KEY', () => {});
+  });
+}
+
+if (hasOpenAIApiKey) {
+  describe('OpenAI strict tool schema', async () => {
+    await llmStrict(
+      new LLM({
+        temperature: 0,
+        strictToolSchema: true,
+      }),
+    );
+  });
+} else {
+  describe('OpenAI strict tool schema', () => {
+    it.skip('requires OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/openai/src/responses/llm.test.ts
+++ b/plugins/openai/src/responses/llm.test.ts
@@ -2,24 +2,38 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { llm, llmStrict } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { LLM } from './llm.js';
 
-describe('OpenAI Responses', async () => {
-  await llm(
-    new LLM({
-      temperature: 0,
-      strictToolSchema: false,
-    }),
-    true,
-  );
-});
+const hasOpenAIApiKey = Boolean(process.env.OPENAI_API_KEY);
 
-describe('OpenAI Responses strict tool schema', async () => {
-  await llmStrict(
-    new LLM({
-      temperature: 0,
-      strictToolSchema: true,
-    }),
-  );
-});
+if (hasOpenAIApiKey) {
+  describe('OpenAI Responses', async () => {
+    await llm(
+      new LLM({
+        temperature: 0,
+        strictToolSchema: false,
+      }),
+      true,
+    );
+  });
+} else {
+  describe('OpenAI Responses', () => {
+    it.skip('requires OPENAI_API_KEY', () => {});
+  });
+}
+
+if (hasOpenAIApiKey) {
+  describe('OpenAI Responses strict tool schema', async () => {
+    await llmStrict(
+      new LLM({
+        temperature: 0,
+        strictToolSchema: true,
+      }),
+    );
+  });
+} else {
+  describe('OpenAI Responses strict tool schema', () => {
+    it.skip('requires OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/openai/src/stt.test.ts
+++ b/plugins/openai/src/stt.test.ts
@@ -3,9 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { VAD } from '@livekit/agents-plugin-silero';
 import { stt } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { STT } from './stt.js';
 
-describe('OpenAI', async () => {
-  await stt(new STT(), await VAD.load(), { streaming: false });
-});
+const hasOpenAIApiKey = Boolean(process.env.OPENAI_API_KEY);
+
+if (hasOpenAIApiKey) {
+  describe('OpenAI', async () => {
+    await stt(new STT(), await VAD.load(), { streaming: false });
+  });
+} else {
+  describe('OpenAI', () => {
+    it.skip('requires OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/openai/src/tts.test.ts
+++ b/plugins/openai/src/tts.test.ts
@@ -2,10 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { tts } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { STT } from './stt.js';
 import { TTS } from './tts.js';
 
-describe('OpenAI', async () => {
-  await tts(new TTS(), new STT(), { streaming: false });
-});
+const hasOpenAIApiKey = Boolean(process.env.OPENAI_API_KEY);
+
+if (hasOpenAIApiKey) {
+  describe('OpenAI', async () => {
+    await tts(new TTS(), new STT(), { streaming: false });
+  });
+} else {
+  describe('OpenAI', () => {
+    it.skip('requires OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/resemble/src/tts.test.ts
+++ b/plugins/resemble/src/tts.test.ts
@@ -3,9 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { TTS } from './tts.js';
 
-describe('Resemble', async () => {
-  await tts(new TTS(), new STT());
-});
+const hasResembleConfig = Boolean(process.env.RESEMBLE_API_KEY && process.env.OPENAI_API_KEY);
+
+if (hasResembleConfig) {
+  describe('Resemble', async () => {
+    await tts(new TTS(), new STT());
+  });
+} else {
+  describe('Resemble', () => {
+    it.skip('requires RESEMBLE_API_KEY and OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/rime/src/tts.test.ts
+++ b/plugins/rime/src/tts.test.ts
@@ -3,9 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, it } from 'vitest';
 import { TTS } from './tts.js';
 
-describe('Rime TTS', async () => {
-  await tts(new TTS(), new STT(), { streaming: false });
-});
+const hasRimeConfig = Boolean(process.env.RIME_API_KEY && process.env.OPENAI_API_KEY);
+
+if (hasRimeConfig) {
+  describe('Rime TTS', async () => {
+    await tts(new TTS(), new STT(), { streaming: false });
+  });
+} else {
+  describe('Rime TTS', () => {
+    it.skip('requires RIME_API_KEY and OPENAI_API_KEY', () => {});
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -479,6 +479,9 @@ importers:
       '@livekit/agents':
         specifier: workspace:*
         version: link:../../agents
+      '@livekit/agents-plugin-openai':
+        specifier: workspace:^
+        version: link:../openai
       '@livekit/agents-plugin-silero':
         specifier: workspace:*
         version: link:../silero
@@ -3621,7 +3624,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -4873,7 +4876,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,9 @@ import { loadEnv } from 'vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig(({ mode }) => ({
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version ?? '0.0.0-test'),
+  },
   test: {
     include: ['**/*.test.ts'],
     // it is recommended to define a name when using inline configs
@@ -13,5 +16,6 @@ export default defineConfig(({ mode }) => ({
     // Default timeout for unit tests (5s), integration tests override this per-suite
     testTimeout: 5_000,
     env: loadEnv(mode, process.cwd(), ''),
+    setupFiles: ['./vitest.setup.ts'],
   },
 }));

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { initializeLogger } from './agents/src/log.js';
+
+initializeLogger({ pretty: false, level: 'silent' });


### PR DESCRIPTION
- Stabilize the Vitest environment by defining __PACKAGE_VERSION__ in tests and initializing the logger once in a global setup file
- Gate provider integration tests on the required local credentials so the full suite passes cleanly in normal local/dev environments