### PR TITLE
fix: stabilize session.run() for TaskGroup and cascading agent handoffs

### DIFF
--- a/.changeset/sharp-apples-appear.md
+++ b/.changeset/sharp-apples-appear.md
@@ -1,0 +1,9 @@
+---
+"@livekit/agents": patch
+"@livekit/agents-plugin-google": patch
+"@livekit/agents-plugin-openai": patch
+"@livekit/agents-plugin-phonic": patch
+---
+
+- Make reusable Realtime Session across Handoffs & Agent Tasks
+- Add say() capability to phonic realtime model

--- a/.changeset/tasty-pillows-serve.md
+++ b/.changeset/tasty-pillows-serve.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Reuse STT Pipeline Across Agent Handoff

--- a/.changeset/twenty-cheetahs-pretend.md
+++ b/.changeset/twenty-cheetahs-pretend.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Stabilize `session.run()` for Testing with TaskGroup / Cascading Handoffs

--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ examples/src/test_*.ts
 # OpenTelemetry trace test output
 .traces/
 *.traces.json
+.worktrees/

--- a/agents/src/llm/realtime.ts
+++ b/agents/src/llm/realtime.ts
@@ -49,6 +49,9 @@ export interface RealtimeCapabilities {
   autoToolReplyGeneration: boolean;
   audioOutput: boolean;
   manualFunctionCalls: boolean;
+  midSessionContextUpdate?: boolean;
+  midSessionInstructionsUpdate?: boolean;
+  midSessionToolsUpdate?: boolean;
 }
 
 export interface InputTranscriptionCompleted {
@@ -155,6 +158,13 @@ export abstract class RealtimeSession extends EventEmitter {
     return;
   }
 
+  say(
+    _text: string | ReadableStream<string>,
+    _options?: { allowInterruptions?: boolean },
+  ): Promise<GenerationCreatedEvent> {
+    throw new Error(`${this.constructor.name} does not implement say(). use a TTS model instead`);
+  }
+
   private async _mainTaskImpl(signal: AbortSignal): Promise<void> {
     const reader = this.deferredInputStream.stream.getReader();
     while (true) {
@@ -167,6 +177,14 @@ export abstract class RealtimeSession extends EventEmitter {
   }
 
   setInputAudioStream(audioStream: ReadableStream<AudioFrame>): void {
-    this.deferredInputStream.setSource(audioStream);
+    if (this.deferredInputStream.isSourceSet) {
+      // Reused sessions must detach the previous audio source before rebinding.
+      void this.deferredInputStream.detachSource();
+    }
+    try {
+      this.deferredInputStream.setSource(audioStream);
+    } catch (error) {
+      throw error;
+    }
   }
 }

--- a/agents/src/llm/realtime.ts
+++ b/agents/src/llm/realtime.ts
@@ -4,7 +4,7 @@
 import type { AudioFrame } from '@livekit/rtc-node';
 import { EventEmitter } from 'events';
 import type { ReadableStream } from 'node:stream/web';
-import { DeferredReadableStream } from '../stream/deferred_stream.js';
+import { MultiInputStream } from '../stream/multi_input_stream.js';
 import { Task } from '../utils.js';
 import type { TimedString } from '../voice/io.js';
 import type { ChatContext, FunctionCall } from './chat_context.js';
@@ -87,7 +87,8 @@ export abstract class RealtimeModel {
 
 export abstract class RealtimeSession extends EventEmitter {
   protected _realtimeModel: RealtimeModel;
-  private deferredInputStream = new DeferredReadableStream<AudioFrame>();
+  private inputAudioStream = new MultiInputStream<AudioFrame>();
+  private inputAudioStreamId?: string;
   private _mainTask: Task<void>;
 
   constructor(realtimeModel: RealtimeModel) {
@@ -149,6 +150,7 @@ export abstract class RealtimeSession extends EventEmitter {
 
   async close(): Promise<void> {
     this._mainTask.cancel();
+    await this.inputAudioStream.close();
   }
 
   /**
@@ -166,7 +168,7 @@ export abstract class RealtimeSession extends EventEmitter {
   }
 
   private async _mainTaskImpl(signal: AbortSignal): Promise<void> {
-    const reader = this.deferredInputStream.stream.getReader();
+    const reader = this.inputAudioStream.stream.getReader();
     while (true) {
       const { done, value } = await reader.read();
       if (done || signal.aborted) {
@@ -177,14 +179,9 @@ export abstract class RealtimeSession extends EventEmitter {
   }
 
   setInputAudioStream(audioStream: ReadableStream<AudioFrame>): void {
-    if (this.deferredInputStream.isSourceSet) {
-      // Reused sessions must detach the previous audio source before rebinding.
-      void this.deferredInputStream.detachSource();
+    if (this.inputAudioStreamId !== undefined) {
+      void this.inputAudioStream.removeInputStream(this.inputAudioStreamId);
     }
-    try {
-      this.deferredInputStream.setSource(audioStream);
-    } catch (error) {
-      throw error;
-    }
+    this.inputAudioStreamId = this.inputAudioStream.addInputStream(audioStream);
   }
 }

--- a/agents/src/stream/deferred_stream.ts
+++ b/agents/src/stream/deferred_stream.ts
@@ -41,7 +41,7 @@ export class DeferredReadableStream<T> {
   private transform: IdentityTransform<T>;
   private writer: WritableStreamDefaultWriter<T>;
   private sourceReader?: ReadableStreamDefaultReader<T>;
-  private detachRequested = false;
+  private sourceAttached = false;
 
   constructor() {
     this.transform = new IdentityTransform<T>();
@@ -60,10 +60,11 @@ export class DeferredReadableStream<T> {
    * Call once the actual source is ready.
    */
   setSource(source: ReadableStream<T>) {
-    if (this.isSourceSet) {
+    if (this.sourceAttached) {
       throw new Error('Stream source already set');
     }
 
+    this.sourceAttached = true;
     const sourceReader = source.getReader();
     this.sourceReader = sourceReader;
     void this.pump(sourceReader);
@@ -84,11 +85,6 @@ export class DeferredReadableStream<T> {
 
       sourceError = e;
     } finally {
-      if (this.detachRequested) {
-        this.detachRequested = false;
-        return;
-      }
-
       // any other error from source will be propagated to the consumer
       if (sourceError) {
         try {
@@ -130,8 +126,7 @@ export class DeferredReadableStream<T> {
     }
 
     const sourceReader = this.sourceReader!;
-    this.detachRequested = true;
-    // Clear source first so future setSource() calls can reattach cleanly.
+    // Clear active source reader reference before releasing lock.
     this.sourceReader = undefined;
 
     // release lock will make any pending read() throw TypeError

--- a/agents/src/stream/deferred_stream.ts
+++ b/agents/src/stream/deferred_stream.ts
@@ -41,6 +41,7 @@ export class DeferredReadableStream<T> {
   private transform: IdentityTransform<T>;
   private writer: WritableStreamDefaultWriter<T>;
   private sourceReader?: ReadableStreamDefaultReader<T>;
+  private detachRequested = false;
 
   constructor() {
     this.transform = new IdentityTransform<T>();
@@ -83,6 +84,11 @@ export class DeferredReadableStream<T> {
 
       sourceError = e;
     } finally {
+      if (this.detachRequested) {
+        this.detachRequested = false;
+        return;
+      }
+
       // any other error from source will be propagated to the consumer
       if (sourceError) {
         try {
@@ -124,6 +130,7 @@ export class DeferredReadableStream<T> {
     }
 
     const sourceReader = this.sourceReader!;
+    this.detachRequested = true;
     // Clear source first so future setSource() calls can reattach cleanly.
     this.sourceReader = undefined;
 

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -947,6 +947,41 @@ export async function waitForTrackPublication({
   }
 }
 
+/**
+ * Yields values from a ReadableStream until the stream ends or the signal is aborted.
+ * Handles reader cleanup and stream-release errors internally.
+ */
+export async function* readStream<T>(
+  stream: ReadableStream<T>,
+  signal?: AbortSignal,
+): AsyncGenerator<T> {
+  const reader = stream.getReader();
+  try {
+    if (signal) {
+      const abortPromise = waitForAbort(signal);
+      while (true) {
+        const result = await Promise.race([reader.read(), abortPromise]);
+        if (!result) break;
+        const { done, value } = result;
+        if (done) break;
+        yield value;
+      }
+    } else {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        yield value;
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // stream cleanup errors are expected (releasing reader, controller closed, etc.)
+    }
+  }
+}
+
 export async function waitForAbort(signal: AbortSignal) {
   const abortFuture = new Future<void>();
   const handler = () => {

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -983,6 +983,10 @@ export async function* readStream<T>(
 }
 
 export async function waitForAbort(signal: AbortSignal) {
+  if (signal.aborted) {
+    return;
+  }
+
   const abortFuture = new Future<void>();
   const handler = () => {
     abortFuture.resolve();

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -605,31 +605,22 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
       );
     }
 
-    await session._updateActivity(this, {
-      previousActivity: 'pause',
-      newActivity: 'start',
-      blockedTasks,
-    });
-
-    let runState = session._globalRunState;
-    if (speechHandle && runState && !runState.done()) {
-      // Only unwatch the parent speech handle if there are other handles keeping the run alive.
-      // When watchedHandleCount is 1 (only the parent), unwatching would drop it to 0 and
-      // mark the run done prematurely — before function_call_output and assistant message arrive.
-      if (runState._watchedHandleCount() > 1) {
-        runState._unwatchHandle(speechHandle);
-      }
-      // it is OK to call _markDoneIfNeeded here, the above _updateActivity will call onEnter
-      // and newly added handles keep the run alive.
-      runState._markDoneIfNeeded();
-    }
+    const startTransitionTask = Task.from(
+      () =>
+        session._updateActivity(this, {
+          previousActivity: 'pause',
+          newActivity: 'start',
+          blockedTasks,
+        }),
+      undefined,
+      'AgentTask_startTransition',
+    );
+    session._trackRunHandle(startTransitionTask);
+    await startTransitionTask.result;
 
     try {
       return await this.future.await;
     } finally {
-      // runState could have changed after future resolved
-      runState = session._globalRunState;
-
       if (session.currentAgent !== this) {
         this.#logger.warn(
           `${this.constructor.name} completed, but the agent has changed in the meantime. ` +
@@ -637,21 +628,28 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
         );
         await oldActivity.close();
       } else {
-        if (speechHandle && runState && !runState.done()) {
-          runState._watchHandle(speechHandle);
-        }
-
         const mergedChatCtx = oldAgent._chatCtx.merge(this._chatCtx, {
           excludeFunctionCall: true,
           excludeInstructions: true,
         });
         oldAgent._chatCtx.items = mergedChatCtx.items;
 
-        await session._updateActivity(oldAgent, {
-          previousActivity: 'close',
-          newActivity: 'resume',
-          waitOnEnter: false,
-        });
+        const resumeTransitionTask = Task.from(
+          async () => {
+            await session._updateActivity(oldAgent, {
+              previousActivity: 'close',
+              newActivity: 'resume',
+              waitOnEnter: false,
+            });
+            // Drain any cascading transitions triggered by the resumed agent's
+            // onEnter (e.g. TaskGroup starting the next child task).
+            await session._drainActivityLock();
+          },
+          undefined,
+          'AgentTask_resumeTransition',
+        );
+        session._trackRunHandle(resumeTransitionTask);
+        await resumeTransitionTask.result;
       }
     }
   }

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -641,8 +641,6 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
               newActivity: 'resume',
               waitOnEnter: false,
             });
-            // Drain any cascading transitions triggered by the resumed agent's
-            // onEnter (e.g. TaskGroup starting the next child task).
             await session._drainActivityLock();
           },
           undefined,

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2876,10 +2876,6 @@ export class AgentActivity implements RecognitionHooks {
       throw new Error('realtimeSession is not available');
     }
 
-    // Parity gap (python->ts): Python also waits on a user-silence event when interruptions
-    // are enabled. TS voice runtime currently does not expose an equivalent wait primitive here.
-    // Behavior equivalent: we gate on tool/speech authorization and interruption status before
-    // issuing realtime say().
     await speechHandle.waitIfNotInterrupted([speechHandle._waitForAuthorization()]);
 
     if (speechHandle.interrupted) {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -455,21 +455,25 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   async _detachSttPipelineIfReusable(newActivity: AgentActivity): Promise<STTPipeline | undefined> {
-    if (!this.audioRecognition || !this.stt || !newActivity.stt) {
+    const hasAudioRecognition = !!this.audioRecognition;
+    const hasSttOld = !!this.stt;
+    const hasSttNew = !!newActivity.stt;
+    const sameSttInstance = this.stt === newActivity.stt;
+    const sameSttNode = Object.getPrototypeOf(this.agent).sttNode === Object.getPrototypeOf(newActivity.agent).sttNode;
+
+    if (!hasAudioRecognition || !hasSttOld || !hasSttNew) {
       return undefined;
     }
 
-    if (this.stt !== newActivity.stt) {
+    if (!sameSttInstance) {
       return undefined;
     }
 
-    if (
-      Object.getPrototypeOf(this.agent).sttNode !== Object.getPrototypeOf(newActivity.agent).sttNode
-    ) {
+    if (!sameSttNode) {
       return undefined;
     }
 
-    return await this.audioRecognition.detachSttPipeline();
+    return await this.audioRecognition!.detachSttPipeline();
   }
 
   get currentSpeech(): SpeechHandle | undefined {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2892,14 +2892,6 @@ export class AgentActivity implements RecognitionHooks {
         allowInterruptions: speechHandle.allowInterruptions,
       });
     } catch (e) {
-      if (e instanceof Error && e.message.includes('does not implement say()')) {
-        this.logger.error(
-          'say() is not implemented for %s; use a TTS model instead',
-          this.realtimeSession.realtimeModel.provider,
-        );
-        this.agentSession._updateAgentState('listening');
-        return;
-      }
       this.logger.error('failed to say text: %s', String(e));
       this.agentSession._updateAgentState('listening');
       return;

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -827,7 +827,7 @@ export class AgentActivity implements RecognitionHooks {
     if (this.realtimeSession !== undefined && !audio && !this.tts) {
       task = this.createSpeechTask({
         taskFn: (abortController: AbortController) =>
-          this.realtimeSayTask(handle, text, {}, abortController),
+          this.realtimeSayTask(handle, text, addToChatCtx, {}, abortController),
         ownedSpeechHandle: handle,
         name: 'AgentActivity.realtime_say',
       });
@@ -2365,6 +2365,7 @@ export class AgentActivity implements RecognitionHooks {
     ev: GenerationCreatedEvent,
     modelSettings: ModelSettings,
     replyAbortController: AbortController,
+    addToChatCtx: boolean = true,
   ): Promise<void> {
     return tracer.startActiveSpan(
       async (span) =>
@@ -2373,6 +2374,7 @@ export class AgentActivity implements RecognitionHooks {
           ev,
           modelSettings,
           replyAbortController,
+          addToChatCtx,
           span,
         }),
       {
@@ -2387,12 +2389,14 @@ export class AgentActivity implements RecognitionHooks {
     ev,
     modelSettings,
     replyAbortController,
+    addToChatCtx,
     span,
   }: {
     speechHandle: SpeechHandle;
     ev: GenerationCreatedEvent;
     modelSettings: ModelSettings;
     replyAbortController: AbortController;
+    addToChatCtx: boolean;
     span: Span;
   }): Promise<void> {
     speechHandle._agentTurnContext = otelContext.active();
@@ -2664,7 +2668,7 @@ export class AgentActivity implements RecognitionHooks {
           });
         }
 
-        if (forwardedText) {
+        if (forwardedText && addToChatCtx) {
           const message = ChatMessage.create({
             role: 'assistant',
             content: forwardedText,
@@ -2689,7 +2693,7 @@ export class AgentActivity implements RecognitionHooks {
       return;
     }
 
-    if (messageOutputs.length > 0) {
+    if (messageOutputs.length > 0 && addToChatCtx) {
       // there should be only one message
       const [msgId, textOut, _, __] = messageOutputs[0]!;
       const message = ChatMessage.create({
@@ -2862,6 +2866,7 @@ export class AgentActivity implements RecognitionHooks {
   private async realtimeSayTask(
     speechHandle: SpeechHandle,
     text: string | ReadableStream<string>,
+    addToChatCtx: boolean,
     modelSettings: ModelSettings,
     replyAbortController: AbortController,
   ): Promise<void> {
@@ -2892,6 +2897,7 @@ export class AgentActivity implements RecognitionHooks {
           'say() is not implemented for %s; use a TTS model instead',
           this.realtimeSession.realtimeModel.provider,
         );
+        this.agentSession._updateAgentState('listening');
         return;
       }
       this.logger.error('failed to say text: %s', String(e));
@@ -2904,6 +2910,7 @@ export class AgentActivity implements RecognitionHooks {
       generationEv,
       modelSettings,
       replyAbortController,
+      addToChatCtx,
     );
   }
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -61,6 +61,7 @@ import {
   type EndOfTurnInfo,
   type PreemptiveGenerationInfo,
   type RecognitionHooks,
+  type STTPipeline,
 } from './audio_recognition.js';
 import {
   AgentSessionEventTypes,
@@ -292,19 +293,27 @@ export class AgentActivity implements RecognitionHooks {
     this.isDefaultInterruptionByAudioActivityEnabled = this.isInterruptionByAudioActivityEnabled;
   }
 
-  async start(): Promise<void> {
+  async start(options?: { reuseSttPipeline?: STTPipeline }): Promise<void> {
     const unlock = await this.lock.lock();
     try {
-      await this._startSession({ spanName: 'start_agent_activity', runOnEnter: true });
+      await this._startSession({
+        spanName: 'start_agent_activity',
+        runOnEnter: true,
+        reuseSttPipeline: options?.reuseSttPipeline,
+      });
     } finally {
       unlock();
     }
   }
 
-  async resume(): Promise<void> {
+  async resume(options?: { reuseSttPipeline?: STTPipeline }): Promise<void> {
     const unlock = await this.lock.lock();
     try {
-      await this._startSession({ spanName: 'resume_agent_activity', runOnEnter: false });
+      await this._startSession({
+        spanName: 'resume_agent_activity',
+        runOnEnter: false,
+        reuseSttPipeline: options?.reuseSttPipeline,
+      });
     } finally {
       unlock();
     }
@@ -313,8 +322,9 @@ export class AgentActivity implements RecognitionHooks {
   private async _startSession(options: {
     spanName: 'start_agent_activity' | 'resume_agent_activity';
     runOnEnter: boolean;
+    reuseSttPipeline?: STTPipeline;
   }): Promise<void> {
-    const { spanName, runOnEnter } = options;
+    const { spanName, runOnEnter, reuseSttPipeline } = options;
     const startSpan = tracer.startSpan({
       name: spanName,
       attributes: { [traceTypes.ATTR_AGENT_LABEL]: this.agent.id },
@@ -415,9 +425,15 @@ export class AgentActivity implements RecognitionHooks {
       sttProvider: this.getSttProvider(),
       getLinkedParticipant: () => this.agentSession._roomIO?.linkedParticipant,
     });
-    this.audioRecognition.start();
-    this.started = true;
 
+    if (reuseSttPipeline) {
+      this.logger.debug('Reusing STT pipeline from previous activity');
+      await this.audioRecognition.start({ sttPipeline: reuseSttPipeline });
+    } else {
+      await this.audioRecognition.start();
+    }
+
+    this.started = true;
     this._resumeSchedulingTask();
 
     if (runOnEnter) {
@@ -436,6 +452,24 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     startSpan.end();
+  }
+
+  async _detachSttPipelineIfReusable(newActivity: AgentActivity): Promise<STTPipeline | undefined> {
+    if (!this.audioRecognition || !this.stt || !newActivity.stt) {
+      return undefined;
+    }
+
+    if (this.stt !== newActivity.stt) {
+      return undefined;
+    }
+
+    if (
+      Object.getPrototypeOf(this.agent).sttNode !== Object.getPrototypeOf(newActivity.agent).sttNode
+    ) {
+      return undefined;
+    }
+
+    return await this.audioRecognition.detachSttPipeline();
   }
 
   get currentSpeech(): SpeechHandle | undefined {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -96,6 +96,22 @@ interface OnEnterData {
   agent: Agent;
 }
 
+export interface ReusableResources {
+  sttPipeline?: STTPipeline;
+  rtSession?: RealtimeSession;
+}
+
+export async function cleanupReusableResources(resources: ReusableResources): Promise<void> {
+  if (resources.sttPipeline) {
+    await resources.sttPipeline.close();
+    resources.sttPipeline = undefined;
+  }
+  if (resources.rtSession) {
+    await resources.rtSession.close();
+    resources.rtSession = undefined;
+  }
+}
+
 interface PreemptiveGeneration {
   speechHandle: SpeechHandle;
   userMessage: ChatMessage;
@@ -293,26 +309,26 @@ export class AgentActivity implements RecognitionHooks {
     this.isDefaultInterruptionByAudioActivityEnabled = this.isInterruptionByAudioActivityEnabled;
   }
 
-  async start(options?: { reuseSttPipeline?: STTPipeline }): Promise<void> {
+  async start(options?: { reuseResources?: ReusableResources }): Promise<void> {
     const unlock = await this.lock.lock();
     try {
       await this._startSession({
         spanName: 'start_agent_activity',
         runOnEnter: true,
-        reuseSttPipeline: options?.reuseSttPipeline,
+        reuseResources: options?.reuseResources,
       });
     } finally {
       unlock();
     }
   }
 
-  async resume(options?: { reuseSttPipeline?: STTPipeline }): Promise<void> {
+  async resume(options?: { reuseResources?: ReusableResources }): Promise<void> {
     const unlock = await this.lock.lock();
     try {
       await this._startSession({
         spanName: 'resume_agent_activity',
         runOnEnter: false,
-        reuseSttPipeline: options?.reuseSttPipeline,
+        reuseResources: options?.reuseResources,
       });
     } finally {
       unlock();
@@ -322,9 +338,9 @@ export class AgentActivity implements RecognitionHooks {
   private async _startSession(options: {
     spanName: 'start_agent_activity' | 'resume_agent_activity';
     runOnEnter: boolean;
-    reuseSttPipeline?: STTPipeline;
+    reuseResources?: ReusableResources;
   }): Promise<void> {
-    const { spanName, runOnEnter, reuseSttPipeline } = options;
+    const { spanName, runOnEnter, reuseResources } = options;
     const startSpan = tracer.startSpan({
       name: spanName,
       attributes: { [traceTypes.ATTR_AGENT_LABEL]: this.agent.id },
@@ -334,38 +350,60 @@ export class AgentActivity implements RecognitionHooks {
     this.agent._agentActivity = this;
 
     if (this.llm instanceof RealtimeModel) {
-      this.realtimeSession = this.llm.session();
+      const rtReused = reuseResources?.rtSession !== undefined;
+      if (rtReused) {
+        this.logger.debug('reusing realtime session from previous activity');
+        this.realtimeSession = reuseResources!.rtSession;
+        reuseResources!.rtSession = undefined; // ownership transferred
+
+        // clear any stale audio/generation state
+        await this.realtimeSession!.interrupt();
+        await this.realtimeSession!.clearAudio();
+      } else {
+        this.realtimeSession = this.llm.session();
+      }
+
       this.realtimeSpans = new Map<string, Span>();
-      this.realtimeSession.on('generation_created', this.onRealtimeGenerationCreated);
-      this.realtimeSession.on('input_speech_started', this.onRealtimeInputSpeechStarted);
-      this.realtimeSession.on('input_speech_stopped', this.onRealtimeInputSpeechStopped);
-      this.realtimeSession.on(
+      this.realtimeSession!.on('generation_created', this.onRealtimeGenerationCreated);
+      this.realtimeSession!.on('input_speech_started', this.onRealtimeInputSpeechStarted);
+      this.realtimeSession!.on('input_speech_stopped', this.onRealtimeInputSpeechStopped);
+      this.realtimeSession!.on(
         'input_audio_transcription_completed',
         this.onRealtimeInputAudioTranscriptionCompleted,
       );
-      this.realtimeSession.on('metrics_collected', this.onMetricsCollected);
-      this.realtimeSession.on('error', this.onModelError);
+      this.realtimeSession!.on('metrics_collected', this.onMetricsCollected);
+      this.realtimeSession!.on('error', this.onModelError);
 
       removeInstructions(this.agent._chatCtx);
-      try {
-        await this.realtimeSession.updateInstructions(this.agent.instructions);
-      } catch (error) {
-        this.logger.error(error, 'failed to update the instructions');
+
+      // skip the update if the session is reused and no mid-session update is supported
+      // this means the content is the same as the previous session
+      const capabilities = this.llm.capabilities;
+      if (!rtReused || capabilities.midSessionInstructionsUpdate) {
+        try {
+          await this.realtimeSession!.updateInstructions(this.agent.instructions);
+        } catch (error) {
+          this.logger.error(error, 'failed to update the instructions');
+        }
       }
 
-      try {
-        await this.realtimeSession.updateChatCtx(this.agent.chatCtx);
-      } catch (error) {
-        this.logger.error(error, 'failed to update the chat context');
+      if (!rtReused || capabilities.midSessionContextUpdate) {
+        try {
+          await this.realtimeSession!.updateChatCtx(this.agent.chatCtx);
+        } catch (error) {
+          this.logger.error(error, 'failed to update the chat context');
+        }
       }
 
-      try {
-        await this.realtimeSession.updateTools(this.tools);
-      } catch (error) {
-        this.logger.error(error, 'failed to update the tools');
+      if (!rtReused || capabilities.midSessionToolsUpdate) {
+        try {
+          await this.realtimeSession!.updateTools(this.tools);
+        } catch (error) {
+          this.logger.error(error, 'failed to update the tools');
+        }
       }
 
-      if (!this.llm.capabilities.audioOutput && !this.tts && this.agentSession.output.audio) {
+      if (!capabilities.audioOutput && !this.tts && this.agentSession.output.audio) {
         this.logger.error(
           'audio output is enabled but RealtimeModel has no audio modality ' +
             'and no TTS is set. Either enable audio modality in the RealtimeModel ' +
@@ -426,9 +464,10 @@ export class AgentActivity implements RecognitionHooks {
       getLinkedParticipant: () => this.agentSession._roomIO?.linkedParticipant,
     });
 
-    if (reuseSttPipeline) {
-      this.logger.debug('Reusing STT pipeline from previous activity');
-      await this.audioRecognition.start({ sttPipeline: reuseSttPipeline });
+    if (reuseResources?.sttPipeline) {
+      this.logger.debug('reusing STT pipeline from previous activity');
+      await this.audioRecognition.start({ sttPipeline: reuseResources.sttPipeline });
+      reuseResources.sttPipeline = undefined; // ownership transferred
     } else {
       await this.audioRecognition.start();
     }
@@ -454,28 +493,61 @@ export class AgentActivity implements RecognitionHooks {
     startSpan.end();
   }
 
-  async _detachSttPipelineIfReusable(newActivity: AgentActivity): Promise<STTPipeline | undefined> {
-    const hasAudioRecognition = !!this.audioRecognition;
-    const hasSttOld = !!this.stt;
-    const hasSttNew = !!newActivity.stt;
-    const sameSttInstance = this.stt === newActivity.stt;
-    const sameSttNode =
-      Object.getPrototypeOf(this.agent).sttNode ===
-      Object.getPrototypeOf(newActivity.agent).sttNode;
+  async _detachReusableResources(newActivity: AgentActivity): Promise<ReusableResources> {
+    const resources: ReusableResources = {};
 
-    if (!hasAudioRecognition || !hasSttOld || !hasSttNew) {
-      return undefined;
+    // stt pipeline
+    if (
+      this.audioRecognition &&
+      this.stt &&
+      newActivity.stt &&
+      this.stt === newActivity.stt &&
+      Object.getPrototypeOf(this.agent).sttNode === Object.getPrototypeOf(newActivity.agent).sttNode
+    ) {
+      resources.sttPipeline = await this.audioRecognition.detachSttPipeline();
     }
 
-    if (!sameSttInstance) {
-      return undefined;
+    // rt session
+    if (this.realtimeSession && this.llm instanceof RealtimeModel && this.llm === newActivity.llm) {
+      const capabilities = this.llm.capabilities;
+
+      // context update is supported or chat context is equivalent
+      let reusable =
+        capabilities.midSessionContextUpdate ||
+        this.realtimeSession.chatCtx
+          .copy({ excludeInstructions: true, excludeHandoff: true })
+          .isEquivalent(
+            newActivity.agent.chatCtx.copy({ excludeInstructions: true, excludeHandoff: true }),
+          );
+
+      // instructions update is supported or instructions are the same
+      reusable =
+        reusable &&
+        (capabilities.midSessionInstructionsUpdate ||
+          this.agent.instructions === newActivity.agent.instructions);
+
+      // tools update is supported or tools are the same
+      reusable =
+        reusable &&
+        (capabilities.midSessionToolsUpdate || isSameToolContext(this.tools, newActivity.tools));
+
+      if (reusable) {
+        // detach: remove event listeners but don't close the session
+        this.realtimeSession.off('generation_created', this.onRealtimeGenerationCreated);
+        this.realtimeSession.off('input_speech_started', this.onRealtimeInputSpeechStarted);
+        this.realtimeSession.off('input_speech_stopped', this.onRealtimeInputSpeechStopped);
+        this.realtimeSession.off(
+          'input_audio_transcription_completed',
+          this.onRealtimeInputAudioTranscriptionCompleted,
+        );
+        this.realtimeSession.off('metrics_collected', this.onMetricsCollected);
+        this.realtimeSession.off('error', this.onModelError);
+        resources.rtSession = this.realtimeSession;
+        this.realtimeSession = undefined; // prevent _closeSessionResources from closing it
+      }
     }
 
-    if (!sameSttNode) {
-      return undefined;
-    }
-
-    return await this.audioRecognition!.detachSttPipeline();
+    return resources;
   }
 
   get currentSpeech(): SpeechHandle | undefined {
@@ -712,17 +784,9 @@ export class AgentActivity implements RecognitionHooks {
     let allowInterruptions = defaultAllowInterruptions;
 
     if (
-      !audio &&
-      !this.tts &&
-      this.agentSession.output.audio &&
-      this.agentSession.output.audioEnabled
-    ) {
-      throw new Error('trying to generate speech from text without a TTS model');
-    }
-
-    if (
       this.llm instanceof RealtimeModel &&
       this.llm.capabilities.turnDetection &&
+      this.tts &&
       allowInterruptions === false
     ) {
       this.logger.warn(
@@ -730,6 +794,20 @@ export class AgentActivity implements RecognitionHooks {
           'disable turnDetection in the RealtimeModel and use VAD on the AgentTask/VoiceAgent instead',
       );
       allowInterruptions = true;
+    }
+
+    if (
+      !audio &&
+      !this.tts &&
+      this.realtimeSession === undefined &&
+      this.agentSession.output.audio &&
+      this.agentSession.output.audioEnabled
+    ) {
+      const modelInfo =
+        this.llm instanceof RealtimeModel
+          ? 'a RealtimeSession that implements say()'
+          : 'a TTS model';
+      throw new Error(`trying to generate speech from text without ${modelInfo}`);
     }
 
     const handle = SpeechHandle.create({
@@ -744,14 +822,29 @@ export class AgentActivity implements RecognitionHooks {
         speechHandle: handle,
       }),
     );
-    const task = this.createSpeechTask({
-      taskFn: (abortController: AbortController) =>
-        this.ttsTask(handle, text, addToChatCtx, {}, abortController, audio),
-      ownedSpeechHandle: handle,
-      name: 'AgentActivity.say_tts',
-    });
 
-    task.result.finally(() => this.onPipelineReplyDone());
+    let task: Task<void>;
+    if (this.realtimeSession !== undefined && !audio && !this.tts) {
+      task = this.createSpeechTask({
+        taskFn: (abortController: AbortController) =>
+          this.realtimeSayTask(handle, text, {}, abortController),
+        ownedSpeechHandle: handle,
+        name: 'AgentActivity.realtime_say',
+      });
+    } else {
+      task = this.createSpeechTask({
+        taskFn: (abortController: AbortController) =>
+          this.ttsTask(handle, text, addToChatCtx, {}, abortController, audio),
+        ownedSpeechHandle: handle,
+        name: 'AgentActivity.tts_say',
+      });
+    }
+
+    // Avoid duplicate state transitions for realtime say path: realtimeGenerationTask already
+    // performs end-of-speech transitions internally.
+    if (this.realtimeSession === undefined || audio !== undefined || this.tts) {
+      task.result.finally(() => this.onPipelineReplyDone());
+    }
     this.scheduleSpeech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL);
     return handle;
   }
@@ -2766,6 +2859,54 @@ export class AgentActivity implements RecognitionHooks {
     };
   }
 
+  private async realtimeSayTask(
+    speechHandle: SpeechHandle,
+    text: string | ReadableStream<string>,
+    modelSettings: ModelSettings,
+    replyAbortController: AbortController,
+  ): Promise<void> {
+    speechHandleStorage.enterWith(speechHandle);
+
+    if (!this.realtimeSession) {
+      throw new Error('realtimeSession is not available');
+    }
+
+    // Parity gap (python->ts): Python also waits on a user-silence event when interruptions
+    // are enabled. TS voice runtime currently does not expose an equivalent wait primitive here.
+    // Behavior equivalent: we gate on tool/speech authorization and interruption status before
+    // issuing realtime say().
+    await speechHandle.waitIfNotInterrupted([speechHandle._waitForAuthorization()]);
+
+    if (speechHandle.interrupted) {
+      return;
+    }
+
+    let generationEv: GenerationCreatedEvent;
+    try {
+      generationEv = await this.realtimeSession.say(text, {
+        allowInterruptions: speechHandle.allowInterruptions,
+      });
+    } catch (e) {
+      if (e instanceof Error && e.message.includes('does not implement say()')) {
+        this.logger.error(
+          'say() is not implemented for %s; use a TTS model instead',
+          this.realtimeSession.realtimeModel.provider,
+        );
+        return;
+      }
+      this.logger.error('failed to say text: %s', String(e));
+      this.agentSession._updateAgentState('listening');
+      return;
+    }
+
+    await this.realtimeGenerationTask(
+      speechHandle,
+      generationEv,
+      modelSettings,
+      replyAbortController,
+    );
+  }
+
   private async realtimeReplyTask({
     speechHandle,
     modelSettings: { toolChoice },
@@ -2858,8 +2999,13 @@ export class AgentActivity implements RecognitionHooks {
     this._mainTask = Task.from(({ signal }) => this.mainTask(signal));
   }
 
-  async pause(options: { blockedTasks?: Task<any>[] } = {}): Promise<void> {
-    const { blockedTasks = [] } = options;
+  async pause(
+    options: {
+      blockedTasks?: Task<any>[];
+      newActivity?: AgentActivity;
+    } = {},
+  ): Promise<ReusableResources | undefined> {
+    const { blockedTasks = [], newActivity } = options;
     const unlock = await this.lock.lock();
 
     try {
@@ -2867,31 +3013,49 @@ export class AgentActivity implements RecognitionHooks {
         name: 'pause_agent_activity',
         attributes: { [traceTypes.ATTR_AGENT_LABEL]: this.agent.id },
       });
+
+      let resources: ReusableResources | undefined;
       try {
         await this._pauseSchedulingTask(blockedTasks);
+
+        // detach after speech tasks are done but before _closeSessionResources
+        if (newActivity) {
+          resources = await this._detachReusableResources(newActivity);
+        }
+
         await this._closeSessionResources();
+      } catch (error) {
+        if (resources) {
+          await cleanupReusableResources(resources);
+        }
+        throw error;
       } finally {
         span.end();
       }
+
+      return resources;
     } finally {
       unlock();
     }
   }
 
-  async drain(): Promise<void> {
+  async drain(options?: { newActivity?: AgentActivity }): Promise<ReusableResources | undefined> {
     // Create drain_agent_activity as a ROOT span (new trace) to match Python behavior
-    return tracer.startActiveSpan(async (span) => this._drainImpl(span), {
+    return tracer.startActiveSpan(async (span) => this._drainImpl(span, options?.newActivity), {
       name: 'drain_agent_activity',
       context: ROOT_CONTEXT,
     });
   }
 
-  private async _drainImpl(span: Span): Promise<void> {
+  private async _drainImpl(
+    span: Span,
+    newActivity?: AgentActivity,
+  ): Promise<ReusableResources | undefined> {
     span.setAttribute(traceTypes.ATTR_AGENT_LABEL, this.agent.id);
 
     const unlock = await this.lock.lock();
     try {
-      if (this._schedulingPaused) return;
+      if (this._schedulingPaused) return undefined;
 
       this._onExitTask = this.createSpeechTask({
         taskFn: () =>
@@ -2907,6 +3071,12 @@ export class AgentActivity implements RecognitionHooks {
 
       await this._onExitTask.result;
       await this._pauseSchedulingTask([]);
+
+      // detach after speech tasks are done but before _closeSessionResources
+      if (newActivity) {
+        return await this._detachReusableResources(newActivity);
+      }
+      return undefined;
     } finally {
       unlock();
     }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -459,7 +459,9 @@ export class AgentActivity implements RecognitionHooks {
     const hasSttOld = !!this.stt;
     const hasSttNew = !!newActivity.stt;
     const sameSttInstance = this.stt === newActivity.stt;
-    const sameSttNode = Object.getPrototypeOf(this.agent).sttNode === Object.getPrototypeOf(newActivity.agent).sttNode;
+    const sameSttNode =
+      Object.getPrototypeOf(this.agent).sttNode ===
+      Object.getPrototypeOf(newActivity.agent).sttNode;
 
     if (!hasAudioRecognition || !hasSttOld || !hasSttNew) {
       return undefined;

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -488,6 +488,7 @@ export class AgentActivity implements RecognitionHooks {
         inlineTask: true,
         name: 'AgentActivity_onEnter',
       });
+      this.agentSession._trackRunHandle(this._onEnterTask);
     }
 
     startSpan.end();

--- a/agents/src/voice/agent_activity_handoff.test.ts
+++ b/agents/src/voice/agent_activity_handoff.test.ts
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { AudioFrame } from '@livekit/rtc-node';
+import { describe, expect, it, vi } from 'vitest';
+import { type SpeechEvent } from '../stt/stt.js';
+import { Agent } from './agent.js';
+import { AgentActivity } from './agent_activity.js';
+
+type FakeActivity = {
+  agent: Agent;
+  audioRecognition: { detachSttPipeline: ReturnType<typeof vi.fn> } | undefined;
+  stt: unknown;
+};
+
+function createFakeActivity(agent: Agent, stt: unknown) {
+  const detachedPipeline = { id: Symbol('pipeline') };
+  const activity = {
+    agent,
+    audioRecognition: {
+      detachSttPipeline: vi.fn(async () => detachedPipeline),
+    },
+    stt,
+  } as FakeActivity;
+
+  return { activity, detachedPipeline };
+}
+
+async function detachIfReusable(oldActivity: FakeActivity, newActivity: FakeActivity) {
+  return await (AgentActivity.prototype as any)._detachSttPipelineIfReusable.call(
+    oldActivity,
+    newActivity,
+  );
+}
+
+describe('AgentActivity STT handoff reuse eligibility', () => {
+  it('reuses the pipeline when both activities share the same STT instance and sttNode', async () => {
+    const sharedStt = { id: 'shared-stt' };
+    const oldActivity = createFakeActivity(new Agent({ instructions: 'a' }), sharedStt);
+    const newActivity = createFakeActivity(new Agent({ instructions: 'b' }), sharedStt);
+
+    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+
+    expect(result).toBe(oldActivity.detachedPipeline);
+    expect(oldActivity.activity.audioRecognition?.detachSttPipeline).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reuse when the STT instances differ', async () => {
+    const oldActivity = createFakeActivity(new Agent({ instructions: 'a' }), { id: 'stt-a' });
+    const newActivity = createFakeActivity(new Agent({ instructions: 'b' }), { id: 'stt-b' });
+
+    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+
+    expect(result).toBeUndefined();
+    expect(oldActivity.activity.audioRecognition?.detachSttPipeline).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse when either activity has no STT', async () => {
+    const sharedStt = { id: 'shared-stt' };
+    const oldActivity = createFakeActivity(new Agent({ instructions: 'a' }), undefined);
+    const newActivity = createFakeActivity(new Agent({ instructions: 'b' }), sharedStt);
+
+    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+
+    expect(result).toBeUndefined();
+    expect(oldActivity.activity.audioRecognition?.detachSttPipeline).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse when the agents override sttNode differently', async () => {
+    const sharedStt = { id: 'shared-stt' };
+
+    class AgentA extends Agent {
+      async sttNode(_audio: ReadableStream<AudioFrame>, _modelSettings: any) {
+        return null as ReadableStream<SpeechEvent | string> | null;
+      }
+    }
+
+    class AgentB extends Agent {
+      async sttNode(_audio: ReadableStream<AudioFrame>, _modelSettings: any) {
+        return null as ReadableStream<SpeechEvent | string> | null;
+      }
+    }
+
+    const oldActivity = createFakeActivity(new AgentA({ instructions: 'a' }), sharedStt);
+    const newActivity = createFakeActivity(new AgentB({ instructions: 'b' }), sharedStt);
+
+    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+
+    expect(result).toBeUndefined();
+    expect(oldActivity.activity.audioRecognition?.detachSttPipeline).not.toHaveBeenCalled();
+  });
+
+  it('reuses when the new agent inherits the same sttNode implementation', async () => {
+    const sharedStt = { id: 'shared-stt' };
+
+    class AgentA extends Agent {
+      async sttNode(_audio: ReadableStream<AudioFrame>, _modelSettings: any) {
+        return null as ReadableStream<SpeechEvent | string> | null;
+      }
+    }
+
+    class AgentB extends AgentA {}
+
+    const oldActivity = createFakeActivity(new AgentA({ instructions: 'a' }), sharedStt);
+    const newActivity = createFakeActivity(new AgentB({ instructions: 'b' }), sharedStt);
+
+    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+
+    expect(result).toBe(oldActivity.detachedPipeline);
+    expect(oldActivity.activity.audioRecognition?.detachSttPipeline).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reuse when the old activity has no audioRecognition', async () => {
+    const sharedStt = { id: 'shared-stt' };
+    const oldActivity = createFakeActivity(new Agent({ instructions: 'a' }), sharedStt);
+    const newActivity = createFakeActivity(new Agent({ instructions: 'b' }), sharedStt);
+    oldActivity.activity.audioRecognition = undefined;
+
+    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/agents/src/voice/agent_activity_handoff.test.ts
+++ b/agents/src/voice/agent_activity_handoff.test.ts
@@ -3,14 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AudioFrame } from '@livekit/rtc-node';
 import { describe, expect, it, vi } from 'vitest';
-import { type SpeechEvent } from '../stt/stt.js';
+import { ChatContext } from '../llm/chat_context.js';
+import { type RealtimeCapabilities, RealtimeModel, type RealtimeSession } from '../llm/realtime.js';
+import type { SpeechEvent } from '../stt/stt.js';
 import { Agent } from './agent.js';
-import { AgentActivity } from './agent_activity.js';
+import {
+  AgentActivity,
+  type ReusableResources,
+  cleanupReusableResources,
+} from './agent_activity.js';
 
 type FakeActivity = {
   agent: Agent;
   audioRecognition: { detachSttPipeline: ReturnType<typeof vi.fn> } | undefined;
   stt: unknown;
+  llm: unknown;
+  tools: unknown;
+  realtimeSession: unknown;
 };
 
 function createFakeActivity(agent: Agent, stt: unknown) {
@@ -21,13 +30,19 @@ function createFakeActivity(agent: Agent, stt: unknown) {
       detachSttPipeline: vi.fn(async () => detachedPipeline),
     },
     stt,
+    llm: undefined,
+    tools: [],
+    realtimeSession: undefined,
   } as FakeActivity;
 
   return { activity, detachedPipeline };
 }
 
-async function detachIfReusable(oldActivity: FakeActivity, newActivity: FakeActivity) {
-  return await (AgentActivity.prototype as any)._detachSttPipelineIfReusable.call(
+async function detachResources(
+  oldActivity: FakeActivity,
+  newActivity: FakeActivity,
+): Promise<ReusableResources> {
+  return await (AgentActivity.prototype as any)._detachReusableResources.call(
     oldActivity,
     newActivity,
   );
@@ -39,9 +54,9 @@ describe('AgentActivity STT handoff reuse eligibility', () => {
     const oldActivity = createFakeActivity(new Agent({ instructions: 'a' }), sharedStt);
     const newActivity = createFakeActivity(new Agent({ instructions: 'b' }), sharedStt);
 
-    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+    const resources = await detachResources(oldActivity.activity, newActivity.activity);
 
-    expect(result).toBe(oldActivity.detachedPipeline);
+    expect(resources.sttPipeline).toBe(oldActivity.detachedPipeline);
     expect(oldActivity.activity.audioRecognition?.detachSttPipeline).toHaveBeenCalledTimes(1);
   });
 
@@ -49,9 +64,9 @@ describe('AgentActivity STT handoff reuse eligibility', () => {
     const oldActivity = createFakeActivity(new Agent({ instructions: 'a' }), { id: 'stt-a' });
     const newActivity = createFakeActivity(new Agent({ instructions: 'b' }), { id: 'stt-b' });
 
-    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+    const resources = await detachResources(oldActivity.activity, newActivity.activity);
 
-    expect(result).toBeUndefined();
+    expect(resources.sttPipeline).toBeUndefined();
     expect(oldActivity.activity.audioRecognition?.detachSttPipeline).not.toHaveBeenCalled();
   });
 
@@ -60,9 +75,9 @@ describe('AgentActivity STT handoff reuse eligibility', () => {
     const oldActivity = createFakeActivity(new Agent({ instructions: 'a' }), undefined);
     const newActivity = createFakeActivity(new Agent({ instructions: 'b' }), sharedStt);
 
-    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+    const resources = await detachResources(oldActivity.activity, newActivity.activity);
 
-    expect(result).toBeUndefined();
+    expect(resources.sttPipeline).toBeUndefined();
     expect(oldActivity.activity.audioRecognition?.detachSttPipeline).not.toHaveBeenCalled();
   });
 
@@ -84,9 +99,9 @@ describe('AgentActivity STT handoff reuse eligibility', () => {
     const oldActivity = createFakeActivity(new AgentA({ instructions: 'a' }), sharedStt);
     const newActivity = createFakeActivity(new AgentB({ instructions: 'b' }), sharedStt);
 
-    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+    const resources = await detachResources(oldActivity.activity, newActivity.activity);
 
-    expect(result).toBeUndefined();
+    expect(resources.sttPipeline).toBeUndefined();
     expect(oldActivity.activity.audioRecognition?.detachSttPipeline).not.toHaveBeenCalled();
   });
 
@@ -104,9 +119,9 @@ describe('AgentActivity STT handoff reuse eligibility', () => {
     const oldActivity = createFakeActivity(new AgentA({ instructions: 'a' }), sharedStt);
     const newActivity = createFakeActivity(new AgentB({ instructions: 'b' }), sharedStt);
 
-    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+    const resources = await detachResources(oldActivity.activity, newActivity.activity);
 
-    expect(result).toBe(oldActivity.detachedPipeline);
+    expect(resources.sttPipeline).toBe(oldActivity.detachedPipeline);
     expect(oldActivity.activity.audioRecognition?.detachSttPipeline).toHaveBeenCalledTimes(1);
   });
 
@@ -116,8 +131,208 @@ describe('AgentActivity STT handoff reuse eligibility', () => {
     const newActivity = createFakeActivity(new Agent({ instructions: 'b' }), sharedStt);
     oldActivity.activity.audioRecognition = undefined;
 
-    const result = await detachIfReusable(oldActivity.activity, newActivity.activity);
+    const resources = await detachResources(oldActivity.activity, newActivity.activity);
 
-    expect(result).toBeUndefined();
+    expect(resources.sttPipeline).toBeUndefined();
+  });
+});
+
+describe('AgentActivity RT session reuse eligibility', () => {
+  function createFakeRtSession(): RealtimeSession {
+    return {
+      chatCtx: ChatContext.empty(),
+      off: vi.fn(),
+      on: vi.fn(),
+      interrupt: vi.fn(),
+      clearAudio: vi.fn(),
+      close: vi.fn(async () => {}),
+    } as unknown as RealtimeSession;
+  }
+
+  class FakeRealtimeModel extends RealtimeModel {
+    get model() {
+      return 'fake';
+    }
+    session(): RealtimeSession {
+      throw new Error('not implemented');
+    }
+    async close() {}
+  }
+
+  function createFakeRealtimeModel(capabilitiesOverrides: Partial<RealtimeCapabilities> = {}) {
+    const capabilities: RealtimeCapabilities = {
+      messageTruncation: false,
+      turnDetection: false,
+      userTranscription: false,
+      autoToolReplyGeneration: false,
+      audioOutput: true,
+      manualFunctionCalls: false,
+      midSessionContextUpdate: false,
+      midSessionInstructionsUpdate: false,
+      midSessionToolsUpdate: false,
+      ...capabilitiesOverrides,
+    };
+    return new FakeRealtimeModel(capabilities);
+  }
+
+  function createRtActivity(agent: Agent, llm: unknown, rtSession?: RealtimeSession): FakeActivity {
+    return {
+      agent,
+      audioRecognition: undefined,
+      stt: undefined,
+      llm,
+      tools: agent.toolCtx,
+      realtimeSession: rtSession,
+    };
+  }
+
+  it('reuses RT session when same LLM, same instructions, equivalent context, and same tools', async () => {
+    const sharedLlm = createFakeRealtimeModel();
+    const rtSession = createFakeRtSession();
+
+    const oldAgent = new Agent({ instructions: 'hello' });
+    const newAgent = new Agent({ instructions: 'hello' });
+    const oldActivity = createRtActivity(oldAgent, sharedLlm, rtSession);
+    const newActivity = createRtActivity(newAgent, sharedLlm);
+
+    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
+      oldActivity,
+      newActivity,
+    );
+
+    expect(resources.rtSession).toBe(rtSession);
+    expect(oldActivity.realtimeSession).toBeUndefined();
+    expect(rtSession.off).toHaveBeenCalled();
+  });
+
+  it('does not reuse RT session when LLM instances differ', async () => {
+    const rtSession = createFakeRtSession();
+
+    const oldLlm = createFakeRealtimeModel();
+    const newLlm = createFakeRealtimeModel();
+    const oldActivity = createRtActivity(new Agent({ instructions: 'a' }), oldLlm, rtSession);
+    const newActivity = createRtActivity(new Agent({ instructions: 'a' }), newLlm);
+
+    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
+      oldActivity,
+      newActivity,
+    );
+
+    expect(resources.rtSession).toBeUndefined();
+  });
+
+  it('does not reuse RT session when instructions differ and midSessionInstructionsUpdate is false', async () => {
+    const sharedLlm = createFakeRealtimeModel({ midSessionInstructionsUpdate: false });
+    const rtSession = createFakeRtSession();
+
+    const oldActivity = createRtActivity(new Agent({ instructions: 'old' }), sharedLlm, rtSession);
+    const newActivity = createRtActivity(new Agent({ instructions: 'new' }), sharedLlm);
+
+    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
+      oldActivity,
+      newActivity,
+    );
+
+    expect(resources.rtSession).toBeUndefined();
+  });
+
+  it('reuses RT session when instructions differ but midSessionInstructionsUpdate is true', async () => {
+    const sharedLlm = createFakeRealtimeModel({ midSessionInstructionsUpdate: true });
+    const rtSession = createFakeRtSession();
+
+    const oldActivity = createRtActivity(new Agent({ instructions: 'old' }), sharedLlm, rtSession);
+    const newActivity = createRtActivity(new Agent({ instructions: 'new' }), sharedLlm);
+
+    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
+      oldActivity,
+      newActivity,
+    );
+
+    expect(resources.rtSession).toBe(rtSession);
+  });
+
+  it('reuses RT session when context differs but midSessionContextUpdate is true', async () => {
+    const sharedLlm = createFakeRealtimeModel({ midSessionContextUpdate: true });
+    const rtSession = createFakeRtSession();
+    // Give the session a non-empty chat context
+    (rtSession as any).chatCtx = ChatContext.empty();
+
+    const oldActivity = createRtActivity(new Agent({ instructions: 'same' }), sharedLlm, rtSession);
+    const newActivity = createRtActivity(new Agent({ instructions: 'same' }), sharedLlm);
+
+    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
+      oldActivity,
+      newActivity,
+    );
+
+    expect(resources.rtSession).toBe(rtSession);
+  });
+
+  it('does not reuse when no RT session exists', async () => {
+    const sharedLlm = createFakeRealtimeModel();
+    const oldActivity = createRtActivity(new Agent({ instructions: 'a' }), sharedLlm, undefined);
+    const newActivity = createRtActivity(new Agent({ instructions: 'a' }), sharedLlm);
+
+    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
+      oldActivity,
+      newActivity,
+    );
+
+    expect(resources.rtSession).toBeUndefined();
+  });
+
+  it('does not reuse when LLM is not a RealtimeModel', async () => {
+    const rtSession = createFakeRtSession();
+    const nonRealtimeLlm = { id: 'plain-llm' };
+
+    const oldActivity = createRtActivity(
+      new Agent({ instructions: 'a' }),
+      nonRealtimeLlm,
+      rtSession,
+    );
+    const newActivity = createRtActivity(new Agent({ instructions: 'a' }), nonRealtimeLlm);
+
+    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
+      oldActivity,
+      newActivity,
+    );
+
+    expect(resources.rtSession).toBeUndefined();
+  });
+});
+
+describe('cleanupReusableResources', () => {
+  it('closes both STT pipeline and RT session', async () => {
+    const sttClose = vi.fn(async () => {});
+    const rtClose = vi.fn(async () => {});
+    const resources: ReusableResources = {
+      sttPipeline: { close: sttClose } as any,
+      rtSession: { close: rtClose } as any,
+    };
+
+    await cleanupReusableResources(resources);
+
+    expect(sttClose).toHaveBeenCalledTimes(1);
+    expect(rtClose).toHaveBeenCalledTimes(1);
+    expect(resources.sttPipeline).toBeUndefined();
+    expect(resources.rtSession).toBeUndefined();
+  });
+
+  it('handles partial resources (only STT)', async () => {
+    const sttClose = vi.fn(async () => {});
+    const resources: ReusableResources = {
+      sttPipeline: { close: sttClose } as any,
+    };
+
+    await cleanupReusableResources(resources);
+
+    expect(sttClose).toHaveBeenCalledTimes(1);
+    expect(resources.sttPipeline).toBeUndefined();
+  });
+
+  it('handles empty resources', async () => {
+    const resources: ReusableResources = {};
+    await cleanupReusableResources(resources);
+    // should not throw
   });
 });

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -36,7 +36,7 @@ import {
   type ResolvedSessionConnectOptions,
   type SessionConnectOptions,
 } from '../types.js';
-import { Task } from '../utils.js';
+import { Event, Task } from '../utils.js';
 import type { VAD } from '../vad.js';
 import type { Agent } from './agent.js';
 import {
@@ -274,6 +274,11 @@ export class AgentSession<
 
   /** @internal */
   _userSpeakingSpan?: Span;
+
+  /** @internal - true while run() setup is in flight */
+  _runStartInFlight = false;
+
+  private _activityChanged = new Event();
 
   private logger = log();
 
@@ -706,6 +711,60 @@ export class AgentSession<
   }
 
   /**
+   * @internal
+   * Wait for all in-flight activity transitions to complete.
+   *
+   * _updateActivity holds the activityLock for its critical section, then
+   * releases it before awaiting onEnter.  If onEnter triggers a nested
+   * _updateActivity (e.g. Agent → TaskGroup → AgentTask),
+   * each nested call queues behind the lock in FIFO order.
+   *
+   * A single lock acquire only waits for the *next* holder — not the full
+   * chain.  So we loop: snapshot the current agent, acquire+release the lock
+   * (which blocks until the next queued _updateActivity finishes its critical
+   * section), then check whether the agent changed.  If it did, another
+   * transition ran, so we loop again.  When two consecutive iterations see
+   * the same agent, the chain has settled.
+   */
+  async _drainActivityLock(): Promise<void> {
+    let prevActivity: AgentActivity | undefined;
+    do {
+      prevActivity = this.activity;
+      (await this.activityLock.lock())();
+    } while (this.activity !== prevActivity);
+  }
+
+  /** @internal */
+  _trackRunHandle(handle: SpeechHandle | Task<void>): void {
+    if (this._globalRunState && !this._globalRunState.done()) {
+      this._globalRunState._watchHandle(handle);
+    }
+  }
+
+  /**
+   * Wait for the current activity to be ready to accept input.
+   *
+   * After _drainActivityLock, the final activity is normally already started
+   * with schedulingPaused=false. This loop handles edge cases where a
+   * transition is still settling.
+   */
+  private async waitForRunReadyActivity(): Promise<void> {
+    while (this.activity?.schedulingPaused) {
+      if (this.closing) {
+        throw new Error('AgentSession is closing, cannot use generateReply()');
+      }
+
+      this._activityChanged.clear();
+      if (!this.activity?.schedulingPaused) break;
+      await this._activityChanged.wait();
+    }
+
+    if (!this.activity || this.closing) {
+      throw new Error('AgentSession is closing, cannot use generateReply()');
+    }
+  }
+
+  /**
    * Run a test with user input and return a result for assertions.
    *
    * This method is primarily used for testing agent behavior without
@@ -728,29 +787,29 @@ export class AgentSession<
     userInput: string;
     outputType?: z.ZodType<T>;
   }): RunResult<T> {
-    if (this._globalRunState && !this._globalRunState.done()) {
+    if (this._runStartInFlight || (this._globalRunState && !this._globalRunState.done())) {
       throw new Error('nested runs are not supported');
     }
 
-    const runState = new RunResult<T>({
-      userInput,
-      outputType,
-    });
+    this._runStartInFlight = true;
 
-    this._globalRunState = runState;
-
-    // Defer generateReply through the activityLock to ensure any in-progress
-    // activity transition (e.g. AgentTask started from onEnter) completes first.
-    // TS Task.from starts onEnter synchronously, so the transition may already be
-    // mid-flight by the time run() is called after session.start() resolves.
-    // Acquiring and immediately releasing the lock guarantees FIFO ordering:
-    // the transition's lock section finishes before we route generateReply.
     (async () => {
       try {
-        const unlock = await this.activityLock.lock();
-        unlock();
+        // Drain the activity lock until no more transitions are queued.
+        // Each nested _updateActivity from the bootstrap chain (e.g.
+        // Agent → TaskGroup → AgentTask) acquires and
+        // releases the lock in FIFO order. We keep re-acquiring until the
+        // activity stabilizes (no change between two consecutive acquisitions).
+        await this._drainActivityLock();
+        await this.waitForRunReadyActivity();
+
+        this._globalRunState = runState;
+        this._runStartInFlight = false;
+
+        runState._setMinCreatedAt(Date.now());
         this.generateReply({ userInput });
       } catch (e) {
+        this._runStartInFlight = false;
         runState._reject(e instanceof Error ? e : new Error(String(e)));
       }
     })();
@@ -845,6 +904,10 @@ export class AgentSession<
         } else {
           await this.activity!.resume({ reuseResources: reusableResources });
         }
+
+        // Set event AFTER start/resume so waiters see schedulingPaused=false.
+        this._activityChanged.set();
+
         reusableResources = undefined;
 
         onEnterTask = this.activity!._onEnterTask;

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -39,8 +39,12 @@ import {
 import { Task } from '../utils.js';
 import type { VAD } from '../vad.js';
 import type { Agent } from './agent.js';
-import { AgentActivity } from './agent_activity.js';
-import type { STTPipeline, _TurnDetector } from './audio_recognition.js';
+import {
+  AgentActivity,
+  type ReusableResources,
+  cleanupReusableResources,
+} from './agent_activity.js';
+import type { _TurnDetector } from './audio_recognition.js';
 import {
   type AgentEvent,
   AgentSessionEventTypes,
@@ -762,7 +766,7 @@ export class AgentSession<
     const runWithContext = async () => {
       const unlock = await this.activityLock.lock();
       let onEnterTask: Task<void> | undefined;
-      let reusedSttPipeline: STTPipeline | undefined;
+      let reusableResources: ReusableResources | undefined;
 
       try {
         this.agent = agent;
@@ -785,15 +789,16 @@ export class AgentSession<
           this.nextActivity = agent._agentActivity;
         }
 
-        if (prevActivityObj && this.nextActivity && prevActivityObj !== this.nextActivity) {
-          reusedSttPipeline = await prevActivityObj._detachSttPipelineIfReusable(this.nextActivity);
-        }
-
         if (prevActivityObj && prevActivityObj !== this.nextActivity) {
           if (previousActivity === 'pause') {
-            await prevActivityObj.pause({ blockedTasks });
+            reusableResources = await prevActivityObj.pause({
+              blockedTasks,
+              newActivity: this.nextActivity,
+            });
           } else {
-            await prevActivityObj.drain();
+            reusableResources = await prevActivityObj.drain({
+              newActivity: this.nextActivity,
+            });
             await prevActivityObj.close();
           }
         }
@@ -803,8 +808,10 @@ export class AgentSession<
             { agentId: this.nextActivity?.agent.id },
             'Session is closing, skipping start of next activity',
           );
-          await reusedSttPipeline?.close();
-          reusedSttPipeline = undefined;
+          if (reusableResources) {
+            await cleanupReusableResources(reusableResources);
+            reusableResources = undefined;
+          }
           this.nextActivity = undefined;
           this.activity = undefined;
           return;
@@ -834,11 +841,11 @@ export class AgentSession<
         );
 
         if (newActivity === 'start') {
-          await this.activity!.start({ reuseSttPipeline: reusedSttPipeline });
+          await this.activity!.start({ reuseResources: reusableResources });
         } else {
-          await this.activity!.resume({ reuseSttPipeline: reusedSttPipeline });
+          await this.activity!.resume({ reuseResources: reusableResources });
         }
-        reusedSttPipeline = undefined;
+        reusableResources = undefined;
 
         onEnterTask = this.activity!._onEnterTask;
 
@@ -846,9 +853,11 @@ export class AgentSession<
           this.activity!.attachAudioInput(this._input.audio.stream);
         }
       } catch (error) {
-        // JS safeguard: session cleanup owns the detached pipeline until the next activity
+        // JS safeguard: session cleanup owns the detached resources until the next activity
         // starts successfully, preventing leaks when handoff fails mid-transition.
-        await reusedSttPipeline?.close();
+        if (reusableResources) {
+          await cleanupReusableResources(reusableResources);
+        }
         throw error;
       } finally {
         unlock();

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -734,6 +734,11 @@ export class AgentSession<
     } while (this.activity !== prevActivity);
   }
 
+  private _notifyActivityChanged(): void {
+    this._activityChanged.set();
+  }
+
+
   /** @internal */
   _trackRunHandle(handle: SpeechHandle | Task<void>): void {
     if (this._globalRunState && !this._globalRunState.done()) {
@@ -790,6 +795,11 @@ export class AgentSession<
     if (this._runStartInFlight || (this._globalRunState && !this._globalRunState.done())) {
       throw new Error('nested runs are not supported');
     }
+
+    const runState = new RunResult<T>({
+      userInput,
+      outputType,
+    });
 
     this._runStartInFlight = true;
 
@@ -905,8 +915,45 @@ export class AgentSession<
           await this.activity!.resume({ reuseResources: reusableResources });
         }
 
-        // Set event AFTER start/resume so waiters see schedulingPaused=false.
-        this._activityChanged.set();
+        // Notify AFTER start/resume so waiters see schedulingPaused=false.
+        this._notifyActivityChanged();
+
+        // If a RunResult is active and the activity's onEnter is still running
+        // (e.g. a resumed TaskGroup whose loop will start the next child task),
+        // track a handle that waits for the next activity change. Registered
+        // AFTER notify so it waits for the subsequent transition, not this one.
+        // For resumed activities whose onEnter is still running (e.g. a
+        // TaskGroup loop advancing to the next child), track a handle that
+        // waits for the child transition. Only for 'resume' — freshly started
+        // activities haven't triggered cascading transitions yet.
+        // For resumed activities whose onEnter is still running (e.g. a
+        // TaskGroup loop advancing to the next child), track a handle that
+        // waits for the child transition. Only for 'resume' — freshly started
+        // activities haven't triggered cascading transitions yet.
+        if (
+          newActivity === 'resume' &&
+          this._globalRunState &&
+          !this._globalRunState.done() &&
+          this.activity?._onEnterTask &&
+          !this.activity._onEnterTask.done
+        ) {
+          this._activityChanged.clear();
+          const onEnterDone = this.activity._onEnterTask.result.then(
+            () => {},
+            () => {},
+          );
+          const settleTask = Task.from(
+            async () => {
+              // Race: either the next transition fires, or onEnter finishes
+              // without triggering one (e.g. last task in the group).
+              await Promise.race([this._activityChanged.wait(), onEnterDone]);
+              await this._drainActivityLock();
+            },
+            undefined,
+            'activity_settleWait',
+          );
+          this._trackRunHandle(settleTask);
+        }
 
         reusableResources = undefined;
 

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -738,7 +738,6 @@ export class AgentSession<
     this._activityChanged.set();
   }
 
-
   /** @internal */
   _trackRunHandle(handle: SpeechHandle | Task<void>): void {
     if (this._globalRunState && !this._globalRunState.done()) {
@@ -918,18 +917,12 @@ export class AgentSession<
         // Notify AFTER start/resume so waiters see schedulingPaused=false.
         this._notifyActivityChanged();
 
-        // If a RunResult is active and the activity's onEnter is still running
-        // (e.g. a resumed TaskGroup whose loop will start the next child task),
-        // track a handle that waits for the next activity change. Registered
-        // AFTER notify so it waits for the subsequent transition, not this one.
         // For resumed activities whose onEnter is still running (e.g. a
         // TaskGroup loop advancing to the next child), track a handle that
-        // waits for the child transition. Only for 'resume' — freshly started
-        // activities haven't triggered cascading transitions yet.
-        // For resumed activities whose onEnter is still running (e.g. a
-        // TaskGroup loop advancing to the next child), track a handle that
-        // waits for the child transition. Only for 'resume' — freshly started
-        // activities haven't triggered cascading transitions yet.
+        // waits for the child transition then drains the cascade. Only for
+        // 'resume' — freshly started activities haven't triggered cascading
+        // transitions yet. Registered AFTER notify so it waits for the
+        // subsequent transition, not this one.
         if (
           newActivity === 'resume' &&
           this._globalRunState &&

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -40,7 +40,7 @@ import { Task } from '../utils.js';
 import type { VAD } from '../vad.js';
 import type { Agent } from './agent.js';
 import { AgentActivity } from './agent_activity.js';
-import type { _TurnDetector } from './audio_recognition.js';
+import type { STTPipeline, _TurnDetector } from './audio_recognition.js';
 import {
   type AgentEvent,
   AgentSessionEventTypes,
@@ -223,6 +223,7 @@ export class AgentSession<
   private _input: AgentInput;
   private _output: AgentOutput;
 
+  private closing = false;
   private closingTask: Promise<void> | null = null;
   private userAwayTimer: NodeJS.Timeout | null = null;
 
@@ -515,6 +516,7 @@ export class AgentSession<
       return;
     }
 
+    this.closing = false;
     this._usageCollector = new ModelUsageCollector();
 
     let ctx: JobContext | undefined = undefined;
@@ -760,6 +762,7 @@ export class AgentSession<
     const runWithContext = async () => {
       const unlock = await this.activityLock.lock();
       let onEnterTask: Task<void> | undefined;
+      let reusedSttPipeline: STTPipeline | undefined;
 
       try {
         this.agent = agent;
@@ -782,6 +785,10 @@ export class AgentSession<
           this.nextActivity = agent._agentActivity;
         }
 
+        if (prevActivityObj && this.nextActivity && prevActivityObj !== this.nextActivity) {
+          reusedSttPipeline = await prevActivityObj._detachSttPipelineIfReusable(this.nextActivity);
+        }
+
         if (prevActivityObj && prevActivityObj !== this.nextActivity) {
           if (previousActivity === 'pause') {
             await prevActivityObj.pause({ blockedTasks });
@@ -789,6 +796,18 @@ export class AgentSession<
             await prevActivityObj.drain();
             await prevActivityObj.close();
           }
+        }
+
+        if (this.closing && newActivity === 'start') {
+          this.logger.warn(
+            { agentId: this.nextActivity?.agent.id },
+            'Session is closing, skipping start of next activity',
+          );
+          await reusedSttPipeline?.close();
+          reusedSttPipeline = undefined;
+          this.nextActivity = undefined;
+          this.activity = undefined;
+          return;
         }
 
         this.activity = this.nextActivity;
@@ -815,16 +834,22 @@ export class AgentSession<
         );
 
         if (newActivity === 'start') {
-          await this.activity!.start();
+          await this.activity!.start({ reuseSttPipeline: reusedSttPipeline });
         } else {
-          await this.activity!.resume();
+          await this.activity!.resume({ reuseSttPipeline: reusedSttPipeline });
         }
+        reusedSttPipeline = undefined;
 
         onEnterTask = this.activity!._onEnterTask;
 
         if (this._input.audio) {
           this.activity!.attachAudioInput(this._input.audio.stream);
         }
+      } catch (error) {
+        // JS safeguard: session cleanup owns the detached pipeline until the next activity
+        // starts successfully, preventing leaks when handoff fails mid-transition.
+        await reusedSttPipeline?.close();
+        throw error;
       } finally {
         unlock();
       }
@@ -1130,6 +1155,7 @@ export class AgentSession<
       return;
     }
 
+    this.closing = true;
     this._cancelUserAwayTimer();
     this._onAecWarmupExpired();
     this.off(AgentSessionEventTypes.UserInputTranscribed, this._onUserInputTranscribed);

--- a/agents/src/voice/agent_session_handoff.test.ts
+++ b/agents/src/voice/agent_session_handoff.test.ts
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { Agent } from './agent.js';
+import { AgentActivity } from './agent_activity.js';
+import { AgentSession } from './agent_session.js';
+
+function createFakeLock() {
+  return {
+    lock: vi.fn(async () => () => {}),
+  };
+}
+
+function createFakeSession() {
+  return {
+    activityLock: createFakeLock(),
+    rootSpanContext: undefined,
+    agent: undefined,
+    activity: undefined,
+    nextActivity: undefined,
+    _globalRunState: undefined,
+    _chatCtx: ChatContext.empty(),
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+    },
+    sessionOptions: {
+      turnHandling: {
+        interruption: {
+          enabled: true,
+          minDuration: 0,
+          minWords: 0,
+        },
+        endpointing: {
+          minDelay: 0,
+          maxDelay: 0,
+        },
+      },
+    },
+    interruptionDetection: undefined,
+    turnDetection: undefined,
+    vad: undefined,
+    stt: undefined,
+    llm: undefined,
+    tts: undefined,
+    useTtsAlignedTranscript: false,
+    _input: {},
+  } as unknown as AgentSession;
+}
+
+describe('AgentSession STT pipeline handoff', () => {
+  it('passes a detached STT pipeline into the next resumed activity', async () => {
+    const pipeline = {
+      close: vi.fn(async () => {}),
+    };
+    const previousAgent = new Agent({ instructions: 'old' });
+    const nextAgent = new Agent({ instructions: 'new' });
+    const previousActivity = {
+      agent: previousAgent,
+      _detachSttPipelineIfReusable: vi.fn(async () => pipeline),
+      drain: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      pause: vi.fn(async () => {}),
+    };
+    const nextActivity = {
+      agent: nextAgent,
+      resume: vi.fn(async () => {}),
+      start: vi.fn(async () => {}),
+      attachAudioInput: vi.fn(),
+      _onEnterTask: undefined,
+    };
+    nextAgent._agentActivity = nextActivity as any;
+
+    const session = createFakeSession();
+    (session as any).activity = previousActivity as any;
+
+    await AgentSession.prototype._updateActivity.call(session, nextAgent, {
+      newActivity: 'resume',
+      waitOnEnter: false,
+    });
+
+    expect(previousActivity._detachSttPipelineIfReusable).toHaveBeenCalledWith(nextActivity);
+    expect(nextActivity.resume).toHaveBeenCalledWith({ reuseSttPipeline: pipeline });
+    expect(pipeline.close).not.toHaveBeenCalled();
+  });
+
+  it('closes the detached pipeline if the next activity fails to start', async () => {
+    const pipeline = {
+      close: vi.fn(async () => {}),
+    };
+    const previousAgent = new Agent({ instructions: 'old' });
+    const nextAgent = new Agent({ instructions: 'new' });
+    const previousActivity = {
+      agent: previousAgent,
+      _detachSttPipelineIfReusable: vi.fn(async () => pipeline),
+      drain: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      pause: vi.fn(async () => {}),
+    };
+    const nextActivity = {
+      agent: nextAgent,
+      resume: vi.fn(async () => {
+        throw new Error('resume failed');
+      }),
+      start: vi.fn(async () => {}),
+      attachAudioInput: vi.fn(),
+      _onEnterTask: undefined,
+    };
+    nextAgent._agentActivity = nextActivity as any;
+
+    const session = createFakeSession();
+    (session as any).activity = previousActivity as any;
+
+    await expect(
+      AgentSession.prototype._updateActivity.call(session, nextAgent, {
+        newActivity: 'resume',
+        waitOnEnter: false,
+      }),
+    ).rejects.toThrow('resume failed');
+
+    expect(pipeline.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close the adopted pipeline after the next activity starts successfully', async () => {
+    const pipeline = {
+      close: vi.fn(async () => {}),
+    };
+    const previousAgent = new Agent({ instructions: 'old' });
+    const nextAgent = new Agent({ instructions: 'new' });
+    const previousActivity = {
+      agent: previousAgent,
+      _detachSttPipelineIfReusable: vi.fn(async () => pipeline),
+      drain: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      pause: vi.fn(async () => {}),
+    };
+    const nextActivity = {
+      agent: nextAgent,
+      resume: vi.fn(async () => {}),
+      start: vi.fn(async () => {}),
+      attachAudioInput: vi.fn(() => {
+        throw new Error('attach failed');
+      }),
+      _onEnterTask: undefined,
+    };
+    nextAgent._agentActivity = nextActivity as any;
+
+    const session = createFakeSession();
+    (session as any).activity = previousActivity as any;
+    (session as any)._input = { audio: { stream: {} } } as any;
+
+    await expect(
+      AgentSession.prototype._updateActivity.call(session, nextAgent, {
+        newActivity: 'resume',
+        waitOnEnter: false,
+      }),
+    ).rejects.toThrow('attach failed');
+
+    expect(nextActivity.resume).toHaveBeenCalledWith({ reuseSttPipeline: pipeline });
+    expect(pipeline.close).not.toHaveBeenCalled();
+  });
+
+  it('skips STT detach when the same activity object is reused', async () => {
+    const agent = new Agent({ instructions: 'same' });
+    const activity = {
+      agent,
+      _detachSttPipelineIfReusable: vi.fn(async () => undefined),
+      drain: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      pause: vi.fn(async () => {}),
+      resume: vi.fn(async () => {}),
+      start: vi.fn(async () => {}),
+      attachAudioInput: vi.fn(),
+      _onEnterTask: undefined,
+    };
+    agent._agentActivity = activity as any;
+
+    const session = createFakeSession();
+    (session as any).activity = activity as any;
+
+    await AgentSession.prototype._updateActivity.call(session, agent, {
+      newActivity: 'resume',
+      waitOnEnter: false,
+    });
+
+    expect(activity._detachSttPipelineIfReusable).not.toHaveBeenCalled();
+    expect(activity.resume).toHaveBeenCalledWith({ reuseSttPipeline: undefined });
+  });
+
+  it('skips starting a new activity while the session is closing and closes the detached pipeline', async () => {
+    const pipeline = {
+      close: vi.fn(async () => {}),
+    };
+    const previousAgent = new Agent({ instructions: 'old' });
+    const nextAgent = new Agent({ instructions: 'new' });
+    const previousActivity = {
+      agent: previousAgent,
+      _detachSttPipelineIfReusable: vi.fn(async () => pipeline),
+      drain: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      pause: vi.fn(async () => {}),
+    };
+
+    const startSpy = vi.spyOn(AgentActivity.prototype, 'start').mockResolvedValue(undefined);
+
+    try {
+      const session = createFakeSession();
+      (session as any).activity = previousActivity as any;
+      (session as any).closing = true;
+
+      await AgentSession.prototype._updateActivity.call(session, nextAgent, {
+        newActivity: 'start',
+        waitOnEnter: false,
+      });
+
+      expect(previousActivity._detachSttPipelineIfReusable).toHaveBeenCalledTimes(1);
+      expect(previousActivity.close).toHaveBeenCalledTimes(1);
+      expect(pipeline.close).toHaveBeenCalledTimes(1);
+      expect(startSpy).not.toHaveBeenCalled();
+      expect((session as any).activity).toBeUndefined();
+      expect((session as any).nextActivity).toBeUndefined();
+    } finally {
+      startSpy.mockRestore();
+    }
+  });
+});

--- a/agents/src/voice/agent_session_handoff.test.ts
+++ b/agents/src/voice/agent_session_handoff.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ChatContext } from '../llm/chat_context.js';
 import { Agent } from './agent.js';
-import { AgentActivity } from './agent_activity.js';
+import { AgentActivity, type ReusableResources } from './agent_activity.js';
 import { AgentSession } from './agent_session.js';
 
 function createFakeLock() {
@@ -50,19 +50,18 @@ function createFakeSession() {
   } as unknown as AgentSession;
 }
 
-describe('AgentSession STT pipeline handoff', () => {
-  it('passes a detached STT pipeline into the next resumed activity', async () => {
-    const pipeline = {
-      close: vi.fn(async () => {}),
+describe('AgentSession reusable resources handoff', () => {
+  it('passes reusable resources from drain into the next resumed activity', async () => {
+    const resources: ReusableResources = {
+      sttPipeline: { close: vi.fn(async () => {}) } as any,
     };
     const previousAgent = new Agent({ instructions: 'old' });
     const nextAgent = new Agent({ instructions: 'new' });
     const previousActivity = {
       agent: previousAgent,
-      _detachSttPipelineIfReusable: vi.fn(async () => pipeline),
-      drain: vi.fn(async () => {}),
+      drain: vi.fn(async () => resources),
       close: vi.fn(async () => {}),
-      pause: vi.fn(async () => {}),
+      pause: vi.fn(async () => resources),
     };
     const nextActivity = {
       agent: nextAgent,
@@ -81,23 +80,22 @@ describe('AgentSession STT pipeline handoff', () => {
       waitOnEnter: false,
     });
 
-    expect(previousActivity._detachSttPipelineIfReusable).toHaveBeenCalledWith(nextActivity);
-    expect(nextActivity.resume).toHaveBeenCalledWith({ reuseSttPipeline: pipeline });
-    expect(pipeline.close).not.toHaveBeenCalled();
+    expect(previousActivity.drain).toHaveBeenCalledWith({ newActivity: nextActivity });
+    expect(nextActivity.resume).toHaveBeenCalledWith({ reuseResources: resources });
   });
 
-  it('closes the detached pipeline if the next activity fails to start', async () => {
-    const pipeline = {
-      close: vi.fn(async () => {}),
+  it('cleans up reusable resources if the next activity fails to start', async () => {
+    const closeFn = vi.fn(async () => {});
+    const resources: ReusableResources = {
+      sttPipeline: { close: closeFn } as any,
     };
     const previousAgent = new Agent({ instructions: 'old' });
     const nextAgent = new Agent({ instructions: 'new' });
     const previousActivity = {
       agent: previousAgent,
-      _detachSttPipelineIfReusable: vi.fn(async () => pipeline),
-      drain: vi.fn(async () => {}),
+      drain: vi.fn(async () => resources),
       close: vi.fn(async () => {}),
-      pause: vi.fn(async () => {}),
+      pause: vi.fn(async () => resources),
     };
     const nextActivity = {
       agent: nextAgent,
@@ -120,21 +118,21 @@ describe('AgentSession STT pipeline handoff', () => {
       }),
     ).rejects.toThrow('resume failed');
 
-    expect(pipeline.close).toHaveBeenCalledTimes(1);
+    expect(closeFn).toHaveBeenCalledTimes(1);
   });
 
-  it('does not close the adopted pipeline after the next activity starts successfully', async () => {
-    const pipeline = {
-      close: vi.fn(async () => {}),
+  it('does not cleanup reusable resources after the next activity starts successfully', async () => {
+    const closeFn = vi.fn(async () => {});
+    const resources: ReusableResources = {
+      sttPipeline: { close: closeFn } as any,
     };
     const previousAgent = new Agent({ instructions: 'old' });
     const nextAgent = new Agent({ instructions: 'new' });
     const previousActivity = {
       agent: previousAgent,
-      _detachSttPipelineIfReusable: vi.fn(async () => pipeline),
-      drain: vi.fn(async () => {}),
+      drain: vi.fn(async () => resources),
       close: vi.fn(async () => {}),
-      pause: vi.fn(async () => {}),
+      pause: vi.fn(async () => resources),
     };
     const nextActivity = {
       agent: nextAgent,
@@ -158,18 +156,18 @@ describe('AgentSession STT pipeline handoff', () => {
       }),
     ).rejects.toThrow('attach failed');
 
-    expect(nextActivity.resume).toHaveBeenCalledWith({ reuseSttPipeline: pipeline });
-    expect(pipeline.close).not.toHaveBeenCalled();
+    expect(nextActivity.resume).toHaveBeenCalledWith({ reuseResources: resources });
+    // pipeline was already transferred, so cleanup should NOT have been called
+    expect(closeFn).not.toHaveBeenCalled();
   });
 
-  it('skips STT detach when the same activity object is reused', async () => {
+  it('skips detach when the same activity object is reused', async () => {
     const agent = new Agent({ instructions: 'same' });
     const activity = {
       agent,
-      _detachSttPipelineIfReusable: vi.fn(async () => undefined),
-      drain: vi.fn(async () => {}),
+      drain: vi.fn(async () => undefined),
       close: vi.fn(async () => {}),
-      pause: vi.fn(async () => {}),
+      pause: vi.fn(async () => undefined),
       resume: vi.fn(async () => {}),
       start: vi.fn(async () => {}),
       attachAudioInput: vi.fn(),
@@ -185,22 +183,23 @@ describe('AgentSession STT pipeline handoff', () => {
       waitOnEnter: false,
     });
 
-    expect(activity._detachSttPipelineIfReusable).not.toHaveBeenCalled();
-    expect(activity.resume).toHaveBeenCalledWith({ reuseSttPipeline: undefined });
+    expect(activity.drain).not.toHaveBeenCalled();
+    expect(activity.pause).not.toHaveBeenCalled();
+    expect(activity.resume).toHaveBeenCalledWith({ reuseResources: undefined });
   });
 
-  it('skips starting a new activity while the session is closing and closes the detached pipeline', async () => {
-    const pipeline = {
-      close: vi.fn(async () => {}),
+  it('skips starting a new activity while the session is closing and cleans up resources', async () => {
+    const closeFn = vi.fn(async () => {});
+    const resources: ReusableResources = {
+      sttPipeline: { close: closeFn } as any,
     };
     const previousAgent = new Agent({ instructions: 'old' });
     const nextAgent = new Agent({ instructions: 'new' });
     const previousActivity = {
       agent: previousAgent,
-      _detachSttPipelineIfReusable: vi.fn(async () => pipeline),
-      drain: vi.fn(async () => {}),
+      drain: vi.fn(async () => resources),
       close: vi.fn(async () => {}),
-      pause: vi.fn(async () => {}),
+      pause: vi.fn(async () => resources),
     };
 
     const startSpy = vi.spyOn(AgentActivity.prototype, 'start').mockResolvedValue(undefined);
@@ -215,9 +214,9 @@ describe('AgentSession STT pipeline handoff', () => {
         waitOnEnter: false,
       });
 
-      expect(previousActivity._detachSttPipelineIfReusable).toHaveBeenCalledTimes(1);
+      expect(previousActivity.drain).toHaveBeenCalledTimes(1);
       expect(previousActivity.close).toHaveBeenCalledTimes(1);
-      expect(pipeline.close).toHaveBeenCalledTimes(1);
+      expect(closeFn).toHaveBeenCalledTimes(1);
       expect(startSpy).not.toHaveBeenCalled();
       expect((session as any).activity).toBeUndefined();
       expect((session as any).nextActivity).toBeUndefined();

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -30,7 +30,7 @@ import { mergeReadableStreams } from '../stream/merge_readable_streams.js';
 import { type StreamChannel, createStreamChannel } from '../stream/stream_channel.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { traceTypes, tracer } from '../telemetry/index.js';
-import { Task, delay, waitForAbort } from '../utils.js';
+import { Task, cancelAndWait, delay, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
 import type { STTNode } from './io.js';
@@ -67,6 +67,68 @@ export interface RecognitionHooks {
   onPreemptiveGeneration: (info: PreemptiveGenerationInfo) => void;
 
   retrieveChatCtx: () => ChatContext;
+}
+
+export class STTPipeline {
+  static readonly PUMP_TASK_CANCEL_TIMEOUT = 5000;
+
+  private sttNode: STTNode;
+  private _audioChannel: StreamChannel<AudioFrame> = createStreamChannel();
+  private _eventChannel: StreamChannel<SpeechEvent> = createStreamChannel();
+
+  private _pumpTask = Task.from(({ signal }) => this.sttPump(signal));
+
+  constructor(sttNode: STTNode) {
+    this.sttNode = sttNode;
+    this._pumpTask.addDoneCallback(() => this._eventChannel.close());
+  }
+
+  get audioChannel() {
+    return this._audioChannel;
+  }
+
+  get eventChannel() {
+    return this._eventChannel;
+  }
+
+  private async sttPump(signal: AbortSignal): Promise<void> {
+    const node = await this.sttNode(this._audioChannel.stream(), {});
+
+    if (node === null) return;
+
+    const reader = node.getReader();
+    try {
+      const abortPromise = waitForAbort(signal);
+
+      while (true) {
+        const result = await Promise.race([reader.read(), abortPromise]);
+        if (!result) break;
+
+        const { done, value } = result;
+        if (done) break;
+
+        if (typeof value === 'string') {
+          throw new Error(`STT node must yield SpeechEvent, got: ${typeof value}`);
+        }
+
+        await this._eventChannel.write(value);
+      }
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch (error) {
+        if (isStreamReaderReleaseError(error)) {
+          // ignore reader release errors
+          return;
+        }
+        throw error;
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    await cancelAndWait([this._pumpTask], STTPipeline.PUMP_TASK_CANCEL_TIMEOUT);
+  }
 }
 
 export interface _TurnDetector {
@@ -154,7 +216,7 @@ export class AudioRecognition {
   private bounceEOUTask?: Task<void>;
   private commitUserTurnTask?: Task<void>;
   private vadTask?: Task<void>;
-  private sttTask?: Task<void>;
+  private sttConsumerTask?: Task<void>;
   private interruptionTask?: Task<void>;
 
   // interruption detection
@@ -227,14 +289,14 @@ export class AudioRecognition {
     this.turnDetectionMode = options.turnDetection;
   }
 
-  async start() {
+  async start(options?: { sttPipeline?: STTPipeline }) {
     this.vadTask = Task.from(({ signal }) => this.createVadTask(this.vad, signal));
     this.vadTask.result.catch((err) => {
       this.logger.error(`Error running VAD task: ${err}`);
     });
 
-    this.sttTask = Task.from(({ signal }) => this.createSttTask(this.stt, signal));
-    this.sttTask.result.catch((err) => {
+    this.sttConsumerTask = Task.from(({ signal }) => this.createSttTask(this.stt, signal));
+    this.sttConsumerTask.result.catch((err) => {
       this.logger.error(`Error running STT task: ${err}`);
     });
 
@@ -247,7 +309,7 @@ export class AudioRecognition {
   }
 
   async stop() {
-    await this.sttTask?.cancelAndWait();
+    await this.sttConsumerTask?.cancelAndWait();
     await this.vadTask?.cancelAndWait();
     await this.interruptionTask?.cancelAndWait();
   }
@@ -1151,9 +1213,9 @@ export class AudioRecognition {
     this.finalTranscriptConfidence = [];
     this.userTurnCommitted = false;
 
-    this.sttTask?.cancelAndWait().finally(() => {
-      this.sttTask = Task.from(({ signal }) => this.createSttTask(this.stt, signal));
-      this.sttTask.result.catch((err) => {
+    this.sttConsumerTask?.cancelAndWait().finally(() => {
+      this.sttConsumerTask = Task.from(({ signal }) => this.createSttTask(this.stt, signal));
+      this.sttConsumerTask.result.catch((err) => {
         this.logger.error(`Error running STT task: ${err}`);
       });
     });
@@ -1209,7 +1271,7 @@ export class AudioRecognition {
     this.detachInputAudioStream();
     this.silenceAudioWriter.releaseLock();
     await this.commitUserTurnTask?.cancelAndWait();
-    await this.sttTask?.cancelAndWait();
+    await this.sttConsumerTask?.cancelAndWait();
     await this.vadTask?.cancelAndWait();
     await this.bounceEOUTask?.cancelAndWait();
     await this.interruptionTask?.cancelAndWait();

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { Mutex } from '@livekit/mutex';
 import type { ParticipantKind } from '@livekit/rtc-node';
 import { AudioFrame } from '@livekit/rtc-node';
 import {
@@ -24,13 +25,13 @@ import {
 import type { LanguageCode } from '../language.js';
 import { type ChatContext } from '../llm/chat_context.js';
 import { log } from '../log.js';
-import { DeferredReadableStream, isStreamReaderReleaseError } from '../stream/deferred_stream.js';
+import { DeferredReadableStream } from '../stream/deferred_stream.js';
 import { IdentityTransform } from '../stream/identity_transform.js';
 import { mergeReadableStreams } from '../stream/merge_readable_streams.js';
 import { type StreamChannel, createStreamChannel } from '../stream/stream_channel.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { traceTypes, tracer } from '../telemetry/index.js';
-import { Task, cancelAndWait, delay, waitForAbort } from '../utils.js';
+import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
 import type { STTNode } from './io.js';
@@ -75,11 +76,11 @@ export class STTPipeline {
   private sttNode: STTNode;
   private _audioChannel: StreamChannel<AudioFrame> = createStreamChannel();
   private _eventChannel: StreamChannel<SpeechEvent> = createStreamChannel();
-
-  private _pumpTask = Task.from(({ signal }) => this.sttPump(signal));
+  private _pumpTask: Task<void>;
 
   constructor(sttNode: STTNode) {
     this.sttNode = sttNode;
+    this._pumpTask = Task.from(({ signal }) => this.sttPump(signal));
     this._pumpTask.addDoneCallback(() => this._eventChannel.close());
   }
 
@@ -93,36 +94,13 @@ export class STTPipeline {
 
   private async sttPump(signal: AbortSignal): Promise<void> {
     const node = await this.sttNode(this._audioChannel.stream(), {});
-
     if (node === null) return;
 
-    const reader = node.getReader();
-    try {
-      const abortPromise = waitForAbort(signal);
-
-      while (true) {
-        const result = await Promise.race([reader.read(), abortPromise]);
-        if (!result) break;
-
-        const { done, value } = result;
-        if (done) break;
-
-        if (typeof value === 'string') {
-          throw new Error(`STT node must yield SpeechEvent, got: ${typeof value}`);
-        }
-
-        await this._eventChannel.write(value);
+    for await (const value of readStream(node, signal)) {
+      if (typeof value === 'string') {
+        throw new Error(`STT node must yield SpeechEvent, got: ${typeof value}`);
       }
-    } finally {
-      try {
-        reader.releaseLock();
-      } catch (error) {
-        if (isStreamReaderReleaseError(error)) {
-          // ignore reader release errors
-          return;
-        }
-        throw error;
-      }
+      await this._eventChannel.write(value);
     }
   }
 
@@ -181,6 +159,7 @@ export interface ParticipantLike {
 export class AudioRecognition {
   private hooks: RecognitionHooks;
   private stt?: STTNode;
+  private sttPipeline?: STTPipeline;
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
@@ -211,10 +190,13 @@ export class AudioRecognition {
   private sttInputStream: ReadableStream<AudioFrame>;
   private silenceAudioTransform = new IdentityTransform<AudioFrame>();
   private silenceAudioWriter: WritableStreamDefaultWriter<AudioFrame>;
+  private sttOwnershipTransferred = false;
+  private readonly sttLifecycleLock = new Mutex();
 
   // all cancellable tasks
   private bounceEOUTask?: Task<void>;
   private commitUserTurnTask?: Task<void>;
+  private sttForwardTask?: Task<void>;
   private vadTask?: Task<void>;
   private sttConsumerTask?: Task<void>;
   private interruptionTask?: Task<void>;
@@ -290,14 +272,11 @@ export class AudioRecognition {
   }
 
   async start(options?: { sttPipeline?: STTPipeline }) {
+    this.startSttTasks(options?.sttPipeline);
+
     this.vadTask = Task.from(({ signal }) => this.createVadTask(this.vad, signal));
     this.vadTask.result.catch((err) => {
       this.logger.error(`Error running VAD task: ${err}`);
-    });
-
-    this.sttConsumerTask = Task.from(({ signal }) => this.createSttTask(this.stt, signal));
-    this.sttConsumerTask.result.catch((err) => {
-      this.logger.error(`Error running STT task: ${err}`);
     });
 
     this.interruptionTask = Task.from(({ signal }) =>
@@ -310,6 +289,7 @@ export class AudioRecognition {
 
   async stop() {
     await this.sttConsumerTask?.cancelAndWait();
+    await this.sttForwardTask?.cancelAndWait();
     await this.vadTask?.cancelAndWait();
     await this.interruptionTask?.cancelAndWait();
   }
@@ -939,56 +919,61 @@ export class AudioRecognition {
       });
   }
 
-  private async createSttTask(stt: STTNode | undefined, signal: AbortSignal) {
-    if (!stt) return;
+  private startSttTasks(reusePipeline?: STTPipeline) {
+    if (!this.stt) return;
 
-    this.logger.debug('createSttTask: create stt stream from stt node');
+    this.sttPipeline = reusePipeline ?? new STTPipeline(this.stt);
 
-    const sttStream = await stt(this.sttInputStream, {});
+    this.transcriptBuffer = [];
+    this.ignoreUserTranscriptUntil = undefined;
+    this._inputStartedAt = undefined;
+    this.sttOwnershipTransferred = false;
 
-    if (signal.aborted || sttStream === null) return;
+    const pipeline = this.sttPipeline;
 
-    if (sttStream instanceof ReadableStream) {
-      const reader = sttStream.getReader();
+    this.sttForwardTask = Task.from(({ signal }) => this.forwardInputAudioToStt(pipeline, signal));
+    this.sttForwardTask.result.catch((err) => {
+      this.logger.error(`Error forwarding audio to STT pipeline: ${err}`);
+    });
 
-      signal.addEventListener('abort', async () => {
-        try {
-          reader.releaseLock();
-          await sttStream?.cancel();
-        } catch (e) {
-          this.logger.debug('createSttTask: error during abort handler:', e);
-        }
-      });
+    this.sttConsumerTask = Task.from(({ signal }) => this.consumeSttEvents(pipeline, signal));
+    this.sttConsumerTask.result.catch((err) => {
+      this.logger.error(`Error running STT task: ${err}`);
+    });
+  }
 
-      try {
-        while (true) {
-          if (signal.aborted) break;
+  private async stopSttTasks() {
+    await this.sttConsumerTask?.cancelAndWait();
+    this.sttConsumerTask = undefined;
+    await this.sttForwardTask?.cancelAndWait();
+    this.sttForwardTask = undefined;
+  }
 
-          const { done, value: ev } = await reader.read();
-          if (done) break;
+  async detachSttPipeline(): Promise<STTPipeline | undefined> {
+    const unlock = await this.sttLifecycleLock.lock();
+    try {
+      const pipeline = this.sttPipeline;
+      this.sttPipeline = undefined;
+      this.sttOwnershipTransferred = pipeline !== undefined;
 
-          if (typeof ev === 'string') {
-            throw new Error('STT node must yield SpeechEvent');
-          } else {
-            await this.onSTTEvent(ev);
-          }
-        }
-      } catch (e) {
-        if (isStreamReaderReleaseError(e)) {
-          return;
-        }
-        this.logger.error({ error: e }, 'createSttTask: error reading sttStream');
-      } finally {
-        reader.releaseLock();
-        try {
-          await sttStream.cancel();
-        } catch (e) {
-          this.logger.debug(
-            'createSttTask: error cancelling sttStream (may already be cancelled):',
-            e,
-          );
-        }
-      }
+      await this.sttConsumerTask?.cancelAndWait();
+      this.sttConsumerTask = undefined;
+
+      return pipeline;
+    } finally {
+      unlock();
+    }
+  }
+
+  private async forwardInputAudioToStt(pipeline: STTPipeline, signal: AbortSignal) {
+    for await (const frame of readStream(this.sttInputStream, signal)) {
+      await pipeline.audioChannel.write(frame);
+    }
+  }
+
+  private async consumeSttEvents(pipeline: STTPipeline, signal: AbortSignal) {
+    for await (const ev of readStream(pipeline.eventChannel.stream(), signal)) {
+      await this.onSTTEvent(ev);
     }
   }
 
@@ -1213,11 +1198,29 @@ export class AudioRecognition {
     this.finalTranscriptConfidence = [];
     this.userTurnCommitted = false;
 
-    this.sttConsumerTask?.cancelAndWait().finally(() => {
-      this.sttConsumerTask = Task.from(({ signal }) => this.createSttTask(this.stt, signal));
-      this.sttConsumerTask.result.catch((err) => {
-        this.logger.error(`Error running STT task: ${err}`);
-      });
+    const restartStt = async () => {
+      const unlock = await this.sttLifecycleLock.lock();
+      try {
+        if (!this.stt || this.sttOwnershipTransferred) {
+          return;
+        }
+
+        await this.stopSttTasks();
+        await this.sttPipeline?.close();
+        this.sttPipeline = undefined;
+
+        if (this.sttOwnershipTransferred) {
+          return;
+        }
+
+        this.startSttTasks();
+      } finally {
+        unlock();
+      }
+    };
+
+    void restartStt().catch((err) => {
+      this.logger.error(`Error resetting STT task: ${err}`);
     });
   }
 
@@ -1271,7 +1274,13 @@ export class AudioRecognition {
     this.detachInputAudioStream();
     this.silenceAudioWriter.releaseLock();
     await this.commitUserTurnTask?.cancelAndWait();
-    await this.sttConsumerTask?.cancelAndWait();
+    await this.stopSttTasks();
+
+    if (this.sttPipeline) {
+      await this.sttPipeline.close();
+      this.sttPipeline = undefined;
+    }
+
     await this.vadTask?.cancelAndWait();
     await this.bounceEOUTask?.cancelAndWait();
     await this.interruptionTask?.cancelAndWait();

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -96,11 +96,15 @@ export class STTPipeline {
     const node = await this.sttNode(this._audioChannel.stream(), {});
     if (node === null) return;
 
-    for await (const value of readStream(node, signal)) {
-      if (typeof value === 'string') {
-        throw new Error(`STT node must yield SpeechEvent, got: ${typeof value}`);
+    try {
+      for await (const value of readStream(node, signal)) {
+        if (typeof value === 'string') {
+          throw new Error(`STT node must yield SpeechEvent, got: ${typeof value}`);
+        }
+        await this._eventChannel.write(value);
       }
-      await this._eventChannel.write(value);
+    } finally {
+      await node.cancel().catch(() => {});
     }
   }
 

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { ReadableStreamDefaultController } from 'node:stream/web';
+import { describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { initializeLogger } from '../log.js';
+import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
+import { AudioRecognition, STTPipeline, type RecognitionHooks } from './audio_recognition.js';
+import type { STTNode } from './io.js';
+
+function createHooks() {
+  const hooks: RecognitionHooks = {
+    onInterruption: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onEndOfTurn: vi.fn(async () => true),
+    onPreemptiveGeneration: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+  };
+
+  return hooks;
+}
+
+async function flushTasks() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 200) {
+  const startedAt = Date.now();
+  while (!check()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error('timed out waiting for condition');
+    }
+    await flushTasks();
+  }
+}
+
+function createRecognition(sttNode: STTNode, hooks = createHooks()) {
+  return {
+    hooks,
+    recognition: new AudioRecognition({
+      recognitionHooks: hooks,
+      stt: sttNode,
+      minEndpointingDelay: 0,
+      maxEndpointingDelay: 0,
+    }),
+  };
+}
+
+describe('AudioRecognition STT pipeline handoff', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('reuses an injected STT pipeline instead of opening a second STT stream', async () => {
+    let sttNodeCalls = 0;
+
+    const sttNode: STTNode = async () => {
+      sttNodeCalls += 1;
+      return new ReadableStream<SpeechEvent | string>({
+        start() {},
+      });
+    };
+
+    const pipeline = new STTPipeline(sttNode);
+    const { recognition } = createRecognition(sttNode);
+
+    try {
+      await recognition.start({ sttPipeline: pipeline });
+      await waitFor(() => sttNodeCalls === 1);
+
+      expect(sttNodeCalls).toBe(1);
+    } finally {
+      await recognition.close();
+      await pipeline.close();
+    }
+  });
+
+  it('detaches the pipeline so a new consumer can receive subsequent STT events', async () => {
+    let controller: ReadableStreamDefaultController<SpeechEvent | string> | undefined;
+
+    const sttNode: STTNode = async () =>
+      new ReadableStream<SpeechEvent | string>({
+        start(ctrl) {
+          controller = ctrl;
+        },
+      });
+
+    const pipeline = new STTPipeline(sttNode);
+    const first = createRecognition(sttNode);
+    const second = createRecognition(sttNode);
+
+    try {
+      await first.recognition.start({ sttPipeline: pipeline });
+      await waitFor(() => controller !== undefined);
+
+      const detachedPipeline = await (first.recognition as any).detachSttPipeline();
+      await first.recognition.close();
+
+      await second.recognition.start({ sttPipeline: detachedPipeline });
+      await flushTasks();
+
+      controller?.enqueue({
+        type: SpeechEventType.FINAL_TRANSCRIPT,
+        alternatives: [{ text: 'reused pipeline', confidence: 0.9 }],
+      });
+      await waitFor(() => second.hooks.onFinalTranscript.mock.calls.length === 1);
+
+      expect(first.hooks.onFinalTranscript).not.toHaveBeenCalled();
+      expect(second.hooks.onFinalTranscript).toHaveBeenCalledTimes(1);
+    } finally {
+      controller?.close();
+      await first.recognition.close();
+      await second.recognition.close();
+      await pipeline.close();
+    }
+  });
+
+  it('resets handoff-sensitive STT state when attaching a pipeline', async () => {
+    const sttNode: STTNode = async () =>
+      new ReadableStream<SpeechEvent | string>({
+        start() {},
+      });
+
+    const pipeline = new STTPipeline(sttNode);
+    const { recognition } = createRecognition(sttNode);
+
+    (recognition as any).transcriptBuffer = [
+      { type: SpeechEventType.FINAL_TRANSCRIPT, alternatives: [{ text: 'stale transcript' }] },
+    ];
+    (recognition as any).ignoreUserTranscriptUntil = Date.now();
+    (recognition as any)._inputStartedAt = Date.now();
+
+    try {
+      await recognition.start({ sttPipeline: pipeline });
+
+      expect((recognition as any).transcriptBuffer).toEqual([]);
+      expect((recognition as any).ignoreUserTranscriptUntil).toBeUndefined();
+      expect((recognition as any)._inputStartedAt).toBeUndefined();
+    } finally {
+      await recognition.close();
+      await pipeline.close();
+    }
+  });
+
+  it('recreates the owned STT pipeline when clearing the user turn', async () => {
+    let sttNodeCalls = 0;
+
+    const sttNode: STTNode = async () => {
+      sttNodeCalls += 1;
+      return new ReadableStream<SpeechEvent | string>({
+        start() {},
+      });
+    };
+
+    const { recognition } = createRecognition(sttNode);
+
+    try {
+      await recognition.start();
+      await waitFor(() => sttNodeCalls === 1);
+
+      recognition.clearUserTurn();
+
+      await waitFor(() => sttNodeCalls === 2);
+    } finally {
+      await recognition.close();
+    }
+  });
+
+  it('keeps an STT pipeline alive across overlapping clearUserTurn calls', async () => {
+    let sttNodeCalls = 0;
+
+    const sttNode: STTNode = async () => {
+      sttNodeCalls += 1;
+      return new ReadableStream<SpeechEvent | string>({
+        start() {},
+      });
+    };
+
+    const { recognition } = createRecognition(sttNode);
+
+    try {
+      await recognition.start();
+      await waitFor(() => sttNodeCalls === 1);
+
+      recognition.clearUserTurn();
+      recognition.clearUserTurn();
+
+      await flushTasks();
+      await flushTasks();
+      await flushTasks();
+
+      expect((recognition as any).sttPipeline).toBeDefined();
+    } finally {
+      await recognition.close();
+    }
+  });
+
+  it('does not recreate a new pipeline after ownership was detached for handoff', async () => {
+    let sttNodeCalls = 0;
+
+    const sttNode: STTNode = async () => {
+      sttNodeCalls += 1;
+      return new ReadableStream<SpeechEvent | string>({
+        start() {},
+      });
+    };
+
+    const { recognition } = createRecognition(sttNode);
+
+    try {
+      await recognition.start();
+      await waitFor(() => sttNodeCalls === 1);
+
+      await (recognition as any).detachSttPipeline();
+      recognition.clearUserTurn();
+
+      await flushTasks();
+      await flushTasks();
+      await flushTasks();
+
+      expect(sttNodeCalls).toBe(1);
+      expect((recognition as any).sttPipeline).toBeUndefined();
+    } finally {
+      await recognition.close();
+    }
+  });
+});

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ChatContext } from '../llm/chat_context.js';
 import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
-import { AudioRecognition, STTPipeline, type RecognitionHooks } from './audio_recognition.js';
+import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
 import type { STTNode } from './io.js';
 
 function createHooks() {

--- a/agents/src/voice/testing/run_result.ts
+++ b/agents/src/voice/testing/run_result.ts
@@ -35,6 +35,13 @@ type OutputSchema<T> = z.ZodType<T>;
 
 // Environment variable for verbose output
 const evalsVerbose = parseInt(process.env.LIVEKIT_EVALS_VERBOSE || '0', 10);
+const rawVerboseMaxChars = parseInt(process.env.LIVEKIT_EVALS_VERBOSE_MAX_CHARS || '300', 10);
+const evalsVerboseMaxChars =
+  Number.isFinite(rawVerboseMaxChars) && rawVerboseMaxChars > 0 ? rawVerboseMaxChars : 300;
+
+function truncateVerboseText(text: string): string {
+  return text.length > evalsVerboseMaxChars ? `${text.slice(0, evalsVerboseMaxChars)}...` : text;
+}
 
 /**
  * Result of a test run containing recorded events and assertion utilities.
@@ -49,6 +56,7 @@ const evalsVerbose = parseInt(process.env.LIVEKIT_EVALS_VERBOSE || '0', 10);
 export class RunResult<T = unknown> {
   private _events: RunEvent[] = [];
   private doneFut = new Future<void>();
+  private minCreatedAt = Number.NEGATIVE_INFINITY;
   private userInput?: string;
   private outputType?: OutputSchema<T>;
   private finalOutputValue?: T;
@@ -65,6 +73,12 @@ export class RunResult<T = unknown> {
   constructor(options?: { userInput?: string; outputType?: OutputSchema<T> }) {
     this.userInput = options?.userInput;
     this.outputType = options?.outputType;
+  }
+
+  /** @internal */
+  _setMinCreatedAt(createdAt: number): void {
+    this.minCreatedAt = createdAt;
+    this._events = this._events.filter((event) => event.item.createdAt >= this.minCreatedAt);
   }
 
   /**
@@ -136,6 +150,9 @@ export class RunResult<T = unknown> {
    * Records an agent handoff event.
    */
   _agentHandoff(params: { item: AgentHandoffItem; oldAgent?: Agent; newAgent: Agent }): void {
+    if (params.item.createdAt < this.minCreatedAt) {
+      return;
+    }
     const event: AgentHandoffEvent = {
       type: 'agent_handoff',
       item: params.item,
@@ -151,6 +168,9 @@ export class RunResult<T = unknown> {
    * Called when a chat item is added during the run.
    */
   _itemAdded(item: ChatItem): void {
+    if (item.createdAt < this.minCreatedAt) {
+      return;
+    }
     if (this.doneFut.done) {
       return;
     }
@@ -225,10 +245,17 @@ export class RunResult<T = unknown> {
     if (isSpeechHandle(handle)) {
       this.lastSpeechHandle = handle;
     }
-
     const allDone = [...this.handles].every((h) => (isSpeechHandle(h) ? h.done() : h.done));
     if (allDone) {
-      this._markDone();
+      // Defer by one microtask so in-flight AgentTask finally blocks can add
+      // resumeTransitionTask before we resolve.  If a new handle appears during
+      // the tick we abort and let the new handle's done callback re-trigger.
+      const countBefore = this.handles.size;
+      Promise.resolve().then(() => {
+        if (this.doneFut.done) return;
+        if (this.handles.size !== countBefore) return;
+        this._markDone();
+      });
     }
   }
 
@@ -882,8 +909,7 @@ export class MessageAssert extends EventAssert {
     if (!success) {
       this._raise(`Judgment failed: ${reason}`);
     } else if (evalsVerbose) {
-      const printMsg =
-        msgContent.length > 30 ? msgContent.slice(0, 30).replace(/\n/g, '\\n') + '...' : msgContent;
+      const printMsg = truncateVerboseText(msgContent.replace(/\n/g, '\\n'));
       console.log(`- Judgment succeeded for \`${printMsg}\`: \`${reason}\``);
     }
 
@@ -973,14 +999,14 @@ function formatEvents(events: RunEvent[], selectedIndex?: number): string[] {
           : Array.isArray(content)
             ? content.filter((c): c is string => typeof c === 'string').join(' ')
             : '';
-      const truncated = textContent.length > 50 ? textContent.slice(0, 50) + '...' : textContent;
+      const truncated = truncateVerboseText(textContent);
       line = `${prefix}[${i}] { type: "message", role: "${role}", content: "${truncated}", interrupted: ${interrupted} }`;
     } else if (isFunctionCallEvent(event)) {
       const { name, args } = event.item;
       line = `${prefix}[${i}] { type: "function_call", name: "${name}", args: ${args} }`;
     } else if (isFunctionCallOutputEvent(event)) {
       const { output, isError } = event.item;
-      const truncated = output.length > 50 ? output.slice(0, 50) + '...' : output;
+      const truncated = truncateVerboseText(output);
       line = `${prefix}[${i}] { type: "function_call_output", output: "${truncated}", isError: ${isError} }`;
     } else if (isAgentHandoffEvent(event)) {
       line = `${prefix}[${i}] { type: "agent_handoff", oldAgent: "${event.oldAgent?.constructor.name}", newAgent: "${event.newAgent.constructor.name}" }`;

--- a/examples/src/health_service/health_service_agent.ts
+++ b/examples/src/health_service/health_service_agent.ts
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  type JobContext,
+  type JobProcess,
+  ServerOptions,
+  beta,
+  cli,
+  defineAgent,
+  inference,
+  llm,
+  voice,
+} from '@livekit/agents';
+import * as openai from '@livekit/agents-plugin-openai';
+import * as silero from '@livekit/agents-plugin-silero';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+type SchedulingIntent = 'schedule';
+
+interface PatientIdentity {
+  fullName: string;
+  dateOfBirth: string;
+}
+
+interface ScheduledVisitResult {
+  confirmationId: string;
+  preferredDateTime: string;
+  status: 'scheduled';
+}
+
+export interface HealthServiceUserData {
+  verifiedIntent?: SchedulingIntent;
+  identifiedPatient?: PatientIdentity;
+  scheduledVisit?: ScheduledVisitResult;
+}
+
+class VerifyIntentTask extends voice.AgentTask<SchedulingIntent> {
+  constructor() {
+    super({
+      instructions: "Verify the user's intent to schedule a patient appointment.",
+      tools: {
+        verifyIntent: llm.tool({
+          description: 'Mark that the user confirmed they want to schedule a patient visit.',
+          parameters: z.object({
+            intent: z.enum(['schedule']),
+          }),
+          execute: async ({ intent }, { ctx }: llm.ToolOptions<HealthServiceUserData>) => {
+            ctx.userData.verifiedIntent = intent;
+            this.complete(intent);
+            return 'Intent verified.';
+          },
+        }),
+      },
+    });
+  }
+
+  async onEnter() {
+    await this.session.generateReply({
+      instructions:
+        'Ask user if they want to schedule an appointment. That said, do not say anything more. Just one brief sentence is enough.',
+      toolChoice: 'none',
+    });
+  }
+}
+
+class IdentifyPatientTask extends voice.AgentTask<PatientIdentity> {
+  constructor() {
+    super({
+      instructions:
+        'You are handling step two of a healthcare scheduling flow. Ask for the patient full name and date of birth, then verify identity with identifyPatient. Dates of birth must be normalized to YYYY-MM-DD before calling the tool.',
+      tools: {
+        identifyPatient: llm.tool({
+          description: 'Identify a patient from their full name and date of birth.',
+          parameters: z.object({
+            fullName: z.string().describe('Full legal name of the patient.'),
+            dateOfBirth: z
+              .string()
+              .describe('Date of birth normalized to YYYY-MM-DD format before the tool call.'),
+          }),
+          execute: async (
+            { fullName, dateOfBirth },
+            { ctx }: llm.ToolOptions<HealthServiceUserData>,
+          ) => {
+            const patient: PatientIdentity = {
+              fullName,
+              dateOfBirth,
+            };
+
+            ctx.userData.identifiedPatient = patient;
+            this.complete(patient);
+            return `Verified patient ${patient.fullName}.`;
+          },
+        }),
+      },
+    });
+  }
+
+  async onEnter() {
+    await this.session.generateReply({
+      instructions:
+        'Ask for the patient full name and date of birth. Once you have both, call identifyPatient.',
+      toolChoice: 'none',
+    });
+  }
+}
+
+class SchedulePatientVisitTask extends voice.AgentTask<ScheduledVisitResult> {
+  constructor() {
+    super({
+      instructions:
+        'You are handling step three of a healthcare scheduling flow. Ask for a preferred date and time, then schedule the appointment by calling schedulePatientVisit.',
+      tools: {
+        schedulePatientVisit: llm.tool({
+          description: 'Schedule a patient appointment for the verified patient (mock success).',
+          parameters: z.object({
+            preferredDateTime: z
+              .string()
+              .describe('User preferred date and time for the appointment.'),
+          }),
+          execute: async (
+            { preferredDateTime },
+            { ctx }: llm.ToolOptions<HealthServiceUserData>,
+          ) => {
+            const patient = ctx.userData.identifiedPatient;
+            if (!patient) {
+              throw new llm.ToolError('No verified patient is available for scheduling.');
+            }
+
+            const visit: ScheduledVisitResult = {
+              confirmationId: `confirm_${Date.now()}`,
+              preferredDateTime,
+              status: 'scheduled',
+            };
+            ctx.userData.scheduledVisit = visit;
+            this.complete(visit);
+            return `Scheduled ${patient.fullName} for ${preferredDateTime}. Confirmation ID: ${visit.confirmationId}.`;
+          },
+        }),
+      },
+    });
+  }
+
+  async onEnter() {
+    await this.session.generateReply({
+      instructions:
+        'Ask the user for their preferred appointment date and time, then call schedulePatientVisit once they provide it.',
+      toolChoice: 'none',
+    });
+  }
+}
+
+export class HealthServiceAgent extends voice.Agent<HealthServiceUserData> {
+  constructor() {
+    super({
+      instructions:
+        'You are a concise healthcare scheduling assistant. When the user asks to schedule a patient appointment, call startPatientSchedulingFlow exactly once.',
+    });
+  }
+
+  async onEnter() {
+    const group = new beta.TaskGroup({
+      summarizeChatCtx: true,
+    });
+
+    group.add(() => new VerifyIntentTask(), {
+      id: 'verify_intent',
+      description: 'Confirm the user wants to schedule a patient appointment',
+    });
+    group.add(() => new IdentifyPatientTask(), {
+      id: 'identify_patient',
+      description: 'Collect patient name and date of birth',
+    });
+    group.add(() => new SchedulePatientVisitTask(), {
+      id: 'schedule_patient_visit',
+      description: 'Offer slots and schedule the patient visit',
+    });
+
+    await group.run();
+    this.session.say(`Your appointment has been scheduled! Thank you for using our service.`);
+  }
+}
+
+export default defineAgent({
+  prewarm: async (proc: JobProcess) => {
+    proc.userData.vad = await silero.VAD.load();
+  },
+  entry: async (ctx: JobContext) => {
+    const session = new voice.AgentSession<HealthServiceUserData>({
+      vad: ctx.proc.userData.vad as silero.VAD,
+      stt: new inference.STT({ model: 'deepgram/nova-3' }),
+      llm: new openai.responses.LLM({
+        model: 'gpt-5.2',
+      }),
+      tts: new inference.TTS({
+        model: 'cartesia/sonic-3',
+        voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc',
+      }),
+      userData: {},
+    });
+
+    await session.start({
+      room: ctx.room,
+      agent: new HealthServiceAgent(),
+    });
+  },
+});
+
+// Only run CLI when executed directly, not when imported for testing.
+// eslint-disable-next-line turbo/no-undeclared-env-vars
+if (process.env.VITEST === undefined) {
+  // eslint-disable-next-line turbo/no-undeclared-env-vars
+  cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+}

--- a/examples/src/health_service/test_agent.test.ts
+++ b/examples/src/health_service/test_agent.test.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { initializeLogger, voice } from '@livekit/agents';
+import * as openai from '@livekit/agents-plugin-openai';
+import { afterEach, beforeEach, describe, it } from 'vitest';
+import { HealthServiceAgent, type HealthServiceUserData } from './health_service_agent.js';
+
+initializeLogger({ pretty: false, level: 'warn' });
+
+function createOpenAILLM(): openai.LLM {
+  return new openai.LLM({
+    model: 'gpt-4.1',
+    temperature: 0.2,
+  });
+}
+
+describe('HealthService Agent (mock task group)', { timeout: 60_000 }, () => {
+  let session: voice.AgentSession;
+  let userData: HealthServiceUserData;
+
+  beforeEach(async () => {
+    userData = {};
+    session = new voice.AgentSession({
+      llm: createOpenAILLM(),
+      userData,
+    });
+  });
+
+  afterEach(async () => {
+    if (session) {
+      await session.close().catch(() => undefined);
+    }
+  });
+
+  const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  it.skipIf(!process.env.OPENAI_API_KEY)(
+    'starts task group on enter and completes verify-intent step',
+    async () => {
+      await session.start({
+        agent: new HealthServiceAgent(),
+      });
+
+      const verifyIntentTurn = session.run({
+        userInput: 'Yes, plz!',
+      });
+      await verifyIntentTurn.wait();
+
+      verifyIntentTurn.expect.containsFunctionCall({ name: 'verifyIntent' });
+
+      const identifyPatientTurn = session.run({
+        userInput: 'My name is Brian Yin and my date of birth is 1900-08-06',
+      });
+      await identifyPatientTurn.wait();
+
+      identifyPatientTurn.expect.containsFunctionCall({ name: 'identifyPatient' });
+
+      const schedulePatientVisitTurn = session.run({
+        userInput: 'My preferred date and time is 2026-08-06 at 10:00 AM',
+      });
+      await schedulePatientVisitTurn.wait();
+
+      schedulePatientVisitTurn.expect.containsFunctionCall({ name: 'schedulePatientVisit' });
+    },
+  );
+});

--- a/examples/src/restaurant_agent.ts
+++ b/examples/src/restaurant_agent.ts
@@ -7,38 +7,20 @@ import {
   ServerOptions,
   cli,
   defineAgent,
+  inference,
   llm,
   voice,
 } from '@livekit/agents';
-import * as deepgram from '@livekit/agents-plugin-deepgram';
-import * as elevenlabs from '@livekit/agents-plugin-elevenlabs';
-import * as livekit from '@livekit/agents-plugin-livekit';
-import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
+// Ref: python examples/voice_agents/restaurant_agent.py - 29-34 lines
 const voices = {
-  greeter: {
-    id: '9BWtsMINqrJLrRacOk9x', // Aria - calm, professional female voice
-    name: 'Aria',
-    category: 'premade',
-  },
-  reservation: {
-    id: 'EXAVITQu4vr4xnSDxMaL', // Sarah - warm, reassuring professional tone
-    name: 'Sarah',
-    category: 'premade',
-  },
-  takeaway: {
-    id: 'CwhRBWXzGAHq8TQ4Fs17', // Roger - confident middle-aged male
-    name: 'Roger',
-    category: 'premade',
-  },
-  checkout: {
-    id: '5Q0t7uMcjvnagumLfvZi', // Paul - authoritative middle-aged male
-    name: 'Paul',
-    category: 'premade',
-  },
+  greeter: 'e07c00bc-4134-4eae-9ea4-1a55fb45746b',
+  reservation: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc',
+  takeaway: '5ee9feff-1265-424a-9d7f-8e4d431a12c7',
+  checkout: 'a167e0f3-df7e-4d52-a9c3-f949145efdab',
 };
 
 type UserData = {
@@ -189,8 +171,8 @@ function createGreeterAgent(menu: string) {
   const greeter = new BaseAgent({
     name: 'greeter',
     instructions: `You are a friendly restaurant receptionist. The menu is: ${menu}\nYour jobs are to greet the caller and understand if they want to make a reservation or order takeaway. Guide them to the right agent using tools.`,
-    // TODO(brian): support parallel tool calls
-    tts: new elevenlabs.TTS({ voice: voices.greeter }),
+    llm: new inference.LLM({ model: 'openai/gpt-4.1-mini' }),
+    tts: new inference.TTS({ model: 'cartesia/sonic-3', voice: voices.greeter }),
     tools: {
       toReservation: llm.tool({
         description: `Called when user wants to make or update a reservation.
@@ -225,7 +207,7 @@ function createReservationAgent() {
   const reservation = new BaseAgent({
     name: 'reservation',
     instructions: `You are a reservation agent at a restaurant. Your jobs are to ask for the reservation time, then customer's name, and phone number. Then confirm the reservation details with the customer.`,
-    tts: new elevenlabs.TTS({ voice: voices.reservation }),
+    tts: new inference.TTS({ model: 'cartesia/sonic-3', voice: voices.reservation }),
     tools: {
       updateName,
       updatePhone,
@@ -267,7 +249,7 @@ function createTakeawayAgent(menu: string) {
   const takeaway = new BaseAgent({
     name: 'takeaway',
     instructions: `Your are a takeaway agent that takes orders from the customer. Our menu is: ${menu}\nClarify special requests and confirm the order with the customer.`,
-    tts: new elevenlabs.TTS({ voice: voices.takeaway }),
+    tts: new inference.TTS({ model: 'cartesia/sonic-3', voice: voices.takeaway }),
     tools: {
       toGreeter,
       updateOrder: llm.tool({
@@ -303,7 +285,7 @@ function createCheckoutAgent(menu: string) {
   const checkout = new BaseAgent({
     name: 'checkout',
     instructions: `You are a checkout agent at a restaurant. The menu is: ${menu}\nYour are responsible for confirming the expense of the order and then collecting customer's name, phone number and credit card information, including the card number, expiry date, and CVV step by step.`,
-    tts: new elevenlabs.TTS({ voice: voices.checkout }),
+    tts: new inference.TTS({ model: 'cartesia/sonic-3', voice: voices.checkout }),
     tools: {
       updateName,
       updatePhone,
@@ -383,12 +365,11 @@ export default defineAgent({
     const vad = ctx.proc.userData.vad! as silero.VAD;
     const session = new voice.AgentSession({
       vad,
-      stt: new deepgram.STT(),
-      tts: new elevenlabs.TTS(),
-      llm: new openai.LLM(),
+      stt: new inference.STT({ model: 'deepgram/nova-3' }),
+      llm: new inference.LLM({ model: 'openai/gpt-4.1-mini' }),
+      tts: new inference.TTS({ model: 'cartesia/sonic-3' }),
       // to use realtime model, replace the stt, llm, tts and vad with the following
-      // llm: new openai.realtime.RealtimeModel(),
-      turnDetection: new livekit.turnDetector.EnglishModel(),
+      // llm: new openai.realtime.RealtimeModel({ voice: 'alloy' }),
       userData,
       voiceOptions: {
         maxToolSteps: 5,

--- a/examples/src/survey_agent.ts
+++ b/examples/src/survey_agent.ts
@@ -1,0 +1,376 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  type JobContext,
+  ServerOptions,
+  beta,
+  cli,
+  defineAgent,
+  llm,
+  voice,
+} from '@livekit/agents';
+// import * as phonic from '@livekit/agents-plugin-phonic';
+import { access, appendFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+type SurveyUserData = {
+  filename: string;
+  candidateName: string;
+  taskResults: Record<string, unknown>;
+};
+
+type IntroResults = {
+  name: string;
+  intro: string;
+};
+
+type EmailResults = {
+  email: string;
+};
+
+type CommuteResults = {
+  canCommute: boolean;
+  commuteMethod: 'driving' | 'bus' | 'subway' | 'none';
+};
+
+type ExperienceResults = {
+  yearsOfExperience: number;
+  experienceDescription: string;
+};
+
+type BehavioralResults = {
+  strengths: string;
+  weaknesses: string;
+  workStyle: 'independent' | 'team_player';
+};
+
+function toCsvValue(value: unknown): string {
+  const raw = typeof value === 'string' ? value : JSON.stringify(value);
+  return `"${raw.replace(/"/g, '""')}"`;
+}
+
+async function writeCsvRow(path: string, data: Record<string, unknown>): Promise<void> {
+  let hasFile = true;
+  try {
+    await access(path);
+  } catch {
+    hasFile = false;
+  }
+
+  const keys = Object.keys(data);
+  const row = keys.map((key) => toCsvValue(data[key])).join(',') + '\n';
+
+  if (!hasFile) {
+    await appendFile(path, keys.join(',') + '\n', 'utf8');
+  }
+  await appendFile(path, row, 'utf8');
+}
+
+function disqualifyTool() {
+  return llm.tool({
+    description:
+      'End the interview if the candidate refuses to cooperate, provides inappropriate answers, or is not a fit.',
+    parameters: z.object({
+      disqualificationReason: z.string().describe('Why the interview should end immediately'),
+    }),
+    execute: async ({ disqualificationReason }, { ctx }: llm.ToolOptions<SurveyUserData>) => {
+      const reason = `[DISQUALIFIED] ${disqualificationReason}`;
+      await writeCsvRow(ctx.userData.filename, {
+        name: ctx.userData.candidateName || 'unknown',
+        disqualificationReason: reason,
+      });
+      await ctx.session.say(
+        `Thanks for your time today. We are ending the interview now. Reason: ${disqualificationReason}.`,
+      );
+      ctx.session.shutdown();
+      return 'Interview ended and disqualification saved.';
+    },
+  });
+}
+
+class IntroTask extends voice.AgentTask<IntroResults> {
+  constructor() {
+    super({
+      instructions:
+        'You are Alex, an interviewer screening a software engineer candidate. Gather the candidate name and short self-introduction.',
+      tools: {
+        saveIntro: llm.tool({
+          description: 'Save candidate name and intro notes.',
+          parameters: z.object({
+            name: z.string().describe('Candidate name'),
+            intro: z.string().describe('Short notes from their introduction'),
+          }),
+          execute: async ({ name, intro }) => {
+            (this.session.userData as SurveyUserData).candidateName = name;
+            this.complete({ name, intro });
+            return `Saved intro for ${name}.`;
+          },
+        }),
+      },
+    });
+  }
+
+  async onEnter() {
+    await this.session.generateReply({
+      instructions:
+        'Welcome the candidate and collect their name plus a brief self-introduction, then call saveIntro.',
+    });
+  }
+}
+
+class EmailTask extends voice.AgentTask<EmailResults> {
+  constructor() {
+    const disqualify = disqualifyTool();
+    super({
+      instructions:
+        'Collect a valid email address. If the candidate refuses, call disqualify immediately.',
+      tools: {
+        disqualify,
+        saveEmail: llm.tool({
+          description: 'Save candidate email address.',
+          parameters: z.object({
+            email: z.string().describe('Candidate email'),
+          }),
+          execute: async ({ email }) => {
+            this.complete({ email });
+            return `Saved email: ${email}`;
+          },
+        }),
+      },
+    });
+  }
+
+  async onEnter() {
+    await this.session.generateReply({
+      instructions: 'Ask for the candidate email and call saveEmail as soon as you get it.',
+    });
+  }
+}
+
+class CommuteTask extends voice.AgentTask<CommuteResults> {
+  constructor() {
+    const disqualify = disqualifyTool();
+    super({
+      instructions:
+        'Collect commute flexibility. The role expects office attendance three days per week.',
+      tools: {
+        disqualify,
+        saveCommute: llm.tool({
+          description: 'Save candidate commute information.',
+          parameters: z.object({
+            canCommute: z.boolean().describe('Whether the candidate can commute to office'),
+            commuteMethod: z
+              .enum(['driving', 'bus', 'subway', 'none'])
+              .describe('Main commute method'),
+          }),
+          execute: async ({ canCommute, commuteMethod }) => {
+            this.complete({ canCommute, commuteMethod });
+            return 'Saved commute flexibility.';
+          },
+        }),
+      },
+    });
+  }
+
+  async onEnter() {
+    await this.session.generateReply({
+      instructions:
+        'Ask if the candidate can commute to office regularly and capture the commute method, then call saveCommute.',
+    });
+  }
+}
+
+class ExperienceTask extends voice.AgentTask<ExperienceResults> {
+  constructor() {
+    const disqualify = disqualifyTool();
+    super({
+      instructions:
+        'Collect years of experience and a concise timeline of previous roles relevant to software engineering.',
+      tools: {
+        disqualify,
+        saveExperience: llm.tool({
+          description: 'Save candidate experience details.',
+          parameters: z.object({
+            yearsOfExperience: z
+              .number()
+              .describe('Total years of professional software experience'),
+            experienceDescription: z.string().describe('Summary of previous roles and employers'),
+          }),
+          execute: async ({ yearsOfExperience, experienceDescription }) => {
+            this.complete({ yearsOfExperience, experienceDescription });
+            return 'Saved experience details.';
+          },
+        }),
+      },
+    });
+  }
+
+  async onEnter() {
+    await this.session.generateReply({
+      instructions:
+        'Ask about years of experience and previous roles, then call saveExperience once gathered.',
+    });
+  }
+}
+
+class BehavioralTask extends voice.AgentTask<BehavioralResults> {
+  private partial: Partial<BehavioralResults> = {};
+
+  constructor() {
+    const disqualify = disqualifyTool();
+    super({
+      instructions:
+        'Collect strengths, weaknesses, and work style. Keep a natural conversational tone and avoid bullet lists.',
+      tools: {
+        disqualify,
+        saveStrengths: llm.tool({
+          description: "Save a concise summary of the candidate's strengths.",
+          parameters: z.object({
+            strengths: z.string().describe('Strengths summary'),
+          }),
+          execute: async ({ strengths }) => {
+            this.partial.strengths = strengths;
+            this.checkCompletion();
+            return 'Saved strengths.';
+          },
+        }),
+        saveWeaknesses: llm.tool({
+          description: "Save a concise summary of the candidate's weaknesses.",
+          parameters: z.object({
+            weaknesses: z.string().describe('Weaknesses summary'),
+          }),
+          execute: async ({ weaknesses }) => {
+            this.partial.weaknesses = weaknesses;
+            this.checkCompletion();
+            return 'Saved weaknesses.';
+          },
+        }),
+        saveWorkStyle: llm.tool({
+          description: "Save candidate's work style.",
+          parameters: z.object({
+            workStyle: z.enum(['independent', 'team_player']).describe('Primary work style'),
+          }),
+          execute: async ({ workStyle }) => {
+            this.partial.workStyle = workStyle;
+            this.checkCompletion();
+            return 'Saved work style.';
+          },
+        }),
+      },
+    });
+  }
+
+  async onEnter() {
+    await this.session.generateReply({
+      instructions:
+        'In a conversational way, gather strengths, weaknesses, and work style, then call save* tools.',
+    });
+  }
+
+  private checkCompletion() {
+    if (this.partial.strengths && this.partial.weaknesses && this.partial.workStyle) {
+      this.complete({
+        strengths: this.partial.strengths,
+        weaknesses: this.partial.weaknesses,
+        workStyle: this.partial.workStyle,
+      });
+      return;
+    }
+
+    this.session.generateReply({
+      instructions:
+        'Continue gathering missing behavioral details in a concise, natural dialogue and use save* tools.',
+    });
+  }
+}
+
+class SurveyAgent extends voice.Agent<SurveyUserData> {
+  constructor() {
+    super({
+      instructions:
+        'You are a survey interviewer for a software engineer screening. Be concise, professional, and natural. Call endScreening when the process is complete.',
+      tools: {
+        endScreening: llm.tool({
+          description: 'End interview and hang up.',
+          execute: async (_, { ctx }: llm.ToolOptions<SurveyUserData>) => {
+            ctx.session.shutdown();
+            return 'Interview concluded.';
+          },
+        }),
+      },
+    });
+  }
+
+  async onEnter() {
+    const group = new beta.TaskGroup({
+      summarizeChatCtx: false,
+    });
+
+    group.add(() => new IntroTask(), {
+      id: 'intro_task',
+      description: 'Collect candidate name and intro',
+    });
+    group.add(() => new EmailTask(), {
+      id: 'email_task',
+      description: 'Collect candidate email',
+    });
+    group.add(() => new CommuteTask(), {
+      id: 'commute_task',
+      description: 'Collect commute flexibility and method',
+    });
+    group.add(() => new ExperienceTask(), {
+      id: 'experience_task',
+      description: 'Collect years of experience and role history',
+    });
+    group.add(() => new BehavioralTask(), {
+      id: 'behavioral_task',
+      description: 'Collect strengths, weaknesses, and work style',
+    });
+
+    const result = await group.run();
+    const summaryItem = this.chatCtx.items[this.chatCtx.items.length - 1];
+    let summaryText = '';
+    if (summaryItem && 'content' in summaryItem) {
+      summaryText =
+        typeof summaryItem.content === 'string'
+          ? summaryItem.content
+          : JSON.stringify(summaryItem.content ?? '');
+    }
+
+    const mergedResults: Record<string, unknown> = {
+      ...result.taskResults,
+      summary: summaryText,
+    };
+    this.session.userData.taskResults = mergedResults;
+    await writeCsvRow(this.session.userData.filename, mergedResults);
+
+    await this.session.say(
+      'The interview is now complete. Thank you for your time. We will follow up within three business days.',
+    );
+  }
+}
+
+export default defineAgent({
+  entry: async (ctx: JobContext) => {
+    const session = new voice.AgentSession<SurveyUserData>({
+      // Manual testing target for #5293 follow-up: realtime say path using Phonic.
+      llm: 'openai/gpt-4.1',
+      stt: 'deepgram/nova-3',
+      tts: 'cartesia/sonic-3',
+      userData: {
+        filename: 'survey_results.csv',
+        candidateName: '',
+        taskResults: {},
+      },
+    });
+
+    await session.start({
+      agent: new SurveyAgent(),
+      room: ctx.room,
+    });
+  },
+});
+
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/survey_agent.ts
+++ b/examples/src/survey_agent.ts
@@ -355,7 +355,6 @@ class SurveyAgent extends voice.Agent<SurveyUserData> {
 export default defineAgent({
   entry: async (ctx: JobContext) => {
     const session = new voice.AgentSession<SurveyUserData>({
-      // Manual testing target for #5293 follow-up: realtime say path using Phonic.
       llm: 'openai/gpt-4.1',
       stt: 'deepgram/nova-3',
       tts: 'cartesia/sonic-3',

--- a/plugins/google/src/beta/realtime/realtime_api.ts
+++ b/plugins/google/src/beta/realtime/realtime_api.ts
@@ -311,6 +311,8 @@ export class RealtimeModel extends llm.RealtimeModel {
       autoToolReplyGeneration: true,
       audioOutput: options.modalities?.includes(Modality.AUDIO) ?? true,
       manualFunctionCalls: false,
+      midSessionInstructionsUpdate: true,
+      midSessionToolsUpdate: false,
     });
 
     // Environment variable fallbacks

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -484,12 +484,18 @@ export class RealtimeSession extends llm.RealtimeSession {
       const futures: Future<void>[] = [];
 
       for (const event of events) {
-        const future = new Future<void>();
-        futures.push(future);
-
         if (event.type === 'conversation.item.create') {
+          const future = new Future<void>();
+          futures.push(future);
           this.itemCreateFutures[event.item.id] = future;
         } else if (event.type == 'conversation.item.delete') {
+          const existingDeleteFuture = this.itemDeleteFutures[event.item_id];
+          if (existingDeleteFuture) {
+            futures.push(existingDeleteFuture);
+            continue;
+          }
+          const future = new Future<void>();
+          futures.push(future);
           this.itemDeleteFutures[event.item_id] = future;
         }
 

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -185,6 +185,9 @@ export class RealtimeModel extends llm.RealtimeModel {
       autoToolReplyGeneration: false,
       audioOutput: modalities.includes('audio'),
       manualFunctionCalls: true,
+      midSessionContextUpdate: true,
+      midSessionInstructionsUpdate: true,
+      midSessionToolsUpdate: true,
     });
 
     const isAzure = !!(options.apiVersion || options.entraToken || options.azureDeployment);

--- a/plugins/openai/src/realtime/realtime_model_beta.ts
+++ b/plugins/openai/src/realtime/realtime_model_beta.ts
@@ -177,6 +177,9 @@ export class RealtimeModel extends llm.RealtimeModel {
       autoToolReplyGeneration: false,
       audioOutput: modalities.includes('audio'),
       manualFunctionCalls: true,
+      midSessionContextUpdate: true,
+      midSessionInstructionsUpdate: true,
+      midSessionToolsUpdate: true,
     });
 
     const isAzure = !!(options.apiVersion || options.entraToken || options.azureDeployment);

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -12,6 +12,7 @@ import {
   stream,
 } from '@livekit/agents';
 import { AudioFrame, AudioResampler } from '@livekit/rtc-node';
+import type { ReadableStream } from 'node:stream/web';
 import type { Phonic } from 'phonic';
 import { PhonicClient } from 'phonic';
 import type { ServerEvent, Voice } from './api_proto.js';
@@ -181,6 +182,7 @@ interface GenerationState {
  * Realtime session for Phonic (https://docs.phonic.co/)
  */
 export class RealtimeSession extends llm.RealtimeSession {
+  private static readonly SAY_TIMEOUT_MS = 10_000;
   private _tools: llm.ToolContext = {};
   private _chatCtx = llm.ChatContext.empty();
 
@@ -376,6 +378,56 @@ export class RealtimeSession extends llm.RealtimeSession {
 
     this.closeCurrentGeneration({ interrupted: false });
     return this.startNewAssistantTurn({ userInitiated: true });
+  }
+
+  async say(
+    text: string | ReadableStream<string>,
+    options?: { allowInterruptions?: boolean },
+  ): Promise<llm.GenerationCreatedEvent> {
+    await Promise.race([
+      this.sendSayAsync(text, options?.allowInterruptions),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('say() timed out.')), RealtimeSession.SAY_TIMEOUT_MS);
+      }),
+    ]);
+
+    this.closeCurrentGeneration({ interrupted: false });
+    return this.startNewAssistantTurn({ userInitiated: true });
+  }
+
+  private async sendSayAsync(
+    text: string | ReadableStream<string>,
+    allowInterruptions?: boolean,
+  ): Promise<void> {
+    if (this.closed) return;
+
+    let fullText: string;
+    if (typeof text === 'string') {
+      fullText = text;
+    } else {
+      const chunks: string[] = [];
+      const reader = text.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+        }
+      } finally {
+        reader.releaseLock();
+      }
+      fullText = chunks.join('');
+    }
+
+    if (!this.socket) {
+      throw new Error('Cannot send say: WebSocket not available');
+    }
+
+    const payload: Record<string, unknown> = { type: 'say', text: fullText };
+    if (allowInterruptions !== undefined) {
+      payload.interruptible = allowInterruptions;
+    }
+    this.socket.socket.send(JSON.stringify(payload));
   }
 
   async commitAudio(): Promise<void> {


### PR DESCRIPTION
## Summary

- `session.run()` now waits for the full agent bootstrap chain to settle before generating a reply, ensuring test events don't include stale bootstrap messages
- `RunResult` stays alive through cascading handoffs (e.g. tool call → `complete()` → TaskGroup resumes → starts next child task), capturing the full transition chain
- Removed the fragile speech-handle unwatch/re-watch dance from `AgentTask.#start()` in favor of cleaner handle tracking and microtask deferral

## Problem

When using `session.run()` with agents that use `TaskGroup` (or any agent whose `onEnter` triggers child-task transitions), two issues occurred:

1. **Unstable first turn**: `run()` would fire `generateReply` before the bootstrap chain (e.g. `Agent → TaskGroup → SubAgentTask`) fully settled, causing the LLM to respond without the correct task's instructions
2. **Missing cascade events**: `RunResult` would resolve as soon as the speech handle finished, missing the subsequent handoff events (e.g. `FirstAgentTask → TaskGroup → SecondAgentTask`) triggered by the tool call's `complete()`

## Changes

**Files:** `agent_session.ts`, `agent.ts`, `agent_activity.ts` (+1 line), `run_result.ts`, `health_service_agent.ts`, `test_agent.test.ts`
- **`_drainActivityLock()`**: `run()` now drains the activity lock in a loop until the bootstrap chain settles (e.g. Agent → TaskGroup → VerifyIntentTask), so `generateReply` targets the correct final activity
- **`_notifyActivityChanged()` moved after `start()`/`resume()`**: Uses the `Event` class so waiters see `schedulingPaused=false`
- **Settle handle for resumed activities**: When resuming an agent whose `onEnter` loop is still running (e.g. TaskGroup advancing to the next child), a tracked handle races `_activityChanged` vs `onEnterDone` to keep `RunResult` alive through the cascade without blocking when no further transition comes
- **`_trackRunHandle(_onEnterTask)`** in `agent_activity.ts`: One line that tracks each new activity's onEnter speech handle — keeps RunResult alive through the new task's onEnter. No-op during bootstrap (no RunResult yet)
- **Microtask-deferred `_markDoneIfNeeded`** in `run_result.ts`: Defers resolution by one microtask so `AgentTask.#start()` finally blocks can add `resumeTransitionTask` before RunResult resolves
- **`_setMinCreatedAt` boundary**: Filters bootstrap events from the first RunResult
- **Simplified `AgentTask.#start()`**: Removed the fragile unwatch/re-watch/`_markDoneIfNeeded` dance — transition tasks are tracked directly
- New `health_service/` example with 3-turn TaskGroup integration test

## Test plan

- [x] `examples/src/health_service/test_agent.test.ts` — 3-turn TaskGroup flow (verifyIntent → identifyPatient → schedulePatientVisit), all with full cascade events
- [x] `examples/src/testing/run_result.test.ts` — 28 tests pass
- [x] `examples/src/testing/task_group.test.ts` — 6 tests pass
- [ ] `examples/src/testing/basic_task_group.test.ts`
- [ ] Verify `restaurant_agent.ts` and `realtime_agent.ts` work in Agent Playground