### PR TITLE
fix(inference): pass extra_headers as HTTP headers instead of in request body

### DIFF
--- a/.changeset/fix-extra-headers-in-body.md
+++ b/.changeset/fix-extra-headers-in-body.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Fix extra_headers being sent in OpenAI request body instead of as HTTP headers in inference LLM

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -336,7 +336,7 @@ export class LLMStream extends llm.LLMStream {
       if (this.provider) {
         extraHeaders['X-LiveKit-Inference-Provider'] = this.provider;
       }
-      requestOptions.extra_headers = extraHeaders;
+      delete requestOptions.extra_headers;
 
       const stream = await this.client.chat.completions.create(
         {
@@ -348,6 +348,7 @@ export class LLMStream extends llm.LLMStream {
           ...requestOptions,
         },
         {
+          headers: extraHeaders,
           timeout: this.connOptions.timeoutMs,
           signal: this.abortController.signal,
         },


### PR DESCRIPTION
## Problem

PR #1208 introduced metadata headers for inference requests. In `agents/src/inference/llm.ts`, `extra_headers` is set on the `requestOptions` object, which is then spread into the first argument (request body) of `client.chat.completions.create()`. The OpenAI API rejects this with a 400 error:

```
APIStatusError: 400 Unrecognized request argument supplied: extra_headers
```

This affects all inference LLM calls made through the `@livekit/agents` package (v1.2.4).

## Solution

- Remove `extra_headers` from `requestOptions` before it is spread into the request body (`delete requestOptions.extra_headers`)
- Pass the headers via the second argument (`RequestOptions.headers`) of `create()`, where the OpenAI SDK expects them

The other inference transports (STT, TTS, interruption HTTP/WS) already handle headers correctly — this bug is isolated to the LLM inference path.

## Verification

1. Build succeeds: `pnpm build:agents`
2. Lint and formatting pass: `pnpm lint`, `pnpm format:check`
3. No public API surface changes: `pnpm api:check`
4. Run an agent that uses the inference LLM layer against the OpenAI API and confirm the 400 error no longer occurs