### PR TITLE
fix: add required parameter to getJobContext, matching Python SDK

### DIFF
--- a/.changeset/silence-jobcontext-warning.md
+++ b/.changeset/silence-jobcontext-warning.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix: add `required` parameter to `getJobContext()`, matching Python SDK's `get_job_context(required=False)` pattern. Removes noisy warn-level log during evals/tests.

--- a/agents/src/inference/utils.ts
+++ b/agents/src/inference/utils.ts
@@ -57,8 +57,8 @@ export function buildMetadataHeaders(): Record<string, string> {
     'User-Agent': `livekit-agents-js/${version} (node ${process.version})`,
   };
 
-  try {
-    const ctx = getJobContext();
+  const ctx = getJobContext(false);
+  if (ctx) {
     const roomSid = ctx.job.room?.sid;
     if (roomSid) {
       headers['X-LiveKit-Room-Id'] = roomSid;
@@ -66,8 +66,6 @@ export function buildMetadataHeaders(): Record<string, string> {
     if (ctx.job.id) {
       headers['X-LiveKit-Job-Id'] = ctx.job.id;
     }
-  } catch {
-    // No job context available — standalone inference usage
   }
 
   return headers;

--- a/agents/src/job.ts
+++ b/agents/src/job.ts
@@ -27,11 +27,14 @@ const jobContextStorage = new AsyncLocalStorage<JobContext>();
 /**
  * Returns the current job context.
  *
- * @throws {Error} if no job context is found
+ * @param required - If true (default), throws when no context is found. If false, returns undefined.
+ * @throws {Error} if no job context is found and required is true
  */
-export function getJobContext(): JobContext {
+export function getJobContext(required?: true): JobContext;
+export function getJobContext(required: false): JobContext | undefined;
+export function getJobContext(required = true): JobContext | undefined {
   const ctx = jobContextStorage.getStore();
-  if (!ctx) {
+  if (!ctx && required) {
     throw new Error('no job context found, are you running this code inside a job entrypoint?');
   }
   return ctx;

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -19,7 +19,7 @@ import {
 } from '../inference/index.js';
 import type { InterruptionDetectionError } from '../inference/interruption/errors.js';
 import type { OverlappingSpeechEvent } from '../inference/interruption/types.js';
-import { type JobContext, getJobContext } from '../job.js';
+import { getJobContext } from '../job.js';
 import type { FunctionCall, FunctionCallOutput } from '../llm/chat_context.js';
 import { AgentHandoffItem, ChatContext, ChatMessage } from '../llm/chat_context.js';
 import type { LLM, RealtimeModel, RealtimeModelError, ToolChoice } from '../llm/index.js';
@@ -446,12 +446,7 @@ export class AgentSession<
       }
     }
 
-    let ctx: JobContext | undefined = undefined;
-    try {
-      ctx = getJobContext();
-    } catch {
-      // JobContext is not available in evals
-    }
+    const ctx = getJobContext(false);
 
     if (ctx) {
       if (room && ctx.room === room && !room.isConnected) {
@@ -524,10 +519,9 @@ export class AgentSession<
     this.closing = false;
     this._usageCollector = new ModelUsageCollector();
 
-    let ctx: JobContext | undefined = undefined;
-    try {
-      ctx = getJobContext();
+    const ctx = getJobContext(false);
 
+    if (ctx) {
       if (record === undefined) {
         record = ctx.job.enableRecording;
       }
@@ -537,9 +531,6 @@ export class AgentSession<
       if (this._enableRecording) {
         ctx.initRecording();
       }
-    } catch (error) {
-      // JobContext is not available in evals
-      this.logger.warn('JobContext is not available');
     }
 
     this.sessionSpan = tracer.startSpan({


### PR DESCRIPTION
## Description

Adds an optional `required` parameter to `getJobContext()`, matching the Python SDK's `get_job_context(required=False)` pattern. When `false`, returns `undefined` instead of throwing. This eliminates the noisy warn-level `"JobContext is not available"` log that fired on every `AgentSession.start()` call during evals/tests.

## Changes Made

- Added overloaded signatures to `getJobContext()` with a `required` parameter (`true` by default for backwards compatibility)
- Replaced try/catch blocks in `AgentSession` with `getJobContext(false)` + conditional
- Applied the same pattern in `inference/utils.ts` (`buildMetadataHeaders`)
- Removed unused `JobContext` type import from `agent_session.ts`

## Pre-Review Checklist

- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title

## Testing

- [x] Ran agent test suite and confirmed the `JobContext is not available` warnings no longer appear
- [x] All tests pass
- [x] Build succeeds

## Additional Notes

The Python SDK uses `get_job_context(required=False)` which returns `None` instead of throwing:
https://github.com/livekit/agents/blob/4930264e21a58c36e0802c39120480352bb27e09/livekit-agents/livekit/agents/voice/agent_session.py#L624

---

**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.