### PR TITLE
fix(voice): await initRecording() to prevent OTEL trace loss in short sessions

### DIFF
--- a/.changeset/giant-tips-fix.md
+++ b/.changeset/giant-tips-fix.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(voice): await initRecording() to prevent OTEL trace loss in short sessions

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -526,7 +526,7 @@ export class AgentSession<
       this._enableRecording = record;
 
       if (this._enableRecording) {
-        ctx.initRecording();
+        await ctx.initRecording();
       }
     }
 


### PR DESCRIPTION
## Summary

`ctx.initRecording()` in `AgentSession.start()` is called without `await`, creating a race condition where the OTLP exporter may not be connected before session events fire. This causes intermittent "No observability data available" in Agent Insights — particularly for short sessions without tool calls, where the session ends before the cloud tracer finishes initializing.

Sessions with tool calls (which take longer due to API round-trips) give the tracer enough time to connect, masking the issue. The session report uploads successfully in all cases, but OTEL traces carrying transcripts and audio metadata are lost.

## Changes

- Await `ctx.initRecording()` in `AgentSession.start()` so the cloud tracer is ready before any events fire

## Test plan

- Deployed with a manual workaround (`await ctx.initRecording()` before `session.start()`) on LiveKit Cloud — Agent Insights data now records consistently for short sessions without tool calls
- Verified no regression for sessions with tool calls