### PR TITLE
fix: use proper types in agent_activity_handoff test

### DIFF
--- a/agents/src/voice/agent_activity_handoff.test.ts
+++ b/agents/src/voice/agent_activity_handoff.test.ts
@@ -2,11 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { AudioFrame } from '@livekit/rtc-node';
+import type { ReadableStream } from 'node:stream/web';
 import { describe, expect, it, vi } from 'vitest';
 import { ChatContext } from '../llm/chat_context.js';
 import { type RealtimeCapabilities, RealtimeModel, type RealtimeSession } from '../llm/realtime.js';
 import type { SpeechEvent } from '../stt/stt.js';
-import { Agent } from './agent.js';
+import { Agent, type ModelSettings } from './agent.js';
 import {
   AgentActivity,
   type ReusableResources,
@@ -42,10 +43,13 @@ async function detachResources(
   oldActivity: FakeActivity,
   newActivity: FakeActivity,
 ): Promise<ReusableResources> {
-  return await (AgentActivity.prototype as any)._detachReusableResources.call(
-    oldActivity,
-    newActivity,
-  );
+  // Access private method via prototype for testing
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fn = (AgentActivity.prototype as any)._detachReusableResources as (
+    this: FakeActivity,
+    newActivity: FakeActivity,
+  ) => Promise<ReusableResources>;
+  return await fn.call(oldActivity, newActivity);
 }
 
 describe('AgentActivity STT handoff reuse eligibility', () => {
@@ -85,13 +89,13 @@ describe('AgentActivity STT handoff reuse eligibility', () => {
     const sharedStt = { id: 'shared-stt' };
 
     class AgentA extends Agent {
-      async sttNode(_audio: ReadableStream<AudioFrame>, _modelSettings: any) {
+      async sttNode(_audio: ReadableStream<AudioFrame>, _modelSettings: ModelSettings) {
         return null as ReadableStream<SpeechEvent | string> | null;
       }
     }
 
     class AgentB extends Agent {
-      async sttNode(_audio: ReadableStream<AudioFrame>, _modelSettings: any) {
+      async sttNode(_audio: ReadableStream<AudioFrame>, _modelSettings: ModelSettings) {
         return null as ReadableStream<SpeechEvent | string> | null;
       }
     }
@@ -109,7 +113,7 @@ describe('AgentActivity STT handoff reuse eligibility', () => {
     const sharedStt = { id: 'shared-stt' };
 
     class AgentA extends Agent {
-      async sttNode(_audio: ReadableStream<AudioFrame>, _modelSettings: any) {
+      async sttNode(_audio: ReadableStream<AudioFrame>, _modelSettings: ModelSettings) {
         return null as ReadableStream<SpeechEvent | string> | null;
       }
     }
@@ -195,10 +199,7 @@ describe('AgentActivity RT session reuse eligibility', () => {
     const oldActivity = createRtActivity(oldAgent, sharedLlm, rtSession);
     const newActivity = createRtActivity(newAgent, sharedLlm);
 
-    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
-      oldActivity,
-      newActivity,
-    );
+    const resources = await detachResources(oldActivity, newActivity);
 
     expect(resources.rtSession).toBe(rtSession);
     expect(oldActivity.realtimeSession).toBeUndefined();
@@ -213,10 +214,7 @@ describe('AgentActivity RT session reuse eligibility', () => {
     const oldActivity = createRtActivity(new Agent({ instructions: 'a' }), oldLlm, rtSession);
     const newActivity = createRtActivity(new Agent({ instructions: 'a' }), newLlm);
 
-    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
-      oldActivity,
-      newActivity,
-    );
+    const resources = await detachResources(oldActivity, newActivity);
 
     expect(resources.rtSession).toBeUndefined();
   });
@@ -228,10 +226,7 @@ describe('AgentActivity RT session reuse eligibility', () => {
     const oldActivity = createRtActivity(new Agent({ instructions: 'old' }), sharedLlm, rtSession);
     const newActivity = createRtActivity(new Agent({ instructions: 'new' }), sharedLlm);
 
-    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
-      oldActivity,
-      newActivity,
-    );
+    const resources = await detachResources(oldActivity, newActivity);
 
     expect(resources.rtSession).toBeUndefined();
   });
@@ -243,10 +238,7 @@ describe('AgentActivity RT session reuse eligibility', () => {
     const oldActivity = createRtActivity(new Agent({ instructions: 'old' }), sharedLlm, rtSession);
     const newActivity = createRtActivity(new Agent({ instructions: 'new' }), sharedLlm);
 
-    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
-      oldActivity,
-      newActivity,
-    );
+    const resources = await detachResources(oldActivity, newActivity);
 
     expect(resources.rtSession).toBe(rtSession);
   });
@@ -254,16 +246,11 @@ describe('AgentActivity RT session reuse eligibility', () => {
   it('reuses RT session when context differs but midSessionChatCtxUpdate is true', async () => {
     const sharedLlm = createFakeRealtimeModel({ midSessionChatCtxUpdate: true });
     const rtSession = createFakeRtSession();
-    // Give the session a non-empty chat context
-    (rtSession as any).chatCtx = ChatContext.empty();
 
     const oldActivity = createRtActivity(new Agent({ instructions: 'same' }), sharedLlm, rtSession);
     const newActivity = createRtActivity(new Agent({ instructions: 'same' }), sharedLlm);
 
-    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
-      oldActivity,
-      newActivity,
-    );
+    const resources = await detachResources(oldActivity, newActivity);
 
     expect(resources.rtSession).toBe(rtSession);
   });
@@ -273,10 +260,7 @@ describe('AgentActivity RT session reuse eligibility', () => {
     const oldActivity = createRtActivity(new Agent({ instructions: 'a' }), sharedLlm, undefined);
     const newActivity = createRtActivity(new Agent({ instructions: 'a' }), sharedLlm);
 
-    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
-      oldActivity,
-      newActivity,
-    );
+    const resources = await detachResources(oldActivity, newActivity);
 
     expect(resources.rtSession).toBeUndefined();
   });
@@ -292,10 +276,7 @@ describe('AgentActivity RT session reuse eligibility', () => {
     );
     const newActivity = createRtActivity(new Agent({ instructions: 'a' }), nonRealtimeLlm);
 
-    const resources = await (AgentActivity.prototype as any)._detachReusableResources.call(
-      oldActivity,
-      newActivity,
-    );
+    const resources = await detachResources(oldActivity, newActivity);
 
     expect(resources.rtSession).toBeUndefined();
   });
@@ -306,8 +287,8 @@ describe('cleanupReusableResources', () => {
     const sttClose = vi.fn(async () => {});
     const rtClose = vi.fn(async () => {});
     const resources: ReusableResources = {
-      sttPipeline: { close: sttClose } as any,
-      rtSession: { close: rtClose } as any,
+      sttPipeline: { close: sttClose } as unknown as ReusableResources['sttPipeline'],
+      rtSession: { close: rtClose } as unknown as ReusableResources['rtSession'],
     };
 
     await cleanupReusableResources(resources);
@@ -321,7 +302,7 @@ describe('cleanupReusableResources', () => {
   it('handles partial resources (only STT)', async () => {
     const sttClose = vi.fn(async () => {});
     const resources: ReusableResources = {
-      sttPipeline: { close: sttClose } as any,
+      sttPipeline: { close: sttClose } as unknown as ReusableResources['sttPipeline'],
     };
 
     await cleanupReusableResources(resources);


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->

Cleans up `no-explicit-any` lint warnings in `agent_activity_handoff.test.ts` by using proper types throughout.

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->

- Import `ReadableStream` from `node:stream/web` and `ModelSettings` from `agent.js` to match base class signatures
- Extract private method access to a single typed `eslint-disable` site instead of repeating `as any` in every test
- Replace `as any` mock casts with `as unknown as ReusableResources['...']`
- Use `import type` for type-only imports

## Pre-Review Checklist

- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
<!-- Describe how you tested these changes -->

- [x] All 16 tests in `agent_activity_handoff.test.ts` pass
- [x] Zero lint warnings for the file

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

N/A

---

**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.