### PR TITLE
fix: resolve TypeScript errors breaking TypeDoc build

### DIFF
--- a/agents/src/audio.ts
+++ b/agents/src/audio.ts
@@ -49,8 +49,11 @@ export class AudioByteStream {
     this.#buf = new Int8Array();
   }
 
-  write(data: ArrayBuffer): AudioFrame[] {
-    this.#buf = new Int8Array([...this.#buf, ...new Int8Array(data)]);
+  write(data: ArrayBufferLike | ArrayBufferView): AudioFrame[] {
+    const bytes = ArrayBuffer.isView(data)
+      ? new Int8Array(data.buffer, data.byteOffset, data.byteLength)
+      : new Int8Array(data);
+    this.#buf = new Int8Array([...this.#buf, ...bytes]);
 
     const frames: AudioFrame[] = [];
     while (this.#buf.length >= this.#bytesPerFrame) {

--- a/plugins/openai/src/llm.ts
+++ b/plugins/openai/src/llm.ts
@@ -521,7 +521,7 @@ export class LLM extends llm.LLM {
     return new LLMStream(this as unknown as inference.LLM, {
       model: this.#opts.model,
       providerFmt: this.#providerFmt,
-      client: this.#client,
+      client: this.#client as any,
       chatCtx,
       toolCtx,
       connOptions,


### PR DESCRIPTION
## Summary
- Widened AudioByteStream.write() parameter type from ArrayBuffer to ArrayBufferLike | ArrayBufferView to accept Buffer, Int8Array, and typed array .buffer properties that plugins already pass
- Added type cast for OpenAI client in plugins/openai/src/llm.ts to work around duplicate openai package resolutions caused by different zod peer dependency versions

## Context
TypeDoc compilation was failing with exit code 3 due to 5 TypeScript errors across plugins (elevenlabs, google, neuphonic, resemble, openai). The root causes:

- 4 plugins passed Buffer, Int8Array, or ArrayBufferLike to AudioByteStream.write() which only accepted ArrayBuffer. Fixed at the source by widening the signature — the implementation already worked with these types via new Int8Array().
- OpenAI plugin hit a #private field mismatch because pnpm resolved two copies of openai@6.8.1 (one with zod@4.3.6, another with zod@3.25.76). Cast to any at the single call site.