### PR TITLE
Port EndCallTool to the Node.js Agents SDK

### DIFF
--- a/agents/src/beta/index.ts
+++ b/agents/src/beta/index.ts
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+// Ref: python livekit-agents/livekit/agents/beta/__init__.py - 1-5 lines
+export {
+  EndCallTool,
+  type EndCallToolCalledEvent,
+  type EndCallToolCompletedEvent,
+  type EndCallToolOptions,
+} from './tools/index.js';
 export {
   TaskGroup,
   type TaskCompletedEvent,

--- a/agents/src/beta/tools/end_call.ts
+++ b/agents/src/beta/tools/end_call.ts
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { getJobContext } from '../../job.js';
+import { RealtimeModel, type ToolContext, tool } from '../../llm/index.js';
+import { log } from '../../log.js';
+import { Future, waitForAbort } from '../../utils.js';
+import {
+  AgentSessionEventTypes,
+  type CloseEvent,
+  type SpeechCreatedEvent,
+} from '../../voice/events.js';
+import type { RunContext, UnknownUserData } from '../../voice/run_context.js';
+import type { SpeechHandle } from '../../voice/speech_handle.js';
+
+// Ref: python livekit-agents/livekit/agents/beta/tools/end_call.py - 11-25 lines
+const END_CALL_DESCRIPTION = `
+Ends the current call and disconnects immediately.
+
+Call when:
+- The user clearly indicates they are done (e.g., "that's all, bye").
+- The agent determines the conversation is complete and should end.
+
+Do not call when:
+- The user asks to pause, hold, or transfer.
+- Intent is unclear.
+
+This is the final action the agent can take.
+Once called, no further interaction is possible with the user.
+Don't generate any other text or response when the tool is called.
+`;
+
+export interface EndCallToolCalledEvent<UserData = UnknownUserData> {
+  ctx: RunContext<UserData>;
+  arguments: Record<string, never>;
+}
+
+export interface EndCallToolCompletedEvent<UserData = UnknownUserData> {
+  ctx: RunContext<UserData>;
+  output: string | null;
+}
+
+export interface EndCallToolOptions<UserData = UnknownUserData> {
+  extraDescription?: string;
+  deleteRoom?: boolean;
+  endInstructions?: string | null;
+  onToolCalled?: (event: EndCallToolCalledEvent<UserData>) => void | Promise<void>;
+  onToolCompleted?: (event: EndCallToolCompletedEvent<UserData>) => void | Promise<void>;
+}
+
+export class EndCallTool<UserData = UnknownUserData> {
+  readonly tools: ToolContext<UserData>;
+
+  private readonly deleteRoom: boolean;
+  private readonly endInstructions: string | null;
+  private readonly onToolCalled?: (event: EndCallToolCalledEvent<UserData>) => void | Promise<void>;
+  private readonly onToolCompleted?: (
+    event: EndCallToolCompletedEvent<UserData>,
+  ) => void | Promise<void>;
+  private shutdownController?: AbortController;
+
+  constructor({
+    extraDescription = '',
+    deleteRoom = true,
+    endInstructions = 'say goodbye to the user',
+    onToolCalled,
+    onToolCompleted,
+  }: EndCallToolOptions<UserData> = {}) {
+    this.deleteRoom = deleteRoom;
+    this.endInstructions = endInstructions;
+    this.onToolCalled = onToolCalled;
+    this.onToolCompleted = onToolCompleted;
+
+    // Ref: python livekit-agents/livekit/agents/beta/tools/end_call.py - 28-62 lines
+    this.tools = {
+      end_call: tool<UserData, string | null>({
+        description: `${END_CALL_DESCRIPTION}\n${extraDescription}`,
+        execute: async (_args, { ctx }) => this.endCall(ctx),
+      }),
+    };
+  }
+
+  // Ref: python livekit-agents/livekit/agents/beta/tools/end_call.py - 64-91 lines
+  private async endCall(ctx: RunContext<UserData>): Promise<string | null> {
+    log().debug('end_call tool called');
+    const llm = ctx.session.currentAgent.getActivityOrThrow().llm;
+
+    ctx.speechHandle.addDoneCallback(() => {
+      if (!(llm instanceof RealtimeModel) || !llm.capabilities.autoToolReplyGeneration) {
+        ctx.session.shutdown();
+        return;
+      }
+
+      this.startDelayedSessionShutdown(ctx);
+    });
+
+    ctx.session.once(AgentSessionEventTypes.Close, this.handleSessionClose);
+
+    if (this.onToolCalled) {
+      await this.onToolCalled({ ctx, arguments: {} });
+    }
+
+    const completedEvent = {
+      ctx,
+      output: this.endInstructions,
+    } satisfies EndCallToolCompletedEvent<UserData>;
+
+    if (this.onToolCompleted) {
+      await this.onToolCompleted(completedEvent);
+    }
+
+    return completedEvent.output;
+  }
+
+  private startDelayedSessionShutdown(ctx: RunContext<UserData>): void {
+    this.shutdownController?.abort();
+
+    const controller = new AbortController();
+    this.shutdownController = controller;
+
+    void this.delayedSessionShutdown(ctx, controller.signal).finally(() => {
+      if (this.shutdownController === controller) {
+        this.shutdownController = undefined;
+      }
+    });
+  }
+
+  // Ref: python livekit-agents/livekit/agents/beta/tools/end_call.py - 93-109 lines
+  private async delayedSessionShutdown(
+    ctx: RunContext<UserData>,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const speechCreatedFuture = new Future<SpeechHandle>();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const onSpeechCreated = (event: SpeechCreatedEvent): void => {
+      if (!speechCreatedFuture.done) {
+        speechCreatedFuture.resolve(event.speechHandle);
+      }
+    };
+
+    ctx.session.on(AgentSessionEventTypes.SpeechCreated, onSpeechCreated);
+
+    try {
+      const replySpeechHandle = await Promise.race([
+        speechCreatedFuture.await,
+        new Promise<undefined>((resolve) => {
+          timeout = setTimeout(() => resolve(undefined), 5000);
+        }),
+        waitForAbort(signal).then(() => undefined),
+      ]);
+
+      if (!replySpeechHandle) {
+        if (signal.aborted) {
+          return;
+        }
+        log().warn('tool reply timed out, shutting down session');
+      } else {
+        await Promise.race([replySpeechHandle.waitForPlayout(), waitForAbort(signal)]);
+      }
+    } catch (error) {
+      if (signal.aborted) {
+        return;
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+      ctx.session.off(AgentSessionEventTypes.SpeechCreated, onSpeechCreated);
+    }
+
+    if (!signal.aborted) {
+      ctx.session.shutdown();
+    }
+  }
+
+  // Ref: python livekit-agents/livekit/agents/beta/tools/end_call.py - 111-129 lines
+  private handleSessionClose = (event: CloseEvent): void => {
+    this.shutdownController?.abort();
+    this.shutdownController = undefined;
+
+    const jobCtx = getJobContext(false);
+    if (!jobCtx) {
+      return;
+    }
+
+    if (this.deleteRoom) {
+      jobCtx.addShutdownCallback(async () => {
+        log().info('deleting the room because the user ended the call');
+        await jobCtx.deleteRoom();
+      });
+    }
+
+    jobCtx.shutdown(event.reason);
+  };
+}

--- a/agents/src/beta/tools/index.ts
+++ b/agents/src/beta/tools/index.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Ref: python livekit-agents/livekit/agents/beta/tools/__init__.py - 1-7 lines
+export {
+  EndCallTool,
+  type EndCallToolCalledEvent,
+  type EndCallToolCompletedEvent,
+  type EndCallToolOptions,
+} from './end_call.js';

--- a/agents/src/job.ts
+++ b/agents/src/job.ts
@@ -11,6 +11,7 @@ import type {
 } from '@livekit/rtc-node';
 import { ParticipantKind, RoomEvent, TrackKind } from '@livekit/rtc-node';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
+import { RoomServiceClient } from 'livekit-server-sdk';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -84,6 +85,8 @@ export type RunningJobInfo = {
   url: string;
   token: string;
   workerId: string;
+  apiKey?: string;
+  apiSecret?: string;
 };
 
 /** Attempted to add a function callback, but the function already exists. */
@@ -188,6 +191,28 @@ export class JobContext<ProcessUserData = Record<string, unknown>> {
   /** Adds a promise to be awaited when {@link JobContext.shutdown | shutdown} is called. */
   addShutdownCallback(callback: () => Promise<void>) {
     this.shutdownCallbacks.push(callback);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/job.py - 534-558 lines
+  async deleteRoom(roomName?: string): Promise<void> {
+    const targetRoom = roomName ?? this.#room.name;
+    if (!targetRoom) {
+      return;
+    }
+
+    const host = new URL(this.#info.url);
+    host.protocol = host.protocol.replace('ws', 'http');
+
+    const client = new RoomServiceClient(host.toString(), this.#info.apiKey, this.#info.apiSecret);
+
+    try {
+      await client.deleteRoom(targetRoom);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!/not[ -]?found/i.test(message)) {
+        this.#logger.warn({ error, room: targetRoom }, 'error while deleting room');
+      }
+    }
   }
 
   async waitForParticipant(identity?: string): Promise<RemoteParticipant> {

--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -745,6 +745,8 @@ export class AgentServer {
             url: asgn.url || this.#opts.wsURL,
             token: asgn.token,
             workerId: this.id,
+            apiKey: this.#opts.apiKey,
+            apiSecret: this.#opts.apiSecret,
           });
         } catch (e) {
           this.#logger.child({ requestId: req.id }).error(e, 'error launching job');


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/75).

Tracking issue: https://github.com/livekit/rosetta/issues/75

## Summary
- add `beta.EndCallTool` to expose the `end_call` prebuilt tool in the Node.js SDK with the same session shutdown flow as the Python implementation for both standard and realtime models
- add `JobContext.deleteRoom()` plumbing so `EndCallTool` can optionally delete the room during job shutdown, matching the source SDK behavior
- export the new beta tool from the public beta API surface

## References
- Source implementation: https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/beta/tools/end_call.py
- Source job helper: https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/job.py#L534-L558
- Docs: https://docs.livekit.io/agents/prebuilt/tools/end-call-tool/#endcalltool