### PR TITLE
fix(tts): don't mark FallbackAdapter primary unavailable on abort-before-first-audio

### DIFF
--- a/.changeset/silent-adults-kiss.md
+++ b/.changeset/silent-adults-kiss.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(tts): don't mark FallbackAdapter primary unavailable on abort-before-first-audio

--- a/agents/src/tts/fallback_adapter.test.ts
+++ b/agents/src/tts/fallback_adapter.test.ts
@@ -196,12 +196,8 @@ describe('TTS FallbackAdapter', () => {
   });
 
   it('should not mark the primary unavailable when closed before any audio is received', async () => {
-    // A caller interruption within the window between text push and first
-    // audio frame (TTFA) must be treated as a clean abort, not a silent
-    // provider failure. Previously the `!sawRawAudio` guard raised
-    // APIConnectionError on abort, which the outer catch translated into
-    // markUnAvailable(primary) — forcing subsequent utterances onto the
-    // fallback for the recovery window.
+    // Regression: abort before first audio frame previously raised
+    // APIConnectionError, causing markUnAvailable on the primary.
     const primary = new MockTTS('primary');
     primary.emitAudio = false;
     const secondary = new MockTTS('secondary');
@@ -217,30 +213,20 @@ describe('TTS FallbackAdapter', () => {
       new ReadableStream<string>({
         start(controller) {
           controller.enqueue('hello world');
-          // Keep the input stream open so the adapter does not naturally
-          // flush; abort is the only path to completion.
         },
       }),
     );
 
-    // Drain the output in the background so the adapter's mainTask is not
-    // starved on output backpressure.
     const iterate = (async () => {
       for await (const event of stream) {
         if (event === SynthesizeStream.END_OF_STREAM) break;
       }
     })();
 
-    // Let forwardBufferToTTS push the token into the inner stream.
     await new Promise((r) => setTimeout(r, 50));
-
-    // Simulate a caller interruption before any audio has been produced.
     stream.close();
-
-    // Wait long enough for the adapter's mainTask to fully unwind both TTS
-    // instances — long enough to exercise the buggy markUnAvailable path
-    // that would otherwise mark the primary (and secondary) unavailable.
     await iterate;
+    // Allow mainTask to fully unwind both TTS instances.
     await new Promise((r) => setTimeout(r, 200));
 
     expect(adapter.status[0]!.available).toBe(true);

--- a/agents/src/tts/fallback_adapter.test.ts
+++ b/agents/src/tts/fallback_adapter.test.ts
@@ -18,6 +18,7 @@ class MockSynthesizeStream extends SynthesizeStream {
   constructor(
     private mockTts: MockTTS,
     private shouldFail: boolean,
+    private emitAudio: boolean,
     connOptions?: APIConnectOptions,
   ) {
     super(mockTts, connOptions);
@@ -37,6 +38,7 @@ class MockSynthesizeStream extends SynthesizeStream {
     for await (const data of this.input) {
       if (this.abortController.signal.aborted) break;
       if (data === SynthesizeStream.FLUSH_SENTINEL) continue;
+      if (!this.emitAudio) continue;
       this.queue.put({
         requestId: 'mock-req',
         segmentId: 'mock-seg',
@@ -53,6 +55,7 @@ class MockChunkedStream extends ChunkedStream {
     private mockTts: MockTTS,
     text: string,
     private shouldFail: boolean,
+    private emitAudio: boolean,
     connOptions?: APIConnectOptions,
   ) {
     super(text, mockTts, connOptions);
@@ -61,6 +64,7 @@ class MockChunkedStream extends ChunkedStream {
     if (this.shouldFail) {
       throw new APIError('mock TTS failed immediately');
     }
+    if (!this.emitAudio) return;
     this.queue.put({
       requestId: 'mock-req',
       segmentId: 'mock-seg',
@@ -73,6 +77,7 @@ class MockChunkedStream extends ChunkedStream {
 class MockTTS extends TTS {
   label: string;
   shouldFail = false;
+  emitAudio = true;
 
   constructor(label: string, sampleRate: number = SAMPLE_RATE) {
     super(sampleRate, 1, { streaming: true });
@@ -80,11 +85,11 @@ class MockTTS extends TTS {
   }
 
   synthesize(text: string, connOptions?: APIConnectOptions): ChunkedStream {
-    return new MockChunkedStream(this, text, this.shouldFail, connOptions);
+    return new MockChunkedStream(this, text, this.shouldFail, this.emitAudio, connOptions);
   }
 
   stream(options?: { connOptions?: APIConnectOptions }): SynthesizeStream {
-    return new MockSynthesizeStream(this, this.shouldFail, options?.connOptions);
+    return new MockSynthesizeStream(this, this.shouldFail, this.emitAudio, options?.connOptions);
   }
 }
 
@@ -187,6 +192,60 @@ describe('TTS FallbackAdapter', () => {
     expect(adapter.status[1]!.available).toBe(true);
 
     stream.close();
+    await adapter.close();
+  });
+
+  it('should not mark the primary unavailable when closed before any audio is received', async () => {
+    // A caller interruption within the window between text push and first
+    // audio frame (TTFA) must be treated as a clean abort, not a silent
+    // provider failure. Previously the `!sawRawAudio` guard raised
+    // APIConnectionError on abort, which the outer catch translated into
+    // markUnAvailable(primary) — forcing subsequent utterances onto the
+    // fallback for the recovery window.
+    const primary = new MockTTS('primary');
+    primary.emitAudio = false;
+    const secondary = new MockTTS('secondary');
+    secondary.emitAudio = false;
+    const adapter = new FallbackAdapter({
+      ttsInstances: [primary, secondary],
+      maxRetryPerTTS: 0,
+      recoveryDelayMs: 60_000,
+    });
+
+    const stream = adapter.stream();
+    stream.updateInputStream(
+      new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue('hello world');
+          // Keep the input stream open so the adapter does not naturally
+          // flush; abort is the only path to completion.
+        },
+      }),
+    );
+
+    // Drain the output in the background so the adapter's mainTask is not
+    // starved on output backpressure.
+    const iterate = (async () => {
+      for await (const event of stream) {
+        if (event === SynthesizeStream.END_OF_STREAM) break;
+      }
+    })();
+
+    // Let forwardBufferToTTS push the token into the inner stream.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Simulate a caller interruption before any audio has been produced.
+    stream.close();
+
+    // Wait long enough for the adapter's mainTask to fully unwind both TTS
+    // instances — long enough to exercise the buggy markUnAvailable path
+    // that would otherwise mark the primary (and secondary) unavailable.
+    await iterate;
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(adapter.status[0]!.available).toBe(true);
+    expect(adapter.status[1]!.available).toBe(true);
+
     await adapter.close();
   });
 

--- a/agents/src/tts/fallback_adapter.ts
+++ b/agents/src/tts/fallback_adapter.ts
@@ -565,6 +565,12 @@ class FallbackSynthesizeStream extends SynthesizeStream {
         // Silent failures must trigger fallback. See `sawRawAudio` above for
         // why we don't check `audioPushed` here.
         if (!sawRawAudio) {
+          // An abort before the first audio frame is a clean interruption,
+          // not a provider failure — do not mark the TTS unavailable.
+          if (this.abortController.signal.aborted) {
+            this.queue.put(SynthesizeStream.END_OF_STREAM);
+            return;
+          }
           throw new APIConnectionError({
             message: 'TTS stream completed but no audio was received',
           });

--- a/agents/src/tts/fallback_adapter.ts
+++ b/agents/src/tts/fallback_adapter.ts
@@ -565,10 +565,10 @@ class FallbackSynthesizeStream extends SynthesizeStream {
         // Silent failures must trigger fallback. See `sawRawAudio` above for
         // why we don't check `audioPushed` here.
         if (!sawRawAudio) {
-          // An abort before the first audio frame is a clean interruption,
-          // not a provider failure — do not mark the TTS unavailable.
+          // Abort before first audio frame is an interruption, not a provider failure.
           if (this.abortController.signal.aborted) {
             this.queue.put(SynthesizeStream.END_OF_STREAM);
+            await readInputLLMStream.catch(() => {});
             return;
           }
           throw new APIConnectionError({


### PR DESCRIPTION
## Description

`tts.FallbackAdapter` marks the primary provider unavailable whenever a `SynthesizeStream` is aborted before its first audio frame arrives. Caller interruptions within the provider's typical TTFA window (a few hundred ms) routinely trip this, forcing subsequent utterances onto the fallback TTS for the entire `recoveryDelayMs` — silent dead air during that window if the fallback is misbehaving.

Root cause: when the outer abort fires before any audio is received, `FallbackSynthesizeStream.run()` drops through to the `!sawRawAudio` guard and throws `APIConnectionError("TTS stream completed but no audio was received")`. The outer catch cannot distinguish that from a real silent provider failure and calls `markUnAvailable(i)`.

## Changes Made

- **`agents/src/tts/fallback_adapter.ts`** — Short-circuit the `!sawRawAudio` branch in `FallbackSynthesizeStream.run()` when `abortController.signal.aborted`. On abort, emit `END_OF_STREAM` and return cleanly instead of throwing. Real silent provider failures (where abort is not signalled) still throw and still mark the primary unavailable.

- **`agents/src/tts/fallback_adapter.test.ts`** — Added a regression test. The primary emits no audio; `stream.close()` is called before the first frame; the test asserts `adapter.status[0].available === true`. Without the fix the primary is marked unavailable. The two existing "silent failure triggers fallback" tests still pass, guarding the regression in the other direction.

## Testing

- [x] `pnpm vitest run agents/src` — 684 passed, 2 skipped.
- [x] `pnpm format:check` clean.
- [x] Added test fails on `main` with `expected false to be true` and passes with the fix.
