### PR TITLE
fix: avoid retrying aborted LLM requests during shutdown

### DIFF
--- a/.changeset/weak-moles-bake.md
+++ b/.changeset/weak-moles-bake.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix: avoid retrying aborted LLM requests during shutdown

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -354,6 +354,10 @@ export class LLMStream extends llm.LLMStream {
         },
       );
 
+      if (this.abortController.signal.aborted) {
+        return;
+      }
+
       for await (const chunk of stream) {
         if (this.abortController.signal.aborted) {
           break;
@@ -382,6 +386,10 @@ export class LLMStream extends llm.LLMStream {
         }
       }
     } catch (error) {
+      if (this.abortController.signal.aborted) {
+        return;
+      }
+
       if (error instanceof OpenAI.APIConnectionTimeoutError) {
         throw new APITimeoutError({ options: { retryable } });
       } else if (error instanceof OpenAI.APIError) {


### PR DESCRIPTION
## Summary
- treat already-aborted inference LLM streams as expected cancellation after request creation
- return early for aborted streams in the error path so shutdown does not reclassify cancellation as a retryable API failure
- prevent noisy retry logs when a participant disconnect aborts an in-flight goodbye generation

## Test plan
- [x] Reproduce the bug locally with a modified `manual_shutdown.ts` end-call flow
- [x] Build `@livekit/agents`
- [x] Verify the fix removes retry spam for aborted LLM requests during session shutdown

Fixes #1245