### PR TITLE
Add dynamic endpointing to the Node.js voice pipeline

### DIFF
--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -351,43 +351,120 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 }
 
 /** @internal */
+// Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-64 lines
 export class ExpFilter {
   #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  #maxValue?: number;
+  #minValue?: number;
+  #value?: number;
 
-  constructor(alpha: number, max?: number) {
+  constructor(
+    alpha: number,
+    options:
+      | number
+      | {
+          initial?: number;
+          maxValue?: number;
+          minValue?: number;
+        } = {},
+  ) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
+
     this.#alpha = alpha;
-    this.#max = max;
+
+    if (typeof options === 'number') {
+      this.#maxValue = options;
+      return;
+    }
+
+    this.#value = options.initial;
+    this.#maxValue = options.maxValue;
+    this.#minValue = options.minValue;
   }
 
-  reset(alpha?: number) {
-    if (alpha) {
+  reset(
+    options: {
+      alpha?: number;
+      initial?: number;
+      maxValue?: number;
+      minValue?: number;
+    } = {},
+  ): void {
+    const { alpha, initial, maxValue, minValue } = options;
+
+    if (alpha !== undefined) {
+      if (!(alpha > 0 && alpha <= 1)) {
+        throw new Error('alpha must be in (0, 1].');
+      }
       this.#alpha = alpha;
     }
-    this.#filtered = undefined;
+
+    if (initial !== undefined) {
+      this.#value = initial;
+    }
+
+    if (minValue !== undefined) {
+      this.#minValue = minValue;
+    }
+
+    if (maxValue !== undefined) {
+      this.#maxValue = maxValue;
+    }
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
+  apply(exp: number, sample = this.#value): number {
+    if (sample === undefined && this.#value === undefined) {
+      throw new Error('sample or initial value must be given.');
+    }
+
+    if (sample !== undefined && this.#value === undefined) {
+      this.#value = sample;
+    } else if (sample !== undefined && this.#value !== undefined) {
       const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
-    } else {
-      this.#filtered = sample;
+      this.#value = a * this.#value + (1 - a) * sample;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (this.#value === undefined) {
+      throw new Error('sample or initial value must be given.');
     }
 
-    return this.#filtered;
+    if (this.#maxValue !== undefined && this.#value > this.#maxValue) {
+      this.#value = this.#maxValue;
+    }
+
+    if (this.#minValue !== undefined && this.#value < this.#minValue) {
+      this.#value = this.#minValue;
+    }
+
+    return this.#value;
+  }
+
+  get value(): number | undefined {
+    return this.#value;
   }
 
   get filtered(): number | undefined {
-    return this.#filtered;
+    return this.#value;
+  }
+
+  get alpha(): number {
+    return this.#alpha;
+  }
+
+  get minValue(): number | undefined {
+    return this.#minValue;
+  }
+
+  get maxValue(): number | undefined {
+    return this.#maxValue;
   }
 
   set alpha(alpha: number) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
     this.#alpha = alpha;
   }
 }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -65,6 +65,7 @@ import {
   type RecognitionHooks,
   type STTPipeline,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import {
   AgentSessionEventTypes,
   createErrorEvent,
@@ -88,6 +89,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import { stripUndefined } from './turn_config/utils.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -188,6 +190,7 @@ export class AgentActivity implements RecognitionHooks {
   private isInterruptionDetectionEnabled: boolean;
   private isInterruptionByAudioActivityEnabled: boolean;
   private isDefaultInterruptionByAudioActivityEnabled: boolean;
+  private interruptionDetected = false;
 
   private readonly onRealtimeGenerationCreated = (ev: GenerationCreatedEvent): void =>
     this.onGenerationCreated(ev);
@@ -206,6 +209,7 @@ export class AgentActivity implements RecognitionHooks {
     this.onError(ev);
 
   private readonly onInterruptionOverlappingSpeech = (ev: OverlappingSpeechEvent): void => {
+    this.interruptionDetected = ev.isInterruption;
     this.agentSession.emit(AgentSessionEventTypes.OverlappingSpeech, ev);
   };
 
@@ -477,12 +481,11 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 321-328 lines
+      endpointing: createEndpointing({
+        ...this.agentSession.sessionOptions.turnHandling.endpointing,
+        ...stripUndefined(this.agent.turnHandling?.endpointing ?? {}),
+      }),
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -922,12 +925,10 @@ export class AgentActivity implements RecognitionHooks {
 
     if (!this.vad) {
       this.agentSession._updateUserState('speaking');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfOverlapSpeech(
-          0,
-          Date.now(),
-          this.agentSession._userSpeakingSpan,
-        );
+      this.interruptionDetected = false;
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1490-1498 lines
+        this.audioRecognition.onStartOfSpeech(Date.now(), 0, this.agentSession._userSpeakingSpan);
       }
     }
 
@@ -947,8 +948,13 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1508-1516 lines
+        this.audioRecognition.onEndOfSpeech(
+          Date.now(),
+          this.agentSession._userSpeakingSpan,
+          this.isInterruptionDetectionEnabled && !this.interruptionDetected,
+        );
       }
       this.agentSession._updateUserState('listening');
     }
@@ -1030,11 +1036,12 @@ export class AgentActivity implements RecognitionHooks {
       lastSpeakingTime: speechStartTime,
       otelContext: otelContext.active(),
     });
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
+    this.interruptionDetected = false;
+    if (this.audioRecognition) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1645-1656 lines
+      this.audioRecognition.onStartOfSpeech(
         speechStartTime,
+        ev?.speechDuration ?? 0,
         this.agentSession._userSpeakingSpan,
       );
     }
@@ -1046,11 +1053,12 @@ export class AgentActivity implements RecognitionHooks {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
+    if (this.audioRecognition) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1665-1679 lines
+      this.audioRecognition.onEndOfSpeech(
         speechEndTime,
         this.agentSession._userSpeakingSpan,
+        this.isInterruptionDetectionEnabled && !this.interruptionDetected,
       );
     }
     this.agentSession._updateUserState('listening', {
@@ -1127,6 +1135,7 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   onInterruption(ev: OverlappingSpeechEvent) {
+    this.interruptionDetected = true;
     this.restoreInterruptionByAudioActivity();
     this.interruptByAudioActivity();
     if (this.audioRecognition) {
@@ -1838,7 +1847,7 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2114,7 +2123,7 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,6 +35,7 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import type { BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
@@ -138,10 +139,8 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
-  /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  /** Endpointing delay tracker. */
+  endpointing: BaseEndpointing;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +169,7 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  private endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -224,8 +222,8 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 125-152 lines
+    this.endpointing = opts.endpointing;
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,8 +273,17 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
-    this.turnDetectionMode = options.turnDetection;
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 192-219 lines
+  updateOptions(options: {
+    turnDetection?: TurnDetectionMode;
+    endpointing?: BaseEndpointing;
+  }): void {
+    if (Object.hasOwn(options, 'turnDetection')) {
+      this.turnDetectionMode = options.turnDetection;
+    }
+    if (options.endpointing !== undefined) {
+      this.endpointing = options.endpointing;
+    }
   }
 
   async start(options?: { sttPipeline?: STTPipeline }) {
@@ -311,12 +318,19 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-243 lines
+  async onStartOfAgentSpeech(startedAt: number = Date.now()) {
     this.isAgentSpeaking = true;
+    this.endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 245-270 lines
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -342,6 +356,28 @@ export class AudioRecognition {
       await this.flushHeldTranscripts();
     }
     this.isAgentSpeaking = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 272-289 lines
+  onStartOfSpeech(startedAt: number, speechDuration = 0, userSpeakingSpan?: Span) {
+    this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+
+    if (!this.isInterruptionEnabled || !this.isAgentSpeaking) {
+      return;
+    }
+
+    this.trySendInterruptionSentinel(
+      InterruptionStreamSentinel.overlapSpeechStarted(speechDuration, startedAt, userSpeakingSpan),
+    );
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-305 lines
+  onEndOfSpeech(endedAt: number, userSpeakingSpan?: Span, shouldIgnore = false) {
+    if (this.speaking) {
+      this.endpointing.onEndOfSpeech(endedAt, shouldIgnore && this.isAgentSpeaking);
+    }
+
+    this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
   }
 
   /** Start interruption inference when agent is speaking and overlap speech starts. */
@@ -805,7 +841,8 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 934-958 lines
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +868,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -7,6 +7,7 @@ import { ChatContext } from '../llm/chat_context.js';
 import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function createHooks() {
@@ -45,8 +46,7 @@ function createRecognition(sttNode: STTNode, hooks = createHooks()) {
     recognition: new AudioRecognition({
       recognitionHooks: hooks,
       stt: sttNode,
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
     }),
   };
 }

--- a/agents/src/voice/audio_recognition_span.test.ts
+++ b/agents/src/voice/audio_recognition_span.test.ts
@@ -22,6 +22,7 @@ import {
   type RecognitionHooks,
   type _TurnDetector,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function setupInMemoryTracing() {
@@ -145,8 +146,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: undefined,
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'stt',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
       sttModel: 'deepgram-nova2',
       sttProvider: 'deepgram',
       getLinkedParticipant: () => ({ sid: 'p1', identity: 'bob', kind: ParticipantKind.AGENT }),
@@ -254,8 +254,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: new FakeVAD(vadEvents),
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'vad',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
       sttModel: 'stt-model',
       sttProvider: 'stt-provider',
       getLinkedParticipant: () => ({ sid: 'p2', identity: 'alice', kind: ParticipantKind.AGENT }),

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,476 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+beforeAll(() => {
+  initializeLogger({ pretty: false, level: 'silent' });
+});
+
+// Ref: python tests/test_endpointing.py - 7-63 lines
+describe('ExpFilter', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    let ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    let emaWithInitial = new ExpFilter(0.5, { initial: 10 });
+    expect(emaWithInitial.value).toBe(10);
+
+    ema = new ExpFilter(1);
+    expect(ema.value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(-0.5)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(1.5)).toThrow('alpha must be in');
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1, 10);
+    expect(result).toBe(10);
+    expect(ema.value).toBe(10);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, { initial: 10 });
+    const result = ema.apply(1, 20);
+    expect(result).toBe(15);
+    expect(ema.value).toBe(15);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, { initial: 10 });
+    ema.apply(1, 20);
+    ema.apply(1, 20);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    let ema = new ExpFilter(0.5, { initial: 10 });
+    expect(ema.value).toBe(10);
+    ema.reset();
+    expect(ema.value).toBe(10);
+
+    ema = new ExpFilter(0.5, { initial: 10 });
+    ema.reset({ initial: 5 });
+    expect(ema.value).toBe(5);
+  });
+});
+
+// Ref: python tests/test_endpointing.py - 64-545 lines
+describe('DynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.2 });
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    expect((ep as any).utterancePause.alpha).toBeCloseTo(0.9, 5);
+    expect((ep as any).turnPause.alpha).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toStrictEqual([0, 0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    let ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(100_000);
+    expect((ep as any).utteranceEndedAt).toBe(100_000);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(99_900);
+    expect((ep as any).utteranceEndedAt).toBe(99_900);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onStartOfSpeech(100_000);
+    expect((ep as any).utteranceStartedAt).toBe(100_000);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onStartOfAgentSpeech(100_000);
+    expect((ep as any).agentSpeechStartedAt).toBe(100_000);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_500);
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(500, 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_800);
+    expect(ep.betweenTurnDelay).toBeCloseTo(800, 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_400);
+    ep.onEndOfSpeech(100_500, false);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_600);
+    ep.onStartOfSpeech(101_500);
+    ep.onEndOfSpeech(102_000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(800, 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    expect((ep as any).agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(100_250, true);
+    expect((ep as any).overlapActive).toBe(true);
+
+    ep.onEndOfSpeech(100_500);
+
+    expect((ep as any).overlapActive).toBe(false);
+    expect((ep as any).agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(300, 5);
+  });
+
+  it('test_update_options', () => {
+    let ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions({ minDelay: 500 });
+    expect(ep.minDelay).toBe(500);
+    expect((ep as any).configuredMinDelay).toBe(500);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions({ maxDelay: 2000 });
+    expect(ep.maxDelay).toBe(2000);
+    expect((ep as any).configuredMaxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions();
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 1 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(102_000);
+    ep.onStartOfSpeech(105_000);
+
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 1 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_100);
+    ep.onStartOfSpeech(100_500);
+
+    expect(ep.maxDelay).toBeGreaterThanOrEqual((ep as any).configuredMinDelay);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    expect((ep as any).agentSpeechStartedAt).toBeDefined();
+
+    ep.onStartOfSpeech(102_000);
+    ep.onEndOfSpeech(103_000, false);
+    expect((ep as any).agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    ep.onStartOfSpeech(100_250, true);
+
+    expect((ep as any).overlapActive).toBe(true);
+    const previousValues = [ep.minDelay, ep.maxDelay];
+
+    ep.onStartOfSpeech(100_350);
+
+    expect((ep as any).overlapActive).toBe(true);
+    expect([ep.minDelay, ep.maxDelay]).toStrictEqual(previousValues);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_900);
+    ep.onStartOfSpeech(101_800);
+    ep.onEndOfSpeech(102_000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(950, 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing({ minDelay: 60, maxDelay: 1000, alpha: 1 });
+
+    ep.onEndOfSpeech(99_000);
+    ep.onStartOfSpeech(100_000);
+
+    ep.onStartOfAgentSpeech(100_200);
+    ep.onStartOfSpeech(100_250, true);
+
+    expect((ep as any).utteranceEndedAt).toBe(100_199);
+    expect(ep.minDelay).toBeCloseTo(60, 5);
+    expect(ep.maxDelay).toBeCloseTo(1000, 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+
+    expect((ep as any).utterancePause.alpha).toBeCloseTo(0.5, 5);
+    expect((ep as any).turnPause.alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect((ep as any).utterancePause.minValue).toBe(500);
+    expect((ep as any).turnPause.maxValue).toBe(2000);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_200);
+    expect(ep.minDelay).toBeCloseTo(500, 5);
+
+    ep.onEndOfSpeech(101_000);
+    ep.onStartOfAgentSpeech(102_800);
+    ep.onStartOfSpeech(103_500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(101_500, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101_800, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect((ep as any).utteranceStartedAt).toBeUndefined();
+    expect((ep as any).utteranceEndedAt).toBeUndefined();
+    expect((ep as any).overlapActive).toBe(false);
+    expect((ep as any).speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_400, false);
+    ep.onEndOfSpeech(100_600, true);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(100_600, true);
+
+    ep.onEndOfSpeech(100_800, true);
+
+    expect((ep as any).utteranceEndedAt).toBe(100_800);
+    expect((ep as any).speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(101_000, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+    ep.onEndOfSpeech(101_500, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect((ep as any).utteranceStartedAt).toBeUndefined();
+    expect((ep as any).utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+
+    ep.onStartOfAgentSpeech(100_000);
+    ep.onStartOfSpeech(100_100, true);
+    expect((ep as any).overlapActive).toBe(true);
+    expect((ep as any).agentSpeechStartedAt).toBe(100_000);
+
+    ep.onEndOfAgentSpeech(101_000);
+
+    expect((ep as any).agentSpeechEndedAt).toBe(101_000);
+    expect((ep as any).agentSpeechStartedAt).toBe(100_000);
+    expect((ep as any).overlapActive).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_900);
+    ep.onStartOfSpeech(101_800, false);
+    ep.onEndOfSpeech(102_000);
+
+    expect(ep.maxDelay).toBeCloseTo(950, 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+
+    expect((ep as any).speaking).toBe(false);
+    ep.onStartOfSpeech(100_000);
+    expect((ep as any).speaking).toBe(true);
+    ep.onEndOfSpeech(100_500);
+    expect((ep as any).speaking).toBe(false);
+  });
+
+  it('test_all_overlapping_and_should_ignore_combos', () => {
+    const cases = [
+      ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+      ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+      ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+      ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+      ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+      ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+      ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+      ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+      ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+    ] as const;
+
+    for (const [
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ] of cases) {
+      const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+      ep.onStartOfSpeech(99_000);
+      ep.onEndOfSpeech(100_000);
+
+      let userStart = 100_400;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100_500);
+        ep.onEndOfAgentSpeech(101_000);
+        userStart = 101_500;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100_150);
+          userStart = 100_350;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100_200);
+          userStart = 101_500;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100_150);
+          userStart = 100_400;
+        } else {
+          ep.onStartOfAgentSpeech(100_900);
+          userStart = 101_800;
+        }
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping);
+
+      const previousMin = ep.minDelay;
+      const previousMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + 500, shouldIgnore);
+
+      const minChanged = ep.minDelay !== previousMin;
+      const maxChanged = ep.maxDelay !== previousMax;
+
+      expect(minChanged, `[${label}] minDelay change mismatch`).toBe(expectMinChange);
+      expect(maxChanged, `[${label}] maxDelay change mismatch`).toBe(expectMaxChange);
+      expect((ep as any).speaking, `[${label}] speaking should be false`).toBe(false);
+      expect((ep as any).overlapActive, `[${label}] overlapping should be false`).toBe(false);
+    }
+  });
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onStartOfSpeech(100_000);
+    ep.onEndOfSpeech(101_000);
+
+    ep.onStartOfAgentSpeech(101_500);
+
+    ep.onStartOfSpeech(102_500, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102_800, true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(103_000);
+
+    ep.onStartOfSpeech(103_500);
+    ep.onEndOfSpeech(104_000);
+
+    expect((ep as any).speaking).toBe(false);
+    expect((ep as any).agentSpeechStartedAt).toBeUndefined();
+  });
+});

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250;
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-47 lines
+export class BaseEndpointing {
+  protected configuredMinDelay: number;
+  protected configuredMaxDelay: number;
+  protected overlapActive = false;
+
+  constructor({ minDelay, maxDelay }: Pick<EndpointingOptions, 'minDelay' | 'maxDelay'>) {
+    this.configuredMinDelay = minDelay;
+    this.configuredMaxDelay = maxDelay;
+  }
+
+  updateOptions({
+    minDelay,
+    maxDelay,
+  }: Partial<Pick<EndpointingOptions, 'minDelay' | 'maxDelay'>> = {}): void {
+    this.configuredMinDelay = minDelay ?? this.configuredMinDelay;
+    this.configuredMaxDelay = maxDelay ?? this.configuredMaxDelay;
+  }
+
+  get minDelay(): number {
+    return this.configuredMinDelay;
+  }
+
+  get maxDelay(): number {
+    return this.configuredMaxDelay;
+  }
+
+  get overlapping(): boolean {
+    return this.overlapActive;
+  }
+
+  onStartOfSpeech(_startedAt: number, overlapping = false): void {
+    this.overlapActive = overlapping;
+  }
+
+  onEndOfSpeech(_endedAt: number, _shouldIgnore = false): void {
+    this.overlapActive = false;
+  }
+
+  onStartOfAgentSpeech(_startedAt: number): void {}
+
+  onEndOfAgentSpeech(_endedAt: number): void {}
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-304 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private readonly logger = log();
+  private utterancePause: ExpFilter;
+  private turnPause: ExpFilter;
+  private utteranceStartedAt?: number;
+  private utteranceEndedAt?: number;
+  private agentSpeechStartedAt?: number;
+  private agentSpeechEndedAt?: number;
+  private speaking = false;
+
+  constructor({
+    minDelay,
+    maxDelay,
+    alpha = 0.9,
+  }: Pick<EndpointingOptions, 'minDelay' | 'maxDelay'> & { alpha?: number }) {
+    super({ minDelay, maxDelay });
+
+    this.utterancePause = new ExpFilter(alpha, {
+      initial: minDelay,
+      minValue: minDelay,
+      maxValue: maxDelay,
+    });
+    this.turnPause = new ExpFilter(alpha, {
+      initial: maxDelay,
+      minValue: minDelay,
+      maxValue: maxDelay,
+    });
+  }
+
+  get minDelay(): number {
+    return this.utterancePause.value ?? this.configuredMinDelay;
+  }
+
+  get maxDelay(): number {
+    return Math.max(this.turnPause.value ?? this.configuredMaxDelay, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this.utteranceEndedAt === undefined || this.utteranceStartedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.utteranceStartedAt - this.utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this.agentSpeechStartedAt === undefined || this.utteranceEndedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.agentSpeechStartedAt - this.utteranceEndedAt);
+  }
+
+  get immediateInterruptionDelay(): [number, number] {
+    if (this.utteranceStartedAt === undefined || this.agentSpeechStartedAt === undefined) {
+      return [0, 0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this.agentSpeechStartedAt = startedAt;
+    this.agentSpeechEndedAt = undefined;
+    this.overlapActive = false;
+  }
+
+  override onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this.agentSpeechStartedAt !== undefined &&
+      (this.agentSpeechEndedAt === undefined || this.agentSpeechEndedAt < this.agentSpeechStartedAt)
+    ) {
+      this.agentSpeechEndedAt = endedAt;
+    }
+    this.overlapActive = false;
+  }
+
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this.overlapActive) {
+      return;
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 160-173 lines
+    if (
+      this.utteranceStartedAt !== undefined &&
+      this.utteranceEndedAt !== undefined &&
+      this.agentSpeechStartedAt !== undefined &&
+      this.utteranceEndedAt < this.utteranceStartedAt &&
+      overlapping
+    ) {
+      this.utteranceEndedAt = this.agentSpeechStartedAt - 1;
+      this.logger.trace({ utteranceEndedAt: this.utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this.utteranceStartedAt = startedAt;
+    this.overlapActive = overlapping;
+    this.speaking = true;
+  }
+
+  override onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 180-203 lines
+    if (shouldIgnore && this.overlapActive) {
+      if (
+        this.utteranceStartedAt !== undefined &&
+        this.agentSpeechStartedAt !== undefined &&
+        Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        this.logger.trace(
+          {
+            delay: Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true within grace period',
+        );
+      } else {
+        this.overlapActive = false;
+        this.speaking = false;
+        this.utteranceStartedAt = undefined;
+        this.utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 205-280 lines
+    if (
+      this.overlapActive ||
+      (this.agentSpeechStartedAt !== undefined && this.agentSpeechEndedAt === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const pause = this.betweenUtteranceDelay;
+
+      if (
+        interruptionDelay > 0 &&
+        interruptionDelay <= this.minDelay &&
+        turnDelay > 0 &&
+        turnDelay <= this.maxDelay &&
+        pause > 0
+      ) {
+        const previousMinDelay = this.minDelay;
+        this.utterancePause.apply(1, pause);
+        this.logger.debug(
+          {
+            reason: 'immediate interruption',
+            pause,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${previousMinDelay} -> ${this.minDelay}`,
+        );
+      } else if (this.betweenTurnDelay > 0) {
+        const previousMaxDelay = this.maxDelay;
+        this.turnPause.apply(1, this.betweenTurnDelay);
+        this.logger.debug(
+          {
+            reason: 'new turn (interruption)',
+            pause: this.betweenTurnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+            betweenUtteranceDelay: this.betweenUtteranceDelay,
+            betweenTurnDelay: this.betweenTurnDelay,
+          },
+          `max endpointing delay updated: ${previousMaxDelay} -> ${this.maxDelay}`,
+        );
+      }
+    } else if (this.betweenTurnDelay > 0) {
+      const previousMaxDelay = this.maxDelay;
+      this.turnPause.apply(1, this.betweenTurnDelay);
+      this.logger.debug(
+        {
+          reason: 'new turn',
+          pause: this.betweenTurnDelay,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `max endpointing delay updated due to pause: ${previousMaxDelay} -> ${this.maxDelay}`,
+      );
+    } else if (
+      this.betweenUtteranceDelay > 0 &&
+      this.agentSpeechEndedAt === undefined &&
+      this.agentSpeechStartedAt === undefined
+    ) {
+      const previousMinDelay = this.minDelay;
+      this.utterancePause.apply(1, this.betweenUtteranceDelay);
+      this.logger.debug(
+        {
+          reason: 'pause between utterances',
+          pause: this.betweenUtteranceDelay,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `min endpointing delay updated: ${previousMinDelay} -> ${this.minDelay}`,
+      );
+    }
+
+    this.utteranceEndedAt = endedAt;
+    this.agentSpeechStartedAt = undefined;
+    this.agentSpeechEndedAt = undefined;
+    this.speaking = false;
+    this.overlapActive = false;
+  }
+
+  override updateOptions({
+    minDelay,
+    maxDelay,
+  }: Partial<Pick<EndpointingOptions, 'minDelay' | 'maxDelay'>> = {}): void {
+    if (minDelay !== undefined) {
+      this.configuredMinDelay = minDelay;
+      this.utterancePause.reset({ initial: minDelay, minValue: minDelay });
+      this.turnPause.reset({ minValue: minDelay });
+    }
+
+    if (maxDelay !== undefined) {
+      this.configuredMaxDelay = maxDelay;
+      this.turnPause.reset({ initial: maxDelay, maxValue: maxDelay });
+      this.utterancePause.reset({ maxValue: maxDelay });
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  if (options.mode === 'dynamic') {
+    return new DynamicEndpointing({
+      minDelay: options.minDelay,
+      maxDelay: options.maxDelay,
+    });
+  }
+
+  return new BaseEndpointing({
+    minDelay: options.minDelay,
+    maxDelay: options.maxDelay,
+  });
+}

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -6,8 +6,8 @@
  */
 export interface EndpointingOptions {
   /**
-   * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on
-   * end-of-utterance prediction.
+   * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adapts the delay within the
+   * configured range based on observed pause timing across the session.
    * @defaultValue "fixed"
    */
   mode: 'fixed' | 'dynamic';


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/74).

Tracking issue: https://github.com/livekit/rosetta/issues/74
Source implementation: https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/endpointing.py
Source tests: https://github.com/livekit/agents/blob/main/tests/test_endpointing.py
Docs: https://docs.livekit.io/reference/agents/turn-handling-options/#endpointingoptions-usage

## Summary
- add the Python-style dynamic endpointing tracker to the Node voice runtime so endpointing delays adapt to observed pause timing instead of staying fixed
- wire the new tracker into audio recognition and agent activity so `turnHandling.endpointing.mode = 'dynamic'` changes live turn completion behavior
- port the source endpointing parity tests into `agents/src/voice/endpointing.test.ts` and update the nearby audio-recognition tests for the new constructor shape