### PR TITLE
feat(inference): handle preflight_transcript events in inference STT plugin

### DIFF
--- a/.changeset/moody-plants-decide.md
+++ b/.changeset/moody-plants-decide.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+feat(inference): handle preflight_transcript events in inference STT plugin

--- a/agents/src/inference/api_protos.ts
+++ b/agents/src/inference/api_protos.ts
@@ -120,6 +120,11 @@ export const sttFinalTranscriptEventSchema = z.object({
   extra: z.unknown().nullable().optional(),
 });
 
+// Preflight transcript event (Deepgram Flux turn-detection: EagerEndOfTurn, TurnResumed, StartOfTurn)
+export const sttPreflightTranscriptEventSchema = sttInterimTranscriptEventSchema.extend({
+  type: z.literal('preflight_transcript'),
+});
+
 // Session created event
 export const sttSessionCreatedEventSchema = z.object({
   type: z.literal('session.created'),
@@ -150,6 +155,7 @@ export const sttServerEventSchema = z.discriminatedUnion('type', [
   sttSessionClosedEventSchema,
   sttInterimTranscriptEventSchema,
   sttFinalTranscriptEventSchema,
+  sttPreflightTranscriptEventSchema,
   sttErrorEventSchema,
 ]);
 
@@ -157,7 +163,11 @@ export const sttServerEventSchema = z.discriminatedUnion('type', [
 export type SttWord = z.infer<typeof sttWordSchema>;
 export type SttInterimTranscriptEvent = z.infer<typeof sttInterimTranscriptEventSchema>;
 export type SttFinalTranscriptEvent = z.infer<typeof sttFinalTranscriptEventSchema>;
-export type SttTranscriptEvent = SttInterimTranscriptEvent | SttFinalTranscriptEvent;
+export type SttPreflightTranscriptEvent = z.infer<typeof sttPreflightTranscriptEventSchema>;
+export type SttTranscriptEvent =
+  | SttInterimTranscriptEvent
+  | SttFinalTranscriptEvent
+  | SttPreflightTranscriptEvent;
 export type SttSessionCreatedEvent = z.infer<typeof sttSessionCreatedEventSchema>;
 export type SttSessionFinalizedEvent = z.infer<typeof sttSessionFinalizedEventSchema>;
 export type SttSessionClosedEvent = z.infer<typeof sttSessionClosedEventSchema>;

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -70,6 +70,8 @@ export interface DeepgramOptions {
   numerals?: boolean;
   /** Opt out of model improvement program. */
   mip_opt_out?: boolean;
+  /** Eager end-of-turn threshold (0.0–1.0). Enables preflight transcripts for preemptive generation. */
+  eager_eot_threshold?: number;
 }
 
 export interface AssemblyAIOptions {
@@ -519,10 +521,13 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
                 resourceCleanup();
                 break;
               case 'interim_transcript':
-                this.processTranscript(event, false);
+                this.processTranscript(event, SpeechEventType.INTERIM_TRANSCRIPT);
                 break;
               case 'final_transcript':
-                this.processTranscript(event, true);
+                this.processTranscript(event, SpeechEventType.FINAL_TRANSCRIPT);
+                break;
+              case 'preflight_transcript':
+                this.processTranscript(event, SpeechEventType.PREFLIGHT_TRANSCRIPT);
                 break;
               case 'error':
                 this.#logger.error({ error: event }, 'Received error from LiveKit STT');
@@ -588,7 +593,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
     }
   }
 
-  private processTranscript(data: SttTranscriptEvent, isFinal: boolean) {
+  private processTranscript(data: SttTranscriptEvent, eventType: SpeechEventType) {
     // Check if queue is closed to avoid race condition during disconnect
     if (this.queue.closed) return;
 
@@ -596,7 +601,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
     const text = data.transcript;
     const language = normalizeLanguage(data.language || this.opts.language || 'en');
 
-    if (!text && !isFinal) return;
+    if (!text && eventType !== SpeechEventType.FINAL_TRANSCRIPT) return;
 
     try {
       // We'll have a more accurate way of detecting when speech started when we have VAD
@@ -623,7 +628,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
         ),
       };
 
-      if (isFinal) {
+      if (eventType === SpeechEventType.FINAL_TRANSCRIPT) {
         if (this.speechDuration > 0) {
           this.queue.put({
             type: SpeechEventType.RECOGNITION_USAGE,
@@ -645,7 +650,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
         }
       } else {
         this.queue.put({
-          type: SpeechEventType.INTERIM_TRANSCRIPT,
+          type: eventType,
           requestId,
           alternatives: [speechData],
         });


### PR DESCRIPTION
## Summary

- Adds `sttPreflightTranscriptEventSchema` Zod schema and updates the `sttServerEventSchema` discriminated union to parse `preflight_transcript` wire events from the agent-gateway (AP-646)
- Refactors `processTranscript` from `isFinal: boolean` to `eventType: SpeechEventType` to naturally support three transcript states (interim, final, preflight), matching the Deepgram direct plugin's `#sendTranscriptEvent` pattern
- Adds `eager_eot_threshold` to `DeepgramOptions` so users can enable Deepgram Flux turn-detection events that produce preflight transcripts

Closes [AJS-386](https://linear.app/livekit/issue/AJS-386/handle-preflight-transcripts-in-js-inference-plugin)

## Test plan

- [x] `pnpm build:agents` compiles successfully
- [x] `pnpm api:check` — no public API surface changes (types are internal)
- [x] Reviewed for behavioral parity with `plugins/deepgram/src/stt_v2.ts` (EagerEndOfTurn → PREFLIGHT_TRANSCRIPT mapping, START_OF_SPEECH gating, empty text guard, no END_OF_SPEECH/RECOGNITION_USAGE on preflight)
- [ ] Verify with `restaurant_agent.ts` using Deepgram Flux model + `eager_eot_threshold` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)