### PR TITLE
feat(xai): expose endpointing option on STT

### DIFF
--- a/.changeset/xai-stt-endpointing.md
+++ b/.changeset/xai-stt-endpointing.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-xai': patch
+---
+
+Expose `endpointing` option on xAI STT to configure silence duration (in milliseconds) before an utterance-final event is fired. Defaults to 100ms (matching AssemblyAI's default) for better compatibility with LiveKit EOT models. Ported from livekit/agents#5493.

--- a/plugins/xai/src/stt.ts
+++ b/plugins/xai/src/stt.ts
@@ -56,13 +56,20 @@ export interface STTOptions {
   sampleRate: number;
   enableDiarization: boolean;
   language: STTLanguages | string;
+  /**
+   * Silence duration in milliseconds before an utterance-final event is fired.
+   * xAI's default is 10ms, but we default to 100ms for better compatibility with LK EOT models.
+   */
+  endpointing: number;
 }
 
+// Ref: python livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py - 57-79 lines
 const defaultSTTOptions: Omit<STTOptions, 'apiKey'> = {
   interimResults: true,
   sampleRate: SAMPLE_RATE,
   enableDiarization: false,
   language: 'en',
+  endpointing: 100,
 };
 
 export class STT extends stt.STT {
@@ -186,6 +193,8 @@ export class SpeechStream extends stt.SpeechStream {
       );
       streamURL.searchParams.set('diarize', String(this.#opts.enableDiarization).toLowerCase());
       streamURL.searchParams.set('language', this.#opts.language);
+      // Ref: python livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py - 372-375 lines
+      streamURL.searchParams.set('endpointing', String(this.#opts.endpointing));
 
       ws = new WebSocket(streamURL, {
         headers: { Authorization: `Bearer ${this.#apiKey}` },


### PR DESCRIPTION
## Summary

Port of [livekit/agents#5493](https://github.com/livekit/agents/pull/5493) — exposes the `endpointing` query parameter on the xAI STT plugin so users can configure how long of a silence gap triggers an utterance-final event.

### What's ported

- **`endpointing` field on `STTOptions`** (`plugins/xai/src/stt.ts`): New required numeric option (milliseconds). Defaults to `100` to match AssemblyAI's default and to provide better compatibility with LiveKit EOT models (xAI's server-side default is only 10ms).
- **Query string propagation**: The `endpointing` value is appended to the WebSocket handshake URL as a search parameter (`?endpointing=<ms>`), mirroring the Python implementation which sends `"endpointing": str(self._opts.endpointing)` alongside the other streaming options.
- **Changeset** (`.changeset/xai-stt-endpointing.md`): `@livekit/agents-plugin-xai` patch bump.

### Where `updateOptions` lives

The Python PR wires the new option through both `STT.update_options` and `SpeechStream.update_options`. In agents-js these are already unified: `STT.updateOptions(opts)` spreads `opts` into `this.#opts` and forwards the same partial to each active `SpeechStream.updateOptions`, which in turn spreads and triggers `#resetWS.resolve()` to re-open the WebSocket with the new query string. Because both methods accept `Partial<STTOptions>`, `endpointing` flows through automatically — no call-site changes were needed beyond adding the field to the interface.

### Implementation nuances (Python → TypeScript)

| Aspect | Python | TypeScript (this PR) |
|---|---|---|
| Option type | `endpointing: int` (separate `NotGivenOr[int]` in `update_options`) | `endpointing: number` on `STTOptions`; `Partial<STTOptions>` in `updateOptions` — same `NotGivenOr`-like ergonomics via `Partial<>` |
| Default value | `100` | `100` (same) |
| Wire format | `str(self._opts.endpointing)` in the streaming query dict | `String(this.#opts.endpointing)` in `URLSearchParams.set()` |
| Docstring location | `__init__` docstring | TSDoc comment directly on the interface field |
| Update propagation | Explicit `endpointing=` kwarg threaded through `STT.update_options → SpeechStream.update_options` | Flows automatically through the existing `Partial<STTOptions>` spread — no new signature fields required |

### What's NOT ported (Python-specific)

- The Python PR duplicates the `endpointing` kwarg across two `update_options` overloads because Python lacks structural typing for `**kwargs`. The TypeScript side achieves the same behavior via `Partial<STTOptions>` without needing explicit parameter duplication.

### Files changed

- `plugins/xai/src/stt.ts` — added `endpointing` to `STTOptions` + default + WS query string
- `.changeset/xai-stt-endpointing.md` — new changeset

## Test plan

- [x] `pnpm build:agents` succeeds
- [x] `@livekit/agents-plugin-xai` CJS build succeeds
- [x] ESLint passes on `plugins/xai/src/stt.ts`
- [ ] Verify with a live xAI STT session that a custom `endpointing` value (e.g. `300`) changes silence-to-final timing
- [ ] Verify default behavior (100ms) is unchanged from user's perspective when the option is omitted

---

This PR is an automated Claude Code Routine created by @toubatbrian (currently in experimentation stage).

cc @toubatbrian @livekit/agent-devs

https://claude.ai/code/session_018y2AbXbMvRCSUnGWgPbHyW