### PR TITLE
fix(tts): unblock FallbackAdapter when primary provider fails silently

### DIFF
--- a/.changeset/shaggy-rings-hear.md
+++ b/.changeset/shaggy-rings-hear.md
@@ -1,0 +1,6 @@
+---
+"@livekit/agents": patch
+"@livekit/agents-plugin-elevenlabs": patch
+---
+
+fix(tts): unblock FallbackAdapter when primary provider fails silently

--- a/agents/src/tts/fallback_adapter.test.ts
+++ b/agents/src/tts/fallback_adapter.test.ts
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream } from 'node:stream/web';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { APIError } from '../_exceptions.js';
+import { initializeLogger } from '../log.js';
+import type { APIConnectOptions } from '../types.js';
+import { FallbackAdapter } from './fallback_adapter.js';
+import { ChunkedStream, SynthesizeStream, TTS } from './tts.js';
+
+const SAMPLE_RATE = 24000;
+
+class MockSynthesizeStream extends SynthesizeStream {
+  label = 'mock.SynthesizeStream';
+
+  constructor(
+    tts: MockTTS,
+    private shouldFail: boolean,
+    connOptions?: APIConnectOptions,
+  ) {
+    super(tts, connOptions);
+  }
+
+  protected async run(): Promise<void> {
+    if (this.shouldFail) {
+      // Throw immediately, before any pushText has been called.
+      // This is the scenario that previously deadlocked the FallbackAdapter:
+      // the inner stream's mainTask finishes before forwardBufferToTTS gets
+      // a chance to call pushText, so #monitorMetricsTask never starts and
+      // this.output is never closed.
+      throw new APIError('mock TTS failed immediately');
+    }
+
+    // Happy path: read text from this.input and emit a single audio frame per token.
+    for await (const data of this.input) {
+      if (this.abortController.signal.aborted) break;
+      if (data === SynthesizeStream.FLUSH_SENTINEL) continue;
+      this.queue.put({
+        requestId: 'mock-req',
+        segmentId: 'mock-seg',
+        frame: new AudioFrame(new Int16Array(160), SAMPLE_RATE, 1, 160),
+        final: false,
+      });
+    }
+  }
+}
+
+class MockChunkedStream extends ChunkedStream {
+  label = 'mock.ChunkedStream';
+  constructor(
+    tts: MockTTS,
+    text: string,
+    private shouldFail: boolean,
+  ) {
+    super(text, tts);
+  }
+  protected async run(): Promise<void> {
+    if (this.shouldFail) {
+      throw new APIError('mock TTS failed immediately');
+    }
+    this.queue.put({
+      requestId: 'mock-req',
+      segmentId: 'mock-seg',
+      frame: new AudioFrame(new Int16Array(160), SAMPLE_RATE, 1, 160),
+      final: true,
+    });
+  }
+}
+
+class MockTTS extends TTS {
+  label: string;
+  shouldFail = false;
+
+  constructor(label: string) {
+    super(SAMPLE_RATE, 1, { streaming: true });
+    this.label = label;
+  }
+
+  synthesize(text: string): ChunkedStream {
+    return new MockChunkedStream(this, text, this.shouldFail);
+  }
+
+  stream(options?: { connOptions?: APIConnectOptions }): SynthesizeStream {
+    return new MockSynthesizeStream(this, this.shouldFail, options?.connOptions);
+  }
+}
+
+describe('TTS FallbackAdapter', () => {
+  beforeAll(() => {
+    initializeLogger({ pretty: false });
+    // Suppress unhandled rejections from background tasks inside SynthesizeStream
+    process.on('unhandledRejection', () => {});
+  });
+
+  it('should fall back to the next TTS when the primary stream fails before any pushText', async () => {
+    const primary = new MockTTS('primary');
+    primary.shouldFail = true;
+    const secondary = new MockTTS('secondary');
+    const adapter = new FallbackAdapter({
+      ttsInstances: [primary, secondary],
+      maxRetryPerTTS: 0,
+      recoveryDelayMs: 60_000,
+    });
+
+    const stream = adapter.stream();
+    stream.updateInputStream(
+      new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue('hello world');
+          controller.close();
+        },
+      }),
+    );
+
+    // With the deadlock bug, this loop hangs forever because the inner
+    // primary stream's this.output is never closed. Use a hard timeout to
+    // turn the deadlock into a test failure.
+    const iterate = (async () => {
+      let frameCount = 0;
+      for await (const event of stream) {
+        if (event === SynthesizeStream.END_OF_STREAM) break;
+        frameCount++;
+      }
+      return frameCount;
+    })();
+
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('fallback adapter deadlocked')), 3000),
+    );
+
+    const frameCount = await Promise.race([iterate, timeout]);
+
+    expect(frameCount).toBeGreaterThan(0);
+    expect(adapter.status[0]!.available).toBe(false);
+    expect(adapter.status[1]!.available).toBe(true);
+
+    stream.close();
+    await adapter.close();
+  });
+});

--- a/agents/src/tts/fallback_adapter.test.ts
+++ b/agents/src/tts/fallback_adapter.test.ts
@@ -50,11 +50,12 @@ class MockSynthesizeStream extends SynthesizeStream {
 class MockChunkedStream extends ChunkedStream {
   label = 'mock.ChunkedStream';
   constructor(
-    tts: MockTTS,
+    private mockTts: MockTTS,
     text: string,
     private shouldFail: boolean,
+    connOptions?: APIConnectOptions,
   ) {
-    super(text, tts);
+    super(text, mockTts, connOptions);
   }
   protected async run(): Promise<void> {
     if (this.shouldFail) {
@@ -63,7 +64,7 @@ class MockChunkedStream extends ChunkedStream {
     this.queue.put({
       requestId: 'mock-req',
       segmentId: 'mock-seg',
-      frame: new AudioFrame(new Int16Array(160), SAMPLE_RATE, 1, 160),
+      frame: new AudioFrame(new Int16Array(160), this.mockTts.sampleRate, 1, 160),
       final: true,
     });
   }
@@ -78,8 +79,8 @@ class MockTTS extends TTS {
     this.label = label;
   }
 
-  synthesize(text: string): ChunkedStream {
-    return new MockChunkedStream(this, text, this.shouldFail);
+  synthesize(text: string, connOptions?: APIConnectOptions): ChunkedStream {
+    return new MockChunkedStream(this, text, this.shouldFail, connOptions);
   }
 
   stream(options?: { connOptions?: APIConnectOptions }): SynthesizeStream {
@@ -186,6 +187,44 @@ describe('TTS FallbackAdapter', () => {
     expect(adapter.status[1]!.available).toBe(true);
 
     stream.close();
+    await adapter.close();
+  });
+
+  it('should fall back in the non-streaming (synthesize) path with mismatched sample rates', async () => {
+    // FallbackChunkedStream has the same phantom-flush vulnerability as
+    // FallbackSynthesizeStream: when the primary's sample rate differs from
+    // the adapter's output rate a resampler is created, and flushing an
+    // unused resampler can return a ghost frame that masks a silent
+    // failure. Exercise the non-streaming adapter.synthesize() path.
+    const primary = new MockTTS('primary', 22050);
+    primary.shouldFail = true;
+    const secondary = new MockTTS('secondary', 24000);
+    const adapter = new FallbackAdapter({
+      ttsInstances: [primary, secondary],
+      maxRetryPerTTS: 0,
+      recoveryDelayMs: 60_000,
+    });
+
+    const chunked = adapter.synthesize('hello world');
+
+    const iterate = (async () => {
+      let frameCount = 0;
+      for await (const _event of chunked) {
+        frameCount++;
+      }
+      return frameCount;
+    })();
+
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('fallback adapter deadlocked')), 3000),
+    );
+
+    const frameCount = await Promise.race([iterate, timeout]);
+
+    expect(frameCount).toBeGreaterThan(0);
+    expect(adapter.status[0]!.available).toBe(false);
+    expect(adapter.status[1]!.available).toBe(true);
+
     await adapter.close();
   });
 });

--- a/agents/src/tts/fallback_adapter.test.ts
+++ b/agents/src/tts/fallback_adapter.test.ts
@@ -16,11 +16,11 @@ class MockSynthesizeStream extends SynthesizeStream {
   label = 'mock.SynthesizeStream';
 
   constructor(
-    tts: MockTTS,
+    private mockTts: MockTTS,
     private shouldFail: boolean,
     connOptions?: APIConnectOptions,
   ) {
-    super(tts, connOptions);
+    super(mockTts, connOptions);
   }
 
   protected async run(): Promise<void> {
@@ -40,7 +40,7 @@ class MockSynthesizeStream extends SynthesizeStream {
       this.queue.put({
         requestId: 'mock-req',
         segmentId: 'mock-seg',
-        frame: new AudioFrame(new Int16Array(160), SAMPLE_RATE, 1, 160),
+        frame: new AudioFrame(new Int16Array(160), this.mockTts.sampleRate, 1, 160),
         final: false,
       });
     }
@@ -73,8 +73,8 @@ class MockTTS extends TTS {
   label: string;
   shouldFail = false;
 
-  constructor(label: string) {
-    super(SAMPLE_RATE, 1, { streaming: true });
+  constructor(label: string, sampleRate: number = SAMPLE_RATE) {
+    super(sampleRate, 1, { streaming: true });
     this.label = label;
   }
 
@@ -117,6 +117,55 @@ describe('TTS FallbackAdapter', () => {
     // With the deadlock bug, this loop hangs forever because the inner
     // primary stream's this.output is never closed. Use a hard timeout to
     // turn the deadlock into a test failure.
+    const iterate = (async () => {
+      let frameCount = 0;
+      for await (const event of stream) {
+        if (event === SynthesizeStream.END_OF_STREAM) break;
+        frameCount++;
+      }
+      return frameCount;
+    })();
+
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('fallback adapter deadlocked')), 3000),
+    );
+
+    const frameCount = await Promise.race([iterate, timeout]);
+
+    expect(frameCount).toBeGreaterThan(0);
+    expect(adapter.status[0]!.available).toBe(false);
+    expect(adapter.status[1]!.available).toBe(true);
+
+    stream.close();
+    await adapter.close();
+  });
+
+  it('should fall back when the primary has a mismatched sample rate and emits no audio', async () => {
+    // Primary runs at 22050Hz, adapter aggregates at 24000Hz → a resampler is
+    // created for the primary. The primary throws with no frames ever pushed,
+    // so `resampler.push()` is never called. Regression test for a bug where
+    // `resampler.flush()` on an unused resampler returned a phantom frame,
+    // flipping `audioPushed` to true and making the adapter incorrectly
+    // treat a silent failure as a success.
+    const primary = new MockTTS('primary', 22050);
+    primary.shouldFail = true;
+    const secondary = new MockTTS('secondary', 24000);
+    const adapter = new FallbackAdapter({
+      ttsInstances: [primary, secondary],
+      maxRetryPerTTS: 0,
+      recoveryDelayMs: 60_000,
+    });
+
+    const stream = adapter.stream();
+    stream.updateInputStream(
+      new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue('hello world');
+          controller.close();
+        },
+      }),
+    );
+
     const iterate = (async () => {
       let frameCount = 0;
       for await (const event of stream) {

--- a/agents/src/tts/fallback_adapter.ts
+++ b/agents/src/tts/fallback_adapter.ts
@@ -480,6 +480,11 @@ class FallbackSynthesizeStream extends SynthesizeStream {
           }
         };
 
+        // Tracks whether the inner stream yielded any real audio frames.
+        // `audioPushed` can be flipped on by a phantom `AudioResampler.flush()`
+        // frame even when nothing was pushed in (rtc-node 0.13.25), so we
+        // cannot use it to detect silent failures.
+        let sawRawAudio = false;
         const processOutput = async () => {
           try {
             for await (const audio of stream) {
@@ -494,6 +499,8 @@ class FallbackSynthesizeStream extends SynthesizeStream {
                 // to consumers before fallback can try the next TTS.
                 continue;
               }
+
+              sawRawAudio = true;
 
               if (resampler) {
                 for (const frame of resampler.push(audio.frame)) {
@@ -511,8 +518,10 @@ class FallbackSynthesizeStream extends SynthesizeStream {
               lastSegmentId = audio.segmentId;
             }
 
-            // Flush resampler
-            if (resampler) {
+            // Only flush the resampler if real audio actually went in —
+            // otherwise flush() can return phantom frames that would mask a
+            // silent failure from the primary provider.
+            if (resampler && sawRawAudio) {
               for (const frame of resampler.flush()) {
                 this.queue.put({
                   requestId: lastRequestId || '',
@@ -549,8 +558,9 @@ class FallbackSynthesizeStream extends SynthesizeStream {
           throw forwardBufferResult.reason;
         }
 
-        // Verify audio was actually received - if not, the TTS failed silently
-        if (!this.audioPushed) {
+        // Silent failures must trigger fallback. See `sawRawAudio` above for
+        // why we don't check `audioPushed` here.
+        if (!sawRawAudio) {
           throw new APIConnectionError({
             message: 'TTS stream completed but no audio was received',
           });

--- a/agents/src/tts/fallback_adapter.ts
+++ b/agents/src/tts/fallback_adapter.ts
@@ -333,12 +333,17 @@ class FallbackChunkedStream extends ChunkedStream {
           maxRetry: this.adapter.maxRetryPerTTS,
         };
         const stream = tts.synthesize(this.inputText, connOptions, this.abortSignal);
-        let audioReceived = false;
+        // Tracks whether the inner stream yielded any real audio frames.
+        // A phantom `AudioResampler.flush()` frame (observed on rtc-node
+        // 0.13.25) could otherwise mask a silent failure as a success.
+        let sawRawAudio = false;
         for await (const audio of stream) {
           if (this.abortController.signal.aborted) {
             stream.close();
             return;
           }
+
+          sawRawAudio = true;
 
           if (resampler) {
             for (const frame of resampler.push(audio.frame)) {
@@ -346,18 +351,18 @@ class FallbackChunkedStream extends ChunkedStream {
                 ...audio,
                 frame,
               });
-              audioReceived = true;
             }
           } else {
             this.queue.put(audio);
-            audioReceived = true;
           }
           lastRequestId = audio.requestId;
           lastSegmentId = audio.segmentId;
         }
 
-        // Flush any remaining resampled frames
-        if (resampler) {
+        // Only flush the resampler if real audio actually went in — otherwise
+        // flush() can return phantom frames that would mask a silent failure
+        // from the primary provider.
+        if (resampler && sawRawAudio) {
           for (const frame of resampler.flush()) {
             this.queue.put({
               requestId: lastRequestId || '',
@@ -365,12 +370,11 @@ class FallbackChunkedStream extends ChunkedStream {
               frame,
               final: true,
             });
-            audioReceived = true;
           }
         }
 
-        // Verify audio was actually received - silent failures should trigger fallback
-        if (!audioReceived) {
+        // Silent failures must trigger fallback.
+        if (!sawRawAudio) {
           throw new APIConnectionError({
             message: 'TTS synthesis completed but no audio was received',
           });

--- a/agents/src/tts/tts.ts
+++ b/agents/src/tts/tts.ts
@@ -204,7 +204,28 @@ export abstract class SynthesizeStream
     // is run **after** the constructor has finished. Otherwise we get
     // runtime error when trying to access class variables in the
     // `run` method.
-    startSoon(() => this.mainTask().finally(() => this.queue.close()));
+    startSoon(async () => {
+      try {
+        await this.mainTask();
+      } catch {
+        // errors are already reported via emitError; swallow here to
+        // avoid an unhandled rejection from this fire-and-forget task.
+      } finally {
+        this.queue.close();
+        // Wait for monitorMetrics (if it ever started) to drain the now-closed
+        // queue; its own .finally will close `this.output`. If it never started
+        // (e.g. mainTask failed before any pushText was called), close `this.output`
+        // directly — otherwise consumers iterating over this stream would hang
+        // forever. This matters for FallbackAdapter, which needs to observe the
+        // inner stream's completion in order to fall back to the next provider.
+        if (this.#monitorMetricsTask) {
+          await this.#monitorMetricsTask.catch(() => {});
+        }
+        if (!this.output.closed) {
+          this.output.close();
+        }
+      }
+    });
   }
 
   private _mainTaskImpl = async (span: Span) => {

--- a/agents/src/tts/tts.ts
+++ b/agents/src/tts/tts.ts
@@ -204,20 +204,16 @@ export abstract class SynthesizeStream
     // is run **after** the constructor has finished. Otherwise we get
     // runtime error when trying to access class variables in the
     // `run` method.
+    // Ensure `this.output` is closed once mainTask settles, even when
+    // `monitorMetrics` never started (no `pushText` was ever called).
+    // Without this, consumers iterating the stream hang forever.
     startSoon(async () => {
       try {
         await this.mainTask();
       } catch {
-        // errors are already reported via emitError; swallow here to
-        // avoid an unhandled rejection from this fire-and-forget task.
+        // already surfaced via emitError; swallow to avoid unhandled rejection.
       } finally {
         this.queue.close();
-        // Wait for monitorMetrics (if it ever started) to drain the now-closed
-        // queue; its own .finally will close `this.output`. If it never started
-        // (e.g. mainTask failed before any pushText was called), close `this.output`
-        // directly — otherwise consumers iterating over this stream would hang
-        // forever. This matters for FallbackAdapter, which needs to observe the
-        // inner stream's completion in order to fall back to the next provider.
         if (this.#monitorMetricsTask) {
           await this.#monitorMetricsTask.catch(() => {});
         }

--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import {
+  type APIConnectOptions,
   APIConnectionError,
   APIError,
   APIStatusError,
@@ -787,8 +788,8 @@ export class TTS extends tts.TTS {
     return new ChunkedStream(this, text, { ...this.#opts });
   }
 
-  stream(): SynthesizeStream {
-    const stream = new SynthesizeStream(this, { ...this.#opts });
+  stream(options?: { connOptions?: APIConnectOptions }): SynthesizeStream {
+    const stream = new SynthesizeStream(this, { ...this.#opts }, options?.connOptions);
     this.#streams.add(stream);
     return stream;
   }
@@ -910,8 +911,8 @@ export class SynthesizeStream extends tts.SynthesizeStream {
 
   label = 'elevenlabs.SynthesizeStream';
 
-  constructor(tts: TTS, opts: ResolvedTTSOptions) {
-    super(tts);
+  constructor(tts: TTS, opts: ResolvedTTSOptions, connOptions?: APIConnectOptions) {
+    super(tts, connOptions);
     this.#tts = tts;
     this.#opts = opts;
     this.#contextId = shortuuid();


### PR DESCRIPTION
## Description

`tts.FallbackAdapter` silently hangs when the primary provider fails without emitting any audio (e.g. ElevenLabs closing its WebSocket with `1008 Invalid API key`). `markUnAvailable(0)` is never called, the secondary provider is never tried, and the call stays silent until the caller disconnects. This PR fixes three bugs that combined to produce that symptom, plus adds regression tests.

## Changes Made

- **`agents/src/tts/tts.ts`** — Base `SynthesizeStream` now closes `this.output` when `mainTask` settles, not just `this.queue`. Previously `this.output` was only closed inside `#monitorMetricsTask.finally(...)`, which is only attached on the first `pushText()` call. `FallbackSynthesizeStream` drives the inner stream by calling `pushText` from its own scheduler, so if the inner plugin's `run()` threw before any `pushText` had been scheduled, `this.output` stayed open forever and the consumer's `Promise.allSettled` never resolved. The fire-and-forget task also swallows the rejection explicitly (the error is already emitted via `emitError`) to avoid unhandled rejections.

- **`agents/src/tts/fallback_adapter.ts`** — `FallbackSynthesizeStream.run()` now tracks `sawRawAudio` separately from `audioPushed`. When the primary's sample rate differs from the adapter's output rate a resampler is created, and on `@livekit/rtc-node@0.13.25` an unused `AudioResampler.flush()` can return a phantom frame — enough to flip `audioPushed` to `true` and make the adapter treat a completely silent failure as a success. `resampler.flush()` is now only called when real audio actually went in, and the silent-failure check is gated on `sawRawAudio`.

- **`plugins/elevenlabs/src/tts.ts`** — `TTS.stream()` now accepts `{ connOptions }` and threads it through `SynthesizeStream`'s constructor to the base class. Previously the plugin silently dropped the argument, so `FallbackAdapter.maxRetryPerTTS` was ignored and fallback always took ~6 s (3 inner retries × 2 s backoff) regardless of configuration.

- **`agents/src/tts/fallback_adapter.test.ts`** (new) — Two regression tests. The first uses matched sample rates and exercises the deadlock path; without the `tts.ts` fix it hangs and a 3 s timeout fires. The second uses mismatched sample rates (22 050 → 24 000) so a resampler is created, exercising the phantom-flush path; without the `fallback_adapter.ts` fix the adapter never falls back to the secondary.

## Pre-Review Checklist

- [x] **Build passes**: `pnpm build`, `pnpm vitest run agents/src` (596/596 pass), `pnpm -F @livekit/agents lint`, `pnpm format:check` all clean locally.
- [x] **AI-generated code reviewed**: comments trimmed to load-bearing *why* explanations.
- [x] **Changes explained**: each of the three bugs described above with its root cause.
- [x] **Scope appropriate**: all three changes are different angles on the same symptom (`FallbackAdapter` silently hanging on primary failure) and were discovered sequentially while investigating.

## Testing

- [x] Automated tests added (`agents/src/tts/fallback_adapter.test.ts`).
- [x] All tests pass: `pnpm vitest run agents/src` → 38 test files, 596 passed, 2 skipped.
