### PR TITLE
feat(deepgram): port flux-general-multi STTv2 support from python

### DIFF
--- a/.changeset/deepgram-flux-general-multi.md
+++ b/.changeset/deepgram-flux-general-multi.md
@@ -1,6 +1,6 @@
 ---
-'@livekit/agents-plugin-deepgram': minor
-'@livekit/agents': minor
+'@livekit/agents-plugin-deepgram': patch
+'@livekit/agents': patch
 ---
 
 Add Deepgram `flux-general-multi` STTv2 model support with multi-language detection. Introduces a new `languageHint` option for biasing the model toward specific languages (only used by `flux-general-multi`), and adds a new `sourceLanguages` field on `SpeechData` that carries all detected languages sorted by prevalence. For multi-language detection, the dominant language is set on `language` while `sourceLanguages` retains the full list.

--- a/.changeset/deepgram-flux-general-multi.md
+++ b/.changeset/deepgram-flux-general-multi.md
@@ -1,0 +1,6 @@
+---
+'@livekit/agents-plugin-deepgram': minor
+'@livekit/agents': minor
+---
+
+Add Deepgram `flux-general-multi` STTv2 model support with multi-language detection. Introduces a new `languageHint` option for biasing the model toward specific languages (only used by `flux-general-multi`), and adds a new `sourceLanguages` field on `SpeechData` that carries all detected languages sorted by prevalence. For multi-language detection, the dominant language is set on `language` while `sourceLanguages` retains the full list.

--- a/agents/src/stt/stt.ts
+++ b/agents/src/stt/stt.ts
@@ -64,6 +64,18 @@ export interface SpeechData {
   words?: TimedString[];
   /** Speaker identifier when the provider supports diarization. */
   speakerId?: string | null;
+  /**
+   * The source languages spoken by the user.
+   *
+   * Populated by STT services that support translation, where `language` holds the
+   * target language and `sourceLanguages` holds the original spoken language(s),
+   * or by multi-language detection services where `language` holds the dominant
+   * language and `sourceLanguages` holds all detected languages sorted by prevalence.
+   *
+   * May contain multiple entries when a single utterance spans multiple source languages.
+   */
+  // Ref: python livekit-agents/livekit/agents/stt/stt.py - 62-68 lines
+  sourceLanguages?: LanguageCode[];
 }
 
 export interface RecognitionUsage {

--- a/plugins/deepgram/src/models.ts
+++ b/plugins/deepgram/src/models.ts
@@ -18,7 +18,8 @@ export type TTSModels =
 
 export type TTSEncoding = 'linear16' | 'mulaw' | 'alaw' | 'mp3' | 'opus' | 'flac' | 'aac';
 
-export type V2Models = 'flux-general-en';
+// Ref: python livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/models.py - 38 line
+export type V2Models = 'flux-general-en' | 'flux-general-multi';
 
 export type STTModels =
   | 'nova-general'

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -36,6 +36,12 @@ export interface STTv2Options {
   eotTimeoutMs?: number;
   mipOptOut?: boolean;
   tags?: string[];
+  /**
+   * List of language hints to bias the model for improved accuracy.
+   * Only usable with `flux-general-multi`.
+   */
+  // Ref: python livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py - 61 line
+  languageHint?: string[];
 }
 
 const defaultSTTv2Options: Omit<STTv2Options, 'apiKey'> = {
@@ -104,6 +110,8 @@ export class STTv2 extends stt.STT {
    * @param opts.eotTimeoutMs - End-of-turn timeout in ms (default: 3000)
    * @param opts.keyterms - List of key terms to improve recognition
    * @param opts.tags - Tags for usage reporting (max 128 chars each)
+   * @param opts.languageHint - List of language hints to bias the model for improved accuracy.
+   *   Only usable with `flux-general-multi`.
    *
    * @throws Error if no API key is provided
    */
@@ -128,6 +136,18 @@ export class STTv2 extends stt.STT {
 
     if (this.#opts.tags) {
       this.#opts.tags = validateTags(this.#opts.tags);
+    }
+
+    // Ref: python livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py - 134-138 lines
+    if (
+      this.#opts.languageHint &&
+      this.#opts.languageHint.length > 0 &&
+      this.#opts.model !== 'flux-general-multi'
+    ) {
+      this.#logger.warn(
+        { model: this.#opts.model },
+        '`languageHint` is only supported by `flux-general-multi` and will be ignored for this model',
+      );
     }
   }
 
@@ -167,6 +187,17 @@ export class STTv2 extends stt.STT {
   updateOptions(opts: Partial<STTv2Options>) {
     this.#opts = { ...this.#opts, ...opts };
     if (opts.tags) this.#opts.tags = validateTags(opts.tags);
+    // Ref: python livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py - 244-249 lines
+    if (
+      opts.languageHint &&
+      opts.languageHint.length > 0 &&
+      this.#opts.model !== 'flux-general-multi'
+    ) {
+      this.#logger.warn(
+        { model: this.#opts.model },
+        '`languageHint` is only supported by `flux-general-multi` and will be ignored for this model',
+      );
+    }
     this.#logger.debug('Updated STTv2 options');
   }
 }
@@ -456,6 +487,11 @@ class SpeechStreamv2 extends stt.SpeechStream {
     if (this.#opts.keyterms.length > 0) params.keyterm = this.#opts.keyterms;
     if (this.#opts.tags && this.#opts.tags.length > 0) params.tag = this.#opts.tags;
 
+    // Ref: python livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py - 480-481 lines
+    if (this.#opts.languageHint && this.#opts.languageHint.length > 0) {
+      params.language_hint = this.#opts.languageHint;
+    }
+
     const baseUrl = this.#opts.endpointUrl.replace(/^http/, 'ws');
     const qs = queryString.stringify(params);
     return `${baseUrl}?${qs}`;
@@ -487,12 +523,20 @@ function parseTranscription(
     confidence = sum / wordsData.length;
   }
 
+  // Ref: python livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py - 587-591 lines
+  const detectedLanguagesRaw = Array.isArray(data.languages) ? (data.languages as string[]) : [];
+  const detectedLanguages = detectedLanguagesRaw.map((lang) => normalizeLanguage(lang));
+  const primaryLanguage =
+    detectedLanguages.length > 0 ? detectedLanguages[0]! : normalizeLanguage(language);
+
   const sd: stt.SpeechData = {
-    language: normalizeLanguage(language),
+    language: primaryLanguage,
     startTime: ((data.audio_window_start as number) || 0) + startTimeOffset,
     endTime: ((data.audio_window_end as number) || 0) + startTimeOffset,
     confidence: confidence,
     text: transcript || '',
+    // Ref: python livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py - 598 line
+    sourceLanguages: detectedLanguages.length > 0 ? detectedLanguages : undefined,
     // Note: Deepgram V2 (Flux) API does not provide word-level timing (start/end).
     // Words only contain 'word' and 'confidence' fields, so startTime/endTime will be 0.
     // See: https://developers.deepgram.com/docs/flux/nova-3-migration

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -185,12 +185,17 @@ export class STTv2 extends stt.STT {
    * @param opts - Partial options to update
    */
   updateOptions(opts: Partial<STTv2Options>) {
-    this.#opts = { ...this.#opts, ...opts };
+    this.#opts = {
+      ...this.#opts,
+      ...opts,
+      language:
+        opts.language !== undefined ? normalizeLanguage(opts.language) : this.#opts.language,
+    };
     if (opts.tags) this.#opts.tags = validateTags(opts.tags);
     // Ref: python livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py - 244-249 lines
     if (
-      opts.languageHint &&
-      opts.languageHint.length > 0 &&
+      this.#opts.languageHint &&
+      this.#opts.languageHint.length > 0 &&
       this.#opts.model !== 'flux-general-multi'
     ) {
       this.#logger.warn(


### PR DESCRIPTION
## Summary

Ports [livekit/agents#5486](https://github.com/livekit/agents/pull/5486) ("(deepgram sttv2): add flux-general-multi support") from the Python `livekit-agents` repo into `agents-js`.

This PR adds support for Deepgram's new `flux-general-multi` STTv2 model, which performs multi-language detection over an utterance. When this model is active, Deepgram returns a `languages` array on each transcript message, ordered by prevalence. The most-prevalent language is exposed as the primary `language`, and the full list is exposed on a new `sourceLanguages` field.

cc @toubatbrian @livekit/agent-devs for review.

## Ported features

### 1. `flux-general-multi` model (`plugins/deepgram/src/models.ts`)

Extended the `V2Models` union:

```ts
// Ref: python livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/models.py - 38 line
export type V2Models = 'flux-general-en' | 'flux-general-multi';
```

### 2. `languageHint` option on `STTv2` (`plugins/deepgram/src/stt_v2.ts`)

New optional `languageHint: string[]` option on `STTv2Options`, serialized into the Deepgram websocket URL as the `language_hint` query parameter. This option is only meaningful with `flux-general-multi`; setting it on any other model logs a warning (matching Python's `logger.warning(...)` behavior). The same warning path is wired into `updateOptions` so late model/hint changes still surface mismatches.

### 3. `source_languages` → `sourceLanguages` on `SpeechData` (`agents/src/stt/stt.ts`)

New optional field on the core `SpeechData` interface:

```ts
// Ref: python livekit-agents/livekit/agents/stt/stt.py - 62-68 lines
sourceLanguages?: LanguageCode[];
```

The docstring mirrors the updated Python docstring: the field is populated either by translation-capable STT services (where `language` is the target and `sourceLanguages` carries the original spoken language(s)) or by multi-language detection services (where `language` is the dominant detected language and `sourceLanguages` carries all detected languages sorted by prevalence).

### 4. `parseTranscription` updates

The Deepgram STTv2 parser now reads `data.languages`, runs each entry through `normalizeLanguage`, and:
- Sets `SpeechData.language` to the dominant (first) detected language when the array is non-empty, falling back to the stream's configured `language` otherwise.
- Sets `SpeechData.sourceLanguages` to the full normalized list (or leaves it `undefined` when the field is absent).

## Implementation nuances vs Python

- **Naming**: Python's `language_hint` (snake_case) maps to JS's `languageHint` (camelCase); the wire parameter stays `language_hint`. Same for `source_languages` → `sourceLanguages`.
- **Language normalization**: Python stores raw `LanguageCode(...)` values from Deepgram. The JS plugin has always run language strings through `normalizeLanguage(...)` before putting them on `SpeechData.language` (this matches the existing pattern used elsewhere in the Deepgram plugin and the wider codebase), so the port normalizes each entry of the `languages` array as well.
- **Logging**: Python uses `%s` positional formatting; JS uses pino-style structured logging (`{ model: ... }, 'message'`). The warning content is preserved verbatim.
- **`source_texts`**: The Python diff updates the docstring for `SpeechData.source_texts` too, but the JS `SpeechData` has never had that field (it was never ported with the translation feature) so nothing to change here. This is noted so we don't silently drift — we can port `sourceTexts` in a follow-up if/when translation STT lands in JS.
- **Docstring-only change to `stt.py`**: The Python PR also tweaks the `source_languages` docstring in core `stt.py`. Those clarifications are inlined into the JSDoc on the new JS field.

## Files changed

| File | Change |
|------|--------|
| `agents/src/stt/stt.ts` | Add `sourceLanguages?: LanguageCode[]` to `SpeechData` with docstring matching Python |
| `plugins/deepgram/src/models.ts` | Add `flux-general-multi` to `V2Models` |
| `plugins/deepgram/src/stt_v2.ts` | Add `languageHint` option, wire it into the websocket URL, warn on model mismatch in constructor + `updateOptions`, populate `sourceLanguages` and override primary `language` from Deepgram's `languages` array |
| `.changeset/deepgram-flux-general-multi.md` | `minor` changeset for `@livekit/agents-plugin-deepgram` and `@livekit/agents` |

## Test plan

- [x] `pnpm build:agents` succeeds
- [x] `pnpm --filter "@livekit/agents-plugin-deepgram..." build` succeeds
- [x] `pnpm format:check` passes
- [x] ESLint surfaces no new errors/warnings (pre-existing warnings unchanged)
- [ ] Manual: run `restaurant_agent.ts` with `new STTv2({ model: 'flux-general-multi', languageHint: ['en', 'es'] })` and verify `sourceLanguages` is populated on `FINAL_TRANSCRIPT` events when switching languages mid-utterance
- [ ] Manual: confirm with `model: 'flux-general-en'` + `languageHint` the warning is emitted and the stream still succeeds (hint ignored)

---

This PR was created by an automated Claude Code Routine maintained by @toubatbrian. The routine is currently in experimentation stage.
