### PR TITLE
fix(examples): rename deprecated WorkerOptions to ServerOptions

### DIFF
--- a/examples/src/anam_realtime_agent.ts
+++ b/examples/src/anam_realtime_agent.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -81,4 +81,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/background_audio.ts
+++ b/examples/src/background_audio.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
   type JobContext,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   initializeLogger,
@@ -76,4 +76,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/basic_agent.ts
+++ b/examples/src/basic_agent.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -119,4 +119,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/basic_eou.ts
+++ b/examples/src/basic_eou.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { type JobContext, WorkerOptions, cli, defineAgent, llm, log } from '@livekit/agents';
+import { type JobContext, ServerOptions, cli, defineAgent, llm, log } from '@livekit/agents';
 import { turnDetector } from '@livekit/agents-plugin-livekit';
 import { fileURLToPath } from 'node:url';
 
@@ -44,4 +44,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/bey_avatar.ts
+++ b/examples/src/bey_avatar.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
   type JobContext,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   log,
@@ -62,4 +62,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/cartesia_tts.ts
+++ b/examples/src/cartesia_tts.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   log,
@@ -69,4 +69,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/comprehensive_test.ts
+++ b/examples/src/comprehensive_test.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   llm,
@@ -277,4 +277,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/custom_text_handler.ts
+++ b/examples/src/custom_text_handler.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -74,4 +74,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/gemini_realtime_agent.ts
+++ b/examples/src/gemini_realtime_agent.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   llm,
@@ -121,4 +121,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/idle_user_timeout_example.ts
+++ b/examples/src/idle_user_timeout_example.ts
@@ -10,7 +10,7 @@ import {
   type JobContext,
   type JobProcess,
   Task,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   delay,
@@ -91,4 +91,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/inworld_tts.ts
+++ b/examples/src/inworld_tts.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   log,
@@ -125,4 +125,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/manual_shutdown.ts
+++ b/examples/src/manual_shutdown.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -90,4 +90,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/multi_agent.ts
+++ b/examples/src/multi_agent.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -99,4 +99,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/play_local_audio_file.ts
+++ b/examples/src/play_local_audio_file.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
   type JobContext,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   log,
@@ -64,4 +64,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/push_to_talk.ts
+++ b/examples/src/push_to_talk.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -70,4 +70,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/raw_function_description.ts
+++ b/examples/src/raw_function_description.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -78,4 +78,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/realtime_agent.ts
+++ b/examples/src/realtime_agent.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   llm,
@@ -95,4 +95,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/realtime_turn_detector.ts
+++ b/examples/src/realtime_turn_detector.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   voice,
@@ -48,4 +48,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/restaurant_agent.ts
+++ b/examples/src/restaurant_agent.ts
@@ -4,7 +4,7 @@
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   llm,
@@ -402,4 +402,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/tool_call_disfluency.ts
+++ b/examples/src/tool_call_disfluency.ts
@@ -5,7 +5,7 @@ import {
   AutoSubscribe,
   type JobContext,
   type JobProcess,
-  WorkerOptions,
+  ServerOptions,
   cli,
   defineAgent,
   llm,
@@ -74,4 +74,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/trugen_avatar.ts
+++ b/examples/src/trugen_avatar.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { type JobContext, WorkerOptions, cli, defineAgent, metrics, voice } from '@livekit/agents';
+import { type JobContext, ServerOptions, cli, defineAgent, metrics, voice } from '@livekit/agents';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as trugen from '@livekit/agents-plugin-trugen';
 import { fileURLToPath } from 'node:url';
@@ -44,4 +44,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));


### PR DESCRIPTION
## Summary
Renamed WorkerOptions to ServerOptions across 21 example files to align with PR #713 Worker → AgentServer renaming.

## Changes
Updated all example files that still used the deprecated WorkerOptions alias to use the new ServerOptions class name.

Closes #870