### PR TITLE
feat(openai): expose maxOutputTokens on Responses API LLM

### DIFF
--- a/.changeset/openai-responses-max-output-tokens.md
+++ b/.changeset/openai-responses-max-output-tokens.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-openai": patch
+---
+
+feat(openai): expose `maxOutputTokens` on Responses API LLM

--- a/plugins/openai/src/responses/llm.ts
+++ b/plugins/openai/src/responses/llm.ts
@@ -28,6 +28,8 @@ export interface LLMOptions {
   strictToolSchema?: boolean;
   /** Specifies the processing tier (e.g. 'auto', 'default', 'priority', 'flex'). */
   serviceTier?: string;
+  /** Upper bound for the number of tokens that can be generated for a response. */
+  maxOutputTokens?: number;
 
   /**
    * Whether to use the WebSocket API.
@@ -118,6 +120,10 @@ class ResponsesHttpLLM extends llm.LLM {
 
     if (this.#opts.serviceTier) {
       modelOptions.service_tier = this.#opts.serviceTier;
+    }
+
+    if (this.#opts.maxOutputTokens !== undefined) {
+      modelOptions.max_output_tokens = this.#opts.maxOutputTokens;
     }
 
     return new ResponsesHttpLLMStream(this, {

--- a/plugins/openai/src/ws/llm.ts
+++ b/plugins/openai/src/ws/llm.ts
@@ -143,6 +143,8 @@ export interface WSLLMOptions {
   strictToolSchema?: boolean;
   /** Specifies the processing tier (e.g. 'auto', 'default', 'priority', 'flex'). */
   serviceTier?: string;
+  /** Upper bound for the number of tokens that can be generated for a response. */
+  maxOutputTokens?: number;
 }
 
 const defaultLLMOptions: WSLLMOptions = {
@@ -270,6 +272,10 @@ export class WSLLM extends llm.LLM {
 
     if (this.#opts.serviceTier) {
       modelOptions.service_tier = this.#opts.serviceTier;
+    }
+
+    if (this.#opts.maxOutputTokens !== undefined) {
+      modelOptions.max_output_tokens = this.#opts.maxOutputTokens;
     }
 
     let inputChatCtx = chatCtx;


### PR DESCRIPTION
## Summary

Adds `maxOutputTokens` as a first-class `LLMOptions` field on both the HTTP and WebSocket Responses API LLM paths — mirroring how `serviceTier` is already handled.

The underlying `/v1/responses` endpoint accepts `max_output_tokens` natively, but the plugin previously required callers to reach for `extraKwargs` on every `chat()` call to set it. This PR makes it a plain option so a bound can be set once at LLM construction time.

### Changes
- `plugins/openai/src/responses/llm.ts`: add `maxOutputTokens?: number` to `LLMOptions` and forward it to `modelOptions.max_output_tokens` on the HTTP path.
- `plugins/openai/src/ws/llm.ts`: add `maxOutputTokens?: number` to `WSLLMOptions` and forward it to `modelOptions.max_output_tokens` on the WebSocket path.
- Changeset added (`@livekit/agents-plugin-openai` patch).

### Usage

```ts
import { llm } from '@livekit/agents-plugin-openai';

const model = new llm.LLM({
  model: 'gpt-4.1',
  maxOutputTokens: 1024,
});
```

## Motivation

Brings the JS Responses plugin in line with the chat-completions `openai.LLM` which already exposes `maxCompletionTokens`, and mirrors the Python-side counterpart PR at livekit/agents#5449.

## Test plan

- [x] `pnpm build:agents && pnpm --filter @livekit/agents-plugin-openai build` — builds clean
- [x] `pnpm format:check` — passes
- [x] `pnpm --filter @livekit/agents-plugin-openai lint` — no new warnings introduced
- [x] Smoke test in [Agent Playground](https://agents-playground.livekit.io) with `new llm.LLM({ model: 'gpt-4.1', maxOutputTokens: 64 })` in both WebSocket and HTTP modes