### PR TITLE
Port dynamic endpointing to the Node.js voice SDK

### DIFF
--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -351,44 +351,94 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 }
 
 /** @internal */
+// Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-64 lines
 export class ExpFilter {
   #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  #maxValue: number | undefined;
+  #minValue: number | undefined;
+  #filtered: number | undefined;
 
-  constructor(alpha: number, max?: number) {
-    this.#alpha = alpha;
-    this.#max = max;
-  }
-
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+  constructor(alpha: number, maxValue?: number, minValue?: number, initialValue?: number) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
     }
-    this.#filtered = undefined;
+
+    this.#alpha = alpha;
+    this.#maxValue = maxValue;
+    this.#minValue = minValue;
+    this.#filtered = initialValue;
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
+  reset(
+    opts: {
+      alpha?: number;
+      initialValue?: number;
+      minValue?: number;
+      maxValue?: number;
+    } = {},
+  ): void {
+    if (opts.alpha !== undefined) {
+      if (!(opts.alpha > 0 && opts.alpha <= 1)) {
+        throw new Error('alpha must be in (0, 1].');
+      }
+      this.#alpha = opts.alpha;
+    }
+    if (opts.initialValue !== undefined) {
+      this.#filtered = opts.initialValue;
+    }
+    if (opts.minValue !== undefined) {
+      this.#minValue = opts.minValue;
+    }
+    if (opts.maxValue !== undefined) {
+      this.#maxValue = opts.maxValue;
+    }
+  }
+
+  apply(exp: number, sample = this.#filtered): number {
+    if (sample !== undefined && this.#filtered === undefined) {
+      this.#filtered = sample;
+    } else if (sample !== undefined && this.#filtered !== undefined) {
       const a = this.#alpha ** exp;
       this.#filtered = a * this.#filtered + (1 - a) * sample;
-    } else {
-      this.#filtered = sample;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (this.#filtered === undefined) {
+      throw new Error('sample or initial value must be given.');
     }
 
+    if (this.#maxValue !== undefined && this.#filtered > this.#maxValue) {
+      this.#filtered = this.#maxValue;
+    }
+
+    if (this.#minValue !== undefined && this.#filtered < this.#minValue) {
+      this.#filtered = this.#minValue;
+    }
+
+    return this.#filtered;
+  }
+
+  get alpha(): number {
+    return this.#alpha;
+  }
+
+  set alpha(alpha: number) {
+    this.#alpha = alpha;
+  }
+
+  get maxValue(): number | undefined {
+    return this.#maxValue;
+  }
+
+  get minValue(): number | undefined {
+    return this.#minValue;
+  }
+
+  get value(): number | undefined {
     return this.#filtered;
   }
 
   get filtered(): number | undefined {
     return this.#filtered;
-  }
-
-  set alpha(alpha: number) {
-    this.#alpha = alpha;
   }
 }
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -65,6 +65,7 @@ import {
   type RecognitionHooks,
   type STTPipeline,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import {
   AgentSessionEventTypes,
   createErrorEvent,
@@ -188,6 +189,7 @@ export class AgentActivity implements RecognitionHooks {
   private isInterruptionDetectionEnabled: boolean;
   private isInterruptionByAudioActivityEnabled: boolean;
   private isDefaultInterruptionByAudioActivityEnabled: boolean;
+  private interruptionDetected = false;
 
   private readonly onRealtimeGenerationCreated = (ev: GenerationCreatedEvent): void =>
     this.onGenerationCreated(ev);
@@ -477,12 +479,18 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 767-778 lines
+      endpointing: createEndpointing({
+        mode:
+          this.agent.turnHandling?.endpointing?.mode ??
+          this.agentSession.sessionOptions.turnHandling.endpointing.mode,
+        minDelay:
+          this.agent.turnHandling?.endpointing?.minDelay ??
+          this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
+        maxDelay:
+          this.agent.turnHandling?.endpointing?.maxDelay ??
+          this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      }),
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -922,12 +930,10 @@ export class AgentActivity implements RecognitionHooks {
 
     if (!this.vad) {
       this.agentSession._updateUserState('speaking');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfOverlapSpeech(
-          0,
-          Date.now(),
-          this.agentSession._userSpeakingSpan,
-        );
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1490-1497 lines
+        this.interruptionDetected = false;
+        this.audioRecognition.onStartOfSpeech(Date.now(), 0, this.agentSession._userSpeakingSpan);
       }
     }
 
@@ -947,8 +953,13 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1508-1514 lines
+        this.audioRecognition.onEndOfSpeech(
+          Date.now(),
+          this.agentSession._userSpeakingSpan,
+          this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
+        );
       }
       this.agentSession._updateUserState('listening');
     }
@@ -1030,11 +1041,12 @@ export class AgentActivity implements RecognitionHooks {
       lastSpeakingTime: speechStartTime,
       otelContext: otelContext.active(),
     });
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
+    if (this.audioRecognition) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1645-1655 lines
+      this.interruptionDetected = false;
+      this.audioRecognition.onStartOfSpeech(
         speechStartTime,
+        ev.speechDuration,
         this.agentSession._userSpeakingSpan,
       );
     }
@@ -1046,11 +1058,12 @@ export class AgentActivity implements RecognitionHooks {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
+    if (this.audioRecognition) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1665-1679 lines
+      this.audioRecognition.onEndOfSpeech(
         speechEndTime,
         this.agentSession._userSpeakingSpan,
+        this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
       );
     }
     this.agentSession._updateUserState('listening', {
@@ -1130,6 +1143,7 @@ export class AgentActivity implements RecognitionHooks {
     this.restoreInterruptionByAudioActivity();
     this.interruptByAudioActivity();
     if (this.audioRecognition) {
+      this.interruptionDetected = true;
       this.audioRecognition.onEndOfAgentSpeech(ev.overlapStartedAt || ev.detectedAt);
     }
   }
@@ -1838,7 +1852,8 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2195-2195 lines
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2114,7 +2129,8 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2540-2540 lines
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,6 +35,7 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import type { BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
@@ -138,10 +139,8 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
-  /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  /** Endpointing strategy. */
+  endpointing: BaseEndpointing;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +169,8 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 125-152 lines
+  private endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -224,8 +223,7 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    this.endpointing = opts.endpointing;
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,7 +273,14 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 192-218 lines
+  updateOptions(options: {
+    endpointing?: BaseEndpointing;
+    turnDetection: TurnDetectionMode | undefined;
+  }): void {
+    if (options.endpointing !== undefined) {
+      this.endpointing = options.endpointing;
+    }
     this.turnDetectionMode = options.turnDetection;
   }
 
@@ -311,12 +316,18 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-270 lines
+  async onStartOfAgentSpeech(startedAt: number) {
     this.isAgentSpeaking = true;
+    this.endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -342,6 +353,27 @@ export class AudioRecognition {
       await this.flushHeldTranscripts();
     }
     this.isAgentSpeaking = false;
+  }
+
+  onStartOfSpeech(startedAt: number, speechDuration = 0, userSpeakingSpan?: Span): void {
+    this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+
+    if (!this.isInterruptionEnabled || !this.isAgentSpeaking) {
+      return;
+    }
+
+    void this.onStartOfOverlapSpeech(speechDuration, startedAt, userSpeakingSpan);
+  }
+
+  onEndOfSpeech(endedAt: number, userSpeakingSpan?: Span, interruption?: boolean): void {
+    if (this.speaking) {
+      this.endpointing.onEndOfSpeech(
+        endedAt,
+        interruption !== undefined && !interruption && this.isAgentSpeaking,
+      );
+    }
+
+    void this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
   }
 
   /** Start interruption inference when agent is speaking and overlap speech starts. */
@@ -805,7 +837,8 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 934-958 lines
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +864,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -7,6 +7,7 @@ import { ChatContext } from '../llm/chat_context.js';
 import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
+import { BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function createHooks() {
@@ -45,8 +46,7 @@ function createRecognition(sttNode: STTNode, hooks = createHooks()) {
     recognition: new AudioRecognition({
       recognitionHooks: hooks,
       stt: sttNode,
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing(0, 0),
     }),
   };
 }

--- a/agents/src/voice/audio_recognition_span.test.ts
+++ b/agents/src/voice/audio_recognition_span.test.ts
@@ -22,6 +22,7 @@ import {
   type RecognitionHooks,
   type _TurnDetector,
 } from './audio_recognition.js';
+import { BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function setupInMemoryTracing() {
@@ -145,8 +146,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: undefined,
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'stt',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing(0, 0),
       sttModel: 'deepgram-nova2',
       sttProvider: 'deepgram',
       getLinkedParticipant: () => ({ sid: 'p1', identity: 'bob', kind: ParticipantKind.AGENT }),
@@ -254,8 +254,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: new FakeVAD(vadEvents),
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'vad',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing(0, 0),
       sttModel: 'stt-model',
       sttProvider: 'stt-provider',
       getLinkedParticipant: () => ({ sid: 'p2', identity: 'alice', kind: ParticipantKind.AGENT }),

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,481 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+initializeLogger({ pretty: false, level: 'silent' });
+
+type DynamicEndpointingInternals = {
+  utterancePause: ExpFilter;
+  turnPause: ExpFilter;
+  utteranceStartedAt?: number;
+  utteranceEndedAt?: number;
+  agentSpeechStartedAt?: number;
+  agentSpeechEndedAt?: number;
+  speaking: boolean;
+  configuredMinDelay: number;
+  configuredMaxDelay: number;
+};
+
+function internals(ep: DynamicEndpointing): DynamicEndpointingInternals {
+  return ep as unknown as DynamicEndpointingInternals;
+}
+
+// Ref: python tests/test_endpointing.py - 7-63 lines
+describe('ExponentialMovingAverage', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    const ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    const emaWithInitial = new ExpFilter(0.5, undefined, undefined, 10);
+    expect(emaWithInitial.value).toBe(10);
+
+    expect(new ExpFilter(1.0).value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0.0)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(-0.5)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(1.5)).toThrow(/alpha must be in/);
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1.0, 10.0);
+    expect(result).toBe(10.0);
+    expect(ema.value).toBe(10.0);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    const result = ema.apply(1.0, 20.0);
+    expect(result).toBe(15.0);
+    expect(ema.value).toBe(15.0);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    ema.apply(1.0, 20.0);
+    ema.apply(1.0, 20.0);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    expect(ema.value).toBe(10.0);
+    ema.reset();
+    expect(ema.value).toBe(10.0);
+
+    const emaWithReset = new ExpFilter(0.5, undefined, undefined, 10.0);
+    emaWithReset.reset({ initialValue: 5.0 });
+    expect(emaWithReset.value).toBe(5.0);
+  });
+});
+
+// Ref: python tests/test_endpointing.py - 64-545 lines
+describe('DynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.2);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(internals(ep).utterancePause.alpha).toBeCloseTo(0.9, 5);
+    expect(internals(ep).turnPause.alpha).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toEqual([0, 0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100_000);
+    expect(internals(ep).utteranceEndedAt).toBe(100_000);
+
+    const second = new DynamicEndpointing(300, 1000);
+    second.onEndOfSpeech(99_900);
+    expect(internals(second).utteranceEndedAt).toBe(99_900);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfSpeech(100_000);
+    expect(internals(ep).utteranceStartedAt).toBe(100_000);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100_000);
+    expect(internals(ep).agentSpeechStartedAt).toBe(100_000);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_500);
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(500, 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_800);
+    expect(ep.betweenTurnDelay).toBeCloseTo(800, 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_400);
+    ep.onEndOfSpeech(100_500, false);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_600);
+    ep.onStartOfSpeech(101_500);
+    ep.onEndOfSpeech(102_000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 600 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    expect(internals(ep).agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(100_250, true);
+    expect(ep.overlapping).toBe(true);
+
+    ep.onEndOfSpeech(100_500);
+
+    expect(ep.overlapping).toBe(false);
+    expect(internals(ep).agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(300, 5);
+  });
+
+  it('test_update_options', () => {
+    const minEp = new DynamicEndpointing(300, 1000);
+    minEp.updateOptions({ minDelay: 500 });
+    expect(minEp.minDelay).toBe(500);
+    expect(internals(minEp).configuredMinDelay).toBe(500);
+
+    const maxEp = new DynamicEndpointing(300, 1000);
+    maxEp.updateOptions({ maxDelay: 2000 });
+    expect(maxEp.maxDelay).toBe(2000);
+    expect(internals(maxEp).configuredMaxDelay).toBe(2000);
+
+    const both = new DynamicEndpointing(300, 1000);
+    both.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(both.minDelay).toBe(500);
+    expect(both.maxDelay).toBe(2000);
+
+    const unchanged = new DynamicEndpointing(300, 1000);
+    unchanged.updateOptions();
+    expect(unchanged.minDelay).toBe(300);
+    expect(unchanged.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(102_000);
+    ep.onStartOfSpeech(105_000);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_100);
+    ep.onStartOfSpeech(100_500);
+    expect(ep.maxDelay).toBeGreaterThanOrEqual(internals(ep).configuredMinDelay);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    expect(internals(ep).agentSpeechStartedAt).toBeDefined();
+
+    ep.onStartOfSpeech(102_000);
+    ep.onEndOfSpeech(103_000, false);
+    expect(internals(ep).agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    ep.onStartOfSpeech(100_250, true);
+
+    expect(ep.overlapping).toBe(true);
+    const previous = [ep.minDelay, ep.maxDelay];
+
+    ep.onStartOfSpeech(100_350);
+
+    expect(ep.overlapping).toBe(true);
+    expect([ep.minDelay, ep.maxDelay]).toEqual(previous);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_900);
+    ep.onStartOfSpeech(101_800);
+    ep.onEndOfSpeech(102_000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing(60, 1000, 1.0);
+
+    ep.onEndOfSpeech(99_000);
+    ep.onStartOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    ep.onStartOfSpeech(100_250, true);
+
+    expect(internals(ep).utteranceEndedAt).toBe(100_199);
+    expect(ep.minDelay).toBeCloseTo(60, 5);
+    expect(ep.maxDelay).toBeCloseTo(1000, 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+    expect(internals(ep).utterancePause.alpha).toBeCloseTo(0.5, 5);
+    expect(internals(ep).turnPause.alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(internals(ep).utterancePause.minValue).toBe(500);
+    expect(internals(ep).turnPause.maxValue).toBe(2000);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_200);
+    expect(ep.minDelay).toBeCloseTo(500, 5);
+
+    ep.onEndOfSpeech(101_000);
+    ep.onStartOfAgentSpeech(102_800);
+    ep.onStartOfSpeech(103_500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(101_500, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101_800, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect(internals(ep).utteranceStartedAt).toBeUndefined();
+    expect(internals(ep).utteranceEndedAt).toBeUndefined();
+    expect(ep.overlapping).toBe(false);
+    expect(internals(ep).speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_400, false);
+    ep.onEndOfSpeech(100_600, true);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(100_600, true);
+
+    ep.onEndOfSpeech(100_800, true);
+
+    expect(internals(ep).utteranceEndedAt).toBe(100_800);
+    expect(internals(ep).speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(101_000, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+    ep.onEndOfSpeech(101_500, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect(internals(ep).utteranceStartedAt).toBeUndefined();
+    expect(internals(ep).utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    ep.onStartOfAgentSpeech(100_000);
+    ep.onStartOfSpeech(100_100, true);
+    expect(ep.overlapping).toBe(true);
+    expect(internals(ep).agentSpeechStartedAt).toBe(100_000);
+
+    ep.onEndOfAgentSpeech(101_000);
+
+    expect(internals(ep).agentSpeechEndedAt).toBe(101_000);
+    expect(internals(ep).agentSpeechStartedAt).toBe(100_000);
+    expect(ep.overlapping).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_900);
+    ep.onStartOfSpeech(101_800, false);
+    ep.onEndOfSpeech(102_000);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    expect(internals(ep).speaking).toBe(false);
+    ep.onStartOfSpeech(100_000);
+    expect(internals(ep).speaking).toBe(true);
+    ep.onEndOfSpeech(100_500);
+    expect(internals(ep).speaking).toBe(false);
+  });
+
+  it.each([
+    ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+    ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+    ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+    ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+    ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+    ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+    ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+    ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+    ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+  ] as const)(
+    'test_all_overlapping_and_should_ignore_combos[%s]',
+    (
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ) => {
+      const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+      ep.onStartOfSpeech(99_000);
+      ep.onEndOfSpeech(100_000);
+
+      let userStart = 100_400;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100_500);
+        ep.onEndOfAgentSpeech(101_000);
+        userStart = 101_500;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100_150);
+          userStart = 100_350;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100_200);
+          userStart = 101_500;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100_150);
+          userStart = 100_400;
+        } else {
+          ep.onStartOfAgentSpeech(100_900);
+          userStart = 101_800;
+        }
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping);
+
+      const previousMin = ep.minDelay;
+      const previousMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + 500, shouldIgnore);
+
+      expect(ep.minDelay !== previousMin, `[${label}] minDelay change mismatch`).toBe(
+        expectMinChange,
+      );
+      expect(ep.maxDelay !== previousMax, `[${label}] maxDelay change mismatch`).toBe(
+        expectMaxChange,
+      );
+      expect(internals(ep).speaking, `[${label}] speaking should be false`).toBe(false);
+      expect(ep.overlapping, `[${label}] overlapping should be false`).toBe(false);
+    },
+  );
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onStartOfSpeech(100_000);
+    ep.onEndOfSpeech(101_000);
+
+    ep.onStartOfAgentSpeech(101_500);
+
+    ep.onStartOfSpeech(102_500, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102_800, true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(103_000);
+    ep.onStartOfSpeech(103_500);
+    ep.onEndOfSpeech(104_000);
+
+    expect(internals(ep).speaking).toBe(false);
+    expect(internals(ep).agentSpeechStartedAt).toBeUndefined();
+  });
+});

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 7-8 lines
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250;
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-48 lines
+export class BaseEndpointing {
+  protected configuredMinDelay: number;
+  protected configuredMaxDelay: number;
+  protected isOverlapping = false;
+
+  constructor(minDelay: number, maxDelay: number) {
+    this.configuredMinDelay = minDelay;
+    this.configuredMaxDelay = maxDelay;
+  }
+
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this.configuredMinDelay = minDelay;
+    }
+    if (maxDelay !== undefined) {
+      this.configuredMaxDelay = maxDelay;
+    }
+  }
+
+  get minDelay(): number {
+    return this.configuredMinDelay;
+  }
+
+  get maxDelay(): number {
+    return this.configuredMaxDelay;
+  }
+
+  get overlapping(): boolean {
+    return this.isOverlapping;
+  }
+
+  onStartOfSpeech(startedAt: number, overlapping = false): void {
+    void startedAt;
+    this.isOverlapping = overlapping;
+  }
+
+  onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    void endedAt;
+    void shouldIgnore;
+    this.isOverlapping = false;
+  }
+
+  onStartOfAgentSpeech(startedAt: number): void {
+    void startedAt;
+  }
+
+  onEndOfAgentSpeech(endedAt: number): void {
+    void endedAt;
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-304 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private readonly logger = log();
+  private readonly utterancePause: ExpFilter;
+  private readonly turnPause: ExpFilter;
+  private utteranceStartedAt: number | undefined;
+  private utteranceEndedAt: number | undefined;
+  private agentSpeechStartedAt: number | undefined;
+  private agentSpeechEndedAt: number | undefined;
+  private speaking = false;
+
+  constructor(minDelay: number, maxDelay: number, alpha = 0.9) {
+    super(minDelay, maxDelay);
+    this.utterancePause = new ExpFilter(alpha, maxDelay, minDelay, minDelay);
+    this.turnPause = new ExpFilter(alpha, maxDelay, minDelay, maxDelay);
+  }
+
+  get minDelay(): number {
+    return this.utterancePause.value ?? this.configuredMinDelay;
+  }
+
+  get maxDelay(): number {
+    return Math.max(this.turnPause.value ?? this.configuredMaxDelay, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this.utteranceEndedAt === undefined || this.utteranceStartedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.utteranceStartedAt - this.utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this.agentSpeechStartedAt === undefined || this.utteranceEndedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.agentSpeechStartedAt - this.utteranceEndedAt);
+  }
+
+  get immediateInterruptionDelay(): [number, number] {
+    if (this.utteranceStartedAt === undefined || this.agentSpeechStartedAt === undefined) {
+      return [0, 0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this.agentSpeechStartedAt = startedAt;
+    this.agentSpeechEndedAt = undefined;
+    this.isOverlapping = false;
+  }
+
+  override onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this.agentSpeechStartedAt !== undefined &&
+      (this.agentSpeechEndedAt === undefined || this.agentSpeechEndedAt < this.agentSpeechStartedAt)
+    ) {
+      this.agentSpeechEndedAt = endedAt;
+    }
+    this.isOverlapping = false;
+  }
+
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this.isOverlapping) {
+      return;
+    }
+
+    if (
+      this.utteranceStartedAt !== undefined &&
+      this.utteranceEndedAt !== undefined &&
+      this.agentSpeechStartedAt !== undefined &&
+      this.utteranceEndedAt < this.utteranceStartedAt &&
+      overlapping
+    ) {
+      this.utteranceEndedAt = this.agentSpeechStartedAt - 1;
+      this.logger.trace({ utteranceEndedAt: this.utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this.utteranceStartedAt = startedAt;
+    this.isOverlapping = overlapping;
+    this.speaking = true;
+  }
+
+  override onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    if (shouldIgnore && this.isOverlapping) {
+      const withinGracePeriod =
+        this.utteranceStartedAt !== undefined &&
+        this.agentSpeechStartedAt !== undefined &&
+        Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD;
+
+      if (withinGracePeriod) {
+        this.logger.trace(
+          {
+            distance: Math.abs(this.utteranceStartedAt! - this.agentSpeechStartedAt!),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true within grace period',
+        );
+      } else {
+        this.isOverlapping = false;
+        this.speaking = false;
+        this.utteranceStartedAt = undefined;
+        this.utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    const isInterruption =
+      this.isOverlapping ||
+      (this.agentSpeechStartedAt !== undefined && this.agentSpeechEndedAt === undefined);
+
+    if (isInterruption) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const betweenUtteranceDelay = this.betweenUtteranceDelay;
+
+      if (
+        interruptionDelay > 0 &&
+        interruptionDelay <= this.minDelay &&
+        turnDelay > 0 &&
+        turnDelay <= this.maxDelay &&
+        betweenUtteranceDelay > 0
+      ) {
+        const previousValue = this.minDelay;
+        this.utterancePause.apply(1.0, betweenUtteranceDelay);
+        this.logger.debug(
+          {
+            reason: 'immediate interruption',
+            pause: betweenUtteranceDelay,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${previousValue} -> ${this.minDelay}`,
+        );
+      } else if (this.betweenTurnDelay > 0) {
+        const pause = this.betweenTurnDelay;
+        const previousValue = this.maxDelay;
+        this.turnPause.apply(1.0, pause);
+        this.logger.debug(
+          {
+            reason: 'new turn (interruption)',
+            pause,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+            betweenUtteranceDelay,
+            betweenTurnDelay: pause,
+          },
+          `max endpointing delay updated: ${previousValue} -> ${this.maxDelay}`,
+        );
+      }
+    } else if (this.betweenTurnDelay > 0) {
+      const pause = this.betweenTurnDelay;
+      const previousValue = this.maxDelay;
+      this.turnPause.apply(1.0, pause);
+      this.logger.debug(
+        {
+          reason: 'new turn',
+          pause,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `max endpointing delay updated due to pause: ${previousValue} -> ${this.maxDelay}`,
+      );
+    } else if (
+      this.betweenUtteranceDelay > 0 &&
+      this.agentSpeechEndedAt === undefined &&
+      this.agentSpeechStartedAt === undefined
+    ) {
+      const pause = this.betweenUtteranceDelay;
+      const previousValue = this.minDelay;
+      this.utterancePause.apply(1.0, pause);
+      this.logger.debug(
+        {
+          reason: 'pause between utterances',
+          pause,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `min endpointing delay updated: ${previousValue} -> ${this.minDelay}`,
+      );
+    }
+
+    this.utteranceEndedAt = endedAt;
+    this.agentSpeechStartedAt = undefined;
+    this.agentSpeechEndedAt = undefined;
+    this.speaking = false;
+    this.isOverlapping = false;
+  }
+
+  override updateOptions({
+    minDelay,
+    maxDelay,
+  }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this.configuredMinDelay = minDelay;
+      this.utterancePause.reset({ initialValue: minDelay, minValue: minDelay });
+      this.turnPause.reset({ minValue: minDelay });
+    }
+
+    if (maxDelay !== undefined) {
+      this.configuredMaxDelay = maxDelay;
+      this.turnPause.reset({ initialValue: maxDelay, maxValue: maxDelay });
+      this.utterancePause.reset({ maxValue: maxDelay });
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  switch (options.mode) {
+    case 'dynamic':
+      return new DynamicEndpointing(options.minDelay, options.maxDelay);
+    default:
+      return new BaseEndpointing(options.minDelay, options.maxDelay);
+  }
+}

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -22,6 +22,7 @@ export {
   RoomSessionTransport,
 } from './remote_session.js';
 export * from './events.js';
+export * from './endpointing.js';
 export { type TimedString } from './io.js';
 export * from './report.js';
 export * from './room_io/index.js';


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/93).

Tracking issue: https://github.com/livekit/rosetta/issues/93

## Summary
- port the Python `DynamicEndpointing` strategy and wire it into Node.js voice endpointing so end-of-turn delay adapts to pauses, interruptions, and backchannels
- extend the shared `ExpFilter` helper instead of duplicating the Python filter logic, and export the new endpointing API from `voice/index.ts`
- port the full `tests/test_endpointing.py` contract to `agents/src/voice/endpointing.test.ts`

## Source
- implementation: https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/endpointing.py
- tests: https://github.com/livekit/agents/blob/main/tests/test_endpointing.py