### PR TITLE
feat(baseten): support top_p, presence_penalty, frequency_penalty

### DIFF
--- a/.changeset/baseten-sampling-params.md
+++ b/.changeset/baseten-sampling-params.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-baseten": patch
+---
+
+feat(baseten): support top_p, presence_penalty, and frequency_penalty options on the LLM

--- a/plugins/baseten/src/llm.ts
+++ b/plugins/baseten/src/llm.ts
@@ -17,6 +17,9 @@ export interface LLMOptions {
   baseURL?: string;
   user?: string;
   temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
   client?: OpenAI;
   toolChoice?: llm.ToolChoice;
   parallelToolCalls?: boolean;
@@ -96,8 +99,20 @@ export class OpenAILLM extends llm.LLM {
       extras.max_completion_tokens = this.#opts.maxCompletionTokens;
     }
 
-    if (this.#opts.temperature) {
+    if (this.#opts.temperature !== undefined) {
       extras.temperature = this.#opts.temperature;
+    }
+
+    if (this.#opts.topP !== undefined) {
+      extras.top_p = this.#opts.topP;
+    }
+
+    if (this.#opts.presencePenalty !== undefined) {
+      extras.presence_penalty = this.#opts.presencePenalty;
+    }
+
+    if (this.#opts.frequencyPenalty !== undefined) {
+      extras.frequency_penalty = this.#opts.frequencyPenalty;
     }
 
     if (this.#opts.serviceTier) {
@@ -159,6 +174,9 @@ export class LLM extends OpenAILLM {
       apiKey,
       baseURL: 'https://inference.baseten.co/v1',
       temperature: opts.temperature,
+      topP: opts.topP,
+      presencePenalty: opts.presencePenalty,
+      frequencyPenalty: opts.frequencyPenalty,
       user: opts.user,
       maxCompletionTokens: opts.maxTokens,
       toolChoice: opts.toolChoice,

--- a/plugins/baseten/src/types.ts
+++ b/plugins/baseten/src/types.ts
@@ -15,7 +15,19 @@ export interface BasetenLLMOptions {
   apiKey?: string;
   model: string;
   temperature?: number;
+  /** Nucleus sampling parameter. Forwarded to Baseten as `top_p`. */
+  topP?: number;
   maxTokens?: number;
+  /**
+   * Penalty for new tokens based on whether they appear in the text so far.
+   * Forwarded to Baseten as `presence_penalty`.
+   */
+  presencePenalty?: number;
+  /**
+   * Penalty for new tokens based on their frequency in the text so far.
+   * Forwarded to Baseten as `frequency_penalty`.
+   */
+  frequencyPenalty?: number;
   user?: string;
   toolChoice?: 'none' | 'auto' | 'required' | { type: 'function'; function: { name: string } };
   parallelToolCalls?: boolean;


### PR DESCRIPTION
## Summary

Adds three documented Baseten sampling parameters to `BasetenLLMOptions`:

- `topP` → forwarded as `top_p`
- `presencePenalty` → forwarded as `presence_penalty`
- `frequencyPenalty` → forwarded as `frequency_penalty`

These mirror how `temperature` and `maxTokens` are already plumbed through the plugin. Baseten's inference docs list all four as supported options.

## Details

- New fields on `BasetenLLMOptions` in `plugins/baseten/src/types.ts` with TSDoc.
- Forwarded through the internal `LLMOptions` interface and into the `extras` bag in `OpenAILLM.chat()` in `plugins/baseten/src/llm.ts`.
- The Baseten `LLM` subclass constructor passes the new fields into `super({...})`.
- Drive-by: switched the existing `temperature` plumbing from a truthy check to `!== undefined` so that `temperature: 0` is preserved (previously dropped silently).
- Uses `!== undefined` for all three new fields so `0` is a valid value.

## Test plan

- [x] `pnpm -w format:write` clean
- [x] `pnpm --filter @livekit/agents-plugin-baseten lint` clean
- [x] `pnpm --filter @livekit/agents-plugin-baseten... build` succeeds
- [ ] Exercised live against Baseten inference endpoint (requires `BASETEN_API_KEY`)