### PR TITLE
fix(phonic): Add `preserveFunctionCallHistory` flag to AgentTasks and use this function call history in Phonic plugin resets

### DIFF
--- a/.changeset/lemon-stars-float.md
+++ b/.changeset/lemon-stars-float.md
@@ -1,0 +1,6 @@
+---
+'@livekit/agents-plugin-phonic': patch
+'@livekit/agents': patch
+---
+
+add `preserveFunctionCallHistory` option to `AgentTask` and `TaskGroup` and use function call history in Phonic plugin

--- a/agents/src/beta/workflows/task_group.ts
+++ b/agents/src/beta/workflows/task_group.ts
@@ -37,6 +37,7 @@ export interface TaskGroupOptions {
   returnExceptions?: boolean;
   chatCtx?: ChatContext;
   onTaskCompleted?: (event: TaskCompletedEvent) => Promise<void>;
+  preserveFunctionCallHistory?: boolean;
 }
 
 export class TaskGroup extends AgentTask<TaskGroupResult> {
@@ -48,9 +49,15 @@ export class TaskGroup extends AgentTask<TaskGroupResult> {
   private _currentTask?: AgentTask;
 
   constructor(options: TaskGroupOptions = {}) {
-    const { summarizeChatCtx = true, returnExceptions = false, chatCtx, onTaskCompleted } = options;
+    const {
+      summarizeChatCtx = true,
+      returnExceptions = false,
+      chatCtx,
+      onTaskCompleted,
+      preserveFunctionCallHistory = false,
+    } = options;
 
-    super({ instructions: '*empty*', chatCtx });
+    super({ instructions: '*empty*', chatCtx, preserveFunctionCallHistory });
 
     this._summarizeChatCtx = summarizeChatCtx;
     this._returnExceptions = returnExceptions;

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -648,7 +648,6 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
         }
 
         const mergedChatCtx = oldAgent._chatCtx.merge(this._chatCtx, {
-          // excludeFunctionCall: true,
           excludeInstructions: true,
         });
         oldAgent._chatCtx.items = mergedChatCtx.items;

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -529,11 +529,22 @@ export class Agent<UserData = any> {
   };
 }
 
+export interface AgentTaskOptions<UserData = any> extends AgentOptions<UserData> {
+  preserveFunctionCallHistory?: boolean;
+}
+
 export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData> {
   private started = false;
   private future = new Future<ResultT>();
+  private _preserveFunctionCallHistory: boolean;
 
   #logger = log();
+
+  constructor(options: AgentTaskOptions<UserData>) {
+    const { preserveFunctionCallHistory = false, ...rest } = options;
+    super(rest);
+    this._preserveFunctionCallHistory = preserveFunctionCallHistory;
+  }
 
   get done(): boolean {
     return this.future.done;
@@ -648,6 +659,7 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
         }
 
         const mergedChatCtx = oldAgent._chatCtx.merge(this._chatCtx, {
+          excludeFunctionCall: !this._preserveFunctionCallHistory,
           excludeInstructions: true,
         });
         oldAgent._chatCtx.items = mergedChatCtx.items;

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -648,7 +648,7 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
         }
 
         const mergedChatCtx = oldAgent._chatCtx.merge(this._chatCtx, {
-          excludeFunctionCall: true,
+          // excludeFunctionCall: true,
           excludeInstructions: true,
         });
         oldAgent._chatCtx.items = mergedChatCtx.items;

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -440,7 +440,6 @@ export class RealtimeSession extends llm.RealtimeSession {
 
     if (this.socket) {
       this.#logger.info('Sending mid-session reset to Phonic');
-      this.#logger.debug({ systemPrompt }, 'Phonic reset system prompt');
       this.socket.sendReset({
         type: 'reset',
         config: this.buildConfigOptions({ systemPrompt, toolsPayload }),

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -24,6 +24,7 @@ const PHONIC_INPUT_FRAME_MS = 20;
 const DEFAULT_MODEL = 'merritt';
 const WS_CLOSE_NORMAL = 1000;
 const TOOL_CALL_OUTPUT_TIMEOUT_MS = 60_000;
+const TOOL_CALL_OUTPUT_MAX_CHARS_FOR_HISTORY = 16_000;
 const CONVERSATION_HISTORY_PREFIX =
   '\n\nThis conversation is being continued from an existing ' +
   'conversation. You are the assistant speaking to the user. ' +
@@ -301,17 +302,8 @@ export class RealtimeSession extends llm.RealtimeSession {
   async updateChatCtx(chatCtx: llm.ChatContext): Promise<void> {
     if (!this.configSent) {
       if (chatCtx.items.length > 0) {
-        const turnHistory = chatCtx.items
-          .filter(
-            (item): item is llm.ChatMessage =>
-              item.type === 'message' &&
-              'textContent' in item &&
-              item.textContent !== undefined &&
-              item.textContent.trim() !== '',
-          )
-          .map((item) => `${item.role}: ${item.textContent}`)
-          .join('\n');
-        if (turnHistory.trim() !== '') {
+        const turnHistory = this.buildTurnHistory(chatCtx);
+        if (turnHistory) {
           this.#logger.debug(
             'updateChatCtx called with messages prior to config being sent to Phonic. Including conversation state in system instructions.',
           );
@@ -448,6 +440,7 @@ export class RealtimeSession extends llm.RealtimeSession {
 
     if (this.socket) {
       this.#logger.info('Sending mid-session reset to Phonic');
+      this.#logger.debug({ systemPrompt }, 'Phonic reset system prompt');
       this.socket.sendReset({
         type: 'reset',
         config: this.buildConfigOptions({ systemPrompt, toolsPayload }),
@@ -894,16 +887,13 @@ export class RealtimeSession extends llm.RealtimeSession {
   }
 
   private buildTurnHistory(chatCtx: llm.ChatContext): string | undefined {
-    const messages = chatCtx.items.filter(
-      (item): item is llm.ChatMessage =>
-        item.type === 'message' &&
-        'textContent' in item &&
-        item.textContent !== undefined &&
-        item.textContent.trim() !== '',
-    );
-    if (messages.length === 0) return undefined;
-    const history = messages.map((m) => `${m.role}: ${m.textContent}`).join('\n');
-    return history.trim() || undefined;
+    const lines: string[] = [];
+    for (const item of chatCtx.items) {
+      const text = chatItemToText(item);
+      if (text) lines.push(text);
+    }
+    if (lines.length === 0) return undefined;
+    return lines.join('\n');
   }
 
   private *resampleAudio(frame: AudioFrame): Generator<AudioFrame> {
@@ -935,4 +925,19 @@ export class RealtimeSession extends llm.RealtimeSession {
       yield frame;
     }
   }
+}
+
+function chatItemToText(item: llm.ChatItem): string | undefined {
+  if (item.type === 'message') {
+    if (item.textContent === undefined) return undefined;
+    return `<${item.role}>${item.textContent}</${item.role}>`;
+  }
+  if (item.type === 'function_call') {
+    return `<tool_call name="${item.name}">${item.args}</tool_call>`;
+  }
+  if (item.type === 'function_call_output') {
+    const tag = item.isError ? 'tool_error' : 'tool_output';
+    return `<${tag} name="${item.name}">${item.output.slice(0, TOOL_CALL_OUTPUT_MAX_CHARS_FOR_HISTORY)}</${tag}>`;
+  }
+  return undefined;
 }

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -929,8 +929,9 @@ export class RealtimeSession extends llm.RealtimeSession {
 
 function chatItemToText(item: llm.ChatItem): string | undefined {
   if (item.type === 'message') {
-    if (item.textContent === undefined) return undefined;
-    return `<${item.role}>${item.textContent}</${item.role}>`;
+    const text = item.textContent?.trim();
+    if (!text) return undefined;
+    return `<${item.role}>${text}</${item.role}>`;
   }
   if (item.type === 'function_call') {
     return `<tool_call name="${item.name}">${item.args}</tool_call>`;


### PR DESCRIPTION
## Description
We noticed that for Task Groups in typescript, the mergedChatCtx has excludeFunctionCall: true , which could cause the next agent to not realize a tool has already been called when transitioning between tasks. It seems that for the Python SDK, there is a preserve_function_call_history flag. 

We would like to add it here and use it in our plugin as well. 

`buildTurnHistory` previously only serialized text messages, dropping tool calls and their outputs from the system prompt sent on mid-session reset. This PR includes the tool calls and changes the format of the turn history to XML. 

## demo video:
https://screen.studio/share/58lb9tb4

## Pre-Review Checklist
- [ ] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [ ] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.