### PR TITLE
fix(voice): clear forwardedText when interrupted before any text syncs

### DIFF
--- a/.changeset/fix-unplayed-response-chat-ctx.md
+++ b/.changeset/fix-unplayed-response-chat-ctx.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(voice): don't commit unplayed LLM response to chat context when interruption happens before any text is synchronized

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2203,6 +2203,8 @@ export class AgentActivity implements RecognitionHooks {
           );
           if (playbackEv.synchronizedTranscript) {
             forwardedText = playbackEv.synchronizedTranscript;
+          } else {
+            forwardedText = '';
           }
         } else {
           forwardedText = '';
@@ -2693,6 +2695,8 @@ export class AgentActivity implements RecognitionHooks {
             );
             if (playbackEv.synchronizedTranscript) {
               forwardedText = playbackEv.synchronizedTranscript;
+            } else {
+              forwardedText = '';
             }
           } else {
             forwardedText = '';


### PR DESCRIPTION
Closes #1269

## Description
<!-- Provide a clear and concise description of what this PR does -->
When the user interrupts the agent immediately after the first audio frame is queued but before the transcription synchronizer has produced any text, the full unplayed LLM response was incorrectly inserted into the chat context. This caused the agent to "remember" things it never actually said.

The fix clears `forwardedText` in the `else` branch when `playbackEv.synchronizedTranscript` is empty, rather than letting it retain the initial value of `textOut?.text` (the full generated response).

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- `agent_activity.ts` (standard pipeline): clear `forwardedText = ''` when `synchronizedTranscript` is empty after first frame was played
- `agent_activity.ts` (realtime path): same fix for the realtime generation branch
- Changeset

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [x] All tests pass

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->
The Python `livekit-agents` repo has the same structural bug (`if synchronized_transcript is not None:` without an `else`) — worth mirroring upstream.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.