### PR TITLE
feat: add UserData generic to JobProcess

### DIFF
--- a/.changeset/job-process-userdata-generic.md
+++ b/.changeset/job-process-userdata-generic.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": minor
+---
+
+feat: add UserData generic to JobProcess, JobContext, and defineAgent

--- a/.changeset/job-process-userdata-generic.md
+++ b/.changeset/job-process-userdata-generic.md
@@ -1,5 +1,5 @@
 ---
-"@livekit/agents": minor
+"@livekit/agents": patch
 ---
 
 feat: add UserData generic to JobProcess, JobContext, and defineAgent

--- a/agents/src/generator.ts
+++ b/agents/src/generator.ts
@@ -4,9 +4,9 @@
 import type { JobContext, JobProcess } from './job.js';
 
 /** @see {@link defineAgent} */
-export interface Agent {
-  entry: (ctx: JobContext) => Promise<void>;
-  prewarm?: (proc: JobProcess) => unknown;
+export interface Agent<ProcessUserData = Record<string, unknown>> {
+  entry: (ctx: JobContext<ProcessUserData>) => Promise<void>;
+  prewarm?: (proc: JobProcess<ProcessUserData>) => unknown;
 }
 
 /** Helper to check if an object is an agent before running it.
@@ -33,6 +33,8 @@ export function isAgent(obj: unknown): obj is Agent {
  * })
  * ```
  */
-export function defineAgent(agent: Agent): Agent {
+export function defineAgent<ProcessUserData = Record<string, unknown>>(
+  agent: Agent<ProcessUserData>,
+): Agent<ProcessUserData> {
   return agent;
 }

--- a/agents/src/job.ts
+++ b/agents/src/job.ts
@@ -22,8 +22,7 @@ import type { AgentSession } from './voice/agent_session.js';
 import { type SessionReport, createSessionReport } from './voice/report.js';
 
 // AsyncLocalStorage for job context, similar to Python's contextvars
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const jobContextStorage = new AsyncLocalStorage<JobContext<any>>();
+const jobContextStorage = new AsyncLocalStorage<JobContext<unknown>>();
 
 /**
  * Returns the current job context.
@@ -45,7 +44,7 @@ export function getJobContext<
  * @internal
  */
 export function runWithJobContext<T>(context: JobContext, fn: () => T): T {
-  return jobContextStorage.run(context, fn);
+  return jobContextStorage.run(context as JobContext<unknown>, fn);
 }
 
 /**
@@ -53,7 +52,7 @@ export function runWithJobContext<T>(context: JobContext, fn: () => T): T {
  * @internal
  */
 export function runWithJobContextAsync<T>(context: JobContext, fn: () => Promise<T>): Promise<T> {
-  return jobContextStorage.run(context, fn);
+  return jobContextStorage.run(context as JobContext<unknown>, fn);
 }
 
 /** Which tracks, if any, should the agent automatically subscribe to? */

--- a/agents/src/job.ts
+++ b/agents/src/job.ts
@@ -22,19 +22,22 @@ import type { AgentSession } from './voice/agent_session.js';
 import { type SessionReport, createSessionReport } from './voice/report.js';
 
 // AsyncLocalStorage for job context, similar to Python's contextvars
-const jobContextStorage = new AsyncLocalStorage<JobContext>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const jobContextStorage = new AsyncLocalStorage<JobContext<any>>();
 
 /**
  * Returns the current job context.
  *
  * @throws {Error} if no job context is found
  */
-export function getJobContext(): JobContext {
+export function getJobContext<
+  ProcessUserData = Record<string, unknown>,
+>(): JobContext<ProcessUserData> {
   const ctx = jobContextStorage.getStore();
   if (!ctx) {
     throw new Error('no job context found, are you running this code inside a job entrypoint?');
   }
-  return ctx;
+  return ctx as JobContext<ProcessUserData>;
 }
 
 /**
@@ -85,18 +88,21 @@ export class FunctionExistsError extends Error {
 }
 
 /** The job and environment context as seen by the agent, accessible by the entrypoint function. */
-export class JobContext {
-  #proc: JobProcess;
+export class JobContext<ProcessUserData = Record<string, unknown>> {
+  #proc: JobProcess<ProcessUserData>;
   #info: RunningJobInfo;
   #room: Room;
   #onConnect: () => void;
   #onShutdown: (s: string) => void;
   /** @internal */
   shutdownCallbacks: (() => Promise<void>)[] = [];
-  #participantEntrypoints: ((job: JobContext, p: RemoteParticipant) => Promise<void>)[] = [];
+  #participantEntrypoints: ((
+    job: JobContext<ProcessUserData>,
+    p: RemoteParticipant,
+  ) => Promise<void>)[] = [];
   #participantTasks: {
     [id: string]: {
-      callback: (job: JobContext, p: RemoteParticipant) => Promise<void>;
+      callback: (job: JobContext<ProcessUserData>, p: RemoteParticipant) => Promise<void>;
       result: Promise<void>;
     };
   } = {};
@@ -112,7 +118,7 @@ export class JobContext {
   private connected: boolean = false;
 
   constructor(
-    proc: JobProcess,
+    proc: JobProcess<ProcessUserData>,
     info: RunningJobInfo,
     room: Room,
     onConnect: () => void,
@@ -134,7 +140,7 @@ export class JobContext {
     this._sessionDirectory = path.join(os.tmpdir(), 'livekit-agents', `job-${this.#info.job.id}`);
   }
 
-  get proc(): JobProcess {
+  get proc(): JobProcess<ProcessUserData> {
     return this.#proc;
   }
 
@@ -367,7 +373,9 @@ export class JobContext {
    *
    * @throws {@link FunctionExistsError} if an entrypoint already exists
    */
-  addParticipantEntrypoint(callback: (job: JobContext, p: RemoteParticipant) => Promise<void>) {
+  addParticipantEntrypoint(
+    callback: (job: JobContext<ProcessUserData>, p: RemoteParticipant) => Promise<void>,
+  ) {
     if (this.#participantEntrypoints.includes(callback)) {
       throw new FunctionExistsError('entrypoints cannot be added more than once');
     }
@@ -390,9 +398,9 @@ export class JobContext {
   }
 }
 
-export class JobProcess {
+export class JobProcess<UserData = Record<string, unknown>> {
   #pid = process.pid;
-  userData: { [id: string]: unknown } = {};
+  userData = {} as UserData;
 
   get pid(): number {
     return this.#pid;


### PR DESCRIPTION
Allows users to define typed process-level userData instead of relying on unchecked index access and type assertions.

## Description

Adds a `UserData` generic type parameter to `JobProcess`, `JobContext`, `Agent`, and `defineAgent`. Defaults to `Record<string, unknown>` so all existing code continues to work unchanged.

## Changes Made

- `JobProcess<UserData>` — `userData` property is now typed as `UserData` instead of `{ [id: string]: unknown }`
- `JobContext<ProcUserData>` — threads the generic through `proc`, participant entrypoints, etc.
- `getJobContext<ProcUserData>()` — accepts an optional generic to narrow the return type
- `Agent<ProcUserData>` and `defineAgent<ProcUserData>()` — generic flows through `entry` and `prewarm` callbacks

## Pre-Review Checklist

- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable)

## Testing

- [x] All 628 existing tests pass
- [x] Type tests in `tool_context.type.test.ts` pass
- [x] `pnpm build:agents` succeeds (including tsc declaration emit)
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes

N/A

---

**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.