### PR TITLE
feat: add Cerebras LLM plugin with payload optimization

### DIFF
--- a/.changeset/cerebras-plugin-release.md
+++ b/.changeset/cerebras-plugin-release.md
@@ -1,0 +1,8 @@
+---
+"@livekit/agents-plugin-cerebras": patch
+---
+
+Add Cerebras plugin for LiveKit Node Agents.
+
+Supports LLM streaming, tool calling, and optional msgpack/gzip
+payload compression via the OpenAI-compatible Cerebras API.

--- a/plugins/cerebras/README.md
+++ b/plugins/cerebras/README.md
@@ -1,0 +1,13 @@
+# Cerebras plugin for LiveKit Node Agents
+
+Support for LLM with [Cerebras](https://cerebras.ai/) fast inference.
+
+## Installation
+
+```bash
+pnpm add @livekit/agents-plugin-cerebras
+```
+
+## Pre-requisites
+
+For credentials, you'll need a Cerebras account and API key. Credentials can be passed directly or via `CEREBRAS_API_KEY` environment variable.

--- a/plugins/cerebras/api-extractor.json
+++ b/plugins/cerebras/api-extractor.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "extends": "../../api-extractor-shared.json",
+  "mainEntryPointFilePath": "./dist/index.d.ts"
+}

--- a/plugins/cerebras/package.json
+++ b/plugins/cerebras/package.json
@@ -36,10 +36,12 @@
   "devDependencies": {
     "@livekit/agents": "workspace:*",
     "@livekit/agents-plugin-openai": "workspace:*",
+    "@livekit/agents-plugins-test": "workspace:*",
     "@livekit/rtc-node": "catalog:",
     "@microsoft/api-extractor": "^7.35.0",
     "tsup": "^8.3.5",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "zod": "^3.25.76 || ^4.1.8"
   },
   "dependencies": {
     "@msgpack/msgpack": "^3.0.0",

--- a/plugins/cerebras/package.json
+++ b/plugins/cerebras/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@livekit/agents-plugin-cerebras",
+  "version": "1.2.6",
+  "description": "Cerebras plugin for LiveKit Node Agents",
+  "main": "dist/index.js",
+  "require": "dist/index.cjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "import": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "require": {
+      "types": "./dist/index.d.cts",
+      "default": "./dist/index.cjs"
+    }
+  },
+  "author": "LiveKit",
+  "type": "module",
+  "repository": "git@github.com:livekit/agents-js.git",
+  "license": "Apache-2.0",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup --onSuccess \"pnpm build:types\"",
+    "build:types": "tsc --declaration --emitDeclarationOnly && node ../../scripts/copyDeclarationOutput.js",
+    "clean": "rm -rf dist",
+    "clean:build": "pnpm clean && pnpm build",
+    "lint": "eslint -f unix \"src/**/*.{ts,js}\"",
+    "api:check": "api-extractor run --typescript-compiler-folder ../../node_modules/typescript",
+    "api:update": "api-extractor run --local --typescript-compiler-folder ../../node_modules/typescript --verbose"
+  },
+  "devDependencies": {
+    "@livekit/agents": "workspace:*",
+    "@livekit/agents-plugin-openai": "workspace:*",
+    "@livekit/rtc-node": "catalog:",
+    "@microsoft/api-extractor": "^7.35.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@msgpack/msgpack": "^3.0.0",
+    "openai": "^6.8.1"
+  },
+  "peerDependencies": {
+    "@livekit/agents": "workspace:*",
+    "@livekit/agents-plugin-openai": "workspace:*",
+    "@livekit/rtc-node": "catalog:"
+  }
+}

--- a/plugins/cerebras/src/index.ts
+++ b/plugins/cerebras/src/index.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { Plugin } from '@livekit/agents';
+
+export { LLM } from './llm.js';
+export type { LLMOptions } from './llm.js';
+export type { CerebrasChatModels } from './models.js';
+
+class CerebrasPlugin extends Plugin {
+  constructor() {
+    super({
+      title: 'cerebras',
+      version: __PACKAGE_VERSION__,
+      package: __PACKAGE_NAME__,
+    });
+  }
+}
+
+Plugin.registerPlugin(new CerebrasPlugin());

--- a/plugins/cerebras/src/llm.test.ts
+++ b/plugins/cerebras/src/llm.test.ts
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { llm, voice } from '@livekit/agents';
+import { encode } from '@msgpack/msgpack';
+import { gzipSync } from 'node:zlib';
+import OpenAI from 'openai';
+import { assert, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type { LLMOptions } from './llm.js';
+import { LLM } from './llm.js';
+
+assert(process.env.CEREBRAS_API_KEY, 'CEREBRAS_API_KEY must be set');
+
+// llama3.1-8b is fast and has generous rate limits but can't do tool calls reliably;
+// qwen-3-235b is needed for function calling but has tight per-minute token quotas.
+const CHAT_MODEL = 'llama3.1-8b';
+const TOOL_MODEL = 'qwen-3-235b-a22b-instruct-2507';
+
+interface CapturedRequest {
+  url: string;
+  headers: Headers;
+}
+
+/**
+ * Wraps a real fetch, applying msgpack/gzip compression and capturing outgoing
+ * request metadata for assertion.  TypeScript equivalent of Python's
+ * `HeaderCapturingTransport` + `_CerebrasClient`.
+ */
+function createCapturingFetch(opts: { useMsgpack: boolean; useGzip: boolean }): {
+  fetch: typeof globalThis.fetch;
+  capturedRequests: CapturedRequest[];
+} {
+  const capturedRequests: CapturedRequest[] = [];
+
+  const fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    if (init?.method === 'POST' && init.body && typeof init.body === 'string') {
+      const headers = new Headers(init.headers);
+
+      let body: Uint8Array;
+      if (opts.useMsgpack) {
+        body = encode(JSON.parse(init.body));
+        headers.set('Content-Type', 'application/vnd.msgpack');
+      } else {
+        body = new TextEncoder().encode(init.body);
+      }
+
+      if (opts.useGzip) {
+        body = gzipSync(body, { level: 5 });
+        headers.set('Content-Encoding', 'gzip');
+      }
+
+      capturedRequests.push({ url: extractUrl(input), headers });
+      return globalThis.fetch(input, { ...init, body: Buffer.from(body), headers });
+    }
+
+    capturedRequests.push({ url: extractUrl(input), headers: new Headers(init?.headers) });
+    return globalThis.fetch(input, init);
+  };
+
+  return { fetch: fetch as typeof globalThis.fetch, capturedRequests };
+}
+
+function extractUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+function cerebrasLLM(opts: Partial<LLMOptions> = {}): LLM {
+  return new LLM({ model: CHAT_MODEL, ...opts });
+}
+
+function cerebrasLLMWithCapture(opts: { useGzip: boolean; useMsgpack: boolean }): {
+  llm: LLM;
+  capturedRequests: CapturedRequest[];
+} {
+  const { fetch, capturedRequests } = createCapturingFetch(opts);
+  const client = new OpenAI({
+    apiKey: process.env.CEREBRAS_API_KEY,
+    baseURL: 'https://api.cerebras.ai/v1',
+    fetch,
+  });
+  return { llm: new LLM({ model: CHAT_MODEL, client }), capturedRequests };
+}
+
+class WeatherAgent extends voice.Agent {
+  constructor() {
+    super({
+      instructions: 'You are a helpful assistant.',
+      tools: {
+        get_weather: llm.tool({
+          description: 'Get the current weather for a location.',
+          parameters: z.object({
+            location: z.string().describe('The city name'),
+          }),
+          execute: async ({ location }) => {
+            return `The weather in ${location} is sunny, 72°F.`;
+          },
+        }),
+      },
+    });
+  }
+}
+
+describe('Cerebras', { timeout: 30_000 }, () => {
+  it('basic chat completion returns a non-empty assistant message', async () => {
+    const session = new voice.AgentSession({ llm: cerebrasLLM() });
+    await session.start({
+      agent: new voice.Agent({ instructions: 'You are a helpful assistant.' }),
+    });
+
+    const result = session.run({ userInput: 'Say hello in exactly one word.' });
+    await result.wait();
+
+    result.expect.nextEvent().isMessage({ role: 'assistant' });
+    result.expect.noMoreEvents();
+
+    await session.close();
+  });
+
+  it('LLM can invoke a tool and the result is returned', async () => {
+    const session = new voice.AgentSession({ llm: new LLM({ model: TOOL_MODEL }) });
+    await session.start({ agent: new WeatherAgent() });
+
+    const result = session.run({ userInput: 'What is the weather in Tokyo?' });
+    await result.wait();
+
+    result.expect.nextEvent().isFunctionCall({
+      name: 'get_weather',
+      args: { location: 'Tokyo' },
+    });
+    result.expect.nextEvent().isFunctionCallOutput({
+      output: JSON.stringify('The weather in Tokyo is sunny, 72°F.'),
+    });
+    result.expect.nextEvent().isMessage({ role: 'assistant' });
+    result.expect.noMoreEvents();
+
+    await session.close();
+  });
+
+  it('gzip-only sends Content-Encoding: gzip with JSON content type', async () => {
+    const { llm: model, capturedRequests } = cerebrasLLMWithCapture({
+      useGzip: true,
+      useMsgpack: false,
+    });
+    const session = new voice.AgentSession({ llm: model });
+    await session.start({
+      agent: new voice.Agent({ instructions: 'You are a helpful assistant.' }),
+    });
+
+    const result = session.run({ userInput: 'Say hello in exactly one word.' });
+    await result.wait();
+
+    result.expect.nextEvent().isMessage({ role: 'assistant' });
+    result.expect.noMoreEvents();
+
+    await session.close();
+
+    const chatReqs = capturedRequests.filter((r) => r.url.includes('/chat/completions'));
+    expect(chatReqs.length).toBeGreaterThan(0);
+    expect(chatReqs[0]!.headers.get('content-type')).toBe('application/json');
+    expect(chatReqs[0]!.headers.get('content-encoding')).toBe('gzip');
+  });
+
+  it('msgpack-only sends Content-Type: application/vnd.msgpack without gzip', async () => {
+    const { llm: model, capturedRequests } = cerebrasLLMWithCapture({
+      useGzip: false,
+      useMsgpack: true,
+    });
+    const session = new voice.AgentSession({ llm: model });
+    await session.start({
+      agent: new voice.Agent({ instructions: 'You are a helpful assistant.' }),
+    });
+
+    const result = session.run({ userInput: 'Say hello in exactly one word.' });
+    await result.wait();
+
+    result.expect.nextEvent().isMessage({ role: 'assistant' });
+    result.expect.noMoreEvents();
+
+    await session.close();
+
+    const chatReqs = capturedRequests.filter((r) => r.url.includes('/chat/completions'));
+    expect(chatReqs.length).toBeGreaterThan(0);
+    expect(chatReqs[0]!.headers.get('content-type')).toBe('application/vnd.msgpack');
+    expect(chatReqs[0]!.headers.get('content-encoding')).toBeNull();
+  });
+
+  it('both flags send msgpack content type with gzip encoding', async () => {
+    const { llm: model, capturedRequests } = cerebrasLLMWithCapture({
+      useGzip: true,
+      useMsgpack: true,
+    });
+    const session = new voice.AgentSession({ llm: model });
+    await session.start({
+      agent: new voice.Agent({ instructions: 'You are a helpful assistant.' }),
+    });
+
+    const result = session.run({ userInput: 'Say hello in exactly one word.' });
+    await result.wait();
+
+    result.expect.nextEvent().isMessage({ role: 'assistant' });
+    result.expect.noMoreEvents();
+
+    await session.close();
+
+    const chatReqs = capturedRequests.filter((r) => r.url.includes('/chat/completions'));
+    expect(chatReqs.length).toBeGreaterThan(0);
+    expect(chatReqs[0]!.headers.get('content-type')).toBe('application/vnd.msgpack');
+    expect(chatReqs[0]!.headers.get('content-encoding')).toBe('gzip');
+  });
+
+  it('with both flags off sends standard JSON without gzip', async () => {
+    const session = new voice.AgentSession({
+      llm: cerebrasLLM({ gzipCompression: false, msgpackEncoding: false }),
+    });
+    await session.start({
+      agent: new voice.Agent({ instructions: 'You are a helpful assistant.' }),
+    });
+
+    const result = session.run({ userInput: 'Say hello in exactly one word.' });
+    await result.wait();
+
+    result.expect.nextEvent().isMessage({ role: 'assistant' });
+    result.expect.noMoreEvents();
+
+    await session.close();
+  });
+
+  it('streaming chat returns content via the LLM directly', async () => {
+    const model = cerebrasLLM();
+    const chatCtx = new llm.ChatContext();
+    chatCtx.addMessage({ role: 'system', content: 'You are a helpful assistant.' });
+    chatCtx.addMessage({ role: 'user', content: 'Count from 1 to 5.' });
+
+    const stream = model.chat({ chatCtx });
+    let text = '';
+    for await (const chunk of stream) {
+      if (chunk.delta?.content) {
+        text += chunk.delta.content;
+      }
+    }
+
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain('3');
+  });
+});

--- a/plugins/cerebras/src/llm.ts
+++ b/plugins/cerebras/src/llm.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { gzipSync } from 'node:zlib';
+import { llm } from '@livekit/agents';
+import { LLM as OpenAILLM } from '@livekit/agents-plugin-openai';
+import { encode } from '@msgpack/msgpack';
+import OpenAI from 'openai';
+import type { CerebrasChatModels } from './models.js';
+
+export interface LLMOptions {
+  model: string | CerebrasChatModels;
+  apiKey?: string;
+  baseURL?: string;
+  user?: string;
+  temperature?: number;
+  client?: OpenAI;
+  toolChoice?: llm.ToolChoice;
+  parallelToolCalls?: boolean;
+  gzipCompression?: boolean;
+  msgpackEncoding?: boolean;
+}
+
+const defaultLLMOptions: LLMOptions = {
+  model: 'llama-4-scout-17b-16e-instruct',
+  baseURL: 'https://api.cerebras.ai/v1',
+  gzipCompression: true,
+  msgpackEncoding: true,
+};
+
+/**
+ * Create a custom fetch that compresses request payloads via msgpack and/or gzip.
+ *
+ * @see https://inference-docs.cerebras.ai/payload-optimization
+ */
+function createCompressedFetch(opts: {
+  useMsgpack: boolean;
+  useGzip: boolean;
+}): typeof globalThis.fetch {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    if (init?.method === 'POST' && init.body && typeof init.body === 'string') {
+      const headers = new Headers(init.headers);
+
+      let body: Uint8Array;
+      if (opts.useMsgpack) {
+        body = encode(JSON.parse(init.body));
+        headers.set('Content-Type', 'application/vnd.msgpack');
+      } else {
+        body = new TextEncoder().encode(init.body);
+      }
+
+      if (opts.useGzip) {
+        body = gzipSync(body, { level: 5 });
+        headers.set('Content-Encoding', 'gzip');
+      }
+
+      return globalThis.fetch(input, { ...init, body: Buffer.from(body), headers });
+    }
+    return globalThis.fetch(input, init);
+  };
+}
+
+export class LLM extends OpenAILLM {
+  constructor(opts: Partial<LLMOptions> = {}) {
+    const merged = { ...defaultLLMOptions, ...opts };
+
+    merged.apiKey = merged.apiKey || process.env.CEREBRAS_API_KEY;
+    if (merged.apiKey === undefined && !merged.client) {
+      throw new Error(
+        'Cerebras API key is required, either as an argument or as $CEREBRAS_API_KEY',
+      );
+    }
+
+    if (!merged.client && (merged.gzipCompression || merged.msgpackEncoding)) {
+      merged.client = new OpenAI({
+        apiKey: merged.apiKey,
+        baseURL: merged.baseURL,
+        fetch: createCompressedFetch({
+          useMsgpack: merged.msgpackEncoding ?? true,
+          useGzip: merged.gzipCompression ?? true,
+        }),
+      });
+    }
+
+    super(merged);
+  }
+
+  override label(): string {
+    return 'cerebras.LLM';
+  }
+}

--- a/plugins/cerebras/src/llm.ts
+++ b/plugins/cerebras/src/llm.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { gzipSync } from 'node:zlib';
-import { llm } from '@livekit/agents';
+import type { llm } from '@livekit/agents';
 import { LLM as OpenAILLM } from '@livekit/agents-plugin-openai';
 import { encode } from '@msgpack/msgpack';
+import { gzipSync } from 'node:zlib';
 import OpenAI from 'openai';
 import type { CerebrasChatModels } from './models.js';
 

--- a/plugins/cerebras/src/models.ts
+++ b/plugins/cerebras/src/models.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export type CerebrasChatModels =
+  | 'llama3.1-8b'
+  | 'llama-3.3-70b'
+  | 'llama-4-scout-17b-16e-instruct'
+  | 'llama-4-maverick-17b-128e-instruct'
+  | 'qwen-3-32b'
+  | 'qwen-3-235b-a22b-instruct-2507'
+  | 'qwen-3-235b-a22b-thinking-2507'
+  | 'qwen-3-coder-480b'
+  | 'gpt-oss-120b';

--- a/plugins/cerebras/tsconfig.json
+++ b/plugins/cerebras/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "declarationDir": "./dist",
+    "outDir": "./dist"
+  },
+  "typedocOptions": {
+    "name": "plugins/agents-plugin-cerebras",
+    "entryPointStrategy": "resolve",
+    "entryPoints": ["src/index.ts"]
+  }
+}

--- a/plugins/cerebras/tsup.config.ts
+++ b/plugins/cerebras/tsup.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'tsup';
+import defaults from '../../tsup.config';
+
+export default defineConfig({
+  ...defaults,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,6 +537,9 @@ importers:
       '@livekit/agents-plugin-openai':
         specifier: workspace:*
         version: link:../openai
+      '@livekit/agents-plugins-test':
+        specifier: workspace:*
+        version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
         version: 0.13.25
@@ -549,6 +552,9 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
+      zod:
+        specifier: ^3.25.76 || ^4.1.8
+        version: 4.3.6
 
   plugins/deepgram:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,34 @@ importers:
         specifier: ^5.0.0
         version: 5.4.5
 
+  plugins/cerebras:
+    dependencies:
+      '@msgpack/msgpack':
+        specifier: ^3.0.0
+        version: 3.1.3
+      openai:
+        specifier: ^6.8.1
+        version: 6.8.1(ws@8.20.0)(zod@4.3.6)
+    devDependencies:
+      '@livekit/agents':
+        specifier: workspace:*
+        version: link:../../agents
+      '@livekit/agents-plugin-openai':
+        specifier: workspace:*
+        version: link:../openai
+      '@livekit/rtc-node':
+        specifier: 'catalog:'
+        version: 0.13.25
+      '@microsoft/api-extractor':
+        specifier: ^7.35.0
+        version: 7.43.7(@types/node@22.19.1)
+      tsup:
+        specifier: ^8.3.5
+        version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@22.19.1))(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   plugins/deepgram:
     dependencies:
       ws:
@@ -2199,6 +2227,10 @@ packages:
 
   '@mistralai/mistralai@1.15.1':
     resolution: {integrity: sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw==}
+
+  '@msgpack/msgpack@3.1.3':
+    resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
+    engines: {node: '>= 18'}
 
   '@next/eslint-plugin-next@14.2.3':
     resolution: {integrity: sha512-L3oDricIIjgj1AVnRdRor21gI7mShlSwU/1ZGHmqM3LzHhXXhdkrfeNY5zif25Bi5Dd7fiJHsbhoZCHfXYvlAw==}
@@ -6666,6 +6698,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@msgpack/msgpack@3.1.3': {}
 
   '@next/eslint-plugin-next@14.2.3':
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `@livekit/agents-plugin-cerebras` with LLM support via the OpenAI-compatible Cerebras API
- Supports msgpack encoding and gzip compression for request payloads ([docs](https://inference-docs.cerebras.ai/payload-optimization))
- Integration tests covering chat, function calling, streaming, and header assertions for all compression modes

## Test plan
- [x] `pnpm vitest run plugins/cerebras/src/llm.test.ts` — 7/7 tests pass (requires `CEREBRAS_API_KEY`)