### PR TITLE
fix(deepgram): avoid double-encoding STT query params

### DIFF
--- a/.changeset/fix-deepgram-query-encoding.md
+++ b/.changeset/fix-deepgram-query-encoding.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-deepgram": patch
+---
+
+fix(deepgram): avoid double-encoding STT query params

--- a/plugins/deepgram/src/_utils.test.ts
+++ b/plugins/deepgram/src/_utils.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { appendQueryParams } from './_utils.js';
+
+describe('appendQueryParams', () => {
+  it('preserves non-ASCII keyterm and keywords values in the websocket URL', () => {
+    const url = new URL('wss://api.deepgram.com/v1/listen');
+
+    appendQueryParams(url, {
+      keyterm: ['słucham', 'dzień dobry', 'znamię', 'dziękuję'],
+      keywords: ['potwierdź:3', 'żółć:1.5'],
+    });
+
+    expect(url.searchParams.getAll('keyterm')).toEqual([
+      'słucham',
+      'dzień dobry',
+      'znamię',
+      'dziękuję',
+    ]);
+    expect(url.searchParams.getAll('keywords')).toEqual(['potwierdź:3', 'żółć:1.5']);
+    expect(url.toString()).not.toContain('%25');
+  });
+});

--- a/plugins/deepgram/src/_utils.ts
+++ b/plugins/deepgram/src/_utils.ts
@@ -48,3 +48,22 @@ export class PeriodicCollector<T> {
     this.lastFlushTime = performance.now() / 1000;
   }
 }
+
+type QueryParamScalar = string | number | boolean;
+type QueryParamValue = QueryParamScalar | QueryParamScalar[];
+
+export function appendQueryParams(
+  url: URL,
+  params: Record<string, QueryParamValue | undefined>,
+): void {
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined) return;
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => url.searchParams.append(key, String(item)));
+      return;
+    }
+
+    url.searchParams.append(key, String(value));
+  });
+}

--- a/plugins/deepgram/src/stt.ts
+++ b/plugins/deepgram/src/stt.ts
@@ -17,7 +17,7 @@ import {
 } from '@livekit/agents';
 import type { AudioFrame } from '@livekit/rtc-node';
 import { WebSocket } from 'ws';
-import { PeriodicCollector } from './_utils.js';
+import { PeriodicCollector, appendQueryParams } from './_utils.js';
 import type { STTLanguages, STTModels } from './models.js';
 
 export interface STTOptions {
@@ -195,15 +195,7 @@ export class SpeechStream extends stt.SpeechStream {
         language: this.#opts.language,
         mip_opt_out: this.#opts.mipOptOut,
       };
-      Object.entries(params).forEach(([k, v]) => {
-        if (v !== undefined) {
-          if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
-            streamURL.searchParams.append(k, encodeURIComponent(v));
-          } else {
-            v.forEach((x) => streamURL.searchParams.append(k, encodeURIComponent(x)));
-          }
-        }
-      });
+      appendQueryParams(streamURL, params);
 
       ws = new WebSocket(streamURL, {
         headers: { Authorization: `Token ${this.#opts.apiKey}` },


### PR DESCRIPTION
## Summary
- preserve Deepgram STT query parameters for `keyterm` and `keywords`, including non-ASCII values
- add regression coverage so Deepgram receives the original terms instead of percent-escaped text

## Description
The Deepgram STT websocket URL currently turns `keyterm` and `keywords` values into percent-escaped strings before they are added to the query string. `URLSearchParams` already performs query encoding, so these values end up encoded twice.

That means Deepgram can receive values like `s%C5%82ucham` instead of `słucham`. The request still succeeds, but keyword prompting silently stops working for languages that rely on diacritics. The same issue also affects boosted `keywords` entries.

## Why this matters
- it breaks `keyterm` prompting for languages such as Polish, Czech, German, Spanish, and Portuguese
- it can break `keywords` boosts when the values include non-ASCII text or `:` separators
- the failure is silent, so users see degraded transcription quality without an explicit error

## Testing
- [x] Added regression coverage for non-ASCII `keyterm` values and boosted `keywords`
- [x] `pnpm vitest run plugins/deepgram/src/_utils.test.ts`
