### PR TITLE
feat(inference): introduce XAIModels type and enhance LLMModels with reasoning support

### DIFF
--- a/.changeset/three-masks-greet.md
+++ b/.changeset/three-masks-greet.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+feat(inference): introduce XAIModels type and enhance LLMModels with reasoning support

--- a/agents/src/inference/index.ts
+++ b/agents/src/inference/index.ts
@@ -12,6 +12,7 @@ export {
   type GatewayOptions,
   type InferenceLLMOptions,
   type LLMModels,
+  type XAIModels,
 } from './llm.js';
 
 export {

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -133,9 +133,7 @@ function dropUnsupportedParams(
 
   for (const [prefix, unsupported] of Object.entries(UNSUPPORTED_PARAMS)) {
     if (modelName.startsWith(prefix)) {
-      result = Object.fromEntries(
-        Object.entries(result).filter(([k]) => !unsupported.has(k)),
-      );
+      result = Object.fromEntries(Object.entries(result).filter(([k]) => !unsupported.has(k)));
       break;
     }
   }

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -44,6 +44,13 @@ export type MoonshotModels = 'moonshotai/kimi-k2-instruct';
 
 export type DeepSeekModels = 'deepseek-ai/deepseek-v3' | 'deepseek-ai/deepseek-v3.2';
 
+export type XAIModels =
+  | 'xai/grok-4-1-fast-non-reasoning'
+  | 'xai/grok-4-1-fast-reasoning'
+  | 'xai/grok-4.20-0309-non-reasoning'
+  | 'xai/grok-4.20-0309-reasoning'
+  | 'xai/grok-4.20-multi-agent-0309';
+
 type ChatCompletionPredictionContentParam =
   Expand<OpenAI.Chat.Completions.ChatCompletionPredictionContent>;
 type WebSearchOptions = Expand<OpenAI.Chat.Completions.ChatCompletionCreateParams.WebSearchOptions>;
@@ -83,7 +90,67 @@ export interface ChatCompletionOptions extends Record<string, unknown> {
   // response_format?: OpenAI.Chat.Completions.ChatCompletionCreateParams['response_format']
 }
 
-export type LLMModels = OpenAIModels | GoogleModels | MoonshotModels | DeepSeekModels | AnyString;
+export type LLMModels =
+  | OpenAIModels
+  | GoogleModels
+  | MoonshotModels
+  | DeepSeekModels
+  | XAIModels
+  | AnyString;
+
+const REASONING_UNSUPPORTED_PARAMS = new Set([
+  'temperature',
+  'top_p',
+  'presence_penalty',
+  'frequency_penalty',
+  'logit_bias',
+  'logprobs',
+  'top_logprobs',
+  'n',
+]);
+
+const XAI_REASONING_UNSUPPORTED_PARAMS = new Set(['presence_penalty', 'frequency_penalty', 'stop']);
+
+const UNSUPPORTED_PARAMS: Record<string, Set<string>> = {
+  o1: REASONING_UNSUPPORTED_PARAMS,
+  o3: REASONING_UNSUPPORTED_PARAMS,
+  o4: REASONING_UNSUPPORTED_PARAMS,
+  'gpt-5': REASONING_UNSUPPORTED_PARAMS,
+  'grok-4-1-fast-reasoning': XAI_REASONING_UNSUPPORTED_PARAMS,
+  'grok-4.20-0309-reasoning': XAI_REASONING_UNSUPPORTED_PARAMS,
+  'grok-4.20-multi-agent': XAI_REASONING_UNSUPPORTED_PARAMS,
+};
+
+const REASONING_EFFORT_TOOL_INCOMPATIBLE_PREFIXES = new Set(['gpt-5.2', 'gpt-5.4']);
+
+function dropUnsupportedParams(
+  model: string,
+  params: Record<string, unknown>,
+  tools?: unknown[],
+): Record<string, unknown> {
+  const modelName = model.includes('/') ? model.split('/').pop()! : model;
+  let result = { ...params };
+
+  for (const [prefix, unsupported] of Object.entries(UNSUPPORTED_PARAMS)) {
+    if (modelName.startsWith(prefix)) {
+      result = Object.fromEntries(
+        Object.entries(result).filter(([k]) => !unsupported.has(k)),
+      );
+      break;
+    }
+  }
+
+  if (
+    tools &&
+    tools.length > 0 &&
+    Array.from(REASONING_EFFORT_TOOL_INCOMPATIBLE_PREFIXES).some((p) => modelName.startsWith(p))
+  ) {
+    const { reasoning_effort: _, ...rest } = result;
+    result = rest;
+  }
+
+  return result;
+}
 
 export interface InferenceLLMOptions {
   model: LLMModels;
@@ -316,7 +383,11 @@ export class LLMStream extends llm.LLMStream {
           })
         : undefined;
 
-      const requestOptions: Record<string, unknown> = { ...this.modelOptions };
+      const requestOptions: Record<string, unknown> = dropUnsupportedParams(
+        this.model,
+        { ...this.modelOptions },
+        tools,
+      );
       if (!tools) {
         delete requestOptions.tool_choice;
       }

--- a/agents/src/llm/provider_format/openai.ts
+++ b/agents/src/llm/provider_format/openai.ts
@@ -5,6 +5,18 @@ import type { ChatContext, ChatItem, ImageContent } from '../chat_context.js';
 import { type SerializedImage, serializeImage } from '../utils.js';
 import { groupToolCalls } from './utils.js';
 
+const EXTRA_CONTENT_KEYS = ['google', 'livekit', 'xai'] as const;
+
+function filterExtra(extra: Record<string, unknown>): Record<string, unknown> {
+  const filtered: Record<string, unknown> = {};
+  for (const key of EXTRA_CONTENT_KEYS) {
+    if (extra[key]) {
+      filtered[key] = extra[key];
+    }
+  }
+  return filtered;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function toChatCtx(chatCtx: ChatContext, injectDummyUserMessage: boolean = true) {
   const itemGroups = groupToolCalls(chatCtx);
@@ -24,10 +36,12 @@ export async function toChatCtx(chatCtx: ChatContext, injectDummyUserMessage: bo
         function: { name: toolCall.name, arguments: toolCall.args },
       };
 
-      // Include provider-specific extra content (e.g., Google thought signatures)
-      const googleExtra = getGoogleExtra(toolCall);
-      if (googleExtra) {
-        tc.extra_content = { google: googleExtra };
+      const extraContent = toolCall.extra ? filterExtra(toolCall.extra) : {};
+      if (!extraContent.google && toolCall.thoughtSignature) {
+        extraContent.google = { thoughtSignature: toolCall.thoughtSignature };
+      }
+      if (Object.keys(extraContent).length > 0) {
+        tc.extra_content = extraContent;
       }
       return tc;
     });
@@ -72,6 +86,13 @@ async function toChatItem(item: ChatItem) {
       result.content = listContent;
     }
 
+    if (item.extra) {
+      const extraContent = filterExtra(item.extra);
+      if (Object.keys(extraContent).length > 0) {
+        result.extra_content = extraContent;
+      }
+    }
+
     return result;
   } else if (item.type === 'function_call') {
     const tc: Record<string, any> = {
@@ -80,10 +101,12 @@ async function toChatItem(item: ChatItem) {
       function: { name: item.name, arguments: item.args },
     };
 
-    // Include provider-specific extra content (e.g., Google thought signatures)
-    const googleExtra = getGoogleExtra(item);
-    if (googleExtra) {
-      tc.extra_content = { google: googleExtra };
+    const extraContent = item.extra ? filterExtra(item.extra) : {};
+    if (!extraContent.google && item.thoughtSignature) {
+      extraContent.google = { thoughtSignature: item.thoughtSignature };
+    }
+    if (Object.keys(extraContent).length > 0) {
+      tc.extra_content = extraContent;
     }
 
     return {
@@ -100,15 +123,6 @@ async function toChatItem(item: ChatItem) {
   // Skip other item types (e.g., agent_handoff)
   // These should be filtered by groupToolCalls, but this is a safety net
   throw new Error(`Unsupported item type: ${item['type']}`);
-}
-
-function getGoogleExtra(
-  item: Partial<{ extra?: Record<string, unknown>; thoughtSignature?: string }>,
-): Record<string, unknown> | undefined {
-  const googleExtra =
-    (item.extra?.google as Record<string, unknown> | undefined) ||
-    (item.thoughtSignature ? { thoughtSignature: item.thoughtSignature } : undefined);
-  return googleExtra;
 }
 
 async function toImageContent(content: ImageContent) {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2184,6 +2184,9 @@ export class AgentActivity implements RecognitionHooks {
           interrupted: true,
           createdAt: replyStartedAt,
           metrics: assistantMetrics,
+          ...(Object.keys(llmGenData.generatedExtra).length > 0
+            ? { extra: llmGenData.generatedExtra }
+            : {}),
         });
         chatCtx.insert(message);
         this.agent._chatCtx.insert(message);
@@ -2218,6 +2221,9 @@ export class AgentActivity implements RecognitionHooks {
         createdAt: replyStartedAt,
         content: textOut.text,
         metrics: assistantMetrics,
+        ...(Object.keys(llmGenData.generatedExtra).length > 0
+          ? { extra: llmGenData.generatedExtra }
+          : {}),
       });
       chatCtx.insert(message);
       this.agent._chatCtx.insert(message);

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -60,6 +60,7 @@ const TTS_READ_IDLE_TIMEOUT_MS = 10_000;
 export class _LLMGenerationData {
   generatedText: string = '';
   generatedToolCalls: FunctionCall[];
+  generatedExtra: Record<string, unknown> = {};
   id: string;
   ttft?: number;
 
@@ -507,6 +508,10 @@ export function performLLMInference(
               data.generatedToolCalls.push(toolCall);
               await toolCallWriter.write(toolCall);
             }
+          }
+
+          if (chunk.delta.extra) {
+            Object.assign(data.generatedExtra, chunk.delta.extra);
           }
 
           if (chunk.delta.content) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,7 +409,7 @@ importers:
         version: 8.5.10
       tsup:
         specifier: ^8.3.5
-        version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@22.19.1))(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@22.19.1))(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -744,7 +744,7 @@ importers:
         version: 0.13.25
       tsup:
         specifier: ^8.3.5
-        version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@22.19.1))(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@22.19.1))(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -7380,13 +7380,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@22.15.30)(tsx@4.21.0)
 
-  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@22.19.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.17(vite@7.3.2(@types/node@22.19.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.1)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@22.19.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.2':
     dependencies:
@@ -10421,14 +10421,14 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@22.19.1)(tsx@4.21.0):
+  vite@7.3.2(@types/node@22.19.1)(tsx@4.21.0):
     dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.55.1
-      tinyglobby: 0.2.15
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rollup: 4.60.1
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.19.1
       fsevents: 2.3.3
@@ -10550,7 +10550,7 @@ snapshots:
   vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@22.19.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.17(vite@7.3.2(@types/node@22.19.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.17
       '@vitest/runner': 4.0.17
       '@vitest/snapshot': 4.0.17
@@ -10567,7 +10567,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@22.19.1)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@22.19.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->

Add XAI (Grok) model support to the LiveKit inference layer. This introduces the `XAIModels` type, strips unsupported parameters for XAI reasoning models, generalizes the provider-specific `extra_content` handling (previously Google-only) to support multiple providers (Google, LiveKit, XAI), and propagates LLM-generated extra metadata through to chat context messages.

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- **`agents/src/inference/llm.ts`**: Added `XAIModels` type with 5 Grok model variants. Added `dropUnsupportedParams` function that strips parameters incompatible with reasoning models (OpenAI o-series, GPT-5, XAI Grok reasoning). XAI reasoning models only need `presence_penalty`, `frequency_penalty`, and `stop` stripped (they still support `temperature`/`top_p`). Also strips `reasoning_effort` from GPT-5.2/5.4 when tools are present. Applied `dropUnsupportedParams` to the request options in `LLMStream.run()`.
- **`agents/src/inference/index.ts`**: Exported the new `XAIModels` type.
- **`agents/src/llm/provider_format/openai.ts`**: Replaced the Google-specific `getGoogleExtra` helper with a generalized `filterExtra` function using an allowlist of provider keys (`google`, `livekit`, `xai`). Applied `filterExtra` to tool calls, function call items, and message items when serializing to OpenAI provider format.
- **`agents/src/voice/generation.ts`**: Added `generatedExtra` field to `_LLMGenerationData` and accumulate `chunk.delta.extra` from the LLM stream via `Object.assign`.
- **`agents/src/voice/agent_activity.ts`**: Pass `generatedExtra` as the `extra` field on assistant `ChatMessage` creation for both interrupted and non-interrupted playout paths.

## Pre-Review Checklist
- [X] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [X] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [X] **Changes explained**: All changes are properly documented and justified above
- [X] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable)

## Testing
<!-- Describe how you tested these changes -->
Tested using https://agents-playground.livekit.io/  and locally running agent-gateway
- [X] Automated tests added/updated (if applicable)
- [X] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

- The `dropUnsupportedParams` logic and `UNSUPPORTED_PARAMS` map are a direct port from the Python `agents` repo (`livekit-agents/livekit/agents/inference/llm.py`), maintaining parity across SDKs.
- The `Object.assign` shallow merge for `generatedExtra` matches the Python SDK's `dict.update()` semantics — this is fine given providers send extra metadata once per stream rather than progressively across chunks.
- No new tests were added for `dropUnsupportedParams` or `filterExtra`. Consider adding unit tests for prefix matching edge cases (e.g., ensuring `grok-4-1-fast-non-reasoning` does *not* match the reasoning entry).

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.