### PR TITLE
Port dynamic endpointing to the Node.js voice pipeline

### DIFF
--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -350,36 +350,72 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
   }
 }
 
+export interface ExpFilterOptions {
+  initial?: number;
+  minValue?: number;
+  maxValue?: number;
+}
+
 /** @internal */
+// Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-64 lines
 export class ExpFilter {
   #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  #filtered?: number;
+  #maxValue?: number;
+  #minValue?: number;
 
-  constructor(alpha: number, max?: number) {
+  constructor(alpha: number, { initial, minValue, maxValue }: ExpFilterOptions = {}) {
+    this.#assertAlpha(alpha);
     this.#alpha = alpha;
-    this.#max = max;
+    this.#filtered = initial;
+    this.#minValue = minValue;
+    this.#maxValue = maxValue;
   }
 
-  reset(alpha?: number) {
-    if (alpha) {
+  reset({ alpha, initial, minValue, maxValue }: ExpFilterOptions & { alpha?: number } = {}): void {
+    if (alpha !== undefined) {
+      this.#assertAlpha(alpha);
       this.#alpha = alpha;
     }
-    this.#filtered = undefined;
+    if (initial !== undefined) {
+      this.#filtered = initial;
+    }
+    if (minValue !== undefined) {
+      this.#minValue = minValue;
+    }
+    if (maxValue !== undefined) {
+      this.#maxValue = maxValue;
+    }
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
+  apply(exp: number, sample = this.#filtered): number {
+    if (sample !== undefined && this.#filtered === undefined) {
+      this.#filtered = sample;
+    } else if (sample !== undefined && this.#filtered !== undefined) {
       const a = this.#alpha ** exp;
       this.#filtered = a * this.#filtered + (1 - a) * sample;
-    } else {
-      this.#filtered = sample;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (this.#filtered === undefined) {
+      throw new Error('sample or initial value must be given.');
     }
 
+    if (this.#maxValue !== undefined && this.#filtered > this.#maxValue) {
+      this.#filtered = this.#maxValue;
+    }
+    if (this.#minValue !== undefined && this.#filtered < this.#minValue) {
+      this.#filtered = this.#minValue;
+    }
+
+    return this.#filtered;
+  }
+
+  updateBase(alpha: number): void {
+    this.#assertAlpha(alpha);
+    this.#alpha = alpha;
+  }
+
+  get value(): number | undefined {
     return this.#filtered;
   }
 
@@ -387,8 +423,27 @@ export class ExpFilter {
     return this.#filtered;
   }
 
+  get alpha(): number {
+    return this.#alpha;
+  }
+
+  get minValue(): number | undefined {
+    return this.#minValue;
+  }
+
+  get maxValue(): number | undefined {
+    return this.#maxValue;
+  }
+
   set alpha(alpha: number) {
+    this.#assertAlpha(alpha);
     this.#alpha = alpha;
+  }
+
+  #assertAlpha(alpha: number): void {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
   }
 }
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -477,6 +477,10 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 326-328 lines
+      endpointingMode:
+        this.agent.turnHandling?.endpointing?.mode ??
+        this.agentSession.sessionOptions.turnHandling.endpointing.mode,
       minEndpointingDelay:
         this.agent.turnHandling?.endpointing?.minDelay ??
         this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
@@ -1838,7 +1842,8 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2195-2195 lines
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,7 +35,9 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import { type BaseEndpointing, createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export interface EndOfTurnInfo {
@@ -137,6 +139,8 @@ export interface AudioRecognitionOptions {
   turnDetector?: _TurnDetector;
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
+  /** Endpointing mode. */
+  endpointingMode?: EndpointingOptions['mode'];
   interruptionDetection?: AdaptiveInterruptionDetector;
   /** Minimum endpointing delay in milliseconds. */
   minEndpointingDelay: number;
@@ -170,6 +174,7 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
+  private endpointing: BaseEndpointing;
   private minEndpointingDelay: number;
   private maxEndpointingDelay: number;
   private lastLanguage?: LanguageCode;
@@ -226,6 +231,12 @@ export class AudioRecognition {
     this.turnDetectionMode = opts.turnDetectionMode;
     this.minEndpointingDelay = opts.minEndpointingDelay;
     this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-305 lines
+    this.endpointing = createEndpointing({
+      mode: opts.endpointingMode ?? 'fixed',
+      minDelay: opts.minEndpointingDelay,
+      maxDelay: opts.maxEndpointingDelay,
+    });
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -311,12 +322,19 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-243 lines
+  async onStartOfAgentSpeech(startedAt = Date.now()) {
     this.isAgentSpeaking = true;
+    this.endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 245-270 lines
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -704,7 +722,10 @@ export class AudioRecognition {
       case SpeechEventType.START_OF_SPEECH:
         if (this.turnDetectionMode !== 'stt') break;
         {
-          const span = this.ensureUserTurnSpan(Date.now());
+          const startedAt = Date.now();
+          // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 272-289 lines
+          this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+          const span = this.ensureUserTurnSpan(startedAt);
           const ctx = this.userTurnContext(span);
           otelContext.with(ctx, () => {
             this.hooks.onStartOfSpeech({
@@ -730,6 +751,13 @@ export class AudioRecognition {
       case SpeechEventType.END_OF_SPEECH:
         if (this.turnDetectionMode !== 'stt') break;
         {
+          const endedAt = Date.now();
+          // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-305 lines
+          if (this.speaking) {
+            this.endpointing.onEndOfSpeech(endedAt, {
+              shouldIgnore: this.isAgentSpeaking,
+            });
+          }
           const span = this.ensureUserTurnSpan();
           const ctx = this.userTurnContext(span);
           otelContext.with(ctx, () => {
@@ -805,7 +833,8 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 934-958 lines
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +860,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');
@@ -1018,6 +1047,8 @@ export class AudioRecognition {
             this.logger.debug('VAD task: START_OF_SPEECH');
             {
               const startTime = Date.now() - ev.speechDuration;
+              // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 272-289 lines
+              this.endpointing.onStartOfSpeech(startTime, this.isAgentSpeaking);
               const span = this.ensureUserTurnSpan(startTime);
               const ctx = this.userTurnContext(span);
               otelContext.with(ctx, () => this.hooks.onStartOfSpeech(ev));
@@ -1047,6 +1078,13 @@ export class AudioRecognition {
           case VADEventType.END_OF_SPEECH:
             this.logger.debug('VAD task: END_OF_SPEECH');
             {
+              const speechEndTime = Date.now() - ev.silenceDuration - ev.inferenceDuration;
+              // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-305 lines
+              if (this.speaking) {
+                this.endpointing.onEndOfSpeech(speechEndTime, {
+                  shouldIgnore: this.isAgentSpeaking,
+                });
+              }
               const span = this.ensureUserTurnSpan();
               const ctx = this.userTurnContext(span);
               otelContext.with(ctx, () => this.hooks.onEndOfSpeech(ev));

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,573 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { ExpFilter } from '../utils.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+const SECOND = 1000;
+
+function expFilterState(filter: ExpFilter) {
+  return filter as unknown as {
+    alpha: number;
+    minValue?: number;
+    maxValue?: number;
+  };
+}
+
+function endpointingState(endpointing: DynamicEndpointing) {
+  return endpointing as unknown as {
+    utterancePause: ExpFilter;
+    turnPause: ExpFilter;
+    utteranceStartedAt?: number;
+    utteranceEndedAt?: number;
+    agentSpeechStartedAt?: number;
+    agentSpeechEndedAt?: number;
+    speaking: boolean;
+  };
+}
+
+// Ref: python tests/test_endpointing.py - 7-63 lines
+describe('TestExponentialMovingAverage', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    let ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    const emaWithInitial = new ExpFilter(0.5, { initial: 10.0 });
+    expect(emaWithInitial.value).toBe(10.0);
+
+    ema = new ExpFilter(1.0);
+    expect(ema.value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0.0)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(-0.5)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(1.5)).toThrow('alpha must be in');
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1.0, 10.0);
+    expect(result).toBe(10.0);
+    expect(ema.value).toBe(10.0);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    const result = ema.apply(1.0, 20.0);
+    expect(result).toBe(15.0);
+    expect(ema.value).toBe(15.0);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    ema.apply(1.0, 20.0);
+    ema.apply(1.0, 20.0);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    let ema = new ExpFilter(0.5, { initial: 10.0 });
+    expect(ema.value).toBe(10.0);
+    ema.reset();
+    expect(ema.value).toBe(10.0);
+
+    ema = new ExpFilter(0.5, { initial: 10.0 });
+    ema.reset({ initial: 5.0 });
+    expect(ema.value).toBe(5.0);
+  });
+});
+
+// Ref: python tests/test_endpointing.py - 64-545 lines
+describe('TestDynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    expect(ep.minDelay).toBe(0.3 * SECOND);
+    expect(ep.maxDelay).toBe(1.0 * SECOND);
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.2,
+    });
+    expect(ep.minDelay).toBe(0.3 * SECOND);
+    expect(ep.maxDelay).toBe(1.0 * SECOND);
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    const state = endpointingState(ep);
+    expect(expFilterState(state.utterancePause).alpha).toBeCloseTo(0.9, 5);
+    expect(expFilterState(state.turnPause).alpha).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toEqual([0, 0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    let ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    ep.onEndOfSpeech(100 * SECOND);
+    expect(endpointingState(ep).utteranceEndedAt).toBe(100 * SECOND);
+
+    ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    ep.onEndOfSpeech(99.9 * SECOND);
+    expect(endpointingState(ep).utteranceEndedAt).toBe(99.9 * SECOND);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    ep.onStartOfSpeech(100 * SECOND);
+    expect(endpointingState(ep).utteranceStartedAt).toBe(100 * SECOND);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    ep.onStartOfAgentSpeech(100 * SECOND);
+    expect(endpointingState(ep).agentSpeechStartedAt).toBe(100 * SECOND);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+
+    ep.onEndOfSpeech(100 * SECOND);
+    ep.onStartOfSpeech(100.5 * SECOND);
+
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(0.5 * SECOND, 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+
+    ep.onEndOfSpeech(100 * SECOND);
+    ep.onStartOfAgentSpeech(100.8 * SECOND);
+
+    expect(ep.betweenTurnDelay).toBeCloseTo(0.8 * SECOND, 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100 * SECOND);
+    ep.onStartOfSpeech(100.4 * SECOND);
+    ep.onEndOfSpeech(100.5 * SECOND, { shouldIgnore: false });
+
+    const expected = 0.5 * 0.4 * SECOND + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.onEndOfSpeech(100 * SECOND);
+    ep.onStartOfAgentSpeech(100.6 * SECOND);
+    ep.onStartOfSpeech(101.5 * SECOND);
+    ep.onEndOfSpeech(102.0 * SECOND, { shouldIgnore: false });
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 0.6 * SECOND + 0.5 * 1.0 * SECOND, 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.onEndOfSpeech(100 * SECOND);
+    ep.onStartOfAgentSpeech(100.2 * SECOND);
+    expect(endpointingState(ep).agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(100.25 * SECOND, true);
+    expect(ep.overlapping).toBe(true);
+
+    ep.onEndOfSpeech(100.5 * SECOND);
+
+    expect(ep.overlapping).toBe(false);
+    expect(endpointingState(ep).agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(0.3 * SECOND, 5);
+  });
+
+  it('test_update_options', () => {
+    let ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    ep.updateOptions({ minDelay: 0.5 * SECOND });
+    expect(ep.minDelay).toBe(0.5 * SECOND);
+
+    ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    ep.updateOptions({ maxDelay: 2.0 * SECOND });
+    expect(ep.maxDelay).toBe(2.0 * SECOND);
+
+    ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    ep.updateOptions({ minDelay: 0.5 * SECOND, maxDelay: 2.0 * SECOND });
+    expect(ep.minDelay).toBe(0.5 * SECOND);
+    expect(ep.maxDelay).toBe(2.0 * SECOND);
+
+    ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+    ep.updateOptions();
+    expect(ep.minDelay).toBe(0.3 * SECOND);
+    expect(ep.maxDelay).toBe(1.0 * SECOND);
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 1.0,
+    });
+
+    ep.onEndOfSpeech(100 * SECOND);
+    ep.onStartOfAgentSpeech(102.0 * SECOND);
+    ep.onStartOfSpeech(105.0 * SECOND);
+
+    expect(ep.maxDelay).toBe(1.0 * SECOND);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 1.0,
+    });
+
+    ep.onEndOfSpeech(100 * SECOND);
+    ep.onStartOfAgentSpeech(100.1 * SECOND);
+    ep.onStartOfSpeech(100.5 * SECOND);
+
+    expect(ep.maxDelay).toBeGreaterThanOrEqual(0.3 * SECOND);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+
+    ep.onEndOfSpeech(100 * SECOND);
+    ep.onStartOfAgentSpeech(100.5 * SECOND);
+    expect(endpointingState(ep).agentSpeechStartedAt).toBeDefined();
+
+    ep.onStartOfSpeech(102.0 * SECOND);
+    ep.onEndOfSpeech(103.0 * SECOND, { shouldIgnore: false });
+    expect(endpointingState(ep).agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.onEndOfSpeech(100 * SECOND);
+    ep.onStartOfAgentSpeech(100.2 * SECOND);
+    ep.onStartOfSpeech(100.25 * SECOND, true);
+
+    expect(ep.overlapping).toBe(true);
+    const prevValue = [ep.minDelay, ep.maxDelay] as const;
+
+    ep.onStartOfSpeech(100.35 * SECOND);
+
+    expect(ep.overlapping).toBe(true);
+    expect([ep.minDelay, ep.maxDelay]).toEqual(prevValue);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.onEndOfSpeech(100 * SECOND);
+    ep.onStartOfAgentSpeech(100.9 * SECOND);
+    ep.onStartOfSpeech(101.8 * SECOND);
+    ep.onEndOfSpeech(102.0 * SECOND, { shouldIgnore: false });
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 0.9 * SECOND + 0.5 * 1.0 * SECOND, 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.06 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 1.0,
+    });
+
+    ep.onEndOfSpeech(99.0 * SECOND);
+    ep.onStartOfSpeech(100.0 * SECOND);
+
+    ep.onStartOfAgentSpeech(100.2 * SECOND);
+    ep.onStartOfSpeech(100.25 * SECOND, true);
+
+    expect(endpointingState(ep).utteranceEndedAt).toBeCloseTo(100.199 * SECOND, 3);
+    expect(ep.minDelay).toBeCloseTo(0.06 * SECOND, 5);
+    expect(ep.maxDelay).toBeCloseTo(1.0 * SECOND, 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.updateOptions({ minDelay: 0.6 * SECOND, maxDelay: 2.0 * SECOND });
+
+    const state = endpointingState(ep);
+    expect(expFilterState(state.utterancePause).alpha).toBeCloseTo(0.5, 5);
+    expect(expFilterState(state.turnPause).alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.updateOptions({ minDelay: 0.5 * SECOND, maxDelay: 2.0 * SECOND });
+    const state = endpointingState(ep);
+    expect(expFilterState(state.utterancePause).minValue).toBe(0.5 * SECOND);
+    expect(expFilterState(state.turnPause).maxValue).toBe(2.0 * SECOND);
+
+    ep.onEndOfSpeech(100.0 * SECOND);
+    ep.onStartOfSpeech(100.2 * SECOND);
+    expect(ep.minDelay).toBeCloseTo(0.5 * SECOND, 5);
+
+    ep.onEndOfSpeech(101.0 * SECOND);
+    ep.onStartOfAgentSpeech(102.8 * SECOND);
+    ep.onStartOfSpeech(103.5 * SECOND);
+    expect(ep.maxDelay).toBeGreaterThan(1.0 * SECOND);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2.0 * SECOND);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.onEndOfSpeech(100.0 * SECOND);
+    ep.onStartOfAgentSpeech(100.5 * SECOND);
+    ep.onStartOfSpeech(101.5 * SECOND, true);
+
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101.8 * SECOND, { shouldIgnore: true });
+
+    const state = endpointingState(ep);
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect(state.utteranceStartedAt).toBeUndefined();
+    expect(state.utteranceEndedAt).toBeUndefined();
+    expect(ep.overlapping).toBe(false);
+    expect(state.speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100.0 * SECOND);
+    ep.onStartOfSpeech(100.4 * SECOND, false);
+    ep.onEndOfSpeech(100.6 * SECOND, { shouldIgnore: true });
+
+    const expected = 0.5 * 0.4 * SECOND + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.onEndOfSpeech(100.0 * SECOND);
+    ep.onStartOfAgentSpeech(100.5 * SECOND);
+    ep.onStartOfSpeech(100.6 * SECOND, true);
+
+    ep.onEndOfSpeech(100.8 * SECOND, { shouldIgnore: true });
+
+    const state = endpointingState(ep);
+    expect(state.utteranceEndedAt).toBe(100.8 * SECOND);
+    expect(state.speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.onEndOfSpeech(100.0 * SECOND);
+    ep.onStartOfAgentSpeech(100.5 * SECOND);
+    ep.onStartOfSpeech(101.0 * SECOND, true);
+
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+    ep.onEndOfSpeech(101.5 * SECOND, { shouldIgnore: true });
+
+    const state = endpointingState(ep);
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect(state.utteranceStartedAt).toBeUndefined();
+    expect(state.utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+
+    ep.onStartOfAgentSpeech(100.0 * SECOND);
+    ep.onStartOfSpeech(100.1 * SECOND, true);
+    expect(ep.overlapping).toBe(true);
+    expect(endpointingState(ep).agentSpeechStartedAt).toBe(100.0 * SECOND);
+
+    ep.onEndOfAgentSpeech(101.0 * SECOND);
+
+    const state = endpointingState(ep);
+    expect(state.agentSpeechEndedAt).toBe(101.0 * SECOND);
+    expect(state.agentSpeechStartedAt).toBe(100.0 * SECOND);
+    expect(ep.overlapping).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.onEndOfSpeech(100.0 * SECOND);
+    ep.onStartOfAgentSpeech(100.9 * SECOND);
+    ep.onStartOfSpeech(101.8 * SECOND, false);
+    ep.onEndOfSpeech(102.0 * SECOND);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 0.9 * SECOND + 0.5 * 1.0 * SECOND, 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing({ minDelay: 0.3 * SECOND, maxDelay: 1.0 * SECOND });
+
+    expect(endpointingState(ep).speaking).toBe(false);
+    ep.onStartOfSpeech(100.0 * SECOND);
+    expect(endpointingState(ep).speaking).toBe(true);
+
+    ep.onEndOfSpeech(100.5 * SECOND);
+    expect(endpointingState(ep).speaking).toBe(false);
+  });
+
+  it.each([
+    ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+    ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+    ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+    ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+    ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+    ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+    ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+    ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+    ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+  ])(
+    'test_all_overlapping_and_should_ignore_combos [%s]',
+    (
+      _label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ) => {
+      const ep = new DynamicEndpointing({
+        minDelay: 0.3 * SECOND,
+        maxDelay: 1.0 * SECOND,
+        alpha: 0.5,
+      });
+
+      ep.onStartOfSpeech(99.0 * SECOND);
+      ep.onEndOfSpeech(100.0 * SECOND);
+
+      let userStart: number;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100.5 * SECOND);
+        ep.onEndOfAgentSpeech(101.0 * SECOND);
+        userStart = 101.5 * SECOND;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100.15 * SECOND);
+          userStart = 100.35 * SECOND;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100.2 * SECOND);
+          userStart = 101.5 * SECOND;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100.15 * SECOND);
+          userStart = 100.4 * SECOND;
+        } else {
+          ep.onStartOfAgentSpeech(100.9 * SECOND);
+          userStart = 101.8 * SECOND;
+        }
+      } else {
+        userStart = 100.4 * SECOND;
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping);
+
+      const prevMin = ep.minDelay;
+      const prevMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + 0.5 * SECOND, { shouldIgnore });
+
+      expect(ep.minDelay !== prevMin).toBe(expectMinChange);
+      expect(ep.maxDelay !== prevMax).toBe(expectMaxChange);
+      expect(endpointingState(ep).speaking).toBe(false);
+      expect(ep.overlapping).toBe(false);
+    },
+  );
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing({
+      minDelay: 0.3 * SECOND,
+      maxDelay: 1.0 * SECOND,
+      alpha: 0.5,
+    });
+
+    ep.onStartOfSpeech(100.0 * SECOND);
+    ep.onEndOfSpeech(101.0 * SECOND);
+
+    ep.onStartOfAgentSpeech(101.5 * SECOND);
+
+    ep.onStartOfSpeech(102.5 * SECOND, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102.8 * SECOND, { shouldIgnore: true });
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(103.0 * SECOND);
+
+    ep.onStartOfSpeech(103.5 * SECOND);
+    ep.onEndOfSpeech(104.0 * SECOND);
+
+    expect(endpointingState(ep).speaking).toBe(false);
+    expect(endpointingState(ep).agentSpeechStartedAt).toBeUndefined();
+  });
+});

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+const logger = log();
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 7-7 lines
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250;
+
+export interface BaseEndpointingOptions {
+  minDelay: number;
+  maxDelay: number;
+}
+
+export interface DynamicEndpointingOptions extends BaseEndpointingOptions {
+  alpha?: number;
+}
+
+export interface EndpointingUpdateOptions {
+  minDelay?: number;
+  maxDelay?: number;
+}
+
+export interface EndpointingSpeechEndOptions {
+  shouldIgnore?: boolean;
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-47 lines
+export class BaseEndpointing {
+  protected minDelayValue: number;
+  protected maxDelayValue: number;
+  protected overlap = false;
+
+  constructor({ minDelay, maxDelay }: BaseEndpointingOptions) {
+    this.minDelayValue = minDelay;
+    this.maxDelayValue = maxDelay;
+  }
+
+  updateOptions({ minDelay, maxDelay }: EndpointingUpdateOptions = {}): void {
+    this.minDelayValue = minDelay ?? this.minDelayValue;
+    this.maxDelayValue = maxDelay ?? this.maxDelayValue;
+  }
+
+  get minDelay(): number {
+    return this.minDelayValue;
+  }
+
+  get maxDelay(): number {
+    return this.maxDelayValue;
+  }
+
+  get overlapping(): boolean {
+    return this.overlap;
+  }
+
+  onStartOfSpeech(_startedAt: number, overlapping = false): void {
+    this.overlap = overlapping;
+  }
+
+  onEndOfSpeech(_endedAt: number, _options: EndpointingSpeechEndOptions = {}): void {
+    this.overlap = false;
+  }
+
+  onStartOfAgentSpeech(_startedAt: number): void {}
+
+  onEndOfAgentSpeech(_endedAt: number): void {}
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-302 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private readonly utterancePause: ExpFilter;
+  private readonly turnPause: ExpFilter;
+  private utteranceStartedAt?: number;
+  private utteranceEndedAt?: number;
+  private agentSpeechStartedAt?: number;
+  private agentSpeechEndedAt?: number;
+  private speaking = false;
+
+  constructor({ minDelay, maxDelay, alpha = 0.9 }: DynamicEndpointingOptions) {
+    super({ minDelay, maxDelay });
+    this.utterancePause = new ExpFilter(alpha, {
+      initial: minDelay,
+      minValue: minDelay,
+      maxValue: maxDelay,
+    });
+    this.turnPause = new ExpFilter(alpha, {
+      initial: maxDelay,
+      minValue: minDelay,
+      maxValue: maxDelay,
+    });
+  }
+
+  override get minDelay(): number {
+    return this.utterancePause.value ?? this.minDelayValue;
+  }
+
+  override get maxDelay(): number {
+    return Math.max(this.turnPause.value ?? this.maxDelayValue, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this.utteranceEndedAt === undefined || this.utteranceStartedAt === undefined) {
+      return 0;
+    }
+    return Math.max(0, this.utteranceStartedAt - this.utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this.agentSpeechStartedAt === undefined || this.utteranceEndedAt === undefined) {
+      return 0;
+    }
+    return Math.max(0, this.agentSpeechStartedAt - this.utteranceEndedAt);
+  }
+
+  get immediateInterruptionDelay(): [number, number] {
+    if (this.utteranceStartedAt === undefined || this.agentSpeechStartedAt === undefined) {
+      return [0, 0];
+    }
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this.agentSpeechStartedAt = startedAt;
+    this.agentSpeechEndedAt = undefined;
+    this.overlap = false;
+  }
+
+  override onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this.agentSpeechStartedAt !== undefined &&
+      (this.agentSpeechEndedAt === undefined || this.agentSpeechEndedAt < this.agentSpeechStartedAt)
+    ) {
+      this.agentSpeechEndedAt = endedAt;
+    }
+    this.overlap = false;
+  }
+
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this.overlap) {
+      return;
+    }
+
+    if (
+      this.utteranceStartedAt !== undefined &&
+      this.utteranceEndedAt !== undefined &&
+      this.agentSpeechStartedAt !== undefined &&
+      this.utteranceEndedAt < this.utteranceStartedAt &&
+      overlapping
+    ) {
+      this.utteranceEndedAt = this.agentSpeechStartedAt - 1;
+      logger.trace({ utteranceEndedAt: this.utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this.utteranceStartedAt = startedAt;
+    this.overlap = overlapping;
+    this.speaking = true;
+  }
+
+  override onEndOfSpeech(
+    endedAt: number,
+    { shouldIgnore = false }: EndpointingSpeechEndOptions = {},
+  ): void {
+    if (shouldIgnore && this.overlap) {
+      const withinGracePeriod =
+        this.utteranceStartedAt !== undefined &&
+        this.agentSpeechStartedAt !== undefined &&
+        Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD;
+
+      if (withinGracePeriod) {
+        logger.trace(
+          {
+            delay: Math.abs((this.utteranceStartedAt ?? 0) - (this.agentSpeechStartedAt ?? 0)),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true because user speech started within the grace period',
+        );
+      } else {
+        this.overlap = false;
+        this.speaking = false;
+        this.utteranceStartedAt = undefined;
+        this.utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    if (
+      this.overlap ||
+      (this.agentSpeechStartedAt !== undefined && this.agentSpeechEndedAt === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const betweenUtteranceDelay = this.betweenUtteranceDelay;
+
+      if (
+        interruptionDelay > 0 &&
+        interruptionDelay <= this.minDelay &&
+        turnDelay > 0 &&
+        turnDelay <= this.maxDelay &&
+        betweenUtteranceDelay > 0
+      ) {
+        const previousMinDelay = this.minDelay;
+        this.utterancePause.apply(1, betweenUtteranceDelay);
+        logger.debug(
+          {
+            reason: 'immediate interruption',
+            pause: betweenUtteranceDelay,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${previousMinDelay} -> ${this.minDelay}`,
+        );
+      } else if (this.betweenTurnDelay > 0) {
+        const previousMaxDelay = this.maxDelay;
+        this.turnPause.apply(1, this.betweenTurnDelay);
+        logger.debug(
+          {
+            reason: 'new turn (interruption)',
+            pause: this.betweenTurnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+            betweenUtteranceDelay,
+            betweenTurnDelay: this.betweenTurnDelay,
+          },
+          `max endpointing delay updated: ${previousMaxDelay} -> ${this.maxDelay}`,
+        );
+      }
+    } else if (this.betweenTurnDelay > 0) {
+      const previousMaxDelay = this.maxDelay;
+      this.turnPause.apply(1, this.betweenTurnDelay);
+      logger.debug(
+        {
+          reason: 'new turn',
+          pause: this.betweenTurnDelay,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `max endpointing delay updated due to pause: ${previousMaxDelay} -> ${this.maxDelay}`,
+      );
+    } else if (
+      this.betweenUtteranceDelay > 0 &&
+      this.agentSpeechEndedAt === undefined &&
+      this.agentSpeechStartedAt === undefined
+    ) {
+      const previousMinDelay = this.minDelay;
+      this.utterancePause.apply(1, this.betweenUtteranceDelay);
+      logger.debug(
+        {
+          reason: 'pause between utterances',
+          pause: this.betweenUtteranceDelay,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `min endpointing delay updated: ${previousMinDelay} -> ${this.minDelay}`,
+      );
+    }
+
+    this.utteranceEndedAt = endedAt;
+    this.agentSpeechStartedAt = undefined;
+    this.agentSpeechEndedAt = undefined;
+    this.speaking = false;
+    this.overlap = false;
+  }
+
+  override updateOptions({ minDelay, maxDelay }: EndpointingUpdateOptions = {}): void {
+    if (minDelay !== undefined) {
+      this.minDelayValue = minDelay;
+      this.utterancePause.reset({ initial: minDelay, minValue: minDelay });
+      this.turnPause.reset({ minValue: minDelay });
+    }
+    if (maxDelay !== undefined) {
+      this.maxDelayValue = maxDelay;
+      this.turnPause.reset({ initial: maxDelay, maxValue: maxDelay });
+      this.utterancePause.reset({ maxValue: maxDelay });
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  switch (options.mode ?? 'fixed') {
+    case 'dynamic':
+      return new DynamicEndpointing({
+        minDelay: options.minDelay,
+        maxDelay: options.maxDelay,
+      });
+    case 'fixed':
+    default:
+      return new BaseEndpointing({
+        minDelay: options.minDelay,
+        maxDelay: options.maxDelay,
+      });
+  }
+}

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -22,6 +22,8 @@ export {
   RoomSessionTransport,
 } from './remote_session.js';
 export * from './events.js';
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-316 lines
+export * from './endpointing.js';
 export { type TimedString } from './io.js';
 export * from './report.js';
 export * from './room_io/index.js';

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -5,9 +5,10 @@
  * Configuration for endpointing, which determines when the user's turn is complete.
  */
 export interface EndpointingOptions {
+  // Ref: python livekit-agents/livekit/agents/voice/turn.py - 47-69 lines
   /**
-   * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on
-   * end-of-utterance prediction.
+   * Endpointing mode. `"fixed"` uses the configured delays, `"dynamic"` adapts the delays
+   * based on pauses between utterances and interruptions.
    * @defaultValue "fixed"
    */
   mode: 'fixed' | 'dynamic';


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/78).

Tracking issue: https://github.com/livekit/rosetta/issues/78

## Summary
- port the Python `DynamicEndpointing` and `create_endpointing` flow into the Node.js voice pipeline, wiring it into `AudioRecognition` and agent playout timestamps.
- upgrade the shared `ExpFilter` helper to match the Python behavior used by dynamic endpointing, including validation, reset semantics, and clamp bounds.
- port every source endpointing test from `tests/test_endpointing.py` into `agents/src/voice/endpointing.test.ts` for parity.

## Source
- https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/endpointing.py
- https://github.com/livekit/agents/blob/main/tests/test_endpointing.py