### PR TITLE
feat(voice): add dynamic endpointing

### DIFF
--- a/.changeset/slow-candles-float.md
+++ b/.changeset/slow-candles-float.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': minor
+---
+
+feat(voice): add dynamic endpointing support

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -354,30 +354,66 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 export class ExpFilter {
   #alpha: number;
   #max?: number;
+  #min?: number;
   #filtered?: number = undefined;
 
-  constructor(alpha: number, max?: number) {
-    this.#alpha = alpha;
-    this.#max = max;
-  }
-
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+  // Ref: source livekit-agents/livekit/agents/utils/exp_filter.py - 5-64
+  constructor(
+    alpha: number,
+    options?: {
+      max?: number;
+      min?: number;
+      initial?: number;
+    },
+  ) {
+    if (alpha <= 0 || alpha > 1) {
+      throw new Error('alpha must be in (0, 1].');
     }
-    this.#filtered = undefined;
+
+    this.#alpha = alpha;
+    this.#max = options?.max;
+    this.#min = options?.min;
+    this.#filtered = options?.initial;
   }
 
+  // Ref: source livekit-agents/livekit/agents/utils/exp_filter.py - 21-37
+  reset(options?: { alpha?: number; initial?: number; min?: number; max?: number }) {
+    if (options?.alpha !== undefined) {
+      if (options.alpha <= 0 || options.alpha > 1) {
+        throw new Error('alpha must be in (0, 1].');
+      }
+
+      this.#alpha = options.alpha;
+    }
+
+    if (options?.initial !== undefined) {
+      this.#filtered = options.initial;
+    }
+
+    if (options?.min !== undefined) {
+      this.#min = options.min;
+    }
+
+    if (options?.max !== undefined) {
+      this.#max = options.max;
+    }
+  }
+
+  // Ref: source livekit-agents/livekit/agents/utils/exp_filter.py - 38-57
   apply(exp: number, sample: number): number {
-    if (this.#filtered) {
+    if (this.#filtered !== undefined) {
       const a = this.#alpha ** exp;
       this.#filtered = a * this.#filtered + (1 - a) * sample;
     } else {
       this.#filtered = sample;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
+    if (this.#max !== undefined && this.#filtered > this.#max) {
       this.#filtered = this.#max;
+    }
+
+    if (this.#min !== undefined && this.#filtered < this.#min) {
+      this.#filtered = this.#min;
     }
 
     return this.#filtered;
@@ -387,7 +423,27 @@ export class ExpFilter {
     return this.#filtered;
   }
 
+  get value(): number | undefined {
+    return this.#filtered;
+  }
+
+  get alpha(): number {
+    return this.#alpha;
+  }
+
+  get min(): number | undefined {
+    return this.#min;
+  }
+
+  get max(): number | undefined {
+    return this.#max;
+  }
+
   set alpha(alpha: number) {
+    if (alpha <= 0 || alpha > 1) {
+      throw new Error('alpha must be in (0, 1].');
+    }
+
     this.#alpha = alpha;
   }
 }

--- a/agents/src/voice/agent.test.ts
+++ b/agents/src/voice/agent.test.ts
@@ -421,5 +421,93 @@ describe('Agent', () => {
         }
       }
     });
+
+    it('should drive audio recognition from realtime speech events without VAD', () => {
+      const audioRecognition = {
+        onStartOfSpeech: vi.fn(),
+        onEndOfSpeech: vi.fn(),
+      };
+      const activity = Object.create(AgentActivity.prototype) as any;
+      activity.audioRecognition = audioRecognition;
+      activity.isInterruptionDetectionEnabled = false;
+      activity.interruptionDetected = false;
+      activity.agent = {
+        vad: undefined,
+      };
+      activity.agentSession = {
+        vad: undefined,
+        _updateUserState: vi.fn(),
+        _userSpeakingSpan: { spanId: 'user-speaking' },
+        emit: vi.fn(),
+      };
+      activity.logger = { info: vi.fn(), error: vi.fn() };
+      activity.interrupt = vi.fn();
+
+      AgentActivity.prototype.onInputSpeechStarted.call(activity, {} as any);
+      expect(audioRecognition.onStartOfSpeech).toHaveBeenCalledWith(
+        expect.any(Number),
+        0,
+        activity.agentSession._userSpeakingSpan,
+      );
+      expect(activity.agentSession._updateUserState).toHaveBeenCalledWith('speaking');
+      expect(activity.interrupt).toHaveBeenCalledTimes(1);
+
+      AgentActivity.prototype.onInputSpeechStopped.call(activity, {
+        userTranscriptionEnabled: false,
+      } as any);
+      expect(audioRecognition.onEndOfSpeech).toHaveBeenCalledWith(
+        expect.any(Number),
+        activity.agentSession._userSpeakingSpan,
+        undefined,
+      );
+      expect(activity.agentSession._updateUserState).toHaveBeenCalledWith('listening');
+    });
+
+    it('should synthesize overlap speech before interrupting audio activity', () => {
+      const audioRecognition = {
+        onStartOfSpeech: vi.fn(),
+        currentTranscript: '',
+      };
+      const realtimeSession = {
+        startUserActivity: vi.fn(),
+        interrupt: vi.fn(),
+      };
+      const currentSpeech = {
+        interrupted: false,
+        allowInterruptions: true,
+        interrupt: vi.fn(),
+        id: 'speech-1',
+      };
+      const activity = Object.create(AgentActivity.prototype) as any;
+      activity.audioRecognition = audioRecognition;
+      activity.agent = {
+        llm: undefined,
+        stt: undefined,
+      };
+      activity.agentSession = {
+        _aecWarmupRemaining: 0,
+        agentState: 'speaking',
+        llm: undefined,
+        stt: undefined,
+        sessionOptions: {
+          turnHandling: {
+            interruption: {
+              minWords: 0,
+            },
+          },
+        },
+      };
+      activity.isInterruptionByAudioActivityEnabled = true;
+      activity._currentSpeech = currentSpeech;
+      activity.realtimeSession = realtimeSession;
+      activity.logger = { info: vi.fn() };
+
+      (activity as any).interruptByAudioActivity();
+
+      expect(audioRecognition.onStartOfSpeech).toHaveBeenCalledWith(expect.any(Number));
+      expect(realtimeSession.startUserActivity).toHaveBeenCalledTimes(1);
+      expect(realtimeSession.interrupt).toHaveBeenCalledTimes(1);
+      expect(currentSpeech.interrupt).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -65,6 +65,7 @@ import {
   type RecognitionHooks,
   type STTPipeline,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import {
   AgentSessionEventTypes,
   createErrorEvent,
@@ -88,6 +89,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -185,6 +187,7 @@ export class AgentActivity implements RecognitionHooks {
   private _preemptiveGeneration?: PreemptiveGeneration;
   private _preemptiveGenerationCount = 0;
   private interruptionDetector?: AdaptiveInterruptionDetector;
+  private interruptionDetected = false;
   private isInterruptionDetectionEnabled: boolean;
   private isInterruptionByAudioActivityEnabled: boolean;
   private isDefaultInterruptionByAudioActivityEnabled: boolean;
@@ -469,6 +472,12 @@ export class AgentActivity implements RecognitionHooks {
       this.vad.on('metrics_collected', this.onMetricsCollected);
     }
 
+    // Ref: source livekit-agents/livekit/agents/voice/agent_activity.py - 321-329
+    const endpointing = createEndpointing({
+      ...this.agentSession.sessionOptions.turnHandling.endpointing,
+      ...this.agent.turnHandling?.endpointing,
+    });
+
     this.audioRecognition = new AudioRecognition({
       recognitionHooks: this,
       // Disable stt node if stt is not provided
@@ -477,12 +486,7 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      endpointing,
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -661,20 +665,6 @@ export class AgentActivity implements RecognitionHooks {
     return this.agent.turnHandling ?? this.agentSession.sessionOptions.turnHandling;
   }
 
-  // get minEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.minDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.minDelay
-  //   );
-  // }
-
-  // get maxEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.maxDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay
-  //   );
-  // }
-
   get toolCtx(): ToolContext {
     return this.agent.toolCtx;
   }
@@ -715,11 +705,14 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
+  // Ref: source livekit-agents/livekit/agents/voice/agent_activity.py - 431-482
   updateOptions({
     toolChoice,
+    endpointing,
     turnDetection,
   }: {
     toolChoice?: ToolChoice | null;
+    endpointing?: EndpointingOptions;
     turnDetection?: TurnDetectionMode;
   }): void {
     if (toolChoice !== undefined) {
@@ -743,7 +736,10 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (this.audioRecognition) {
-      this.audioRecognition.updateOptions({ turnDetection: this.turnDetectionMode });
+      this.audioRecognition.updateOptions({
+        endpointing: endpointing ? createEndpointing(endpointing) : undefined,
+        turnDetection: this.turnDetectionMode,
+      });
     }
   }
 
@@ -917,15 +913,18 @@ export class AgentActivity implements RecognitionHooks {
 
   // -- Realtime Session events --
 
+  // Ref: source livekit-agents/livekit/agents/voice/agent_activity.py - 1490-1506
   onInputSpeechStarted(_ev: InputSpeechStartedEvent): void {
     this.logger.info('onInputSpeechStarted');
 
     if (!this.vad) {
+      const speechStartTime = Date.now();
       this.agentSession._updateUserState('speaking');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfOverlapSpeech(
+      this.interruptionDetected = false;
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfSpeech(
+          speechStartTime,
           0,
-          Date.now(),
           this.agentSession._userSpeakingSpan,
         );
       }
@@ -943,12 +942,18 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
+  // Ref: source livekit-agents/livekit/agents/voice/agent_activity.py - 1508-1522
   onInputSpeechStopped(ev: InputSpeechStoppedEvent): void {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
+      const speechEndTime = Date.now();
+      if (this.audioRecognition) {
+        this.audioRecognition.onEndOfSpeech(
+          speechEndTime,
+          this.agentSession._userSpeakingSpan,
+          this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
+        );
       }
       this.agentSession._updateUserState('listening');
     }
@@ -1020,6 +1025,7 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   // recognition hooks
+  // Ref: source livekit-agents/livekit/agents/voice/agent_activity.py - 1645-1663
   onStartOfSpeech(ev: VADEvent): void {
     let speechStartTime = Date.now();
     if (ev) {
@@ -1030,27 +1036,28 @@ export class AgentActivity implements RecognitionHooks {
       lastSpeakingTime: speechStartTime,
       otelContext: otelContext.active(),
     });
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
+    this.interruptionDetected = false;
+    if (this.audioRecognition) {
+      this.audioRecognition.onStartOfSpeech(
         speechStartTime,
+        ev.speechDuration,
         this.agentSession._userSpeakingSpan,
       );
     }
   }
 
+  // Ref: source livekit-agents/livekit/agents/voice/agent_activity.py - 1665-1694
   onEndOfSpeech(ev: VADEvent): void {
     let speechEndTime = Date.now();
     if (ev) {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
+    if (this.audioRecognition) {
+      this.audioRecognition.onEndOfSpeech(
         speechEndTime,
         this.agentSession._userSpeakingSpan,
+        this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
       );
     }
     this.agentSession._updateUserState('listening', {
@@ -1072,6 +1079,7 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
+  // Ref: source livekit-agents/livekit/agents/voice/agent_activity.py - 1565-1642
   private interruptByAudioActivity(): void {
     if (!this.isInterruptionByAudioActivityEnabled) {
       return;
@@ -1117,6 +1125,10 @@ export class AgentActivity implements RecognitionHooks {
       !this._currentSpeech.interrupted &&
       this._currentSpeech.allowInterruptions
     ) {
+      if (this.audioRecognition && this.agentSession.agentState === 'speaking') {
+        this.audioRecognition.onStartOfSpeech(Date.now());
+      }
+
       this.logger.info(
         { 'speech id': this._currentSpeech.id },
         'speech interrupted by audio activity',
@@ -1126,7 +1138,9 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
+  // Ref: source livekit-agents/livekit/agents/voice/agent_activity.py - 1721-1731
   onInterruption(ev: OverlappingSpeechEvent) {
+    this.interruptionDetected = true;
     this.restoreInterruptionByAudioActivity();
     this.interruptByAudioActivity();
     if (this.audioRecognition) {
@@ -1837,8 +1851,10 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -1924,7 +1940,7 @@ export class AgentActivity implements RecognitionHooks {
 
     if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+      if (this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
       this.restoreInterruptionByAudioActivity();
@@ -2113,8 +2129,10 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2271,8 +2289,10 @@ export class AgentActivity implements RecognitionHooks {
 
       if (this.agentSession.agentState === 'speaking') {
         this.agentSession._updateAgentState('listening');
-        if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+        if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        }
+        if (this.isInterruptionDetectionEnabled) {
           this.restoreInterruptionByAudioActivity();
         }
       }
@@ -2314,11 +2334,11 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._updateAgentState('thinking');
     } else if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
-          this.restoreInterruptionByAudioActivity();
-        }
+      if (this.audioRecognition) {
+        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+      }
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
       }
     }
 

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,6 +35,7 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import type { BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
@@ -138,10 +139,8 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
-  /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  /** Endpointing strategy. */
+  endpointing: BaseEndpointing;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +169,7 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  private endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -224,8 +222,7 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    this.endpointing = opts.endpointing;
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,7 +272,15 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
+  // Ref: source livekit-agents/livekit/agents/voice/audio_recognition.py - 200-218
+  updateOptions(options: {
+    endpointing?: BaseEndpointing;
+    turnDetection: TurnDetectionMode | undefined;
+  }): void {
+    if (options.endpointing !== undefined) {
+      this.endpointing = options.endpointing;
+    }
+
     this.turnDetectionMode = options.turnDetection;
   }
 
@@ -311,12 +316,19 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: source livekit-agents/livekit/agents/voice/audio_recognition.py - 238-243
+  async onStartOfAgentSpeech(startedAt = Date.now()) {
     this.isAgentSpeaking = true;
+    this.endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: source livekit-agents/livekit/agents/voice/audio_recognition.py - 245-270
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -342,6 +354,28 @@ export class AudioRecognition {
       await this.flushHeldTranscripts();
     }
     this.isAgentSpeaking = false;
+  }
+
+  // Ref: source livekit-agents/livekit/agents/voice/audio_recognition.py - 272-305
+  onStartOfSpeech(startedAt: number, speechDuration = 0, userSpeakingSpan?: Span): void {
+    this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+    this.speaking = true;
+
+    if (!this.isInterruptionEnabled || !this.isAgentSpeaking) {
+      return;
+    }
+
+    void this.onStartOfOverlapSpeech(speechDuration, startedAt, userSpeakingSpan);
+  }
+
+  // Ref: source livekit-agents/livekit/agents/voice/audio_recognition.py - 291-329
+  onEndOfSpeech(endedAt: number, userSpeakingSpan?: Span, interruption?: boolean): void {
+    if (this.speaking) {
+      this.endpointing.onEndOfSpeech(endedAt, interruption === false && this.isAgentSpeaking);
+    }
+
+    this.speaking = false;
+    void this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
   }
 
   /** Start interruption inference when agent is speaking and overlap speech starts. */
@@ -805,7 +839,7 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +865,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -7,6 +7,7 @@ import { ChatContext } from '../llm/chat_context.js';
 import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
+import { DynamicEndpointing, createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function createHooks() {
@@ -45,8 +46,7 @@ function createRecognition(sttNode: STTNode, hooks = createHooks()) {
     recognition: new AudioRecognition({
       recognitionHooks: hooks,
       stt: sttNode,
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
     }),
   };
 }
@@ -223,6 +223,37 @@ describe('AudioRecognition STT pipeline handoff', () => {
 
       expect(sttNodeCalls).toBe(1);
       expect((recognition as any).sttPipeline).toBeUndefined();
+    } finally {
+      await recognition.close();
+    }
+  });
+
+  it('preserves learned dynamic endpointing state across clearUserTurn', async () => {
+    const sttNode: STTNode = async () =>
+      new ReadableStream<SpeechEvent | string>({
+        start() {},
+      });
+
+    const endpointing = new DynamicEndpointing(300, 1000, 0.5);
+    endpointing.onEndOfSpeech(100000);
+    endpointing.onStartOfSpeech(100400);
+    endpointing.onEndOfSpeech(100600);
+
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      stt: sttNode,
+      endpointing,
+    });
+
+    const learnedMinDelay = endpointing.minDelay;
+
+    try {
+      await recognition.start();
+      recognition.clearUserTurn();
+      await flushTasks();
+
+      expect((recognition as any).endpointing).toBe(endpointing);
+      expect(endpointing.minDelay).toBe(learnedMinDelay);
     } finally {
       await recognition.close();
     }

--- a/agents/src/voice/audio_recognition_span.test.ts
+++ b/agents/src/voice/audio_recognition_span.test.ts
@@ -22,6 +22,7 @@ import {
   type RecognitionHooks,
   type _TurnDetector,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function setupInMemoryTracing() {
@@ -145,8 +146,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: undefined,
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'stt',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
       sttModel: 'deepgram-nova2',
       sttProvider: 'deepgram',
       getLinkedParticipant: () => ({ sid: 'p1', identity: 'bob', kind: ParticipantKind.AGENT }),
@@ -254,8 +254,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: new FakeVAD(vadEvents),
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'vad',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
       sttModel: 'stt-model',
       sttProvider: 'stt-provider',
       getLinkedParticipant: () => ({ sid: 'p2', identity: 'alice', kind: ParticipantKind.AGENT }),

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,511 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { ExpFilter } from '../utils.js';
+import { AudioRecognition, type RecognitionHooks } from './audio_recognition.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+describe('ExpFilter', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    const ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    const emaWithInitial = new ExpFilter(0.5, { initial: 10 });
+    expect(emaWithInitial.value).toBe(10);
+
+    expect(new ExpFilter(1).value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(-0.5)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(1.5)).toThrow('alpha must be in');
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    expect(ema.apply(1, 10)).toBe(10);
+    expect(ema.value).toBe(10);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, { initial: 10 });
+    expect(ema.apply(1, 20)).toBe(15);
+    expect(ema.value).toBe(15);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, { initial: 10 });
+    ema.apply(1, 20);
+    ema.apply(1, 20);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    const ema = new ExpFilter(0.5, { initial: 10 });
+    expect(ema.value).toBe(10);
+    ema.reset();
+    expect(ema.value).toBe(10);
+
+    const emaWithReset = new ExpFilter(0.5, { initial: 10 });
+    emaWithReset.reset({ initial: 5 });
+    expect(emaWithReset.value).toBe(5);
+  });
+});
+
+describe('DynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.2);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    const state = ep as any;
+    expect(state.utterancePause.alpha).toBeCloseTo(0.9, 5);
+    expect(state.turnPause.alpha).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toEqual([0, 0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    expect((ep as any).utteranceEndedAt).toBe(100000);
+
+    const second = new DynamicEndpointing(300, 1000);
+    second.onEndOfSpeech(99900);
+    expect((second as any).utteranceEndedAt).toBe(99900);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfSpeech(100000);
+    expect((ep as any).utteranceStartedAt).toBe(100000);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100000);
+    expect((ep as any).agentSpeechStartedAt).toBe(100000);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100500);
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(500, 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100800);
+    expect(ep.betweenTurnDelay).toBeCloseTo(800, 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400);
+    ep.onEndOfSpeech(100500, false);
+
+    expect(ep.minDelay).toBeCloseTo(0.5 * 400 + 0.5 * initialMin, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100600);
+    ep.onStartOfSpeech(101500);
+    ep.onEndOfSpeech(102000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 600 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    expect((ep as any).agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(100250, true);
+    expect((ep as any).overlappingState).toBe(true);
+
+    ep.onEndOfSpeech(100500);
+
+    expect((ep as any).overlappingState).toBe(false);
+    expect((ep as any).agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(300, 5);
+  });
+
+  it('test_update_options', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ minDelay: 500 });
+    expect(ep.minDelay).toBe(500);
+    expect((ep as any).minDelayBase).toBe(500);
+
+    const maxOnly = new DynamicEndpointing(300, 1000);
+    maxOnly.updateOptions({ maxDelay: 2000 });
+    expect(maxOnly.maxDelay).toBe(2000);
+    expect((maxOnly as any).maxDelayBase).toBe(2000);
+
+    const both = new DynamicEndpointing(300, 1000);
+    both.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(both.minDelay).toBe(500);
+    expect(both.maxDelay).toBe(2000);
+
+    const none = new DynamicEndpointing(300, 1000);
+    none.updateOptions();
+    expect(none.minDelay).toBe(300);
+    expect(none.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(102000);
+    ep.onStartOfSpeech(105000);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100100);
+    ep.onStartOfSpeech(100500);
+    expect(ep.maxDelay).toBeGreaterThanOrEqual((ep as any).minDelayBase);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    expect((ep as any).agentSpeechStartedAt).toBeDefined();
+
+    ep.onStartOfSpeech(102000);
+    ep.onEndOfSpeech(103000, false);
+    expect((ep as any).agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    const previous = [ep.minDelay, ep.maxDelay];
+    ep.onStartOfSpeech(100350);
+
+    expect((ep as any).overlappingState).toBe(true);
+    expect([ep.minDelay, ep.maxDelay]).toEqual(previous);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800);
+    ep.onEndOfSpeech(102000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing(60, 1000, 1);
+
+    ep.onEndOfSpeech(99000);
+    ep.onStartOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect((ep as any).utteranceEndedAt).toBeCloseTo(100199, 5);
+    expect(ep.minDelay).toBeCloseTo(60, 5);
+    expect(ep.maxDelay).toBeCloseTo(1000, 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+
+    const state = ep as any;
+    expect(state.utterancePause.alpha).toBeCloseTo(0.5, 5);
+    expect(state.turnPause.alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    const state = ep as any;
+    expect(state.utterancePause.min).toBe(500);
+    expect(state.turnPause.max).toBe(2000);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100200);
+    expect(ep.minDelay).toBeCloseTo(500, 5);
+
+    ep.onEndOfSpeech(101000);
+    ep.onStartOfAgentSpeech(102800);
+    ep.onStartOfSpeech(103500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101500, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101800, true);
+
+    const state = ep as any;
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect(state.utteranceStartedAt).toBeUndefined();
+    expect(state.utteranceEndedAt).toBeUndefined();
+    expect(state.overlappingState).toBe(false);
+    expect(state.speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400, false);
+    ep.onEndOfSpeech(100600, true);
+
+    expect(ep.minDelay).toBeCloseTo(0.5 * 400 + 0.5 * initialMin, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(100600, true);
+    ep.onEndOfSpeech(100800, true);
+
+    expect((ep as any).utteranceEndedAt).toBe(100800);
+    expect((ep as any).speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101000, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+    ep.onEndOfSpeech(101500, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect((ep as any).utteranceStartedAt).toBeUndefined();
+    expect((ep as any).utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100000);
+    ep.onStartOfSpeech(100100, true);
+
+    expect((ep as any).overlappingState).toBe(true);
+    expect((ep as any).agentSpeechStartedAt).toBe(100000);
+
+    ep.onEndOfAgentSpeech(101000);
+
+    expect((ep as any).agentSpeechEndedAt).toBe(101000);
+    expect((ep as any).agentSpeechStartedAt).toBe(100000);
+    expect((ep as any).overlappingState).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800, false);
+    ep.onEndOfSpeech(102000);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect((ep as any).speaking).toBe(false);
+    ep.onStartOfSpeech(100000);
+    expect((ep as any).speaking).toBe(true);
+    ep.onEndOfSpeech(100500);
+    expect((ep as any).speaking).toBe(false);
+  });
+
+  it('test_all_overlapping_and_should_ignore_combos', () => {
+    const cases = [
+      ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+      ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+      ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+      ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+      ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+      ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+      ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+      ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+      ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+    ] as const;
+
+    for (const [
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ] of cases) {
+      const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+      ep.onStartOfSpeech(99000);
+      ep.onEndOfSpeech(100000);
+
+      let userStart = 100400;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100500);
+        ep.onEndOfAgentSpeech(101000);
+        userStart = 101500;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100350;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100200);
+          userStart = 101500;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100400;
+        } else {
+          ep.onStartOfAgentSpeech(100900);
+          userStart = 101800;
+        }
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping);
+
+      const previousMin = ep.minDelay;
+      const previousMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + 500, shouldIgnore);
+
+      const minChanged = ep.minDelay !== previousMin;
+      const maxChanged = ep.maxDelay !== previousMax;
+
+      expect(minChanged, `[${label}] minDelay change mismatch`).toBe(expectMinChange);
+      expect(maxChanged, `[${label}] maxDelay change mismatch`).toBe(expectMaxChange);
+      expect((ep as any).speaking, `[${label}] speaking should be false`).toBe(false);
+      expect((ep as any).overlappingState, `[${label}] overlapping should be false`).toBe(false);
+    }
+  });
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onStartOfSpeech(100000);
+    ep.onEndOfSpeech(101000);
+
+    ep.onStartOfAgentSpeech(101500);
+
+    ep.onStartOfSpeech(102500, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102800, true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(103000);
+
+    ep.onStartOfSpeech(103500);
+    ep.onEndOfSpeech(104000);
+
+    expect((ep as any).speaking).toBe(false);
+    expect((ep as any).agentSpeechStartedAt).toBeUndefined();
+  });
+});
+
+describe('AudioRecognition endpointing integration', () => {
+  function createHooks(): RecognitionHooks {
+    return {
+      onInterruption: () => undefined,
+      onStartOfSpeech: () => undefined,
+      onVADInferenceDone: () => undefined,
+      onEndOfSpeech: () => undefined,
+      onInterimTranscript: () => undefined,
+      onFinalTranscript: () => undefined,
+      onEndOfTurn: async () => true,
+      onPreemptiveGeneration: () => undefined,
+      retrieveChatCtx: () => ChatContext.empty(),
+    };
+  }
+
+  it('updates dynamic max delay without adaptive interruption detection', async () => {
+    const endpointing = new DynamicEndpointing(300, 1000, 0.5);
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing,
+    });
+
+    recognition.onStartOfSpeech(99000);
+    recognition.onEndOfSpeech(100000);
+    await recognition.onStartOfAgentSpeech(100900);
+    recognition.onStartOfSpeech(101800);
+    recognition.onEndOfSpeech(102000);
+
+    expect(endpointing.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('replaces the endpointing strategy on updateOptions', () => {
+    const original = new DynamicEndpointing(300, 1000, 0.5);
+    original.onEndOfSpeech(100000);
+    original.onStartOfSpeech(100400);
+    original.onEndOfSpeech(100600);
+
+    const replacement = new DynamicEndpointing(500, 2000, 0.5);
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing: original,
+    });
+
+    recognition.updateOptions({ endpointing: replacement, turnDetection: undefined });
+
+    expect((recognition as any).endpointing).toBe(replacement);
+    expect(replacement.minDelay).toBe(500);
+    expect(original.minDelay).not.toBe(replacement.minDelay);
+  });
+});

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+const logger = log();
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250;
+
+// Ref: source livekit-agents/livekit/agents/voice/endpointing.py - 10-47
+export class BaseEndpointing {
+  protected minDelayBase: number;
+  protected maxDelayBase: number;
+  protected overlappingState = false;
+
+  constructor(minDelay: number, maxDelay: number) {
+    this.minDelayBase = minDelay;
+    this.maxDelayBase = maxDelay;
+  }
+
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    this.minDelayBase = minDelay ?? this.minDelayBase;
+    this.maxDelayBase = maxDelay ?? this.maxDelayBase;
+  }
+
+  get minDelay(): number {
+    return this.minDelayBase;
+  }
+
+  get maxDelay(): number {
+    return this.maxDelayBase;
+  }
+
+  get overlapping(): boolean {
+    return this.overlappingState;
+  }
+
+  onStartOfSpeech(startedAt: number, overlapping = false): void {
+    void startedAt;
+    this.overlappingState = overlapping;
+  }
+
+  onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    void endedAt;
+    void shouldIgnore;
+    this.overlappingState = false;
+  }
+
+  onStartOfAgentSpeech(startedAt: number): void {
+    void startedAt;
+    return;
+  }
+
+  onEndOfAgentSpeech(endedAt: number): void {
+    void endedAt;
+    return;
+  }
+}
+
+// Ref: source livekit-agents/livekit/agents/voice/endpointing.py - 49-304
+export class DynamicEndpointing extends BaseEndpointing {
+  private utterancePause: ExpFilter;
+  private turnPause: ExpFilter;
+  private utteranceStartedAt?: number;
+  private utteranceEndedAt?: number;
+  private agentSpeechStartedAt?: number;
+  private agentSpeechEndedAt?: number;
+  private speaking = false;
+
+  constructor(minDelay: number, maxDelay: number, alpha = 0.9) {
+    super(minDelay, maxDelay);
+
+    this.utterancePause = new ExpFilter(alpha, {
+      initial: minDelay,
+      min: minDelay,
+      max: maxDelay,
+    });
+    this.turnPause = new ExpFilter(alpha, {
+      initial: maxDelay,
+      min: minDelay,
+      max: maxDelay,
+    });
+  }
+
+  get minDelay(): number {
+    return this.utterancePause.value ?? this.minDelayBase;
+  }
+
+  get maxDelay(): number {
+    return Math.max(this.turnPause.value ?? this.maxDelayBase, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this.utteranceEndedAt === undefined || this.utteranceStartedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.utteranceStartedAt - this.utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this.agentSpeechStartedAt === undefined || this.utteranceEndedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.agentSpeechStartedAt - this.utteranceEndedAt);
+  }
+
+  get immediateInterruptionDelay(): [number, number] {
+    if (this.utteranceStartedAt === undefined || this.agentSpeechStartedAt === undefined) {
+      return [0, 0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  // Ref: source livekit-agents/livekit/agents/voice/endpointing.py - 139-153
+  onStartOfAgentSpeech(startedAt: number): void {
+    this.agentSpeechStartedAt = startedAt;
+    this.agentSpeechEndedAt = undefined;
+    this.overlappingState = false;
+  }
+
+  // Ref: source livekit-agents/livekit/agents/voice/endpointing.py - 144-153
+  onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this.agentSpeechStartedAt !== undefined &&
+      (this.agentSpeechEndedAt === undefined || this.agentSpeechEndedAt < this.agentSpeechStartedAt)
+    ) {
+      this.agentSpeechEndedAt = endedAt;
+    }
+
+    this.overlappingState = false;
+  }
+
+  // Ref: source livekit-agents/livekit/agents/voice/endpointing.py - 155-177
+  onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this.overlappingState) {
+      return;
+    }
+
+    if (
+      this.utteranceStartedAt !== undefined &&
+      this.utteranceEndedAt !== undefined &&
+      this.agentSpeechStartedAt !== undefined &&
+      this.utteranceEndedAt < this.utteranceStartedAt &&
+      overlapping
+    ) {
+      this.utteranceEndedAt = this.agentSpeechStartedAt - 1;
+      logger.trace({ utteranceEndedAt: this.utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this.utteranceStartedAt = startedAt;
+    this.overlappingState = overlapping;
+    this.speaking = true;
+  }
+
+  // Ref: source livekit-agents/livekit/agents/voice/endpointing.py - 179-286
+  onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    if (shouldIgnore && this.overlappingState) {
+      if (
+        this.utteranceStartedAt !== undefined &&
+        this.agentSpeechStartedAt !== undefined &&
+        Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        logger.trace(
+          {
+            delay: Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true because user speech started within the grace period',
+        );
+      } else {
+        this.overlappingState = false;
+        this.speaking = false;
+        this.utteranceStartedAt = undefined;
+        this.utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    if (this.overlappingState || this.#isAgentStillSpeaking()) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const betweenUtteranceDelay = this.betweenUtteranceDelay;
+      if (
+        interruptionDelay > 0 &&
+        interruptionDelay <= this.minDelay &&
+        turnDelay > 0 &&
+        turnDelay <= this.maxDelay &&
+        betweenUtteranceDelay > 0
+      ) {
+        const previousMinDelay = this.minDelay;
+        this.utterancePause.apply(1, betweenUtteranceDelay);
+        logger.debug(
+          {
+            previousMinDelay,
+            minDelay: this.minDelay,
+            pause: betweenUtteranceDelay,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+          },
+          'min endpointing delay updated for immediate interruption',
+        );
+      } else {
+        const betweenTurnDelay = this.betweenTurnDelay;
+        if (betweenTurnDelay > 0) {
+          const previousMaxDelay = this.maxDelay;
+          this.turnPause.apply(1, betweenTurnDelay);
+          logger.debug(
+            {
+              previousMaxDelay,
+              maxDelay: this.maxDelay,
+              minDelay: this.minDelay,
+              pause: betweenTurnDelay,
+              betweenUtteranceDelay: this.betweenUtteranceDelay,
+            },
+            'max endpointing delay updated for a new turn interruption',
+          );
+        }
+      }
+    } else {
+      const betweenTurnDelay = this.betweenTurnDelay;
+      if (betweenTurnDelay > 0) {
+        const previousMaxDelay = this.maxDelay;
+        this.turnPause.apply(1, betweenTurnDelay);
+        logger.debug(
+          {
+            previousMaxDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+            pause: betweenTurnDelay,
+          },
+          'max endpointing delay updated for a new turn',
+        );
+      } else {
+        const betweenUtteranceDelay = this.betweenUtteranceDelay;
+        if (
+          betweenUtteranceDelay > 0 &&
+          this.agentSpeechEndedAt === undefined &&
+          this.agentSpeechStartedAt === undefined
+        ) {
+          const previousMinDelay = this.minDelay;
+          this.utterancePause.apply(1, betweenUtteranceDelay);
+          logger.debug(
+            {
+              previousMinDelay,
+              minDelay: this.minDelay,
+              maxDelay: this.maxDelay,
+              pause: betweenUtteranceDelay,
+            },
+            'min endpointing delay updated for a pause between utterances',
+          );
+        }
+      }
+    }
+
+    this.utteranceEndedAt = endedAt;
+    this.agentSpeechStartedAt = undefined;
+    this.agentSpeechEndedAt = undefined;
+    this.speaking = false;
+    this.overlappingState = false;
+  }
+
+  // Ref: source livekit-agents/livekit/agents/voice/endpointing.py - 288-303
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this.minDelayBase = minDelay;
+      this.utterancePause.reset({ initial: minDelay, min: minDelay });
+      this.turnPause.reset({ min: minDelay });
+    }
+
+    if (maxDelay !== undefined) {
+      this.maxDelayBase = maxDelay;
+      this.turnPause.reset({ initial: maxDelay, max: maxDelay });
+      this.utterancePause.reset({ max: maxDelay });
+    }
+  }
+
+  #isAgentStillSpeaking(): boolean {
+    return this.agentSpeechStartedAt !== undefined && this.agentSpeechEndedAt === undefined;
+  }
+}
+
+// Ref: source livekit-agents/livekit/agents/voice/endpointing.py - 305-316
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  if (options.mode === 'dynamic') {
+    return new DynamicEndpointing(options.minDelay, options.maxDelay);
+  }
+
+  return new BaseEndpointing(options.minDelay, options.maxDelay);
+}

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -22,6 +22,7 @@ export {
   RoomSessionTransport,
 } from './remote_session.js';
 export * from './events.js';
+export * from './endpointing.js';
 export { type TimedString } from './io.js';
 export * from './report.js';
 export * from './room_io/index.js';

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -6,8 +6,8 @@
  */
 export interface EndpointingOptions {
   /**
-   * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on
-   * end-of-utterance prediction.
+   * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adapts delays from observed
+   * user pauses, agent turn gaps, and interruption timing.
    * @defaultValue "fixed"
    */
   mode: 'fixed' | 'dynamic';


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/96).

Tracking issue: https://github.com/livekit/rosetta/issues/96

## Summary
- port `DynamicEndpointing`, `createEndpointing`, and the supporting `ExpFilter` behavior from the Python SDK into the Node voice runtime
- wire dynamic endpointing through `AudioRecognition` and `AgentActivity` for VAD, STT, interruption, and realtime/no-VAD speech paths
- add the full source parity suite from `tests/test_endpointing.py` plus target-side regression coverage for runtime wiring and state-reset behavior

## Source
- https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/endpointing.py
- https://github.com/livekit/agents/blob/main/tests/test_endpointing.py