### PR TITLE
feat(voice): add PreemptiveGenerationOptions for fine-grained control

### DIFF
--- a/.changeset/strong-boxes-cross.md
+++ b/.changeset/strong-boxes-cross.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+feat(voice): add PreemptiveGenerationOptions for fine-grained control

--- a/agents/src/stt/stt.ts
+++ b/agents/src/stt/stt.ts
@@ -261,6 +261,13 @@ export abstract class SpeechStream implements AsyncIterableIterator<SpeechEvent>
       try {
         return await this.run();
       } catch (error) {
+        // If the stream was intentionally aborted (e.g. session shutdown), exit
+        // silently. Downstream listeners may already be detached, so emitting an
+        // error here would trigger ERR_UNHANDLED_ERROR in Node's EventEmitter.
+        if (this.abortController.signal.aborted) {
+          return;
+        }
+
         if (error instanceof APIError) {
           const retryInterval = intervalForRetry(this._connOptions, i);
 

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -16,8 +16,11 @@
  */
 import { Heap } from 'heap-js';
 import { describe, expect, it, vi } from 'vitest';
+import type { ChatContext } from '../llm/chat_context.js';
+import { LLM, type LLMStream } from '../llm/llm.js';
 import { Future } from '../utils.js';
 import { AgentActivity } from './agent_activity.js';
+import type { PreemptiveGenerationInfo } from './audio_recognition.js';
 import { SpeechHandle } from './speech_handle.js';
 
 // Break circular dependency: agent_activity.ts → agent.js → beta/workflows/task_group.ts
@@ -224,5 +227,151 @@ describe('AgentActivity - mainTask', () => {
 
     const result = await raceTimeout(mainTaskPromise, 2000);
     expect(result).toBe('resolved');
+  });
+});
+
+/**
+ * Unit tests for the preemptive-generation guards in AgentActivity.
+ *
+ * These tests drive AgentActivity.onPreemptiveGeneration directly against a
+ * lightly-stubbed `this` context so we can exercise the `maxRetries` and
+ * `maxSpeechDuration` guards deterministically, without needing real STT
+ * preflight events or a live turn detector.
+ */
+class FakePreemptiveLLM extends LLM {
+  label(): string {
+    return 'fake.LLM';
+  }
+  chat(): LLMStream {
+    throw new Error('not used in these tests');
+  }
+}
+
+type PreemptiveOpts = {
+  enabled: boolean;
+  preemptiveTts: boolean;
+  maxSpeechDuration: number;
+  maxRetries: number;
+};
+
+function buildPreemptiveRunner(opts: Partial<PreemptiveOpts> = {}) {
+  const preemptiveOpts: PreemptiveOpts = {
+    enabled: true,
+    preemptiveTts: false,
+    maxSpeechDuration: 10_000,
+    maxRetries: 3,
+    ...opts,
+  };
+
+  const generateReply = vi.fn(
+    () => ({ id: 'speech_fake', _cancel: () => {} }) as unknown as SpeechHandle,
+  );
+  const cancelPreemptiveGeneration = vi.fn();
+
+  const fakeChatCtx = { copy: () => fakeChatCtx } as unknown as ChatContext;
+
+  const fakeActivity = {
+    _preemptiveGenerationCount: 0,
+    _preemptiveGeneration: undefined,
+    _currentSpeech: undefined as SpeechHandle | undefined,
+    schedulingPaused: false,
+    llm: new FakePreemptiveLLM(),
+    tools: {},
+    toolChoice: null,
+    agent: { chatCtx: fakeChatCtx },
+    agentSession: {
+      sessionOptions: {
+        turnHandling: { preemptiveGeneration: preemptiveOpts },
+      },
+    },
+    logger: {
+      info: () => {},
+      debug: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+    generateReply,
+    cancelPreemptiveGeneration,
+  };
+
+  const onPreemptiveGeneration = (AgentActivity.prototype as Record<string, unknown>)
+    .onPreemptiveGeneration as (this: unknown, info: PreemptiveGenerationInfo) => void;
+
+  return {
+    fakeActivity,
+    preemptiveOpts,
+    generateReply,
+    cancelPreemptiveGeneration,
+    call: (info: Partial<PreemptiveGenerationInfo> = {}) =>
+      onPreemptiveGeneration.call(fakeActivity, {
+        newTranscript: 'hello world',
+        transcriptConfidence: 0.95,
+        startedSpeakingAt: undefined,
+        ...info,
+      }),
+  };
+}
+
+describe('AgentActivity - onPreemptiveGeneration guards', () => {
+  it('increments counter up to maxRetries then skips further calls within the same turn', () => {
+    const { fakeActivity, generateReply, call } = buildPreemptiveRunner({ maxRetries: 2 });
+
+    call();
+    expect(fakeActivity._preemptiveGenerationCount).toBe(1);
+    expect(generateReply).toHaveBeenCalledTimes(1);
+
+    call();
+    expect(fakeActivity._preemptiveGenerationCount).toBe(2);
+    expect(generateReply).toHaveBeenCalledTimes(2);
+
+    call();
+    expect(fakeActivity._preemptiveGenerationCount).toBe(2);
+    expect(generateReply).toHaveBeenCalledTimes(2);
+
+    call();
+    expect(fakeActivity._preemptiveGenerationCount).toBe(2);
+    expect(generateReply).toHaveBeenCalledTimes(2);
+  });
+
+  it('resumes preemption after the counter is reset (simulates onEndOfTurn)', () => {
+    const { fakeActivity, generateReply, call } = buildPreemptiveRunner({ maxRetries: 2 });
+
+    call();
+    call();
+    call();
+    expect(generateReply).toHaveBeenCalledTimes(2);
+
+    fakeActivity._preemptiveGenerationCount = 0;
+
+    call();
+    expect(fakeActivity._preemptiveGenerationCount).toBe(1);
+    expect(generateReply).toHaveBeenCalledTimes(3);
+  });
+
+  it('skips preemption when startedSpeakingAt exceeds maxSpeechDuration', () => {
+    const { fakeActivity, generateReply, call } = buildPreemptiveRunner({
+      maxSpeechDuration: 3000,
+    });
+
+    call({ startedSpeakingAt: Date.now() - 1000 });
+    expect(fakeActivity._preemptiveGenerationCount).toBe(1);
+    expect(generateReply).toHaveBeenCalledTimes(1);
+
+    call({ startedSpeakingAt: Date.now() - 5000 });
+    expect(fakeActivity._preemptiveGenerationCount).toBe(1);
+    expect(generateReply).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips preemption entirely when enabled is false', () => {
+    const { fakeActivity, generateReply, cancelPreemptiveGeneration, call } = buildPreemptiveRunner(
+      { enabled: false },
+    );
+
+    call();
+    call();
+
+    expect(fakeActivity._preemptiveGenerationCount).toBe(0);
+    expect(generateReply).not.toHaveBeenCalled();
+    expect(cancelPreemptiveGeneration).not.toHaveBeenCalled();
   });
 });

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -179,7 +179,6 @@ export class AgentActivity implements RecognitionHooks {
   // default to null as None, which maps to the default provider tool choice value
   private toolChoice: ToolChoice | null = null;
   private _preemptiveGeneration?: PreemptiveGeneration;
-  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 165 lines
   private _preemptiveGenerationCount = 0;
   private interruptionDetector?: AdaptiveInterruptionDetector;
   private isInterruptionDetectionEnabled: boolean;
@@ -1183,7 +1182,6 @@ export class AgentActivity implements RecognitionHooks {
     // TODO: resume false interruption - start interrupt paused speech task
   }
 
-  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1798-1825 lines
   onPreemptiveGeneration(info: PreemptiveGenerationInfo): void {
     const preemptiveOpts = this.agentSession.sessionOptions.turnHandling.preemptiveGeneration;
     if (
@@ -1197,7 +1195,6 @@ export class AgentActivity implements RecognitionHooks {
 
     this.cancelPreemptiveGeneration();
 
-    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1810-1813 lines
     if (
       info.startedSpeakingAt !== undefined &&
       Date.now() - info.startedSpeakingAt > preemptiveOpts.maxSpeechDuration
@@ -1205,7 +1202,6 @@ export class AgentActivity implements RecognitionHooks {
       return;
     }
 
-    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1815-1816 lines
     if (this._preemptiveGenerationCount >= preemptiveOpts.maxRetries) {
       return;
     }
@@ -1623,7 +1619,6 @@ export class AgentActivity implements RecognitionHooks {
       await oldTask.result;
     }
 
-    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1902 lines
     this._preemptiveGenerationCount = 0;
 
     // When the audio recognition detects the end of a user turn:
@@ -2005,7 +2000,6 @@ export class AgentActivity implements RecognitionHooks {
     let ttsGenData: _TTSGenerationData | null = null;
     let llmOutput: ReadableStream<string>;
 
-    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2409-2467 lines
     // Helper to start TTS inference, used both for preemptive and deferred TTS start.
     // We always tee the LLM output stream upfront when audio is needed, so the ttsTextInput
     // is available regardless of when TTS actually starts.
@@ -2055,7 +2049,6 @@ export class AgentActivity implements RecognitionHooks {
       return;
     }
 
-    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2451-2453 lines
     // Start TTS inference if not already started and audio output is enabled
     if (audioOutput && ttsTask === null) {
       [ttsTask, ttsGenData] = startTtsInference();
@@ -2072,7 +2065,6 @@ export class AgentActivity implements RecognitionHooks {
     // Determine the transcription input source
     let transcriptionInput: ReadableStream<string | TimedString> = llmOutput;
 
-    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2455-2465 lines
     // Check if we should use TTS aligned transcripts
     if (this.useTtsAlignedTranscript && this.tts?.capabilities.alignedTranscript && ttsGenData) {
       // Race timedTextsFut with ttsTask to avoid hanging if TTS fails before resolving the future

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -179,6 +179,8 @@ export class AgentActivity implements RecognitionHooks {
   // default to null as None, which maps to the default provider tool choice value
   private toolChoice: ToolChoice | null = null;
   private _preemptiveGeneration?: PreemptiveGeneration;
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 165 lines
+  private _preemptiveGenerationCount = 0;
   private interruptionDetector?: AdaptiveInterruptionDetector;
   private isInterruptionDetectionEnabled: boolean;
   private isInterruptionByAudioActivityEnabled: boolean;
@@ -1181,9 +1183,11 @@ export class AgentActivity implements RecognitionHooks {
     // TODO: resume false interruption - start interrupt paused speech task
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1798-1825 lines
   onPreemptiveGeneration(info: PreemptiveGenerationInfo): void {
+    const preemptiveOpts = this.agentSession.sessionOptions.turnHandling.preemptiveGeneration;
     if (
-      !this.agentSession.sessionOptions.preemptiveGeneration ||
+      !preemptiveOpts.enabled ||
       this.schedulingPaused ||
       (this._currentSpeech !== undefined && !this._currentSpeech.interrupted) ||
       !(this.llm instanceof LLM)
@@ -1192,6 +1196,21 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     this.cancelPreemptiveGeneration();
+
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1810-1813 lines
+    if (
+      info.startedSpeakingAt !== undefined &&
+      Date.now() - info.startedSpeakingAt > preemptiveOpts.maxSpeechDuration
+    ) {
+      return;
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1815-1816 lines
+    if (this._preemptiveGenerationCount >= preemptiveOpts.maxRetries) {
+      return;
+    }
+
+    this._preemptiveGenerationCount++;
 
     this.logger.info(
       {
@@ -1604,6 +1623,9 @@ export class AgentActivity implements RecognitionHooks {
       await oldTask.result;
     }
 
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1902 lines
+    this._preemptiveGenerationCount = 0;
+
     // When the audio recognition detects the end of a user turn:
     //  - check if realtime model server-side turn detection is enabled
     //  - check if there is no current generation happening
@@ -1983,22 +2005,38 @@ export class AgentActivity implements RecognitionHooks {
     let ttsGenData: _TTSGenerationData | null = null;
     let llmOutput: ReadableStream<string>;
 
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2409-2467 lines
+    // Helper to start TTS inference, used both for preemptive and deferred TTS start.
+    // We always tee the LLM output stream upfront when audio is needed, so the ttsTextInput
+    // is available regardless of when TTS actually starts.
+    let ttsTextInput: ReadableStream<string> | null = null;
+
     if (audioOutput) {
-      // Only tee the stream when we need TTS
-      const [ttsTextInput, textOutput] = llmGenData.textStream.tee();
+      // Always tee the stream when audio output is needed
+      const [_ttsTextInput, textOutput] = llmGenData.textStream.tee();
+      ttsTextInput = _ttsTextInput;
       llmOutput = textOutput;
-      [ttsTask, ttsGenData] = performTTSInference(
+    } else {
+      // No TTS needed, use the stream directly
+      llmOutput = llmGenData.textStream;
+    }
+
+    const startTtsInference = (): [Task<void>, _TTSGenerationData] => {
+      return performTTSInference(
         (...args) => this.agent.ttsNode(...args),
-        ttsTextInput,
+        ttsTextInput!,
         modelSettings,
         replyAbortController,
         this.tts?.model,
         this.tts?.provider,
       );
+    };
+
+    // Start preemptive TTS inference if enabled
+    const preemptiveOpts = this.agentSession.sessionOptions.turnHandling.preemptiveGeneration;
+    if (audioOutput && preemptiveOpts.enabled && preemptiveOpts.preemptiveTts) {
+      [ttsTask, ttsGenData] = startTtsInference();
       tasks.push(ttsTask);
-    } else {
-      // No TTS needed, use the stream directly
-      llmOutput = llmGenData.textStream;
     }
 
     await speechHandle.waitIfNotInterrupted([speechHandle._waitForScheduled()]);
@@ -2017,6 +2055,13 @@ export class AgentActivity implements RecognitionHooks {
       return;
     }
 
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2451-2453 lines
+    // Start TTS inference if not already started and audio output is enabled
+    if (audioOutput && ttsTask === null) {
+      [ttsTask, ttsGenData] = startTtsInference();
+      tasks.push(ttsTask);
+    }
+
     this.agentSession._updateAgentState('thinking');
 
     await speechHandle.waitIfNotInterrupted([speechHandle._waitForAuthorization()]);
@@ -2027,6 +2072,7 @@ export class AgentActivity implements RecognitionHooks {
     // Determine the transcription input source
     let transcriptionInput: ReadableStream<string | TimedString> = llmOutput;
 
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2455-2465 lines
     // Check if we should use TTS aligned transcripts
     if (this.useTtsAlignedTranscript && this.tts?.capabilities.alignedTranscript && ttsGenData) {
       // Race timedTextsFut with ttsTask to avoid hanging if TTS fails before resolving the future

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -103,7 +103,6 @@ export interface InternalSessionOptions<UserData> extends AgentSessionOptions<Us
 
 export const defaultAgentSessionOptions = {
   maxToolSteps: 3,
-  preemptiveGeneration: true,
   userAwayTimeout: 15.0,
   aecWarmupDuration: 3000,
   turnHandling: {},
@@ -113,7 +112,8 @@ export const defaultAgentSessionOptions = {
 /** @deprecated {@link VoiceOptions} has been flattened onto to {@link AgentSessionOptions} */
 export type VoiceOptions = {
   maxToolSteps: number;
-  preemptiveGeneration: boolean;
+  /** @deprecated Use {@link AgentSessionOptions.turnHandling}.preemptiveGeneration instead. */
+  preemptiveGeneration?: boolean;
   userAwayTimeout?: number | null;
   /** @deprecated Use {@link AgentSessionOptions.turnHandling}.interruption.mode instead. */
   allowInterruptions?: boolean;
@@ -160,12 +160,8 @@ export type AgentSessionOptions<UserData = UnknownUserData> = {
 
   maxToolSteps?: number;
   /**
-   * Whether to speculatively begin LLM and TTS requests before an end-of-turn is detected.
-   * When `true`, the agent sends inference calls as soon as a user transcript is received rather
-   * than waiting for a definitive turn boundary. This can reduce response latency by overlapping
-   * model inference with user audio, but may incur extra compute if the user interrupts or
-   * revises mid-utterance.
-   * @defaultValue true
+   * @deprecated Use `turnHandling.preemptiveGeneration` instead.
+   * When set, migrated into `turnHandling.preemptiveGeneration.enabled`.
    */
   preemptiveGeneration?: boolean;
 

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -56,6 +56,8 @@ export interface EndOfTurnInfo {
 export interface PreemptiveGenerationInfo {
   newTranscript: string;
   transcriptConfidence: number;
+  /** Timestamp when user started speaking (milliseconds since epoch), if known. */
+  startedSpeakingAt: number | undefined;
 }
 
 export interface RecognitionHooks {
@@ -617,6 +619,7 @@ export class AudioRecognition {
               { transcript: this.audioTranscript },
               'triggering preemptive generation (FINAL_TRANSCRIPT)',
             );
+            // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1808-1813 lines
             this.hooks.onPreemptiveGeneration({
               newTranscript: this.audioTranscript,
               transcriptConfidence:
@@ -624,6 +627,7 @@ export class AudioRecognition {
                   ? this.finalTranscriptConfidence.reduce((a, b) => a + b, 0) /
                     this.finalTranscriptConfidence.length
                   : 0,
+              startedSpeakingAt: this.speechStartTime,
             });
           }
 
@@ -683,12 +687,14 @@ export class AudioRecognition {
             },
             'triggering preemptive generation (PREFLIGHT_TRANSCRIPT)',
           );
+          // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1808-1813 lines
           this.hooks.onPreemptiveGeneration({
             newTranscript: this.audioPreflightTranscript,
             transcriptConfidence:
               confidenceVals.length > 0
                 ? confidenceVals.reduce((a, b) => a + b, 0) / confidenceVals.length
                 : 0,
+            startedSpeakingAt: this.speechStartTime,
           });
         }
         break;

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -619,7 +619,6 @@ export class AudioRecognition {
               { transcript: this.audioTranscript },
               'triggering preemptive generation (FINAL_TRANSCRIPT)',
             );
-            // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1808-1813 lines
             this.hooks.onPreemptiveGeneration({
               newTranscript: this.audioTranscript,
               transcriptConfidence:
@@ -687,7 +686,6 @@ export class AudioRecognition {
             },
             'triggering preemptive generation (PREFLIGHT_TRANSCRIPT)',
           );
-          // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1808-1813 lines
           this.hooks.onPreemptiveGeneration({
             newTranscript: this.audioPreflightTranscript,
             transcriptConfidence:

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -441,11 +441,15 @@ function toolNames(toolCtx: ToolContext | undefined): string[] {
   return Object.keys(toolCtx);
 }
 
+// Ref: python livekit-agents/livekit/agents/voice/remote_session.py - 328-335 lines
 function protoSerializeOptions(opts: {
-  turnHandling?: { endpointing?: unknown; interruption?: unknown };
+  turnHandling?: {
+    endpointing?: unknown;
+    interruption?: unknown;
+    preemptiveGeneration?: unknown;
+  };
   maxToolSteps?: number;
   userAwayTimeout?: number | null;
-  preemptiveGeneration?: boolean;
   useTtsAlignedTranscript?: boolean;
 }): Record<string, string> {
   return {
@@ -453,7 +457,7 @@ function protoSerializeOptions(opts: {
     interruption: JSON.stringify(opts.turnHandling?.interruption ?? {}),
     max_tool_steps: String(opts.maxToolSteps ?? 0),
     user_away_timeout: String(opts.userAwayTimeout ?? ''),
-    preemptive_generation: String(opts.preemptiveGeneration ?? false),
+    preemptive_generation: JSON.stringify(opts.turnHandling?.preemptiveGeneration ?? {}),
     use_tts_aligned_transcript: String(opts.useTtsAlignedTranscript ?? false),
   };
 }
@@ -812,7 +816,6 @@ export class SessionHost {
           turnHandling: this.session!.sessionOptions.turnHandling,
           maxToolSteps: this.session!.sessionOptions.maxToolSteps,
           userAwayTimeout: this.session!.sessionOptions.userAwayTimeout,
-          preemptiveGeneration: this.session!.sessionOptions.preemptiveGeneration,
           useTtsAlignedTranscript: this.session!.sessionOptions.useTtsAlignedTranscript,
         }),
         createdAt: msToTimestamp(startedAt),

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -441,7 +441,6 @@ function toolNames(toolCtx: ToolContext | undefined): string[] {
   return Object.keys(toolCtx);
 }
 
-// Ref: python livekit-agents/livekit/agents/voice/remote_session.py - 328-335 lines
 function protoSerializeOptions(opts: {
   turnHandling?: {
     endpointing?: unknown;

--- a/agents/src/voice/report.test.ts
+++ b/agents/src/voice/report.test.ts
@@ -14,10 +14,11 @@ type ReportOptions = AgentSessionOptions & Partial<VoiceOptions>;
 function baseOptions(): ReportOptions {
   return {
     maxToolSteps: 3,
-    preemptiveGeneration: false,
     userAwayTimeout: 15,
     useTtsAlignedTranscript: true,
-    turnHandling: {},
+    turnHandling: {
+      preemptiveGeneration: { enabled: false },
+    },
   };
 }
 

--- a/agents/src/voice/report.ts
+++ b/agents/src/voice/report.ts
@@ -131,7 +131,6 @@ export function sessionReportToJSON(report: SessionReport): Record<string, unkno
       min_endpointing_delay: minEndpointingDelay,
       max_endpointing_delay: maxEndpointingDelay,
       max_tool_steps: options.maxToolSteps,
-      // Ref: python livekit-agents/livekit/agents/voice/report.py - 66 lines
       preemptive_generation: options.turnHandling?.preemptiveGeneration ?? {},
     },
     chat_history: report.chatHistory.toJSON({ excludeTimestamp: false }),

--- a/agents/src/voice/report.ts
+++ b/agents/src/voice/report.ts
@@ -131,6 +131,8 @@ export function sessionReportToJSON(report: SessionReport): Record<string, unkno
       min_endpointing_delay: minEndpointingDelay,
       max_endpointing_delay: maxEndpointingDelay,
       max_tool_steps: options.maxToolSteps,
+      // Ref: python livekit-agents/livekit/agents/voice/report.py - 66 lines
+      preemptive_generation: options.turnHandling?.preemptiveGeneration ?? {},
     },
     chat_history: report.chatHistory.toJSON({ excludeTimestamp: false }),
     enable_user_data_training: report.enableRecording,

--- a/agents/src/voice/turn_config/preemptive_generation.ts
+++ b/agents/src/voice/turn_config/preemptive_generation.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Ref: python livekit-agents/livekit/agents/voice/turn.py - 115-143 lines
+/**
+ * Configuration for preemptive generation.
+ */
+export interface PreemptiveGenerationOptions {
+  /**
+   * Whether preemptive generation is enabled.
+   * @defaultValue true
+   */
+  enabled: boolean;
+  /**
+   * Whether to also run TTS preemptively before the turn is confirmed.
+   * When `false` (default), only LLM runs preemptively; TTS starts once the
+   * turn is confirmed and the speech is scheduled.
+   * @defaultValue false
+   */
+  preemptiveTts: boolean;
+  /**
+   * Maximum user speech duration (ms) for which preemptive generation
+   * is attempted. Beyond this threshold, preemptive generation is skipped
+   * since long utterances are more likely to change and users may expect
+   * slower responses.
+   * @defaultValue 10000
+   */
+  maxSpeechDuration: number;
+  /**
+   * Maximum number of preemptive generation attempts per user turn.
+   * The counter resets when the turn completes.
+   * @defaultValue 3
+   */
+  maxRetries: number;
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/turn.py - 136-141 lines
+export const defaultPreemptiveGenerationOptions = {
+  enabled: true,
+  preemptiveTts: false,
+  maxSpeechDuration: 10_000,
+  maxRetries: 3,
+} as const satisfies PreemptiveGenerationOptions;

--- a/agents/src/voice/turn_config/preemptive_generation.ts
+++ b/agents/src/voice/turn_config/preemptive_generation.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Ref: python livekit-agents/livekit/agents/voice/turn.py - 115-143 lines
 /**
  * Configuration for preemptive generation.
  */
@@ -35,7 +34,6 @@ export interface PreemptiveGenerationOptions {
   maxRetries: number;
 }
 
-// Ref: python livekit-agents/livekit/agents/voice/turn.py - 136-141 lines
 export const defaultPreemptiveGenerationOptions = {
   enabled: true,
   preemptiveTts: false,

--- a/agents/src/voice/turn_config/turn_handling.ts
+++ b/agents/src/voice/turn_config/turn_handling.ts
@@ -4,11 +4,29 @@
 import type { TurnDetectionMode } from '../agent_session.js';
 import { type EndpointingOptions, defaultEndpointingOptions } from './endpointing.js';
 import { type InterruptionOptions, defaultInterruptionOptions } from './interruption.js';
+import {
+  type PreemptiveGenerationOptions,
+  defaultPreemptiveGenerationOptions,
+} from './preemptive_generation.js';
 
 /**
  * Configuration for the turn handling system. Used to configure the turn taking behavior of the
  * session.
+ *
+ * @example
+ * ```ts
+ * session.start({
+ *   agent,
+ *   room,
+ *   turnHandling: {
+ *     endpointing: { minDelay: 300 },
+ *     interruption: { enabled: false },
+ *     preemptiveGeneration: { preemptiveTts: true },
+ *   },
+ * });
+ * ```
  */
+// Ref: python livekit-agents/livekit/agents/voice/turn.py - 144-175 lines
 export interface TurnHandlingOptions {
   /**
    * Strategy for deciding when the user has finished speaking.
@@ -31,15 +49,21 @@ export interface TurnHandlingOptions {
    * Configuration for interruption handling.
    */
   interruption: Partial<InterruptionOptions>;
+  /**
+   * Preemptive generation configuration. Use `{ enabled: false }` to disable.
+   */
+  preemptiveGeneration: Partial<PreemptiveGenerationOptions>;
 }
 
 export interface InternalTurnHandlingOptions extends TurnHandlingOptions {
   endpointing: EndpointingOptions;
   interruption: InterruptionOptions;
+  preemptiveGeneration: PreemptiveGenerationOptions;
 }
 
 export const defaultTurnHandlingOptions: InternalTurnHandlingOptions = {
   turnDetection: undefined,
   interruption: defaultInterruptionOptions,
   endpointing: defaultEndpointingOptions,
+  preemptiveGeneration: defaultPreemptiveGenerationOptions,
 };

--- a/agents/src/voice/turn_config/turn_handling.ts
+++ b/agents/src/voice/turn_config/turn_handling.ts
@@ -26,7 +26,6 @@ import {
  * });
  * ```
  */
-// Ref: python livekit-agents/livekit/agents/voice/turn.py - 144-175 lines
 export interface TurnHandlingOptions {
   /**
    * Strategy for deciding when the user has finished speaking.

--- a/agents/src/voice/turn_config/utils.test.ts
+++ b/agents/src/voice/turn_config/utils.test.ts
@@ -6,6 +6,7 @@ import { initializeLogger } from '../../log.js';
 import { defaultAgentSessionOptions } from '../agent_session.js';
 import { defaultEndpointingOptions } from './endpointing.js';
 import { defaultInterruptionOptions } from './interruption.js';
+import { defaultPreemptiveGenerationOptions } from './preemptive_generation.js';
 import { defaultTurnHandlingOptions } from './turn_handling.js';
 import { migrateLegacyOptions, migrateTurnHandling } from './utils.js';
 
@@ -21,9 +22,9 @@ describe('migrateLegacyOptions', () => {
       turnDetection: defaultTurnHandlingOptions.turnDetection,
       endpointing: defaultEndpointingOptions,
       interruption: defaultInterruptionOptions,
+      preemptiveGeneration: defaultPreemptiveGenerationOptions,
     });
     expect(result.maxToolSteps).toBe(defaultAgentSessionOptions.maxToolSteps);
-    expect(result.preemptiveGeneration).toBe(defaultAgentSessionOptions.preemptiveGeneration);
     expect(result.userAwayTimeout).toBe(defaultAgentSessionOptions.userAwayTimeout);
   });
 
@@ -128,6 +129,14 @@ describe('migrateTurnHandling', () => {
     expect(result.turnDetection).toBe('stt');
     expect(result.interruption).toEqual({ enabled: false });
     expect(result.endpointing).toEqual({ minDelay: 400, maxDelay: 3000 });
+  });
+
+  it('should map preemptiveGeneration boolean to preemptiveGeneration.enabled', () => {
+    const resultTrue = migrateTurnHandling({ preemptiveGeneration: true });
+    expect(resultTrue.preemptiveGeneration).toEqual({ enabled: true });
+
+    const resultFalse = migrateTurnHandling({ preemptiveGeneration: false });
+    expect(resultFalse.preemptiveGeneration).toEqual({ enabled: false });
   });
 
   it('should ignore deprecated Agent fields when explicit turnHandling is provided', () => {

--- a/agents/src/voice/turn_config/utils.ts
+++ b/agents/src/voice/turn_config/utils.ts
@@ -10,11 +10,11 @@ import {
 } from '../agent_session.js';
 import { defaultEndpointingOptions } from './endpointing.js';
 import { defaultInterruptionOptions } from './interruption.js';
+import { defaultPreemptiveGenerationOptions } from './preemptive_generation.js';
 import { type TurnHandlingOptions, defaultTurnHandlingOptions } from './turn_handling.js';
 
 const defaultSessionOptions = {
   maxToolSteps: 3,
-  preemptiveGeneration: true,
   userAwayTimeout: 15.0,
   aecWarmupDuration: 3000,
   turnHandling: {},
@@ -25,7 +25,6 @@ const defaultLegacyVoiceOptions: VoiceOptions = {
   minEndpointingDelay: defaultTurnHandlingOptions.endpointing.minDelay,
   maxEndpointingDelay: defaultTurnHandlingOptions.endpointing.maxDelay,
   maxToolSteps: defaultSessionOptions.maxToolSteps,
-  preemptiveGeneration: defaultSessionOptions.preemptiveGeneration,
 };
 
 export function migrateLegacyOptions<UserData>(legacyOptions: AgentSessionOptions<UserData>): {
@@ -51,6 +50,7 @@ export function migrateLegacyOptions<UserData>(legacyOptions: AgentSessionOption
     );
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/turn.py - 205-244 lines
   const turnHandling: TurnHandlingOptions = {
     interruption: {
       discardAudioIfUninterruptible: voiceOptions?.discardAudioIfUninterruptible,
@@ -62,6 +62,9 @@ export function migrateLegacyOptions<UserData>(legacyOptions: AgentSessionOption
       minDelay: voiceOptions?.minEndpointingDelay,
       maxDelay: voiceOptions?.maxEndpointingDelay,
       ...sessionOptions.turnHandling?.endpointing,
+    },
+    preemptiveGeneration: {
+      ...sessionOptions.turnHandling?.preemptiveGeneration,
     },
 
     turnDetection: sessionOptions?.turnHandling?.turnDetection ?? turnDetection,
@@ -79,11 +82,24 @@ export function migrateLegacyOptions<UserData>(legacyOptions: AgentSessionOption
   if (voiceOptions?.maxToolSteps !== undefined) {
     migratedVoiceOptions.maxToolSteps = voiceOptions.maxToolSteps;
   }
-  if (voiceOptions?.preemptiveGeneration !== undefined) {
-    migratedVoiceOptions.preemptiveGeneration = voiceOptions.preemptiveGeneration;
-  }
   if (voiceOptions?.userAwayTimeout !== undefined) {
     migratedVoiceOptions.userAwayTimeout = voiceOptions.userAwayTimeout;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/turn.py - 240-244 lines
+  // Migrate deprecated top-level preemptiveGeneration boolean into turn_handling
+  const deprecatedPreemptiveGen =
+    legacyOptions.preemptiveGeneration ?? voiceOptions?.preemptiveGeneration;
+  if (deprecatedPreemptiveGen !== undefined) {
+    logger.warn(
+      'preemptiveGeneration as a top-level option is deprecated, use turnHandling.preemptiveGeneration instead',
+    );
+    if (turnHandling.preemptiveGeneration.enabled === undefined) {
+      turnHandling.preemptiveGeneration = {
+        ...turnHandling.preemptiveGeneration,
+        enabled: deprecatedPreemptiveGen,
+      };
+    }
   }
 
   const legacyVoiceOptions = { ...defaultLegacyVoiceOptions, ...voiceOptions };
@@ -111,11 +127,16 @@ export function stripUndefined<T extends object>(obj: T): Partial<T> {
   return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)) as Partial<T>;
 }
 
+// Ref: python livekit-agents/livekit/agents/voice/turn.py - 171-179 lines
 export function mergeWithDefaults(config: TurnHandlingOptions) {
   return {
     turnDetection: config.turnDetection ?? defaultTurnHandlingOptions.turnDetection,
     endpointing: { ...defaultEndpointingOptions, ...stripUndefined(config.endpointing) },
     interruption: { ...defaultInterruptionOptions, ...stripUndefined(config.interruption) },
+    preemptiveGeneration: {
+      ...defaultPreemptiveGenerationOptions,
+      ...stripUndefined(config.preemptiveGeneration ?? {}),
+    },
   } as const;
 }
 
@@ -123,9 +144,11 @@ export function mergeWithDefaults(config: TurnHandlingOptions) {
  * Build a partial {@link TurnHandlingOptions} from deprecated Agent constructor fields.
  * Mirrors the Python Agent compatibility path, but keeps the JS API surface explicit.
  */
+// Ref: python livekit-agents/livekit/agents/voice/turn.py - 198-244 lines
 export function migrateTurnHandling(opts: {
   turnDetection?: TurnDetectionMode;
   allowInterruptions?: boolean;
+  preemptiveGeneration?: boolean;
   minEndpointingDelay?: number;
   maxEndpointingDelay?: number;
   turnHandling?: TurnHandlingOptions;
@@ -159,9 +182,16 @@ export function migrateTurnHandling(opts: {
     migrated.turnDetection = opts.turnDetection;
   }
 
+  if (opts.preemptiveGeneration !== undefined) {
+    migrated.preemptiveGeneration = { enabled: opts.preemptiveGeneration };
+  }
+
   return {
     ...(migrated.endpointing ? { endpointing: migrated.endpointing } : {}),
     ...(migrated.interruption ? { interruption: migrated.interruption } : {}),
     ...(migrated.turnDetection !== undefined ? { turnDetection: migrated.turnDetection } : {}),
+    ...(migrated.preemptiveGeneration
+      ? { preemptiveGeneration: migrated.preemptiveGeneration }
+      : {}),
   };
 }

--- a/agents/src/voice/turn_config/utils.ts
+++ b/agents/src/voice/turn_config/utils.ts
@@ -50,7 +50,6 @@ export function migrateLegacyOptions<UserData>(legacyOptions: AgentSessionOption
     );
   }
 
-  // Ref: python livekit-agents/livekit/agents/voice/turn.py - 205-244 lines
   const turnHandling: TurnHandlingOptions = {
     interruption: {
       discardAudioIfUninterruptible: voiceOptions?.discardAudioIfUninterruptible,
@@ -86,7 +85,6 @@ export function migrateLegacyOptions<UserData>(legacyOptions: AgentSessionOption
     migratedVoiceOptions.userAwayTimeout = voiceOptions.userAwayTimeout;
   }
 
-  // Ref: python livekit-agents/livekit/agents/voice/turn.py - 240-244 lines
   // Migrate deprecated top-level preemptiveGeneration boolean into turn_handling
   const deprecatedPreemptiveGen =
     legacyOptions.preemptiveGeneration ?? voiceOptions?.preemptiveGeneration;
@@ -127,7 +125,6 @@ export function stripUndefined<T extends object>(obj: T): Partial<T> {
   return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)) as Partial<T>;
 }
 
-// Ref: python livekit-agents/livekit/agents/voice/turn.py - 171-179 lines
 export function mergeWithDefaults(config: TurnHandlingOptions) {
   return {
     turnDetection: config.turnDetection ?? defaultTurnHandlingOptions.turnDetection,
@@ -144,7 +141,6 @@ export function mergeWithDefaults(config: TurnHandlingOptions) {
  * Build a partial {@link TurnHandlingOptions} from deprecated Agent constructor fields.
  * Mirrors the Python Agent compatibility path, but keeps the JS API surface explicit.
  */
-// Ref: python livekit-agents/livekit/agents/voice/turn.py - 198-244 lines
 export function migrateTurnHandling(opts: {
   turnDetection?: TurnDetectionMode;
   allowInterruptions?: boolean;

--- a/examples/src/basic_agent.ts
+++ b/examples/src/basic_agent.ts
@@ -67,7 +67,6 @@ export default defineAgent({
           'rime/arcana',
         ],
       }),
-      preemptiveGeneration: true,
       turnHandling: {
         turnDetection: new livekit.turnDetector.MultilingualModel(),
         interruption: {
@@ -75,6 +74,10 @@ export default defineAgent({
           falseInterruptionTimeout: 1,
           mode: 'adaptive',
         },
+        // Preemptive generation speculatively starts LLM inference while the user is still
+        // speaking to reduce time-to-first-token. See PreemptiveGenerationOptions for all
+        // tunables (enabled, preemptiveTts, maxSpeechDuration, maxRetries).
+        preemptiveGeneration: {},
       },
       useTtsAlignedTranscript: true,
       aecWarmupDuration: 3000,

--- a/examples/src/basic_agent.ts
+++ b/examples/src/basic_agent.ts
@@ -77,7 +77,9 @@ export default defineAgent({
         // Preemptive generation speculatively starts LLM inference while the user is still
         // speaking to reduce time-to-first-token. See PreemptiveGenerationOptions for all
         // tunables (enabled, preemptiveTts, maxSpeechDuration, maxRetries).
-        preemptiveGeneration: {},
+        preemptiveGeneration: {
+          enabled: true,
+        },
       },
       useTtsAlignedTranscript: true,
       aecWarmupDuration: 3000,

--- a/examples/src/restaurant_agent.ts
+++ b/examples/src/restaurant_agent.ts
@@ -379,8 +379,12 @@ export default defineAgent({
       // to use realtime model, replace the stt, llm, tts and vad with the following
       // llm: new openai.realtime.RealtimeModel({ voice: 'alloy' }),
       userData,
-      voiceOptions: {
-        maxToolSteps: 5,
+      maxToolSteps: 5,
+      turnHandling: {
+        // Preemptive generation speculatively starts LLM inference while the user is still
+        // speaking to reduce time-to-first-token. See PreemptiveGenerationOptions for all
+        // tunables (enabled, preemptiveTts, maxSpeechDuration, maxRetries).
+        preemptiveGeneration: {},
       },
     });
 

--- a/examples/src/restaurant_agent.ts
+++ b/examples/src/restaurant_agent.ts
@@ -384,7 +384,9 @@ export default defineAgent({
         // Preemptive generation speculatively starts LLM inference while the user is still
         // speaking to reduce time-to-first-token. See PreemptiveGenerationOptions for all
         // tunables (enabled, preemptiveTts, maxSpeechDuration, maxRetries).
-        preemptiveGeneration: {},
+        preemptiveGeneration: {
+          enabled: true,
+        },
       },
     });
 


### PR DESCRIPTION
## Summary

Port of [livekit/agents#5428](https://github.com/livekit/agents/pull/5428) — adds `PreemptiveGenerationOptions` with configurable options to reduce wasted compute during preemptive generation.

### Changes

- **New `PreemptiveGenerationOptions` interface** (`turn_config/preemptive_generation.ts`) with:
  - `enabled` (default `true`): whether preemptive generation is active
  - `preemptiveTts` (default `false`): when `false`, only LLM runs preemptively; TTS starts once the turn is confirmed and speech is scheduled
  - `maxSpeechDuration` (default `10000` ms): skip preemptive generation when user has been speaking too long, since long utterances are more likely to change
  - `maxRetries` (default `3`): cap preemptive LLM requests per user turn; counter resets on turn completion

- **Moved `preemptiveGeneration` into `TurnHandlingOptions`**: The option is now configured via `turnHandling.preemptiveGeneration` alongside endpointing and interruption. The old top-level `preemptiveGeneration: boolean` on `AgentSessionOptions` is deprecated with a backward-compatible migration path.

- **Pipeline TTS deferral**: In `_pipelineReplyTaskImpl`, TTS inference is now deferred until after `waitForScheduled` by default. When `preemptiveTts: true`, TTS starts immediately alongside the LLM (previous behavior).

- **Speech duration & retry guards** in `onPreemptiveGeneration`: Preemptive generation is skipped if the user has been speaking longer than `maxSpeechDuration`, or if `maxRetries` attempts have already been made for the current turn.

- **`PreemptiveGenerationInfo` extended** with `startedSpeakingAt` to enable the speech duration check.

### Usage

```ts
const session = new AgentSession({
  turnHandling: {
    endpointing: { minDelay: 300 },
    interruption: { enabled: false },
    preemptiveGeneration: { preemptiveTts: true, maxRetries: 5 },
  },
});
```

### Implementation nuances (JS vs Python)

| Aspect | Python | JS/TS |
|--------|--------|-------|
| Time units | Seconds (`max_speech_duration: 10.0`) | Milliseconds (`maxSpeechDuration: 10_000`) |
| TypedDict vs Interface | `PreemptiveGenerationOptions(TypedDict, total=False)` | `interface PreemptiveGenerationOptions` with `Partial<>` where needed |
| TTS stream teeing | Python uses `text_tee` with lazy branch creation | JS always tees upfront via `ReadableStream.tee()` but defers `performTTSInference()` call |
| Default resolution | `{**defaults, **config}` dict merge | `{ ...defaults, ...stripUndefined(config) }` spread with undefined filtering |
| Counter field | `_preemptive_generation_count: int` on class | `private _preemptiveGenerationCount = 0` |
| Naming | `snake_case` (`preemptive_tts`, `max_speech_duration`) | `camelCase` (`preemptiveTts`, `maxSpeechDuration`) |

### Files changed

- `agents/src/voice/turn_config/preemptive_generation.ts` — **new**: `PreemptiveGenerationOptions` interface and defaults
- `agents/src/voice/turn_config/turn_handling.ts` — added `preemptiveGeneration` to `TurnHandlingOptions` and `InternalTurnHandlingOptions`
- `agents/src/voice/turn_config/utils.ts` — updated migration logic, `mergeWithDefaults`, deprecated boolean migration
- `agents/src/voice/agent_session.ts` — deprecated top-level `preemptiveGeneration`, removed from defaults
- `agents/src/voice/agent_activity.ts` — added retry count, speech duration check, preemptive TTS deferral
- `agents/src/voice/audio_recognition.ts` — added `startedSpeakingAt` to `PreemptiveGenerationInfo`, passed `speechStartTime`
- `agents/src/voice/remote_session.ts` — updated serialization to use structured options from `turnHandling`
- `agents/src/voice/report.ts` — added `preemptive_generation` to report output
- `agents/src/voice/report.test.ts` — updated test defaults
- `agents/src/voice/turn_config/utils.test.ts` — added preemptive generation migration tests

## Test plan

- [x] All 645 tests in `agents/src/` pass
- [x] Build succeeds (`pnpm build:agents`)
- [x] Lint passes (`pnpm lint`)
- [x] Formatting passes (`pnpm format:check`)
- [x] Verify `restaurant_agent.ts` works in Agent Playground with default options (preemptive generation enabled, TTS deferred)
- [x] Verify `restaurant_agent.ts` with `preemptiveTts: true` for full preemptive pipeline
- [x] Verify `preemptiveGeneration: { enabled: false }` correctly disables preemptive generation

cc @toubatbrian @livekit/agent-devs