### PR TITLE
feat: add dedent tagged template literal helper

### DIFF
--- a/.changeset/add-dedent-helper.md
+++ b/.changeset/add-dedent-helper.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+feat: add dedent tagged template literal helper

--- a/agents/src/utils.test.ts
+++ b/agents/src/utils.test.ts
@@ -5,7 +5,7 @@ import { AudioFrame } from '@livekit/rtc-node';
 import { ReadableStream } from 'node:stream/web';
 import { describe, expect, it } from 'vitest';
 import { initializeLogger } from '../src/log.js';
-import { Event, Task, TaskResult, delay, isPending, resampleStream } from '../src/utils.js';
+import { Event, Task, TaskResult, dedent, delay, isPending, resampleStream } from '../src/utils.js';
 
 describe('utils', () => {
   // initialize logger
@@ -625,6 +625,94 @@ describe('utils', () => {
 
       event.set();
       expect(await waiterAfterSet).toBe(true);
+    });
+  });
+
+  describe('dedent', () => {
+    it('should remove common leading indentation', () => {
+      const result = dedent`
+        hello
+        world
+      `;
+      expect(result).toBe('hello\nworld');
+    });
+
+    it('should preserve relative indentation', () => {
+      const result = dedent`
+        hello
+          world
+            nested
+      `;
+      expect(result).toBe('hello\n  world\n    nested');
+    });
+
+    it('should handle interpolations', () => {
+      const name = 'world';
+      const result = dedent`
+        hello ${name}
+        goodbye ${name}
+      `;
+      expect(result).toBe('hello world\ngoodbye world');
+    });
+
+    it('should handle empty lines in the middle', () => {
+      const result = dedent`
+        hello
+
+        world
+      `;
+      expect(result).toBe('hello\n\nworld');
+    });
+
+    it('should handle single line', () => {
+      const result = dedent`
+        hello
+      `;
+      expect(result).toBe('hello');
+    });
+
+    it('should handle no indentation', () => {
+      const result = dedent`
+hello
+world
+`;
+      expect(result).toBe('hello\nworld');
+    });
+
+    it('should handle tab indentation', () => {
+      const result = dedent`
+\t\thello
+\t\t\tworld
+\t\t`;
+      expect(result).toBe('hello\n\tworld');
+    });
+
+    it('should handle empty string', () => {
+      const result = dedent``;
+      expect(result).toBe('');
+    });
+
+    it('should handle string with only whitespace', () => {
+      const result = dedent`
+
+      `;
+      expect(result).toBe('');
+    });
+
+    it('should handle inline usage without leading newline', () => {
+      const result = dedent`hello
+        world`;
+      expect(result).toBe('hello\n        world');
+    });
+
+    it('should handle interpolations that span values', () => {
+      const a = 1;
+      const b = 2;
+      const result = dedent`
+        sum: ${a + b}
+        product: ${a * b}
+      `;
+      expect(result).toBe('sum: 3\nproduct: 2');
     });
   });
 

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -1078,3 +1078,62 @@ export function asError(maybeError: unknown): Error {
   }
   return new Error(String(maybeError));
 }
+
+/**
+ * Tagged template literal that strips common leading indentation from every line,
+ * trims the first empty line and any trailing whitespace.
+ *
+ * Useful for writing multi-line strings inside indented code without the indentation
+ * leaking into the runtime value.
+ *
+ * @example
+ * ```ts
+ * const msg = dedent`
+ *   Hello,
+ *     world!
+ * `;
+ * // "Hello,\n  world!"
+ * ```
+ */
+export function dedent(strings: TemplateStringsArray, ...values: unknown[]): string {
+  // Build the raw string with interpolations
+  let result = '';
+  for (let i = 0; i < strings.length; i++) {
+    result += strings[i];
+    if (i < values.length) {
+      result += String(values[i]);
+    }
+  }
+
+  // Strip the leading newline (first line is usually empty after the backtick)
+  if (result.startsWith('\n')) {
+    result = result.slice(1);
+  }
+
+  const lines = result.split('\n');
+
+  // Find the minimum indentation across non-empty lines
+  let minIndent = Infinity;
+  for (const line of lines) {
+    if (line.trim().length === 0) continue;
+    let spaces = 0;
+    for (const ch of line) {
+      if (ch === ' ' || ch === '\t') {
+        spaces++;
+      } else {
+        break;
+      }
+    }
+    minIndent = Math.min(minIndent, spaces);
+  }
+
+  if (minIndent === Infinity) {
+    minIndent = 0;
+  }
+
+  // Remove common indentation and join
+  return lines
+    .map((line) => line.slice(minIndent))
+    .join('\n')
+    .trimEnd();
+}

--- a/examples/src/comprehensive_test.ts
+++ b/examples/src/comprehensive_test.ts
@@ -6,6 +6,7 @@ import {
   type JobProcess,
   ServerOptions,
   cli,
+  dedent,
   defineAgent,
   llm,
   log,
@@ -147,11 +148,13 @@ class TestAgent extends voice.Agent<UserData> {
     const modelName = realtimeModel ? `${realtimeLlmChoice} realtime` : llmChoice;
 
     super({
-      instructions: `You are a test voice-based agent, you can hear the user's message and respond to it. User is testing your hearing & speaking abilities.
+      instructions: dedent`
+        You are a test voice-based agent, you can hear the user's message and respond to it. User is testing your hearing & speaking abilities.
         You are using ${sttChoice} STT, ${ttsChoice} TTS, ${eouChoice} EOU, ${modelName} LLM.
         You can use the following tools to test your abilities:
         - testTool: Testing agent's tool calling ability
-        - nextAgent: Called when user confirm current agent is working and want to proceed to next agent`,
+        - nextAgent: Called when user confirm current agent is working and want to proceed to next agent
+      `,
       stt: stt,
       tts: tts,
       llm: realtimeModel ?? model,

--- a/examples/src/gemini_realtime_agent.ts
+++ b/examples/src/gemini_realtime_agent.ts
@@ -6,6 +6,7 @@ import {
   type JobProcess,
   ServerOptions,
   cli,
+  dedent,
   defineAgent,
   llm,
   voice,
@@ -86,8 +87,10 @@ class StoryAgent extends voice.Agent<StoryData> {
 
   static create(name: string, location: string) {
     return new StoryAgent({
-      instructions: `You are a storyteller. Use the user's information in order to make the story personalized.
-          The user's name is ${name}, from ${location}`,
+      instructions: dedent`
+        You are a storyteller. Use the user's information in order to make the story personalized.
+        The user's name is ${name}, from ${location}
+      `,
     });
   }
 }

--- a/examples/src/multi_agent.ts
+++ b/examples/src/multi_agent.ts
@@ -6,6 +6,7 @@ import {
   type JobProcess,
   ServerOptions,
   cli,
+  dedent,
   defineAgent,
   inference,
   llm,
@@ -62,8 +63,10 @@ class StoryAgent extends voice.Agent<StoryData> {
 
   static create(name: string, location: string) {
     return new StoryAgent({
-      instructions: `You are a storyteller. Use the user's information in order to make the story personalized.
-        The user's name is ${name}, from ${location}`,
+      instructions: dedent`
+        You are a storyteller. Use the user's information in order to make the story personalized.
+        The user's name is ${name}, from ${location}
+      `,
     });
   }
 }

--- a/examples/src/restaurant_agent.ts
+++ b/examples/src/restaurant_agent.ts
@@ -6,6 +6,7 @@ import {
   type JobProcess,
   ServerOptions,
   cli,
+  dedent,
   defineAgent,
   inference,
   llm,
@@ -175,10 +176,12 @@ function createGreeterAgent(menu: string) {
     tts: new inference.TTS({ model: 'cartesia/sonic-3', voice: voices.greeter }),
     tools: {
       toReservation: llm.tool({
-        description: `Called when user wants to make or update a reservation.
-        This function handles transitioning to the reservation agent
-        who will collect the necessary details like reservation time,
-        customer name and phone number.`,
+        description: dedent`
+          Called when user wants to make or update a reservation.
+          This function handles transitioning to the reservation agent
+          who will collect the necessary details like reservation time,
+          customer name and phone number.
+        `,
         execute: async (_, { ctx }): Promise<llm.AgentHandoff> => {
           return await greeter.transferToAgent({
             name: 'reservation',
@@ -187,9 +190,11 @@ function createGreeterAgent(menu: string) {
         },
       }),
       toTakeaway: llm.tool({
-        description: `Called when the user wants to place a takeaway order.
-        This includes handling orders for pickup, delivery, or when the user wants to
-        proceed to checkout with their existing order.`,
+        description: dedent`
+          Called when the user wants to place a takeaway order.
+          This includes handling orders for pickup, delivery, or when the user wants to
+          proceed to checkout with their existing order.
+        `,
         execute: async (_, { ctx }): Promise<llm.AgentHandoff> => {
           return await greeter.transferToAgent({
             name: 'takeaway',
@@ -213,8 +218,10 @@ function createReservationAgent() {
       updatePhone,
       toGreeter,
       updateReservationTime: llm.tool({
-        description: `Called when the user provides their reservation time.
-        Confirm the time with the user before calling the function.`,
+        description: dedent`
+          Called when the user provides their reservation time.
+          Confirm the time with the user before calling the function.
+        `,
         parameters: z.object({
           time: z.string().describe('The reservation time'),
         }),
@@ -301,8 +308,10 @@ function createCheckoutAgent(menu: string) {
         },
       }),
       updateCreditCard: llm.tool({
-        description: `Called when the user provides their credit card number, expiry date, and CVV.
-        Confirm the spelling with the user before calling the function.`,
+        description: dedent`
+          Called when the user provides their credit card number, expiry date, and CVV.
+          Confirm the spelling with the user before calling the function.
+        `,
         parameters: z.object({
           number: z.string().describe('The credit card number'),
           expiry: z.string().describe('The expiry date of the credit card'),


### PR DESCRIPTION
## Summary
- Add a `dedent()` tagged template literal that strips common leading indentation from multiline strings, preventing code indentation from leaking into runtime values
- Exported from `@livekit/agents` via `utils.ts`
- Convert 7 multiline strings across 4 example files (`restaurant_agent`, `comprehensive_test`, `multi_agent`, `gemini_realtime_agent`) to use `dedent`
- 11 tests covering: indentation removal, relative indent preservation, interpolations, empty lines, tabs, edge cases

## Test plan
- [x] All dedent unit tests pass
- [x] Full utils test suite passes