### PR TITLE
fix(xai/minor): update Grok realtime voices to match xAI API

### DIFF
--- a/.changeset/xai-update-grok-voices.md
+++ b/.changeset/xai-update-grok-voices.md
@@ -2,4 +2,4 @@
 '@livekit/agents-plugin-xai': patch
 ---
 
-update Grok realtime voices to match xAI API (eve, ara, rex, sal, leo) and change default to `eve`
+update Grok realtime voices to match xAI API (eve, ara, rex, sal, leo); default voice is now lowercase `ara`

--- a/.changeset/xai-update-grok-voices.md
+++ b/.changeset/xai-update-grok-voices.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-xai': patch
+---
+
+update Grok realtime voices to match xAI API (eve, ara, rex, sal, leo) and change default to `eve`

--- a/plugins/xai/src/realtime/realtime_model.ts
+++ b/plugins/xai/src/realtime/realtime_model.ts
@@ -8,7 +8,7 @@ type OpenAIRealtimeModelOptions = ConstructorParameters<typeof OpenAIRealtimeMod
 
 const XAI_BASE_URL = 'wss://api.x.ai/v1';
 const DEFAULT_MODEL = 'grok-4-1-fast-non-reasoning';
-const DEFAULT_VOICE = 'Ara';
+const DEFAULT_VOICE = 'eve';
 
 const XAI_DEFAULT_TURN_DETECTION = {
   type: 'server_vad' as const,
@@ -19,7 +19,7 @@ const XAI_DEFAULT_TURN_DETECTION = {
   interrupt_response: true,
 };
 
-export type GrokVoices = 'Ara' | 'Cora' | 'Sage';
+export type GrokVoices = 'eve' | 'ara' | 'rex' | 'sal' | 'leo';
 
 export interface RealtimeModelOptions extends Omit<OpenAIRealtimeModelOptions, 'model'> {
   model?: string;

--- a/plugins/xai/src/realtime/realtime_model.ts
+++ b/plugins/xai/src/realtime/realtime_model.ts
@@ -8,7 +8,7 @@ type OpenAIRealtimeModelOptions = ConstructorParameters<typeof OpenAIRealtimeMod
 
 const XAI_BASE_URL = 'wss://api.x.ai/v1';
 const DEFAULT_MODEL = 'grok-4-1-fast-non-reasoning';
-const DEFAULT_VOICE = 'eve';
+const DEFAULT_VOICE = 'ara';
 
 const XAI_DEFAULT_TURN_DETECTION = {
   type: 'server_vad' as const,


### PR DESCRIPTION
## Summary

- The `GrokVoices` type in the xAI realtime plugin is stale: it lists `Ara | Cora | Sage`, but xAI now exposes five voices — `eve`, `ara`, `rex`, `sal`, `leo` — with lowercase names.
- Aligns `DEFAULT_VOICE` casing to lowercase (`'ara'`) to match the documented naming; same voice as before, just the correct case.

Source: [xAI Voice Agent API — Available Voices](https://docs.x.ai/developers/model-capabilities/audio/voice-agent#available-voices)

### Notes

- Users passing a custom `voice` string are unaffected (the `voice` option still accepts `GrokVoices | string`).
- Default voice is still Ara; only the casing changes to match xAI's documentation.