### PR TITLE
fix: prevent AgentTask inside tool from being killed by premature RunState resolution

### DIFF
--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-
+import type { AudioFrame } from '@livekit/rtc-node';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { ReadableStream } from 'node:stream/web';
-import type { AudioFrame } from '@livekit/rtc-node';
 import {
   LLM as InferenceLLM,
   STT as InferenceSTT,
@@ -24,7 +23,7 @@ import {
   type ToolContext,
 } from '../llm/index.js';
 import { log } from '../log.js';
-import type { SpeechEvent, STT } from '../stt/index.js';
+import type { STT, SpeechEvent } from '../stt/index.js';
 import { StreamAdapter as STTStreamAdapter } from '../stt/index.js';
 import { SentenceTokenizer as BasicSentenceTokenizer } from '../tokenize/basic/index.js';
 import type { TTS } from '../tts/index.js';

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { AudioFrame } from '@livekit/rtc-node';
+
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { ReadableStream } from 'node:stream/web';
+import type { AudioFrame } from '@livekit/rtc-node';
 import {
   LLM as InferenceLLM,
   STT as InferenceSTT,
@@ -23,7 +24,7 @@ import {
   type ToolContext,
 } from '../llm/index.js';
 import { log } from '../log.js';
-import type { STT, SpeechEvent } from '../stt/index.js';
+import type { SpeechEvent, STT } from '../stt/index.js';
 import { StreamAdapter as STTStreamAdapter } from '../stt/index.js';
 import { SentenceTokenizer as BasicSentenceTokenizer } from '../tokenize/basic/index.js';
 import type { TTS } from '../tts/index.js';
@@ -600,8 +601,8 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
       !oldActivity.llm.capabilities.manualFunctionCalls
     ) {
       this.#logger.error(
-        `Realtime model does not support resuming function calls from chat context, ` +
-          `using AgentTask inside a function tool may have unexpected behavior.`,
+        'Realtime model does not support resuming function calls from chat context, ' +
+          'using AgentTask inside a function tool may have unexpected behavior.',
       );
     }
 
@@ -619,9 +620,10 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
       if (runState._watchedHandleCount() > 1) {
         runState._unwatchHandle(speechHandle);
       }
-      // it is OK to call _markDoneIfNeeded here, the above _updateActivity will call onEnter
-      // and newly added handles keep the run alive.
-      runState._markDoneIfNeeded();
+      // Do NOT call _markDoneIfNeeded() here. The AgentTask's activity may create new speech
+      // handles whose pipelines complete before this point, causing the RunState to resolve
+      // while the parent tool execution is still in progress. Handles will resolve the
+      // RunState naturally via their own done callbacks when they truly complete.
     }
 
     try {
@@ -633,7 +635,7 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
       if (session.currentAgent !== this) {
         this.#logger.warn(
           `${this.constructor.name} completed, but the agent has changed in the meantime. ` +
-            `Ignoring handoff to the previous agent, likely due to AgentSession.updateAgent being invoked.`,
+            'Ignoring handoff to the previous agent, likely due to AgentSession.updateAgent being invoked.',
         );
         await oldActivity.close();
       } else {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { ReadableStream, TransformStream } from 'node:stream/web';
 import { Mutex } from '@livekit/mutex';
 import type { AudioFrame } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
-import { ROOT_CONTEXT, context as otelContext, trace } from '@opentelemetry/api';
+import { context as otelContext, ROOT_CONTEXT, trace } from '@opentelemetry/api';
 import { Heap } from 'heap-js';
-import { AsyncLocalStorage } from 'node:async_hooks';
-import { ReadableStream, TransformStream } from 'node:stream/web';
 import type { Logger } from 'pino';
 import type { InterruptionDetectionError } from '../inference/interruption/errors.js';
 import { AdaptiveInterruptionDetector } from '../inference/interruption/interruption_detector.js';
@@ -42,21 +43,21 @@ import type {
   VADMetrics,
 } from '../metrics/base.js';
 import { MultiInputStream } from '../stream/multi_input_stream.js';
-import { STT, type STTError, type SpeechEvent } from '../stt/stt.js';
-import { recordRealtimeMetrics, traceTypes, tracer } from '../telemetry/index.js';
+import { type SpeechEvent, STT, type STTError } from '../stt/stt.js';
+import { recordRealtimeMetrics, tracer, traceTypes } from '../telemetry/index.js';
 import { splitWords } from '../tokenize/basic/word.js';
 import { TTS, type TTSError } from '../tts/tts.js';
-import { Future, Task, cancelAndWait, isDevMode, isHosted, waitFor } from '../utils.js';
+import { cancelAndWait, Future, isDevMode, isHosted, Task, waitFor } from '../utils.js';
 import { VAD, type VADEvent } from '../vad.js';
 import type { Agent, ModelSettings } from './agent.js';
 import {
-  StopResponse,
   _getActivityTaskInfo,
   _setActivityTaskInfo,
   functionCallStorage,
+  StopResponse,
   speechHandleStorage,
 } from './agent.js';
-import { type AgentSession, type TurnDetectionMode } from './agent_session.js';
+import type { AgentSession, TurnDetectionMode } from './agent_session.js';
 import {
   AudioRecognition,
   type EndOfTurnInfo,
@@ -73,15 +74,15 @@ import {
   createSpeechCreatedEvent,
   createUserInputTranscribedEvent,
 } from './events.js';
-import type { ToolExecutionOutput, ToolOutput, _TTSGenerationData } from './generation.js';
+import type { _TTSGenerationData, ToolExecutionOutput, ToolOutput } from './generation.js';
 import {
   type _AudioOut,
   type _TextOut,
   performAudioForwarding,
   performLLMInference,
-  performTTSInference,
   performTextForwarding,
   performToolExecutions,
+  performTTSInference,
   removeInstructions,
   updateInstructions,
 } from './generation.js';
@@ -773,12 +774,7 @@ export class AgentActivity implements RecognitionHooks {
     this.audioStreamId = undefined;
   }
 
-  commitUserTurn(
-    options: {
-      audioDetached?: boolean;
-      throwIfNotReady?: boolean;
-    } = {},
-  ) {
+  commitUserTurn(options: { audioDetached?: boolean; throwIfNotReady?: boolean } = {}) {
     const { audioDetached = false, throwIfNotReady = true } = options;
     if (!this.audioRecognition) {
       if (throwIfNotReady) {
@@ -2206,6 +2202,20 @@ export class AgentActivity implements RecognitionHooks {
       );
       speechHandle._markGenerationDone();
       await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+
+      // Commit any completed FunctionCallOutputs to chatCtx. Without this,
+      // onToolExecutionStarted already added the FunctionCall but the matching
+      // FunctionCallOutput is only in speechHandle._itemAdded — leaving an
+      // orphaned FunctionCall that removeInvalidToolCalls() will strip later,
+      // erasing all evidence of the tool invocation from the LLM's context.
+      const completedOutputs = toolOutput.output
+        .map((o) => o.toolCallOutput)
+        .filter((o): o is FunctionCallOutput => o !== undefined);
+      if (completedOutputs.length > 0) {
+        this.agent._chatCtx.insert(completedOutputs);
+        this.agentSession._toolItemsAdded(completedOutputs);
+      }
+
       return;
     }
 
@@ -2235,10 +2245,8 @@ export class AgentActivity implements RecognitionHooks {
     } else if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
-          this.restoreInterruptionByAudioActivity();
-        }
+        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        this.restoreInterruptionByAudioActivity();
       }
     }
 
@@ -2360,7 +2368,7 @@ export class AgentActivity implements RecognitionHooks {
     ev: GenerationCreatedEvent,
     modelSettings: ModelSettings,
     replyAbortController: AbortController,
-    addToChatCtx: boolean = true,
+    addToChatCtx = true,
   ): Promise<void> {
     return tracer.startActiveSpan(
       async (span) =>
@@ -2911,11 +2919,7 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
-  private scheduleSpeech(
-    speechHandle: SpeechHandle,
-    priority: number,
-    force: boolean = false,
-  ): void {
+  private scheduleSpeech(speechHandle: SpeechHandle, priority: number, force = false): void {
     // when force=true, we allow tool responses to bypass scheduling pause
     // This allows for tool responses to be generated before the AgentActivity is finalized
     if (this.schedulingPaused && !force) {
@@ -2951,10 +2955,7 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   async pause(
-    options: {
-      blockedTasks?: Task<any>[];
-      newActivity?: AgentActivity;
-    } = {},
+    options: { blockedTasks?: Task<any>[]; newActivity?: AgentActivity } = {},
   ): Promise<ReusableResources | undefined> {
     const { blockedTasks = [], newActivity } = options;
     const unlock = await this.lock.lock();

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1,14 +1,13 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-
-import { AsyncLocalStorage } from 'node:async_hooks';
-import { ReadableStream, TransformStream } from 'node:stream/web';
 import { Mutex } from '@livekit/mutex';
 import type { AudioFrame } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
-import { context as otelContext, ROOT_CONTEXT, trace } from '@opentelemetry/api';
+import { ROOT_CONTEXT, context as otelContext, trace } from '@opentelemetry/api';
 import { Heap } from 'heap-js';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { ReadableStream, TransformStream } from 'node:stream/web';
 import type { Logger } from 'pino';
 import type { InterruptionDetectionError } from '../inference/interruption/errors.js';
 import { AdaptiveInterruptionDetector } from '../inference/interruption/interruption_detector.js';
@@ -43,18 +42,18 @@ import type {
   VADMetrics,
 } from '../metrics/base.js';
 import { MultiInputStream } from '../stream/multi_input_stream.js';
-import { type SpeechEvent, STT, type STTError } from '../stt/stt.js';
-import { recordRealtimeMetrics, tracer, traceTypes } from '../telemetry/index.js';
+import { STT, type STTError, type SpeechEvent } from '../stt/stt.js';
+import { recordRealtimeMetrics, traceTypes, tracer } from '../telemetry/index.js';
 import { splitWords } from '../tokenize/basic/word.js';
 import { TTS, type TTSError } from '../tts/tts.js';
-import { cancelAndWait, Future, isDevMode, isHosted, Task, waitFor } from '../utils.js';
+import { Future, Task, cancelAndWait, isDevMode, isHosted, waitFor } from '../utils.js';
 import { VAD, type VADEvent } from '../vad.js';
 import type { Agent, ModelSettings } from './agent.js';
 import {
+  StopResponse,
   _getActivityTaskInfo,
   _setActivityTaskInfo,
   functionCallStorage,
-  StopResponse,
   speechHandleStorage,
 } from './agent.js';
 import type { AgentSession, TurnDetectionMode } from './agent_session.js';
@@ -74,15 +73,15 @@ import {
   createSpeechCreatedEvent,
   createUserInputTranscribedEvent,
 } from './events.js';
-import type { _TTSGenerationData, ToolExecutionOutput, ToolOutput } from './generation.js';
+import type { ToolExecutionOutput, ToolOutput, _TTSGenerationData } from './generation.js';
 import {
   type _AudioOut,
   type _TextOut,
   performAudioForwarding,
   performLLMInference,
+  performTTSInference,
   performTextForwarding,
   performToolExecutions,
-  performTTSInference,
   removeInstructions,
   updateInstructions,
 } from './generation.js';


### PR DESCRIPTION
## Problem

When an `AgentTask` is awaited inside a tool's `execute` function (e.g. a transfer-acknowledgement task inside a `transfer_to_care_home` tool), the SDK can kill the task prematurely:

```
Error: The Task finished before TransferAckTask was completed.
```

There are two bugs at play:

### Bug 1 — Premature RunState resolution kills the AgentTask

The call chain is:

1. Tool `execute` runs → calls `agentTask.run()`
2. `AgentTask.run()` calls `session._updateActivity()`, which pauses the current activity and starts the AgentTask's own activity (including `onEnter`)
3. If `onEnter` generates a reply, a **new speech handle** is created and watched by the `RunResult` (`_globalRunState._watchHandle(newHandle)`)
4. Back in `AgentTask.run()`, the parent speech handle is unwatched (since `watchedHandleCount > 1`), then **`runState._markDoneIfNeeded()` is called explicitly**
5. If the new handle's pipeline already completed (common with fast/mocked TTS), `_markDoneIfNeeded()` sees all remaining watched handles as done → **resolves the RunState**
6. The RunState resolution cascades: the parent Task finishes, its done callback fires, and since the AgentTask's future hasn't resolved yet, it force-completes with an error
7. The tool's catch block runs, but the SDK has already finalized the tool as failed — `performCallForward` (the actual Twilio transfer) is never reached

**Root cause:** The explicit `_markDoneIfNeeded()` call in `AgentTask.run()` is premature. It checks handle states at a moment when the AgentTask's new handles may have already completed their pipelines, but the parent tool execution is still in progress.

### Bug 2 — FunctionCallOutput not committed to chatCtx on interruption

In `_pipelineReplyTaskImpl`, when a speech is interrupted during tool execution:

1. `onToolExecutionStarted` adds the `FunctionCall` to `agent._chatCtx` ✅
2. `onToolExecutionCompleted` adds the `FunctionCallOutput` to `speechHandle._itemAdded` only — **not** to `agent._chatCtx` ❌
3. The interruption path returns without committing the output
4. `removeInvalidToolCalls()` later strips the orphaned `FunctionCall` (no matching output)
5. The LLM has no record that the tool was ever invoked

## Fix

### Fix 1 — Remove premature `_markDoneIfNeeded()` call (`agent.ts`)

Removed the explicit `runState._markDoneIfNeeded()` call after `_updateActivity()` in `AgentTask.run()`. Handles already register their own done callbacks via `_watchHandle()` → `handle.addDoneCallback(() => this._markDoneIfNeeded(handle))`, so the RunState resolves naturally when handles truly complete. The unwatch guard (`watchedHandleCount > 1`) is preserved — it correctly prevents unwatching the last handle.

### Fix 2 — Commit completed FunctionCallOutputs on interruption (`agent_activity.ts`)

After `executeToolsTask.cancelAndWait()` in the interruption path, any completed `FunctionCallOutput` items are now committed to `agent._chatCtx` and emitted via `_toolItemsAdded()`. This mirrors the non-interrupted path (lines 2132-2137) and ensures orphaned `FunctionCall` entries are properly paired with their outputs.

## Test plan

- [x] All 627 existing tests pass (`npx vitest run` — 41 test files, 0 failures)
- [x] Build + typecheck pass (`pnpm --filter @livekit/agents build`)
- [x] Lint passes on changed files
- [ ] Manual validation with Eliza TransferAckTask (tool that calls `agentTask.run()` inside `transfer_to_care_home`)

Co-Authored-By: Ticketmaster <https://github.com/LottieHQ/ticketmaster>