### PR TITLE
Port dynamic endpointing to the Node.js SDK

### DIFF
--- a/.changeset/shiny-pens-share.md
+++ b/.changeset/shiny-pens-share.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": minor
+---
+
+feat(voice): port dynamic endpointing from the Python SDK

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -351,44 +351,124 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 }
 
 /** @internal */
+export interface ExpFilterOptions {
+  max?: number;
+  min?: number;
+  initial?: number;
+}
+
+/** @internal */
+// Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-64 lines
 export class ExpFilter {
-  #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  private alphaValue: number;
+  private maxValue?: number;
+  private minValue?: number;
+  private filteredValue?: number;
 
-  constructor(alpha: number, max?: number) {
-    this.#alpha = alpha;
-    this.#max = max;
+  constructor(alpha: number, max?: number);
+  constructor(alpha: number, options?: ExpFilterOptions);
+  constructor(alpha: number, maxOrOptions?: number | ExpFilterOptions) {
+    this.assertAlpha(alpha);
+    this.alphaValue = alpha;
+
+    if (typeof maxOrOptions === 'number') {
+      this.maxValue = maxOrOptions;
+      return;
+    }
+
+    this.maxValue = maxOrOptions?.max;
+    this.minValue = maxOrOptions?.min;
+    this.filteredValue = maxOrOptions?.initial;
   }
 
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+  reset(alpha?: number): void;
+  reset(options?: ExpFilterOptions & { alpha?: number }): void;
+  reset(alphaOrOptions?: number | (ExpFilterOptions & { alpha?: number })): void {
+    if (typeof alphaOrOptions === 'number') {
+      this.assertAlpha(alphaOrOptions);
+      this.alphaValue = alphaOrOptions;
+      return;
     }
-    this.#filtered = undefined;
+
+    if (!alphaOrOptions) {
+      return;
+    }
+
+    if (alphaOrOptions.alpha !== undefined) {
+      this.assertAlpha(alphaOrOptions.alpha);
+      this.alphaValue = alphaOrOptions.alpha;
+    }
+    if ('initial' in alphaOrOptions) {
+      this.filteredValue = alphaOrOptions.initial;
+    }
+    if ('min' in alphaOrOptions) {
+      this.minValue = alphaOrOptions.min;
+    }
+    if ('max' in alphaOrOptions) {
+      this.maxValue = alphaOrOptions.max;
+    }
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
-      const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
-    } else {
-      this.#filtered = sample;
+  apply(exp: number, sample: number | undefined = this.filteredValue): number {
+    if (sample === undefined && this.filteredValue === undefined) {
+      throw new Error('sample or initial value must be given.');
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (sample !== undefined && this.filteredValue === undefined) {
+      this.filteredValue = sample;
+    } else if (sample !== undefined && this.filteredValue !== undefined) {
+      const a = this.alphaValue ** exp;
+      this.filteredValue = a * this.filteredValue + (1 - a) * sample;
     }
 
-    return this.#filtered;
+    if (this.filteredValue === undefined) {
+      throw new Error('sample or initial value must be given.');
+    }
+
+    if (this.maxValue !== undefined && this.filteredValue > this.maxValue) {
+      this.filteredValue = this.maxValue;
+    }
+
+    if (this.minValue !== undefined && this.filteredValue < this.minValue) {
+      this.filteredValue = this.minValue;
+    }
+
+    return this.filteredValue;
+  }
+
+  get value(): number | undefined {
+    return this.filteredValue;
   }
 
   get filtered(): number | undefined {
-    return this.#filtered;
+    return this.filteredValue;
+  }
+
+  get alpha(): number {
+    return this.alphaValue;
   }
 
   set alpha(alpha: number) {
-    this.#alpha = alpha;
+    this.assertAlpha(alpha);
+    this.alphaValue = alpha;
+  }
+
+  get max(): number | undefined {
+    return this.maxValue;
+  }
+
+  get min(): number | undefined {
+    return this.minValue;
+  }
+
+  updateBase(alpha: number): void {
+    this.alpha = alpha;
+  }
+
+  private assertAlpha(alpha: number): void {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
   }
 }
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -65,6 +65,7 @@ import {
   type RecognitionHooks,
   type STTPipeline,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import {
   AgentSessionEventTypes,
   createErrorEvent,
@@ -88,6 +89,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -185,6 +187,7 @@ export class AgentActivity implements RecognitionHooks {
   private _preemptiveGeneration?: PreemptiveGeneration;
   private _preemptiveGenerationCount = 0;
   private interruptionDetector?: AdaptiveInterruptionDetector;
+  private interruptionDetected = false;
   private isInterruptionDetectionEnabled: boolean;
   private isInterruptionByAudioActivityEnabled: boolean;
   private isDefaultInterruptionByAudioActivityEnabled: boolean;
@@ -206,6 +209,7 @@ export class AgentActivity implements RecognitionHooks {
     this.onError(ev);
 
   private readonly onInterruptionOverlappingSpeech = (ev: OverlappingSpeechEvent): void => {
+    this.interruptionDetected = ev.isInterruption;
     this.agentSession.emit(AgentSessionEventTypes.OverlappingSpeech, ev);
   };
 
@@ -476,13 +480,9 @@ export class AgentActivity implements RecognitionHooks {
       vad: this.vad,
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 326-328, 478-482 lines
+      endpointing: createEndpointing(this.endpointingOptions),
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -661,6 +661,13 @@ export class AgentActivity implements RecognitionHooks {
     return this.agent.turnHandling ?? this.agentSession.sessionOptions.turnHandling;
   }
 
+  private get endpointingOptions(): EndpointingOptions {
+    return {
+      ...this.agentSession.sessionOptions.turnHandling.endpointing,
+      ...this.agent.turnHandling?.endpointing,
+    };
+  }
+
   // get minEndpointingDelay(): number {
   //   return (
   //     this.agent.turnHandling?.endpointing?.minDelay ??
@@ -717,9 +724,11 @@ export class AgentActivity implements RecognitionHooks {
 
   updateOptions({
     toolChoice,
+    endpointing,
     turnDetection,
   }: {
     toolChoice?: ToolChoice | null;
+    endpointing?: EndpointingOptions;
     turnDetection?: TurnDetectionMode;
   }): void {
     if (toolChoice !== undefined) {
@@ -743,7 +752,10 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (this.audioRecognition) {
-      this.audioRecognition.updateOptions({ turnDetection: this.turnDetectionMode });
+      this.audioRecognition.updateOptions({
+        endpointing: endpointing ? createEndpointing(endpointing) : undefined,
+        turnDetection: this.turnDetectionMode,
+      });
     }
   }
 
@@ -1030,14 +1042,16 @@ export class AgentActivity implements RecognitionHooks {
       lastSpeakingTime: speechStartTime,
       otelContext: otelContext.active(),
     });
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1645-1655 lines
+    if (this.audioRecognition) {
+      this.audioRecognition.onStartOfSpeech(
         speechStartTime,
+        ev.speechDuration,
         this.agentSession._userSpeakingSpan,
       );
     }
+
+    this.interruptionDetected = false;
   }
 
   onEndOfSpeech(ev: VADEvent): void {
@@ -1046,11 +1060,12 @@ export class AgentActivity implements RecognitionHooks {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1665-1679 lines
+    if (this.audioRecognition) {
+      this.audioRecognition.onEndOfSpeech(
         speechEndTime,
         this.agentSession._userSpeakingSpan,
+        this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
       );
     }
     this.agentSession._updateUserState('listening', {
@@ -1837,8 +1852,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2189-2197 lines
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -1924,7 +1942,7 @@ export class AgentActivity implements RecognitionHooks {
 
     if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+      if (this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
       this.restoreInterruptionByAudioActivity();
@@ -2113,8 +2131,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2533-2542 lines
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2271,10 +2292,10 @@ export class AgentActivity implements RecognitionHooks {
 
       if (this.agentSession.agentState === 'speaking') {
         this.agentSession._updateAgentState('listening');
-        if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+        if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
-          this.restoreInterruptionByAudioActivity();
         }
+        this.restoreInterruptionByAudioActivity();
       }
 
       this.logger.info(
@@ -2314,12 +2335,10 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._updateAgentState('thinking');
     } else if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
-          this.restoreInterruptionByAudioActivity();
-        }
+      if (this.audioRecognition) {
+        this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
+      this.restoreInterruptionByAudioActivity();
     }
 
     // mark the playout done before waiting for the tool execution

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,6 +35,7 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import type { BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
@@ -137,11 +138,9 @@ export interface AudioRecognitionOptions {
   turnDetector?: _TurnDetector;
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
+  /** Endpointing runtime. */
+  endpointing: BaseEndpointing;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
-  /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +169,7 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  private endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -224,8 +222,7 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    this.endpointing = opts.endpointing;
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,8 +272,17 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
-    this.turnDetectionMode = options.turnDetection;
+  updateOptions(options: {
+    endpointing?: BaseEndpointing;
+    turnDetection?: TurnDetectionMode | undefined;
+  }): void {
+    if (options.endpointing !== undefined) {
+      this.endpointing = options.endpointing;
+    }
+
+    if ('turnDetection' in options) {
+      this.turnDetectionMode = options.turnDetection;
+    }
   }
 
   async start(options?: { sttPipeline?: STTPipeline }) {
@@ -311,12 +317,19 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-270 lines
+  async onStartOfAgentSpeech(startedAt: number) {
     this.isAgentSpeaking = true;
+    this.endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-270 lines
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -367,6 +380,29 @@ export class AudioRecognition {
     }
 
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.overlapSpeechEnded(endedAt));
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 272-305 lines
+  onStartOfSpeech(startedAt: number, speechDuration = 0, userSpeakingSpan?: Span): void {
+    this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+
+    if (!this.isInterruptionEnabled || !this.isAgentSpeaking) {
+      return;
+    }
+
+    void this.onStartOfOverlapSpeech(speechDuration, startedAt, userSpeakingSpan);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-305 lines
+  onEndOfSpeech(endedAt: number, userSpeakingSpan?: Span, interruption?: boolean): void {
+    if (this.speaking) {
+      this.endpointing.onEndOfSpeech(
+        endedAt,
+        interruption !== undefined && !interruption && this.isAgentSpeaking,
+      );
+    }
+
+    void this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
   }
 
   /**
@@ -805,7 +841,8 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 934-989 lines
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +868,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -7,6 +7,7 @@ import { ChatContext } from '../llm/chat_context.js';
 import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function createHooks() {
@@ -45,8 +46,7 @@ function createRecognition(sttNode: STTNode, hooks = createHooks()) {
     recognition: new AudioRecognition({
       recognitionHooks: hooks,
       stt: sttNode,
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
     }),
   };
 }

--- a/agents/src/voice/audio_recognition_span.test.ts
+++ b/agents/src/voice/audio_recognition_span.test.ts
@@ -22,6 +22,7 @@ import {
   type RecognitionHooks,
   type _TurnDetector,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function setupInMemoryTracing() {
@@ -145,8 +146,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: undefined,
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'stt',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
       sttModel: 'deepgram-nova2',
       sttProvider: 'deepgram',
       getLinkedParticipant: () => ({ sid: 'p1', identity: 'bob', kind: ParticipantKind.AGENT }),
@@ -254,8 +254,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: new FakeVAD(vadEvents),
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'vad',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
       sttModel: 'stt-model',
       sttProvider: 'stt-provider',
       getLinkedParticipant: () => ({ sid: 'p2', identity: 'alice', kind: ParticipantKind.AGENT }),

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,500 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+type DynamicEndpointingState = DynamicEndpointing & {
+  utterancePause: ExpFilter;
+  turnPause: ExpFilter;
+  utteranceStartedAt?: number;
+  utteranceEndedAt?: number;
+  agentSpeechStartedAt?: number;
+  agentSpeechEndedAt?: number;
+  configuredMinDelay: number;
+  configuredMaxDelay: number;
+  speaking: boolean;
+};
+
+function getDynamicState(ep: DynamicEndpointing): DynamicEndpointingState {
+  return ep as unknown as DynamicEndpointingState;
+}
+
+beforeAll(() => {
+  initializeLogger({ pretty: false, level: 'silent' });
+});
+
+describe('TestExponentialMovingAverage', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    let ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    ema = new ExpFilter(0.5, { initial: 10 });
+    expect(ema.value).toBe(10);
+
+    ema = new ExpFilter(1.0);
+    expect(ema.value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0.0)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(-0.5)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(1.5)).toThrow(/alpha must be in/);
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1.0, 10.0);
+    expect(result).toBe(10.0);
+    expect(ema.value).toBe(10.0);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    const result = ema.apply(1.0, 20.0);
+    expect(result).toBe(15.0);
+    expect(ema.value).toBe(15.0);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    ema.apply(1.0, 20.0);
+    ema.apply(1.0, 20.0);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    let ema = new ExpFilter(0.5, { initial: 10.0 });
+    expect(ema.value).toBe(10.0);
+    ema.reset();
+    expect(ema.value).toBe(10.0);
+
+    ema = new ExpFilter(0.5, { initial: 10.0 });
+    ema.reset({ initial: 5.0 });
+    expect(ema.value).toBe(5.0);
+  });
+});
+
+describe('TestDynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.2 });
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    const state = getDynamicState(ep);
+
+    expect(state.utterancePause.alpha).toBeCloseTo(0.9, 5);
+    expect(state.turnPause.alpha).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toEqual([0, 0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    let ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(100_000);
+    expect(getDynamicState(ep).utteranceEndedAt).toBe(100_000);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(99_900);
+    expect(getDynamicState(ep).utteranceEndedAt).toBe(99_900);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onStartOfSpeech(100_000);
+    expect(getDynamicState(ep).utteranceStartedAt).toBe(100_000);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onStartOfAgentSpeech(100_000);
+    expect(getDynamicState(ep).agentSpeechStartedAt).toBe(100_000);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_500);
+
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(500, 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_800);
+
+    expect(ep.betweenTurnDelay).toBeCloseTo(800, 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_400);
+    ep.onEndOfSpeech(100_500, false);
+
+    expect(ep.minDelay).toBeCloseTo(0.5 * 400 + 0.5 * initialMin, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_600);
+    ep.onStartOfSpeech(101_500);
+    ep.onEndOfSpeech(102_000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 600 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    expect(getDynamicState(ep).agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(100_250, true);
+    expect(ep.overlapping).toBe(true);
+
+    ep.onEndOfSpeech(100_500);
+
+    expect(ep.overlapping).toBe(false);
+    expect(getDynamicState(ep).agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(300, 5);
+  });
+
+  it('test_update_options', () => {
+    let ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions({ minDelay: 500 });
+    expect(ep.minDelay).toBe(500);
+    expect(getDynamicState(ep).configuredMinDelay).toBe(500);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions({ maxDelay: 2000 });
+    expect(ep.maxDelay).toBe(2000);
+    expect(getDynamicState(ep).configuredMaxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions();
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 1.0 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(102_000);
+    ep.onStartOfSpeech(105_000);
+
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 1.0 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_100);
+    ep.onStartOfSpeech(100_500);
+
+    expect(ep.maxDelay).toBeGreaterThanOrEqual(getDynamicState(ep).configuredMinDelay);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    expect(getDynamicState(ep).agentSpeechStartedAt).toBeDefined();
+
+    ep.onStartOfSpeech(102_000);
+    ep.onEndOfSpeech(103_000, false);
+    expect(getDynamicState(ep).agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    ep.onStartOfSpeech(100_250, true);
+
+    expect(ep.overlapping).toBe(true);
+    const previous = [ep.minDelay, ep.maxDelay];
+
+    ep.onStartOfSpeech(100_350);
+
+    expect(ep.overlapping).toBe(true);
+    expect([ep.minDelay, ep.maxDelay]).toEqual(previous);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_900);
+    ep.onStartOfSpeech(101_800);
+    ep.onEndOfSpeech(102_000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing({ minDelay: 60, maxDelay: 1000, alpha: 1.0 });
+
+    ep.onEndOfSpeech(99_000);
+    ep.onStartOfSpeech(100_000);
+
+    ep.onStartOfAgentSpeech(100_200);
+    ep.onStartOfSpeech(100_250, true);
+
+    expect(getDynamicState(ep).utteranceEndedAt).toBeCloseTo(100_199, 5);
+    expect(ep.minDelay).toBeCloseTo(60, 5);
+    expect(ep.maxDelay).toBeCloseTo(1000, 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const state = getDynamicState(ep);
+
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+
+    expect(state.utterancePause.alpha).toBeCloseTo(0.5, 5);
+    expect(state.turnPause.alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const state = getDynamicState(ep);
+
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(state.utterancePause.min).toBe(500);
+    expect(state.turnPause.max).toBe(2000);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_200);
+    expect(ep.minDelay).toBeCloseTo(500, 5);
+
+    ep.onEndOfSpeech(101_000);
+    ep.onStartOfAgentSpeech(102_800);
+    ep.onStartOfSpeech(103_500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const state = getDynamicState(ep);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(101_500, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101_800, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect(state.utteranceStartedAt).toBeUndefined();
+    expect(state.utteranceEndedAt).toBeUndefined();
+    expect(ep.overlapping).toBe(false);
+    expect(state.speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_400, false);
+    ep.onEndOfSpeech(100_600, true);
+
+    expect(ep.minDelay).toBeCloseTo(0.5 * 400 + 0.5 * initialMin, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const state = getDynamicState(ep);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(100_600, true);
+
+    ep.onEndOfSpeech(100_800, true);
+
+    expect(state.utteranceEndedAt).toBe(100_800);
+    expect(state.speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const state = getDynamicState(ep);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(101_000, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+    ep.onEndOfSpeech(101_500, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect(state.utteranceStartedAt).toBeUndefined();
+    expect(state.utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    const state = getDynamicState(ep);
+
+    ep.onStartOfAgentSpeech(100_000);
+    ep.onStartOfSpeech(100_100, true);
+    expect(ep.overlapping).toBe(true);
+    expect(state.agentSpeechStartedAt).toBe(100_000);
+
+    ep.onEndOfAgentSpeech(101_000);
+
+    expect(state.agentSpeechEndedAt).toBe(101_000);
+    expect(state.agentSpeechStartedAt).toBe(100_000);
+    expect(ep.overlapping).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_900);
+    ep.onStartOfSpeech(101_800, false);
+    ep.onEndOfSpeech(102_000);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    const state = getDynamicState(ep);
+
+    expect(state.speaking).toBe(false);
+    ep.onStartOfSpeech(100_000);
+    expect(state.speaking).toBe(true);
+    ep.onEndOfSpeech(100_500);
+    expect(state.speaking).toBe(false);
+  });
+
+  it('test_all_overlapping_and_should_ignore_combos', () => {
+    const combos = [
+      ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+      ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+      ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+      ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+      ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+      ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+      ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+      ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+      ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+    ] as const;
+
+    for (const [
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ] of combos) {
+      const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+      const state = getDynamicState(ep);
+
+      ep.onStartOfSpeech(99_000);
+      ep.onEndOfSpeech(100_000);
+
+      let userStart = 100_400;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100_500);
+        ep.onEndOfAgentSpeech(101_000);
+        userStart = 101_500;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100_150);
+          userStart = 100_350;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100_200);
+          userStart = 101_500;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100_150);
+          userStart = 100_400;
+        } else {
+          ep.onStartOfAgentSpeech(100_900);
+          userStart = 101_800;
+        }
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping);
+
+      const previousMin = ep.minDelay;
+      const previousMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + 500, shouldIgnore);
+
+      expect(ep.minDelay !== previousMin, `[${label}] min_delay change`).toBe(expectMinChange);
+      expect(ep.maxDelay !== previousMax, `[${label}] max_delay change`).toBe(expectMaxChange);
+      expect(state.speaking, `[${label}] speaking`).toBe(false);
+      expect(ep.overlapping, `[${label}] overlapping`).toBe(false);
+    }
+  });
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const state = getDynamicState(ep);
+
+    ep.onStartOfSpeech(100_000);
+    ep.onEndOfSpeech(101_000);
+
+    ep.onStartOfAgentSpeech(101_500);
+
+    ep.onStartOfSpeech(102_500, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102_800, true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(103_000);
+
+    ep.onStartOfSpeech(103_500);
+    ep.onEndOfSpeech(104_000);
+
+    expect(state.speaking).toBe(false);
+    expect(state.agentSpeechStartedAt).toBeUndefined();
+  });
+});

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250;
+
+export interface EndpointingUpdateOptions {
+  minDelay?: number;
+  maxDelay?: number;
+}
+
+/** @internal */
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 7-47 lines
+export class BaseEndpointing {
+  protected configuredMinDelay: number;
+  protected configuredMaxDelay: number;
+  protected overlappingState = false;
+
+  constructor({ minDelay, maxDelay }: Pick<EndpointingOptions, 'minDelay' | 'maxDelay'>) {
+    this.configuredMinDelay = minDelay;
+    this.configuredMaxDelay = maxDelay;
+  }
+
+  updateOptions({ minDelay, maxDelay }: EndpointingUpdateOptions = {}): void {
+    this.configuredMinDelay = minDelay ?? this.configuredMinDelay;
+    this.configuredMaxDelay = maxDelay ?? this.configuredMaxDelay;
+  }
+
+  get minDelay(): number {
+    return this.configuredMinDelay;
+  }
+
+  get maxDelay(): number {
+    return this.configuredMaxDelay;
+  }
+
+  get overlapping(): boolean {
+    return this.overlappingState;
+  }
+
+  onStartOfSpeech(_startedAt: number, overlapping = false): void {
+    this.overlappingState = overlapping;
+  }
+
+  onEndOfSpeech(_endedAt: number, _shouldIgnore = false): void {
+    this.overlappingState = false;
+  }
+
+  onStartOfAgentSpeech(_startedAt: number): void {}
+
+  onEndOfAgentSpeech(_endedAt: number): void {}
+}
+
+export interface DynamicEndpointingOptions
+  extends Pick<EndpointingOptions, 'minDelay' | 'maxDelay'> {
+  alpha?: number;
+}
+
+/** @internal */
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-304 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private logger = log();
+  private utterancePause: ExpFilter;
+  private turnPause: ExpFilter;
+  private utteranceStartedAt?: number;
+  private utteranceEndedAt?: number;
+  private agentSpeechStartedAt?: number;
+  private agentSpeechEndedAt?: number;
+  private speaking = false;
+
+  constructor({ minDelay, maxDelay, alpha = 0.9 }: DynamicEndpointingOptions) {
+    super({ minDelay, maxDelay });
+
+    this.utterancePause = new ExpFilter(alpha, {
+      initial: minDelay,
+      min: minDelay,
+      max: maxDelay,
+    });
+    this.turnPause = new ExpFilter(alpha, {
+      initial: maxDelay,
+      min: minDelay,
+      max: maxDelay,
+    });
+  }
+
+  get minDelay(): number {
+    return this.utterancePause.value ?? this.configuredMinDelay;
+  }
+
+  get maxDelay(): number {
+    return Math.max(this.turnPause.value ?? this.configuredMaxDelay, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this.utteranceEndedAt === undefined || this.utteranceStartedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.utteranceStartedAt - this.utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this.agentSpeechStartedAt === undefined || this.utteranceEndedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.agentSpeechStartedAt - this.utteranceEndedAt);
+  }
+
+  get immediateInterruptionDelay(): [number, number] {
+    if (this.utteranceStartedAt === undefined || this.agentSpeechStartedAt === undefined) {
+      return [0, 0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  onStartOfAgentSpeech(startedAt: number): void {
+    this.agentSpeechStartedAt = startedAt;
+    this.agentSpeechEndedAt = undefined;
+    this.overlappingState = false;
+  }
+
+  onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this.agentSpeechStartedAt !== undefined &&
+      (this.agentSpeechEndedAt === undefined || this.agentSpeechEndedAt < this.agentSpeechStartedAt)
+    ) {
+      this.agentSpeechEndedAt = endedAt;
+    }
+
+    this.overlappingState = false;
+  }
+
+  onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this.overlappingState) {
+      return;
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 160-173 lines
+    if (
+      this.utteranceStartedAt !== undefined &&
+      this.utteranceEndedAt !== undefined &&
+      this.agentSpeechStartedAt !== undefined &&
+      this.utteranceEndedAt < this.utteranceStartedAt &&
+      overlapping
+    ) {
+      this.utteranceEndedAt = this.agentSpeechStartedAt - 1;
+      this.logger.trace({ utteranceEndedAt: this.utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this.utteranceStartedAt = startedAt;
+    this.overlappingState = overlapping;
+    this.speaking = true;
+  }
+
+  onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 180-203 lines
+    if (shouldIgnore && this.overlappingState) {
+      if (
+        this.utteranceStartedAt !== undefined &&
+        this.agentSpeechStartedAt !== undefined &&
+        Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        this.logger.trace(
+          {
+            pause: Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true within grace period',
+        );
+      } else {
+        this.overlappingState = false;
+        this.speaking = false;
+        this.utteranceStartedAt = undefined;
+        this.utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 205-280 lines
+    if (
+      this.overlappingState ||
+      (this.agentSpeechStartedAt !== undefined && this.agentSpeechEndedAt === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+
+      if (
+        interruptionDelay > 0 &&
+        interruptionDelay <= this.minDelay &&
+        turnDelay > 0 &&
+        turnDelay <= this.maxDelay &&
+        this.betweenUtteranceDelay > 0
+      ) {
+        const pause = this.betweenUtteranceDelay;
+        const previousMinDelay = this.minDelay;
+        this.utterancePause.apply(1.0, pause);
+        this.logger.debug(
+          {
+            reason: 'immediate interruption',
+            pause,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${previousMinDelay} -> ${this.minDelay}`,
+        );
+      } else if (this.betweenTurnDelay > 0) {
+        const pause = this.betweenTurnDelay;
+        const previousMaxDelay = this.maxDelay;
+        this.turnPause.apply(1.0, pause);
+        this.logger.debug(
+          {
+            reason: 'new turn (interruption)',
+            pause,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+            betweenUtteranceDelay: this.betweenUtteranceDelay,
+            betweenTurnDelay: this.betweenTurnDelay,
+          },
+          `max endpointing delay updated: ${previousMaxDelay} -> ${this.maxDelay}`,
+        );
+      }
+    } else if (this.betweenTurnDelay > 0) {
+      const pause = this.betweenTurnDelay;
+      const previousMaxDelay = this.maxDelay;
+      this.turnPause.apply(1.0, pause);
+      this.logger.debug(
+        {
+          reason: 'new turn',
+          pause,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `max endpointing delay updated due to pause: ${previousMaxDelay} -> ${this.maxDelay}`,
+      );
+    } else if (
+      this.betweenUtteranceDelay > 0 &&
+      this.agentSpeechEndedAt === undefined &&
+      this.agentSpeechStartedAt === undefined
+    ) {
+      const pause = this.betweenUtteranceDelay;
+      const previousMinDelay = this.minDelay;
+      this.utterancePause.apply(1.0, pause);
+      this.logger.debug(
+        {
+          reason: 'pause between utterances',
+          pause,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `min endpointing delay updated: ${previousMinDelay} -> ${this.minDelay}`,
+      );
+    }
+
+    this.utteranceEndedAt = endedAt;
+    this.agentSpeechStartedAt = undefined;
+    this.agentSpeechEndedAt = undefined;
+    this.speaking = false;
+    this.overlappingState = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 288-302 lines
+  updateOptions({ minDelay, maxDelay }: EndpointingUpdateOptions = {}): void {
+    if (minDelay !== undefined) {
+      this.configuredMinDelay = minDelay;
+      this.utterancePause.reset({ initial: this.configuredMinDelay, min: this.configuredMinDelay });
+      this.turnPause.reset({ min: this.configuredMinDelay });
+    }
+
+    if (maxDelay !== undefined) {
+      this.configuredMaxDelay = maxDelay;
+      this.turnPause.reset({ initial: this.configuredMaxDelay, max: this.configuredMaxDelay });
+      this.utterancePause.reset({ max: this.configuredMaxDelay });
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  if (options.mode === 'dynamic') {
+    return new DynamicEndpointing(options);
+  }
+
+  return new BaseEndpointing(options);
+}

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -11,6 +11,7 @@ export {
 } from './agent_session.js';
 export * from './avatar/index.js';
 export * from './background_audio.js';
+export * from './endpointing.js';
 export {
   type TextInputCallback,
   type TextInputEvent,

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -7,7 +7,7 @@
 export interface EndpointingOptions {
   /**
    * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on
-   * end-of-utterance prediction.
+   * recent user pauses and interruptions.
    * @defaultValue "fixed"
    */
   mode: 'fixed' | 'dynamic';


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/82).

Tracking issue: https://github.com/livekit/rosetta/issues/82

## Summary
- port the Python SDK's dynamic endpointing runtime into `@livekit/agents`, including `AudioRecognition` and `AgentActivity` integration
- extend the shared `ExpFilter` helper, export the new voice endpointing API, and add a changeset
- port the full `tests/test_endpointing.py` contract to `agents/src/voice/endpointing.test.ts`

## Source
- https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/endpointing.py
- https://github.com/livekit/agents/blob/main/tests/test_endpointing.py