### PR TITLE
feat(assemblyai): new STT plugin for Universal-Streaming (v3)

### DIFF
--- a/.changeset/assemblyai-stt-plugin.md
+++ b/.changeset/assemblyai-stt-plugin.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-assemblyai": patch
+---
+
+feat(assemblyai): new STT plugin for AssemblyAI Universal-Streaming (v3) API. Ported from the Python livekit-plugins-assemblyai plugin.

--- a/plugins/assemblyai/README.md
+++ b/plugins/assemblyai/README.md
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+# AssemblyAI plugin for LiveKit Agents
+
+The Agents Framework is designed for building realtime, programmable
+participants that run on servers. Use it to create conversational, multi-modal
+voice agents that can see, hear, and understand.
+
+This package contains the AssemblyAI plugin, which allows for speech recognition
+via AssemblyAI's Universal-Streaming (v3) API. Refer to the
+[documentation](https://docs.livekit.io/agents/overview/) for information on how
+to use it, or browse the [API
+reference](https://docs.livekit.io/agents-js/modules/plugins_agents_plugin_assemblyai.html).
+See the [repository](https://github.com/livekit/agents-js) for more information
+about the framework as a whole.

--- a/plugins/assemblyai/api-extractor.json
+++ b/plugins/assemblyai/api-extractor.json
@@ -1,0 +1,20 @@
+/**
+ * Config file for API Extractor.  For more info, please visit: https://api-extractor.com
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+
+  /**
+   * Optionally specifies another JSON config file that this file extends from.  This provides a way for
+   * standard settings to be shared across multiple projects.
+   *
+   * If the path starts with "./" or "../", the path is resolved relative to the folder of the file that contains
+   * the "extends" field.  Otherwise, the first path segment is interpreted as an NPM package name, and will be
+   * resolved using NodeJS require().
+   *
+   * SUPPORTED TOKENS: none
+   * DEFAULT VALUE: ""
+   */
+  "extends": "../../api-extractor-shared.json",
+  "mainEntryPointFilePath": "./dist/index.d.ts"
+}

--- a/plugins/assemblyai/package.json
+++ b/plugins/assemblyai/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@livekit/agents-plugin-assemblyai",
+  "version": "1.2.4",
+  "description": "AssemblyAI plugin for LiveKit Agents for Node.js",
+  "main": "dist/index.js",
+  "require": "dist/index.cjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "import": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "require": {
+      "types": "./dist/index.d.cts",
+      "default": "./dist/index.cjs"
+    }
+  },
+  "author": "LiveKit",
+  "type": "module",
+  "repository": "git@github.com:livekit/agents-js.git",
+  "license": "Apache-2.0",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup --onSuccess \"pnpm build:types\"",
+    "build:types": "tsc --declaration --emitDeclarationOnly && node ../../scripts/copyDeclarationOutput.js",
+    "clean": "rm -rf dist",
+    "clean:build": "pnpm clean && pnpm build",
+    "lint": "eslint -f unix \"src/**/*.{ts,js}\"",
+    "api:check": "api-extractor run --typescript-compiler-folder ../../node_modules/typescript",
+    "api:update": "api-extractor run --local --typescript-compiler-folder ../../node_modules/typescript --verbose"
+  },
+  "devDependencies": {
+    "@livekit/agents": "workspace:*",
+    "@livekit/agents-plugin-silero": "workspace:*",
+    "@livekit/agents-plugins-test": "workspace:*",
+    "@livekit/rtc-node": "catalog:",
+    "@microsoft/api-extractor": "^7.35.0",
+    "@types/ws": "^8.5.10",
+    "tsup": "^8.3.5",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "ws": "^8.16.0"
+  },
+  "peerDependencies": {
+    "@livekit/agents": "workspace:*",
+    "@livekit/rtc-node": "catalog:"
+  }
+}

--- a/plugins/assemblyai/src/index.ts
+++ b/plugins/assemblyai/src/index.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { Plugin } from '@livekit/agents';
+
+export * from './models.js';
+export * from './stt.js';
+
+class AssemblyAIPlugin extends Plugin {
+  constructor() {
+    super({
+      title: 'assemblyai',
+      version: __PACKAGE_VERSION__,
+      package: __PACKAGE_NAME__,
+    });
+  }
+}
+
+Plugin.registerPlugin(new AssemblyAIPlugin());

--- a/plugins/assemblyai/src/models.ts
+++ b/plugins/assemblyai/src/models.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 48-54 lines
+export type STTModels =
+  | 'universal-streaming-english'
+  | 'universal-streaming-multilingual'
+  | 'u3-rt-pro'
+  // Deprecated alias — AssemblyAI maps this to `u3-rt-pro` server-side, but the
+  // Python plugin emits a warning and rewrites it. Kept here so TS users don't
+  // break if they already pass it.
+  | 'u3-pro';
+
+// Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 47 lines
+export type STTEncoding = 'pcm_s16le' | 'pcm_mulaw';

--- a/plugins/assemblyai/src/stt.test.ts
+++ b/plugins/assemblyai/src/stt.test.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { VAD } from '@livekit/agents-plugin-silero';
+import { stt } from '@livekit/agents-plugins-test';
+import { describe, it } from 'vitest';
+import { STT } from './stt.js';
+
+const hasAssemblyAIApiKey = Boolean(process.env.ASSEMBLYAI_API_KEY);
+
+if (hasAssemblyAIApiKey) {
+  describe('AssemblyAI', async () => {
+    await stt(new STT(), await VAD.load(), { nonStreaming: false });
+  });
+} else {
+  describe('AssemblyAI', () => {
+    it.skip('requires ASSEMBLYAI_API_KEY', () => {});
+  });
+}

--- a/plugins/assemblyai/src/stt.ts
+++ b/plugins/assemblyai/src/stt.ts
@@ -333,6 +333,7 @@ export class SpeechStream extends stt.SpeechStream {
   // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 357-440 lines
   async #runWS(ws: WebSocket) {
     let closing = false;
+    const sessionController = new AbortController();
 
     // gets cancelled also when sendTask is complete
     const wsMonitor = Task.from(async (controller) => {
@@ -354,10 +355,11 @@ export class SpeechStream extends stt.SpeechStream {
       const audioStream = new AudioByteStream(this.#opts.sampleRate, 1, samplesPerBuffer);
 
       const abortPromise = waitForAbort(this.abortSignal);
+      const sessionAbort = waitForAbort(sessionController.signal);
 
       try {
         while (!this.closed) {
-          const result = await Promise.race([this.input.next(), abortPromise]);
+          const result = await Promise.race([this.input.next(), abortPromise, sessionAbort]);
 
           if (result === undefined) return; // aborted
           if (result.done) break;
@@ -441,6 +443,7 @@ export class SpeechStream extends stt.SpeechStream {
       await Promise.all([sendTask(), listenTask.result, wsMonitor.result]);
     } finally {
       closing = true;
+      sessionController.abort();
       listenTask.cancel();
       configTask.cancel();
       if (messageHandler) ws.off('message', messageHandler);

--- a/plugins/assemblyai/src/stt.ts
+++ b/plugins/assemblyai/src/stt.ts
@@ -237,6 +237,7 @@ export class SpeechStream extends stt.SpeechStream {
       try {
         const ws = await this.#connectWS();
         await this.#runWS(ws);
+        retries = 0;
       } catch (e) {
         if (!this.closed && !this.input.closed) {
           if (retries >= maxRetry) {
@@ -366,10 +367,9 @@ export class SpeechStream extends stt.SpeechStream {
           let frames: AudioFrame[];
           if (data === SpeechStream.FLUSH_SENTINEL) {
             frames = audioStream.flush();
-          } else if (data.sampleRate === this.#opts.sampleRate || data.channels === 1) {
-            // Matches the Deepgram plugin's permissive check — the base class
-            // resamples incoming frames, and the resampler output may not
-            // always be labeled with the target sample rate exactly.
+          } else if (data.sampleRate === this.#opts.sampleRate && data.channels === 1) {
+            // AssemblyAI expects mono PCM. The base SpeechStream only resamples
+            // sample rate, so reject any frame that is not already downmixed.
             frames = audioStream.write(data.data.buffer as ArrayBuffer);
           } else {
             throw new Error('sample rate or channel count of frame does not match');

--- a/plugins/assemblyai/src/stt.ts
+++ b/plugins/assemblyai/src/stt.ts
@@ -1,0 +1,606 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from:
+//   livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+// See `// Ref: python ... - N-M lines` comments throughout for cross-references.
+import {
+  type APIConnectOptions,
+  type AudioBuffer,
+  AudioByteStream,
+  Future,
+  Task,
+  createTimedString,
+  delay,
+  log,
+  normalizeLanguage,
+  stt,
+  waitForAbort,
+} from '@livekit/agents';
+import type { AudioFrame } from '@livekit/rtc-node';
+import type { RawData } from 'ws';
+import { WebSocket } from 'ws';
+import type { STTEncoding, STTModels } from './models.js';
+
+// AssemblyAI Universal-Streaming (v3) message envelope. All fields are optional
+// since we narrow on `type` before reading anything else.
+interface StreamEventMessage {
+  type?: 'Begin' | 'SpeechStarted' | 'Turn' | 'Termination' | string;
+  // Begin
+  id?: string;
+  expires_at?: number;
+  // Turn
+  transcript?: string;
+  utterance?: string;
+  end_of_turn?: boolean;
+  turn_is_formatted?: boolean;
+  language_code?: string;
+  words?: Array<{ text?: string; start?: number; end?: number; confidence?: number }>;
+  // Termination
+  audio_duration_seconds?: number;
+  session_duration_seconds?: number;
+}
+
+// Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 46-66 lines
+export interface STTOptions {
+  apiKey?: string;
+  sampleRate: number;
+  /**
+   * How large each chunk of audio is before being sent to AssemblyAI, in
+   * milliseconds. Corresponds to Python's `buffer_size_seconds` (seconds there,
+   * ms here per this repo's time-unit convention).
+   */
+  bufferSizeMs: number;
+  encoding: STTEncoding;
+  speechModel: STTModels;
+  languageDetection?: boolean;
+  endOfTurnConfidenceThreshold?: number;
+  /** Minimum silence (ms) before a confident end-of-turn is finalized. */
+  minTurnSilence?: number;
+  /** Maximum silence (ms) before end-of-turn is forced regardless of confidence. */
+  maxTurnSilence?: number;
+  formatTurns?: boolean;
+  keytermsPrompt?: string[];
+  /** Only supported with the `u3-rt-pro` model. */
+  prompt?: string;
+  vadThreshold?: number;
+  /**
+   * Enable speaker diarization. Note: AssemblyAI will return per-word speaker
+   * labels, but the JS framework's `stt.SpeechData` type does not yet expose
+   * a `speakerId` field (unlike the Python framework), so the labels are not
+   * currently surfaced on emitted events. Setting this to `true` still has
+   * effect server-side. Once the base `SpeechData` interface gains speaker
+   * support, `#processStreamEvent` should forward `data.words[].speaker` too.
+   */
+  speakerLabels?: boolean;
+  maxSpeakers?: number;
+  domain?: string;
+  baseUrl: string;
+}
+
+// Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 72-97 lines
+const defaultSTTOptions: STTOptions = {
+  apiKey: process.env.ASSEMBLYAI_API_KEY,
+  sampleRate: 16000,
+  bufferSizeMs: 50,
+  encoding: 'pcm_s16le',
+  speechModel: 'universal-streaming-english',
+  baseUrl: 'wss://streaming.assemblyai.com',
+};
+
+// Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 72 lines
+export class STT extends stt.STT {
+  #opts: STTOptions;
+  label = 'assemblyai.STT';
+
+  get model(): string {
+    return this.#opts.speechModel;
+  }
+
+  get provider(): string {
+    return 'AssemblyAI';
+  }
+
+  constructor(opts: Partial<STTOptions> = {}) {
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 111-119 lines
+    super({
+      streaming: true,
+      interimResults: true,
+      alignedTranscript: 'word',
+    });
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 120-122 lines
+    if (opts.speechModel === 'u3-pro') {
+      log().warn("'u3-pro' is deprecated, use 'u3-rt-pro' instead.");
+      opts.speechModel = 'u3-rt-pro';
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 124-125 lines
+    if (opts.prompt !== undefined && opts.speechModel !== 'u3-rt-pro') {
+      throw new Error("The 'prompt' parameter is only supported with the 'u3-rt-pro' model.");
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 127-135 lines
+    const apiKey = opts.apiKey ?? defaultSTTOptions.apiKey;
+    if (!apiKey) {
+      throw new Error(
+        'AssemblyAI API key is required. Pass one in via the `apiKey` parameter, or set it as the `ASSEMBLYAI_API_KEY` environment variable',
+      );
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 147-149 lines
+    // Minimize latency; matches LK's end-of-turn detector well.
+    const minTurnSilence = opts.minTurnSilence ?? 100;
+
+    this.#opts = {
+      ...defaultSTTOptions,
+      ...opts,
+      apiKey,
+      minTurnSilence,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async _recognize(_: AudioBuffer): Promise<stt.SpeechEvent> {
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 185-192 lines
+    throw new Error('Non-streaming recognize is not supported on AssemblyAI STT');
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 212-257 lines
+  updateOptions(opts: Partial<STTOptions>) {
+    this.#opts = { ...this.#opts, ...opts };
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 194-210 lines
+  stream(options?: { connOptions?: APIConnectOptions }): SpeechStream {
+    return new SpeechStream(this, this.#opts, options?.connOptions);
+  }
+}
+
+// Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 260 lines
+export class SpeechStream extends stt.SpeechStream {
+  // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 262 lines
+  static readonly CLOSE_MSG = JSON.stringify({ type: 'Terminate' });
+
+  #opts: STTOptions;
+  #logger = log();
+  #speechDurationInS = 0;
+  #lastPreflightStartTime = 0;
+  #pendingConfigMessages: Record<string, unknown>[] = [];
+  #configMessagePending = new Future();
+  #sessionId: string | null = null;
+  #expiresAt: number | null = null;
+  label = 'assemblyai.SpeechStream';
+
+  constructor(stt: STT, opts: STTOptions, connOptions?: APIConnectOptions) {
+    super(stt, opts.sampleRate, connOptions);
+    this.#opts = opts;
+    this.closed = false;
+  }
+
+  /**
+   * The AssemblyAI session ID. Set when the WebSocket connection is established
+   * (before any speech events). Null until the connection completes.
+   * Share this with the AssemblyAI team when reporting issues.
+   */
+  // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 286-291 lines
+  get sessionId(): string | null {
+    return this.#sessionId;
+  }
+
+  /**
+   * Unix timestamp when the AssemblyAI session expires. Set alongside
+   * {@link sessionId} when the WebSocket connection is established.
+   */
+  // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 293-297 lines
+  get expiresAt(): number | null {
+    return this.#expiresAt;
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 299-351 lines
+  updateOptions(opts: Partial<STTOptions>) {
+    this.#opts = { ...this.#opts, ...opts };
+
+    const configMsg: Record<string, unknown> = { type: 'UpdateConfiguration' };
+    if (opts.prompt !== undefined) configMsg.prompt = opts.prompt;
+    if (opts.keytermsPrompt !== undefined) configMsg.keyterms_prompt = opts.keytermsPrompt;
+    if (opts.maxTurnSilence !== undefined) configMsg.max_turn_silence = opts.maxTurnSilence;
+    if (opts.minTurnSilence !== undefined) configMsg.min_turn_silence = opts.minTurnSilence;
+    if (opts.endOfTurnConfidenceThreshold !== undefined) {
+      configMsg.end_of_turn_confidence_threshold = opts.endOfTurnConfidenceThreshold;
+    }
+    if (opts.vadThreshold !== undefined) configMsg.vad_threshold = opts.vadThreshold;
+
+    // Only send if any actual fields (besides `type`) were specified.
+    if (Object.keys(configMsg).length > 1) {
+      this.#pendingConfigMessages.push(configMsg);
+      if (!this.#configMessagePending.done) this.#configMessagePending.resolve();
+    }
+  }
+
+  /**
+   * Force-finalize the current turn immediately.
+   */
+  // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 353-355 lines
+  forceEndpoint() {
+    this.#pendingConfigMessages.push({ type: 'ForceEndpoint' });
+    if (!this.#configMessagePending.done) this.#configMessagePending.resolve();
+  }
+
+  // Deepgram-style reconnect loop around a single websocket lifetime.
+  protected async run() {
+    const maxRetry = 32;
+    let retries = 0;
+
+    while (!this.input.closed && !this.closed) {
+      try {
+        const ws = await this.#connectWS();
+        await this.#runWS(ws);
+      } catch (e) {
+        if (!this.closed && !this.input.closed) {
+          if (retries >= maxRetry) {
+            throw new Error(`failed to connect to AssemblyAI after ${retries} attempts: ${e}`);
+          }
+
+          const retryDelaySeconds = Math.min(retries * 5, 10);
+          retries++;
+
+          this.#logger.warn(
+            `failed to connect to AssemblyAI, retrying in ${retryDelaySeconds} seconds: ${e} (${retries}/${maxRetry})`,
+          );
+          await delay(retryDelaySeconds * 1000);
+        } else {
+          this.#logger.warn(
+            `AssemblyAI disconnected, connection is closed: ${e} (inputClosed: ${this.input.closed}, isClosed: ${this.closed})`,
+          );
+        }
+      }
+    }
+
+    this.closed = true;
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 442-505 lines
+  async #connectWS(): Promise<WebSocket> {
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 443-461 lines
+    // u3-rt-pro has different silence defaults — if unset, both min and max default to 100ms.
+    let minSilence = this.#opts.minTurnSilence;
+    let maxSilence = this.#opts.maxTurnSilence;
+    if (this.#opts.speechModel === 'u3-rt-pro') {
+      if (minSilence === undefined) minSilence = 100;
+      if (maxSilence === undefined) maxSilence = minSilence;
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 476-480 lines
+    // Default language_detection to true for multilingual / u3-rt-pro models, false otherwise.
+    const defaultLanguageDetection =
+      this.#opts.speechModel.includes('multilingual') || this.#opts.speechModel === 'u3-rt-pro';
+    const languageDetection = this.#opts.languageDetection ?? defaultLanguageDetection;
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 463-502 lines
+    const liveConfig: Record<string, unknown> = {
+      sample_rate: this.#opts.sampleRate,
+      encoding: this.#opts.encoding,
+      speech_model: this.#opts.speechModel,
+      format_turns: this.#opts.formatTurns,
+      end_of_turn_confidence_threshold: this.#opts.endOfTurnConfidenceThreshold,
+      min_turn_silence: minSilence,
+      max_turn_silence: maxSilence,
+      keyterms_prompt:
+        this.#opts.keytermsPrompt !== undefined
+          ? JSON.stringify(this.#opts.keytermsPrompt)
+          : undefined,
+      language_detection: languageDetection,
+      prompt: this.#opts.prompt,
+      vad_threshold: this.#opts.vadThreshold,
+      speaker_labels: this.#opts.speakerLabels,
+      max_speakers: this.#opts.maxSpeakers,
+      domain: this.#opts.domain,
+    };
+
+    const url = new URL(`${this.#opts.baseUrl}/v3/ws`);
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 498-502 lines
+    // Python serializes booleans as the strings "true"/"false", so we mirror that.
+    for (const [key, value] of Object.entries(liveConfig)) {
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'boolean') {
+        url.searchParams.append(key, value ? 'true' : 'false');
+      } else {
+        url.searchParams.append(key, String(value));
+      }
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 492-496 lines
+    const ws = new WebSocket(url, {
+      headers: {
+        Authorization: this.#opts.apiKey!,
+        'Content-Type': 'application/json',
+        'User-Agent': 'AssemblyAI/1.0 (integration=Livekit)',
+      },
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      ws.on('open', () => resolve());
+      ws.on('error', (error) => reject(error));
+      ws.on('close', (code) => reject(new Error(`WebSocket returned ${code}`)));
+    });
+
+    return ws;
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 357-440 lines
+  async #runWS(ws: WebSocket) {
+    let closing = false;
+
+    // gets cancelled also when sendTask is complete
+    const wsMonitor = Task.from(async (controller) => {
+      const closed = new Promise<void>((_, reject) => {
+        ws.once('close', (code, reason) => {
+          if (!closing) {
+            this.#logger.error(`WebSocket closed with code ${code}: ${reason}`);
+            reject(new Error('WebSocket closed'));
+          }
+        });
+      });
+
+      await Promise.race([closed, waitForAbort(controller.signal)]);
+    });
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 361-385 lines
+    const sendTask = async () => {
+      const samplesPerBuffer = Math.floor((this.#opts.sampleRate * this.#opts.bufferSizeMs) / 1000);
+      const audioStream = new AudioByteStream(this.#opts.sampleRate, 1, samplesPerBuffer);
+
+      const abortPromise = waitForAbort(this.abortSignal);
+
+      try {
+        while (!this.closed) {
+          const result = await Promise.race([this.input.next(), abortPromise]);
+
+          if (result === undefined) return; // aborted
+          if (result.done) break;
+
+          const data = result.value;
+
+          let frames: AudioFrame[];
+          if (data === SpeechStream.FLUSH_SENTINEL) {
+            frames = audioStream.flush();
+          } else if (data.sampleRate === this.#opts.sampleRate || data.channels === 1) {
+            // Matches the Deepgram plugin's permissive check — the base class
+            // resamples incoming frames, and the resampler output may not
+            // always be labeled with the target sample rate exactly.
+            frames = audioStream.write(data.data.buffer as ArrayBuffer);
+          } else {
+            throw new Error('sample rate or channel count of frame does not match');
+          }
+
+          for (const frame of frames) {
+            this.#speechDurationInS += frame.samplesPerChannel / frame.sampleRate;
+            ws.send(frame.data.buffer);
+          }
+        }
+      } finally {
+        closing = true;
+        try {
+          ws.send(SpeechStream.CLOSE_MSG);
+        } catch {
+          // ignore — socket may already be closing
+        }
+        wsMonitor.cancel();
+      }
+    };
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 387-418 lines
+    let messageHandler: ((msg: RawData, isBinary: boolean) => void) | null = null;
+    const listenTask = Task.from(async (controller) => {
+      const listenMessage = new Promise<void>((resolve, reject) => {
+        messageHandler = (msg, isBinary) => {
+          if (isBinary) {
+            this.#logger.error('unexpected binary message from AssemblyAI');
+            return;
+          }
+          try {
+            const json = JSON.parse(msg.toString()) as StreamEventMessage;
+            this.#processStreamEvent(json);
+            if (this.closed || closing) {
+              resolve();
+            }
+          } catch (err) {
+            this.#logger.error(`AssemblyAI: error processing message: ${msg}`);
+            reject(err);
+          }
+        };
+        ws.on('message', messageHandler);
+      });
+
+      await Promise.race([listenMessage, waitForAbort(controller.signal)]);
+    });
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 420-424 lines
+    const configTask = Task.from(async (controller) => {
+      // Drain any messages queued while the socket was reconnecting.
+      while (this.#pendingConfigMessages.length > 0) {
+        const msg = this.#pendingConfigMessages.shift()!;
+        ws.send(JSON.stringify(msg));
+      }
+
+      while (!controller.signal.aborted) {
+        await Promise.race([this.#configMessagePending.await, waitForAbort(controller.signal)]);
+        if (controller.signal.aborted) return;
+
+        this.#configMessagePending = new Future();
+        while (this.#pendingConfigMessages.length > 0) {
+          const msg = this.#pendingConfigMessages.shift()!;
+          ws.send(JSON.stringify(msg));
+        }
+      }
+    });
+
+    try {
+      await Promise.all([sendTask(), listenTask.result, wsMonitor.result]);
+    } finally {
+      closing = true;
+      listenTask.cancel();
+      configTask.cancel();
+      if (messageHandler) ws.off('message', messageHandler);
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  #averageConfidence(words: Array<{ confidence?: number }>): number {
+    if (words.length === 0) return 0;
+    return words.reduce((sum, w) => sum + (w.confidence ?? 0), 0) / words.length;
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 507-661 lines
+  #processStreamEvent(data: StreamEventMessage) {
+    const messageType = data.type;
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 510-518 lines
+    if (messageType === 'Begin') {
+      this.#sessionId = data.id ?? null;
+      this.#expiresAt = data.expires_at ?? null;
+      this.#logger.info(
+        `AssemblyAI session started id=${this.#sessionId} expires_at=${this.#expiresAt}`,
+      );
+      return;
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 520-522 lines
+    if (messageType === 'SpeechStarted') {
+      this.queue.put({ type: stt.SpeechEventType.START_OF_SPEECH });
+      return;
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 524-532 lines
+    if (messageType === 'Termination') {
+      this.#logger.debug(
+        `AssemblyAI session terminated audio_duration=${data.audio_duration_seconds}s session_duration=${data.session_duration_seconds}s`,
+      );
+      return;
+    }
+
+    if (messageType !== 'Turn') {
+      return;
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 536-546 lines
+    const words = data.words ?? [];
+    const endOfTurn = Boolean(data.end_of_turn);
+    const turnIsFormatted = Boolean(data.turn_is_formatted);
+    const utterance = data.utterance ?? '';
+    const transcript = data.transcript ?? '';
+    const language = normalizeLanguage(data.language_code ?? 'en');
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 555-564 lines
+    // Word timestamps are in milliseconds:
+    // https://www.assemblyai.com/docs/api-reference/streaming-api/streaming-api#receive.receiveTurn.words
+    const timedWords = words.map((word) =>
+      createTimedString({
+        text: word.text ?? '',
+        startTime: (word.start ?? 0) / 1000 + this.startTimeOffset,
+        endTime: (word.end ?? 0) / 1000 + this.startTimeOffset,
+        confidence: word.confidence ?? 0,
+        startTimeOffset: this.startTimeOffset,
+      }),
+    );
+
+    let startTime = 0;
+    let endTime = 0;
+    let confidence = 0;
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 566-588 lines
+    // `words` are cumulative for the turn — emit as an interim transcript.
+    if (timedWords.length > 0) {
+      const interimText = timedWords.map((w) => w.text).join(' ');
+      startTime = timedWords[0]!.startTime ?? 0;
+      endTime = timedWords[timedWords.length - 1]!.endTime ?? 0;
+      confidence = this.#averageConfidence(timedWords);
+
+      this.queue.put({
+        type: stt.SpeechEventType.INTERIM_TRANSCRIPT,
+        alternatives: [
+          {
+            language,
+            text: interimText,
+            startTime,
+            endTime,
+            confidence,
+            words: timedWords,
+          },
+        ],
+      });
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 590-621 lines
+    // `utterance` is chunk-based (not cumulative) — emit as a preflight transcript
+    // covering only the words since the last preflight.
+    if (utterance) {
+      if (this.#lastPreflightStartTime === 0) {
+        this.#lastPreflightStartTime = startTime;
+      }
+
+      const utteranceWords = timedWords.filter(
+        (w) => w.startTime !== undefined && w.startTime >= this.#lastPreflightStartTime,
+      );
+      const utteranceConfidence = this.#averageConfidence(utteranceWords);
+
+      this.queue.put({
+        type: stt.SpeechEventType.PREFLIGHT_TRANSCRIPT,
+        alternatives: [
+          {
+            language,
+            text: utterance,
+            startTime: this.#lastPreflightStartTime,
+            endTime,
+            confidence: utteranceConfidence,
+            words: utteranceWords,
+          },
+        ],
+      });
+      this.#lastPreflightStartTime = endTime;
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py - 623-661 lines
+    // End-of-turn: emit FINAL_TRANSCRIPT + END_OF_SPEECH.
+    // If the user asked for formatted turns, wait for a formatted final.
+    const waitingForFormatted = this.#opts.formatTurns === true && !turnIsFormatted;
+    if (endOfTurn && !waitingForFormatted) {
+      this.queue.put({
+        type: stt.SpeechEventType.FINAL_TRANSCRIPT,
+        alternatives: [
+          {
+            language,
+            text: transcript,
+            startTime,
+            endTime,
+            confidence,
+            words: timedWords,
+          },
+        ],
+      });
+
+      this.queue.put({ type: stt.SpeechEventType.END_OF_SPEECH });
+
+      if (this.#speechDurationInS > 0) {
+        this.queue.put({
+          type: stt.SpeechEventType.RECOGNITION_USAGE,
+          // Propagate the AssemblyAI session id as the request id so metrics
+          // can be correlated back to a specific connection, mirroring how
+          // Deepgram surfaces its `request_id`.
+          requestId: this.#sessionId ?? undefined,
+          recognitionUsage: {
+            audioDuration: this.#speechDurationInS,
+          },
+        });
+        this.#speechDurationInS = 0;
+        this.#lastPreflightStartTime = 0;
+      }
+    }
+  }
+}

--- a/plugins/assemblyai/tsconfig.json
+++ b/plugins/assemblyai/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
+    "rootDir": "./src",
+    "declarationDir": "./dist",
+    "outDir": "./dist"
+  },
+  "typedocOptions": {
+    "name": "plugins/agents-plugin-assemblyai",
+    "entryPointStrategy": "resolve",
+    "readme": "none",
+    "entryPoints": ["src/index.ts"]
+  }
+}

--- a/plugins/assemblyai/tsup.config.ts
+++ b/plugins/assemblyai/tsup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'tsup';
+
+import defaults from '../../tsup.config';
+
+export default defineConfig({
+  ...defaults,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,37 @@ importers:
         specifier: ^5.0.0
         version: 5.4.5
 
+  plugins/assemblyai:
+    dependencies:
+      ws:
+        specifier: ^8.16.0
+        version: 8.20.0
+    devDependencies:
+      '@livekit/agents':
+        specifier: workspace:*
+        version: link:../../agents
+      '@livekit/agents-plugin-silero':
+        specifier: workspace:*
+        version: link:../silero
+      '@livekit/agents-plugins-test':
+        specifier: workspace:*
+        version: link:../test
+      '@livekit/rtc-node':
+        specifier: 'catalog:'
+        version: 0.13.25
+      '@microsoft/api-extractor':
+        specifier: ^7.35.0
+        version: 7.43.7(@types/node@22.19.1)
+      '@types/ws':
+        specifier: ^8.5.10
+        version: 8.5.10
+      tsup:
+        specifier: ^8.3.5
+        version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@22.19.1))(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   plugins/baseten:
     dependencies:
       dotenv:
@@ -6154,7 +6185,7 @@ snapshots:
       google-auth-library: 10.5.0
       p-retry: 4.6.2
       protobufjs: 7.5.4
-      ws: 8.18.3
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "globalEnv": [
+    "ASSEMBLYAI_API_KEY",
     "AZURE_API_KEY",
     "AZURE_OPENAI_API_KEY",
     "AZURE_OPENAI_DEPLOYMENT",


### PR DESCRIPTION
## Summary

Adds a new `@livekit/agents-plugin-assemblyai` STT plugin for AssemblyAI's Universal-Streaming v3 WebSocket API. Ported line-by-line from the Python [`livekit-plugins-assemblyai`](https://github.com/livekit/agents/tree/main/livekit-plugins/livekit-plugins-assemblyai) plugin; every non-trivial block has a `// Ref: python .../stt.py - N-M lines` comment pointing back to the source so future syncs are straightforward.

Architecture mirrors the existing Deepgram STT plugin: retry loop around a single WebSocket lifetime, concurrent `sendTask` / `listenTask` / `configTask` inside `#runWS`, graceful close via `{"type":"Terminate"}`.

## Features

- **All AssemblyAI v3 options exposed**: `speechModel` (`universal-streaming-english`, `universal-streaming-multilingual`, `u3-rt-pro`), `sampleRate`, `bufferSizeMs`, `min/maxTurnSilence`, `formatTurns`, `keytermsPrompt`, `prompt` (u3-rt-pro only), `vadThreshold`, `endOfTurnConfidenceThreshold`, `speakerLabels`, `maxSpeakers`, `domain`, custom `baseUrl` (e.g. for EU region).
- **Live config updates** via `UpdateConfiguration` messages over the active socket — no reconnect needed, unlike Deepgram's `updateOptions`. Backed by a small pending-queue + `Future` wake pattern.
- **`forceEndpoint()`** to finalize the current turn on demand.
- **`sessionId` / `expiresAt` getters** for debugging; `sessionId` is also propagated as `requestId` on `RECOGNITION_USAGE` events so metrics correlate back to a specific AssemblyAI connection.
- **Turn-event mapping**: `Turn` message → `INTERIM_TRANSCRIPT` (cumulative words), `PREFLIGHT_TRANSCRIPT` (chunk-based from `utterance`), `FINAL_TRANSCRIPT` + `END_OF_SPEECH` on `end_of_turn` (respecting `turn_is_formatted` when `formatTurns` is set).
- **Word timestamps** correctly converted from AssemblyAI's ms to `createTimedString`'s seconds.
- **`u3-pro` → `u3-rt-pro` rename** handled with a deprecation warning, matching Python.

## Known framework gap (not blocking)

`stt.SpeechData` in `@livekit/agents` doesn't yet have a `speakerId` field, so per-word speaker labels from AssemblyAI's diarization are not surfaced on emitted events. The `speakerLabels` option is exposed and sent to the server; a follow-up PR can wire through speaker ids once the base type is extended. See the TSDoc on `speakerLabels` in `plugins/assemblyai/src/stt.ts` for the exact forwarding point.

## Test plan

- [x] `pnpm --filter @livekit/agents-plugin-assemblyai... build` — clean
- [x] `pnpm --filter @livekit/agents-plugin-assemblyai lint` — clean
- [x] `pnpm -w format:check` — clean
- [x] `pnpm lint` (whole monorepo) — 24/24 green, no regressions
- [x] `pnpm build` (whole monorepo) — 24/24 green
- [x] `pnpm vitest run plugins/assemblyai --testTimeout 30000` against the real AssemblyAI API — green, transcription matches reference transcript within the 20% Levenshtein threshold
- [x] Swap into a real voice-agent example (e.g. `examples/src/basic_agent.ts`) and verify turn detection behaves naturally

## Notes for reviewers

- The shared `plugins/test/src/stt.ts` helper has a default 5000ms vitest timeout; AssemblyAI's streaming happy path lands at 5.5-6.2s end-to-end, which is occasionally flaky near the boundary. Running with `--testTimeout 30000` is reliable. This affects the shared helper, not the plugin itself — a follow-up could bump the helper's default.
- Version is pinned to `1.2.4` to match the monorepo's fixed-versioning group (`.changeset/config.json` has `"fixed": [["@livekit/agents", "@livekit/agents-plugin-*", ...]]`). Changeset is `patch` to match recent precedent — a maintainer can bump to `minor` at release time if preferred.
- `turbo.json` gains one line: `ASSEMBLYAI_API_KEY` in `globalEnv`, required so the new test file's env-var check doesn't trip `turbo/no-undeclared-env-vars`.