### PR TITLE
Port dynamic endpointing to the Node.js SDK

### DIFF
--- a/.changeset/green-cameras-fix.md
+++ b/.changeset/green-cameras-fix.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": minor
+---
+
+feat(voice): port dynamic endpointing from the Python SDK

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -351,33 +351,95 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 }
 
 /** @internal */
+export interface ExpFilterOptions {
+  max?: number;
+  min?: number;
+  initial?: number;
+}
+
+/** @internal */
+export interface ExpFilterResetOptions extends ExpFilterOptions {
+  alpha?: number;
+}
+
+/** @internal */
 export class ExpFilter {
   #alpha: number;
   #max?: number;
+  #min?: number;
+  #initial?: number;
   #filtered?: number = undefined;
 
-  constructor(alpha: number, max?: number) {
+  constructor(alpha: number, max?: number);
+  constructor(alpha: number, options?: ExpFilterOptions);
+  constructor(alpha: number, options?: number | ExpFilterOptions) {
+    this.#assertAlpha(alpha);
     this.#alpha = alpha;
-    this.#max = max;
-  }
 
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+    if (typeof options === 'number') {
+      this.#max = options;
+      return;
     }
-    this.#filtered = undefined;
+
+    this.#max = options?.max;
+    this.#min = options?.min;
+    this.#initial = options?.initial;
+    this.#filtered = options?.initial;
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
+  reset(alpha?: number): void;
+  reset(options?: ExpFilterResetOptions): void;
+  reset(options?: number | ExpFilterResetOptions) {
+    if (typeof options === 'number') {
+      this.#assertAlpha(options);
+      this.#alpha = options;
+      this.#filtered = this.#initial;
+      return;
+    }
+
+    const hasOptions = options !== undefined;
+
+    if (options?.alpha !== undefined) {
+      this.#assertAlpha(options.alpha);
+      this.#alpha = options.alpha;
+    }
+
+    if (options?.initial !== undefined) {
+      this.#initial = options.initial;
+      this.#filtered = options.initial;
+    } else if (!hasOptions) {
+      this.#filtered = this.#initial;
+    }
+
+    if (options?.min !== undefined) {
+      this.#min = options.min;
+    }
+
+    if (options?.max !== undefined) {
+      this.#max = options.max;
+    }
+  }
+
+  apply(exp: number, sample?: number): number {
+    const nextSample = sample ?? this.#filtered;
+
+    if (nextSample === undefined) {
+      throw new Error('sample or initial value must be given.');
+    }
+
+    if (this.#filtered !== undefined) {
       const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
+      this.#filtered = a * this.#filtered + (1 - a) * nextSample;
     } else {
-      this.#filtered = sample;
+      this.#filtered = nextSample;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
+    if (this.#max !== undefined && this.#filtered > this.#max) {
       this.#filtered = this.#max;
+    }
+
+    if (this.#min !== undefined && this.#filtered < this.#min) {
+      this.#filtered = this.#min;
     }
 
     return this.#filtered;
@@ -387,8 +449,31 @@ export class ExpFilter {
     return this.#filtered;
   }
 
+  get value(): number | undefined {
+    return this.#filtered;
+  }
+
+  get alpha(): number {
+    return this.#alpha;
+  }
+
+  get max(): number | undefined {
+    return this.#max;
+  }
+
+  get min(): number | undefined {
+    return this.#min;
+  }
+
   set alpha(alpha: number) {
+    this.#assertAlpha(alpha);
     this.#alpha = alpha;
+  }
+
+  #assertAlpha(alpha: number) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
   }
 }
 

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -375,3 +375,75 @@ describe('AgentActivity - onPreemptiveGeneration guards', () => {
     expect(cancelPreemptiveGeneration).not.toHaveBeenCalled();
   });
 });
+
+describe('AgentActivity endpointing integration', () => {
+  it('forwards no-VAD realtime input speech hooks into AudioRecognition', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(123_456);
+    const audioRecognition = {
+      onStartOfSpeech: vi.fn(),
+      onStartOfOverlapSpeech: vi.fn(),
+      onEndOfSpeech: vi.fn(),
+      onEndOfOverlapSpeech: vi.fn(),
+    };
+    const updateUserState = vi.fn();
+    const fakeActivity = {
+      logger: { info: vi.fn(), error: vi.fn() },
+      vad: undefined,
+      isInterruptionDetectionEnabled: true,
+      audioRecognition,
+      agentSession: {
+        _updateUserState: updateUserState,
+        _userSpeakingSpan: { id: 'span' },
+      },
+      interrupt: vi.fn(),
+    };
+
+    try {
+      AgentActivity.prototype.onInputSpeechStarted.call(fakeActivity as any, {} as any);
+      AgentActivity.prototype.onInputSpeechStopped.call(
+        fakeActivity as any,
+        { userTranscriptionEnabled: false } as any,
+      );
+
+      expect(updateUserState).toHaveBeenNthCalledWith(1, 'speaking');
+      expect(audioRecognition.onStartOfSpeech).toHaveBeenCalledWith(123_456);
+      expect(audioRecognition.onStartOfOverlapSpeech).toHaveBeenCalledWith(
+        0,
+        123_456,
+        fakeActivity.agentSession._userSpeakingSpan,
+      );
+
+      expect(audioRecognition.onEndOfSpeech).toHaveBeenCalledWith(123_456);
+      expect(audioRecognition.onEndOfOverlapSpeech).toHaveBeenCalledWith(
+        123_456,
+        fakeActivity.agentSession._userSpeakingSpan,
+      );
+      expect(updateUserState).toHaveBeenNthCalledWith(2, 'listening');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('creates a replacement endpointing instance when updateOptions receives endpointing config', () => {
+    const audioRecognition = { updateOptions: vi.fn() };
+    const fakeActivity = {
+      toolChoice: null,
+      realtimeSession: undefined,
+      turnDetectionMode: 'vad',
+      isDefaultInterruptionByAudioActivityEnabled: true,
+      isInterruptionByAudioActivityEnabled: true,
+      agentSession: { agentState: 'listening' },
+      audioRecognition,
+    };
+
+    AgentActivity.prototype.updateOptions.call(fakeActivity as any, {
+      endpointing: { mode: 'dynamic', minDelay: 111, maxDelay: 222 },
+    });
+
+    const [{ endpointing, turnDetection }] = audioRecognition.updateOptions.mock.calls[0];
+    expect(turnDetection).toBe('vad');
+    expect(endpointing?.constructor.name).toBe('DynamicEndpointing');
+    expect(endpointing?.minDelay).toBe(111);
+    expect(endpointing?.maxDelay).toBe(222);
+  });
+});

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -65,6 +65,7 @@ import {
   type RecognitionHooks,
   type STTPipeline,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import {
   AgentSessionEventTypes,
   createErrorEvent,
@@ -88,6 +89,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -469,6 +471,7 @@ export class AgentActivity implements RecognitionHooks {
       this.vad.on('metrics_collected', this.onMetricsCollected);
     }
 
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 768-778 lines
     this.audioRecognition = new AudioRecognition({
       recognitionHooks: this,
       // Disable stt node if stt is not provided
@@ -477,12 +480,10 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      endpointing: createEndpointing({
+        ...this.agentSession.sessionOptions.turnHandling.endpointing,
+        ...this.agent.turnHandling?.endpointing,
+      }),
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -716,9 +717,11 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   updateOptions({
+    endpointing,
     toolChoice,
     turnDetection,
   }: {
+    endpointing?: EndpointingOptions;
     toolChoice?: ToolChoice | null;
     turnDetection?: TurnDetectionMode;
   }): void {
@@ -743,7 +746,11 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (this.audioRecognition) {
-      this.audioRecognition.updateOptions({ turnDetection: this.turnDetectionMode });
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 476-482 lines
+      this.audioRecognition.updateOptions({
+        endpointing: endpointing ? createEndpointing(endpointing) : undefined,
+        turnDetection: this.turnDetectionMode,
+      });
     }
   }
 
@@ -921,11 +928,14 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info('onInputSpeechStarted');
 
     if (!this.vad) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1490-1497 lines
+      const speechStartedAt = Date.now();
       this.agentSession._updateUserState('speaking');
+      this.audioRecognition?.onStartOfSpeech(speechStartedAt);
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
         this.audioRecognition.onStartOfOverlapSpeech(
           0,
-          Date.now(),
+          speechStartedAt,
           this.agentSession._userSpeakingSpan,
         );
       }
@@ -947,8 +957,14 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1508-1516 lines
+      const speechEndedAt = Date.now();
+      this.audioRecognition?.onEndOfSpeech(speechEndedAt);
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
+        this.audioRecognition.onEndOfOverlapSpeech(
+          speechEndedAt,
+          this.agentSession._userSpeakingSpan,
+        );
       }
       this.agentSession._updateUserState('listening');
     }
@@ -1130,7 +1146,11 @@ export class AgentActivity implements RecognitionHooks {
     this.restoreInterruptionByAudioActivity();
     this.interruptByAudioActivity();
     if (this.audioRecognition) {
-      this.audioRecognition.onEndOfAgentSpeech(ev.overlapStartedAt || ev.detectedAt);
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1721-1730 lines
+      this.audioRecognition.onEndOfAgentSpeech({
+        endedAt: Date.now(),
+        ignoreUserTranscriptUntil: ev.overlapStartedAt || ev.detectedAt,
+      });
     }
   }
 
@@ -1838,7 +1858,8 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2195-2195 lines
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -1925,7 +1946,12 @@ export class AgentActivity implements RecognitionHooks {
     if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2310-2310 lines
+        const agentSpeechEndedAt = Date.now();
+        this.audioRecognition.onEndOfAgentSpeech({
+          endedAt: agentSpeechEndedAt,
+          ignoreUserTranscriptUntil: agentSpeechEndedAt,
+        });
       }
       this.restoreInterruptionByAudioActivity();
     }
@@ -2114,7 +2140,8 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2540-2540 lines
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2272,7 +2299,12 @@ export class AgentActivity implements RecognitionHooks {
       if (this.agentSession.agentState === 'speaking') {
         this.agentSession._updateAgentState('listening');
         if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
+          // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2671-2671 lines
+          const agentSpeechEndedAt = Date.now();
+          this.audioRecognition.onEndOfAgentSpeech({
+            endedAt: agentSpeechEndedAt,
+            ignoreUserTranscriptUntil: agentSpeechEndedAt,
+          });
           this.restoreInterruptionByAudioActivity();
         }
       }
@@ -2316,7 +2348,12 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._updateAgentState('listening');
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
         {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
+          // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2671-2671 lines
+          const agentSpeechEndedAt = Date.now();
+          this.audioRecognition.onEndOfAgentSpeech({
+            endedAt: agentSpeechEndedAt,
+            ignoreUserTranscriptUntil: agentSpeechEndedAt,
+          });
           this.restoreInterruptionByAudioActivity();
         }
       }

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,7 +35,10 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import { createEndpointing } from './endpointing.js';
+import type { BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
+import { defaultEndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export interface EndOfTurnInfo {
@@ -138,10 +141,12 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
+  /** Endpointing strategy. */
+  endpointing?: BaseEndpointing;
   /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
+  minEndpointingDelay?: number;
   /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  maxEndpointingDelay?: number;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +175,7 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  private endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -215,6 +219,7 @@ export class AudioRecognition {
   private transcriptBuffer: SpeechEvent[];
   private isInterruptionEnabled: boolean;
   private isAgentSpeaking: boolean;
+  private interruptionDetected = false;
   private interruptionStreamChannel?: StreamChannel<InterruptionSentinel | AudioFrame>;
   private closed = false;
 
@@ -224,8 +229,13 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    this.endpointing =
+      opts.endpointing ??
+      createEndpointing({
+        ...defaultEndpointingOptions,
+        minDelay: opts.minEndpointingDelay ?? defaultEndpointingOptions.minDelay,
+        maxDelay: opts.maxEndpointingDelay ?? defaultEndpointingOptions.maxDelay,
+      });
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,7 +285,14 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
+  updateOptions(options: {
+    endpointing?: BaseEndpointing;
+    turnDetection: TurnDetectionMode | undefined;
+  }): void {
+    if (options.endpointing) {
+      this.endpointing = options.endpointing;
+    }
+
     this.turnDetectionMode = options.turnDetection;
   }
 
@@ -311,12 +328,25 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-243 lines
+  async onStartOfAgentSpeech(startedAt: number) {
     this.isAgentSpeaking = true;
+    this.endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
-  async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 245-270 lines
+  async onEndOfAgentSpeech({
+    endedAt,
+    ignoreUserTranscriptUntil,
+  }: {
+    endedAt: number;
+    ignoreUserTranscriptUntil: number;
+  }) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(endedAt);
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -332,7 +362,7 @@ export class AudioRecognition {
 
     if (this.isAgentSpeaking) {
       if (this.ignoreUserTranscriptUntil === undefined) {
-        this.onEndOfOverlapSpeech(Date.now());
+        this.onEndOfOverlapSpeech(endedAt);
       }
       this.ignoreUserTranscriptUntil = this.ignoreUserTranscriptUntil
         ? Math.min(ignoreUserTranscriptUntil, this.ignoreUserTranscriptUntil)
@@ -342,6 +372,22 @@ export class AudioRecognition {
       await this.flushHeldTranscripts();
     }
     this.isAgentSpeaking = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 272-303 lines
+  onStartOfSpeech(startedAt: number): void {
+    this.interruptionDetected = false;
+    this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-305 lines
+  onEndOfSpeech(endedAt: number): void {
+    if (this.speaking) {
+      this.endpointing.onEndOfSpeech(
+        endedAt,
+        this.isInterruptionEnabled && this.isAgentSpeaking && !this.interruptionDetected,
+      );
+    }
   }
 
   /** Start interruption inference when agent is speaking and overlap speech starts. */
@@ -703,8 +749,10 @@ export class AudioRecognition {
         break;
       case SpeechEventType.START_OF_SPEECH:
         if (this.turnDetectionMode !== 'stt') break;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 854-865 lines
+        const sttSpeechStartedAt = Date.now();
         {
-          const span = this.ensureUserTurnSpan(Date.now());
+          const span = this.ensureUserTurnSpan(sttSpeechStartedAt);
           const ctx = this.userTurnContext(span);
           otelContext.with(ctx, () => {
             this.hooks.onStartOfSpeech({
@@ -722,13 +770,16 @@ export class AudioRecognition {
             });
           });
         }
+        this.onStartOfSpeech(sttSpeechStartedAt);
         this.speaking = true;
-        this.lastSpeakingTime = Date.now();
+        this.lastSpeakingTime = sttSpeechStartedAt;
 
         this.bounceEOUTask?.cancel();
         break;
       case SpeechEventType.END_OF_SPEECH:
         if (this.turnDetectionMode !== 'stt') break;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 830-852 lines
+        const sttSpeechEndedAt = Date.now();
         {
           const span = this.ensureUserTurnSpan();
           const ctx = this.userTurnContext(span);
@@ -748,6 +799,7 @@ export class AudioRecognition {
             });
           });
         }
+        this.onEndOfSpeech(sttSpeechEndedAt);
         // STT EOT changes user state from speaking to listening without updating VAD internal states.
         // VAD EOS will also skip updating user state from listening (STT enforced) to listening (VAD detected)
         // and user state won't be updated until a new VAD SOS is received.
@@ -759,7 +811,7 @@ export class AudioRecognition {
         }
         this.speaking = false;
         this.userTurnCommitted = true;
-        this.lastSpeakingTime = Date.now();
+        this.lastSpeakingTime = sttSpeechEndedAt;
 
         if (!this.speaking) {
           const chatCtx = this.hooks.retrieveChatCtx();
@@ -770,6 +822,8 @@ export class AudioRecognition {
   }
 
   private onOverlapSpeechEvent(ev: OverlappingSpeechEvent) {
+    this.interruptionDetected = ev.isInterruption;
+
     if (ev.isInterruption) {
       this.hooks.onInterruption(ev);
     }
@@ -805,7 +859,8 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 928-970 lines
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +886,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');
@@ -1016,12 +1071,14 @@ export class AudioRecognition {
         switch (ev.type) {
           case VADEventType.START_OF_SPEECH:
             this.logger.debug('VAD task: START_OF_SPEECH');
+            // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 867-884 lines
+            const vadSpeechStartedAt = Date.now() - ev.speechDuration - ev.inferenceDuration;
             {
-              const startTime = Date.now() - ev.speechDuration;
-              const span = this.ensureUserTurnSpan(startTime);
+              const span = this.ensureUserTurnSpan(vadSpeechStartedAt);
               const ctx = this.userTurnContext(span);
               otelContext.with(ctx, () => this.hooks.onStartOfSpeech(ev));
             }
+            this.onStartOfSpeech(vadSpeechStartedAt);
             this.speaking = true;
 
             // Capture sample rate from the first VAD event if not already set
@@ -1046,11 +1103,14 @@ export class AudioRecognition {
             break;
           case VADEventType.END_OF_SPEECH:
             this.logger.debug('VAD task: END_OF_SPEECH');
+            // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 895-906 lines
+            const vadSpeechEndedAt = Date.now() - ev.silenceDuration - ev.inferenceDuration;
             {
               const span = this.ensureUserTurnSpan();
               const ctx = this.userTurnContext(span);
               otelContext.with(ctx, () => this.hooks.onEndOfSpeech(ev));
             }
+            this.onEndOfSpeech(vadSpeechEndedAt);
 
             // when VAD fires END_OF_SPEECH, it already waited for the silence_duration
             this.speaking = false;

--- a/agents/src/voice/audio_recognition_endpointing.test.ts
+++ b/agents/src/voice/audio_recognition_endpointing.test.ts
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { initializeLogger } from '../log.js';
+import {
+  AudioRecognition,
+  type RecognitionHooks,
+  type _TurnDetector,
+} from './audio_recognition.js';
+import { BaseEndpointing } from './endpointing.js';
+
+class RecordingEndpointing extends BaseEndpointing {
+  readonly speechStarts: Array<{ startedAt: number; overlapping: boolean }> = [];
+  readonly speechEnds: Array<{ endedAt: number; shouldIgnore: boolean }> = [];
+  readonly agentSpeechStarts: number[] = [];
+  readonly agentSpeechEnds: number[] = [];
+
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    super.onStartOfSpeech(startedAt, overlapping);
+    this.speechStarts.push({ startedAt, overlapping });
+  }
+
+  override onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    super.onEndOfSpeech(endedAt, shouldIgnore);
+    this.speechEnds.push({ endedAt, shouldIgnore });
+  }
+
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this.agentSpeechStarts.push(startedAt);
+  }
+
+  override onEndOfAgentSpeech(endedAt: number): void {
+    this.agentSpeechEnds.push(endedAt);
+  }
+}
+
+function createHooks(): RecognitionHooks {
+  return {
+    onInterruption: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onEndOfTurn: vi.fn(async () => true),
+    onPreemptiveGeneration: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+  };
+}
+
+beforeAll(() => {
+  initializeLogger({ pretty: false, level: 'silent' });
+});
+
+describe('AudioRecognition endpointing integration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(100_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 915-990 lines
+  it('uses endpointing.maxDelay when the turn detector predicts an unlikely turn end', async () => {
+    const hooks = createHooks();
+    const endpointing = new RecordingEndpointing(100, 600);
+    const turnDetector: _TurnDetector = {
+      model: 'fake-turn-detector',
+      provider: 'fake-provider',
+      supportsLanguage: async () => true,
+      unlikelyThreshold: async () => 0.2,
+      predictEndOfTurn: async () => 0.1,
+    };
+    const recognition = new AudioRecognition({
+      recognitionHooks: hooks,
+      endpointing,
+      turnDetector,
+      turnDetectionMode: 'vad',
+    });
+
+    try {
+      (recognition as any).audioTranscript = 'hello';
+      (recognition as any).lastSpeakingTime = Date.now();
+
+      (recognition as any).runEOUDetection(ChatContext.empty());
+
+      await vi.advanceTimersByTimeAsync(599);
+      expect(hooks.onEndOfTurn).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(hooks.onEndOfTurn).toHaveBeenCalledTimes(1);
+    } finally {
+      await recognition.close();
+    }
+  });
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 192-220 lines
+  it('replaces the endpointing instance on updateOptions', async () => {
+    const hooks = createHooks();
+    const initialEndpointing = new RecordingEndpointing(100, 100);
+    const replacementEndpointing = new RecordingEndpointing(400, 400);
+    const recognition = new AudioRecognition({
+      recognitionHooks: hooks,
+      endpointing: initialEndpointing,
+      turnDetectionMode: 'vad',
+    });
+
+    try {
+      recognition.updateOptions({
+        endpointing: replacementEndpointing,
+        turnDetection: 'vad',
+      });
+
+      recognition.onStartOfSpeech(100_123);
+
+      expect(initialEndpointing.speechStarts).toEqual([]);
+      expect(replacementEndpointing.speechStarts).toEqual([
+        { startedAt: 100_123, overlapping: false },
+      ]);
+
+      (recognition as any).audioTranscript = 'hello';
+      (recognition as any).lastSpeakingTime = Date.now();
+      (recognition as any).runEOUDetection(ChatContext.empty());
+
+      await vi.advanceTimersByTimeAsync(399);
+      expect(hooks.onEndOfTurn).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(hooks.onEndOfTurn).toHaveBeenCalledTimes(1);
+    } finally {
+      await recognition.close();
+    }
+  });
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-303 lines
+  it('marks overlapping non-interruptions as shouldIgnore on speech end', async () => {
+    const hooks = createHooks();
+    const endpointing = new RecordingEndpointing(100, 600);
+    const recognition = new AudioRecognition({
+      recognitionHooks: hooks,
+      endpointing,
+      turnDetectionMode: 'vad',
+    });
+
+    try {
+      (recognition as any).speaking = true;
+      (recognition as any).isAgentSpeaking = true;
+      (recognition as any).isInterruptionEnabled = true;
+      (recognition as any).interruptionDetected = false;
+
+      recognition.onEndOfSpeech(100_250);
+
+      expect(endpointing.speechEnds).toEqual([{ endedAt: 100_250, shouldIgnore: true }]);
+    } finally {
+      await recognition.close();
+    }
+  });
+});

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,488 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+const toMs = (seconds: number) => seconds * 1000;
+
+function expectClose(actual: number, expected: number) {
+  expect(actual).toBeCloseTo(expected, 5);
+}
+
+beforeAll(() => {
+  initializeLogger({ pretty: false, level: 'silent' });
+});
+
+// Ref: python tests/test_endpointing.py - 7-63 lines
+describe('ExpFilter', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    const ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    const emaWithInitial = new ExpFilter(0.5, { initial: 10 });
+    expect(emaWithInitial.value).toBe(10);
+
+    const emaWithOne = new ExpFilter(1.0);
+    expect(emaWithOne.value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0.0)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(-0.5)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(1.5)).toThrow(/alpha must be in/);
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1.0, 10.0);
+    expect(result).toBe(10.0);
+    expect(ema.value).toBe(10.0);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    const result = ema.apply(1.0, 20.0);
+    expect(result).toBe(15.0);
+    expect(ema.value).toBe(15.0);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    ema.apply(1.0, 20.0);
+    ema.apply(1.0, 20.0);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    let ema = new ExpFilter(0.5, { initial: 10.0 });
+    expect(ema.value).toBe(10.0);
+    ema.reset();
+    expect(ema.value).toBe(10.0);
+
+    ema = new ExpFilter(0.5, { initial: 10.0 });
+    ema.reset({ initial: 5.0 });
+    expect(ema.value).toBe(5.0);
+  });
+});
+
+// Ref: python tests/test_endpointing.py - 64-545 lines
+describe('DynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    expect(ep.minDelay).toBe(toMs(0.3));
+    expect(ep.maxDelay).toBe(toMs(1.0));
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.2);
+    expect(ep.minDelay).toBe(toMs(0.3));
+    expect(ep.maxDelay).toBe(toMs(1.0));
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    expectClose((ep as any).utterancePause.alpha, 0.9);
+    expectClose((ep as any).turnPause.alpha, 0.9);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toEqual([0, 0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    let ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    ep.onEndOfSpeech(100_000);
+    expect((ep as any).utteranceEndedAt).toBe(100_000);
+
+    ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    ep.onEndOfSpeech(99_900);
+    expect((ep as any).utteranceEndedAt).toBe(99_900);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    ep.onStartOfSpeech(100_000);
+    expect((ep as any).utteranceStartedAt).toBe(100_000);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    ep.onStartOfAgentSpeech(100_000);
+    expect((ep as any).agentSpeechStartedAt).toBe(100_000);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_500);
+    expectClose(ep.betweenUtteranceDelay, 500);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_800);
+    expectClose(ep.betweenTurnDelay, 800);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_400);
+    ep.onEndOfSpeech(100_500, false);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expectClose(ep.minDelay, expected);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_600);
+    ep.onStartOfSpeech(101_500);
+    ep.onEndOfSpeech(102_000, false);
+
+    expectClose(ep.maxDelay, 0.5 * 600 + 0.5 * 1000);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    expect((ep as any).agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(100_250, true);
+    expect((ep as any).overlappingState).toBe(true);
+
+    ep.onEndOfSpeech(100_500);
+
+    expect((ep as any).overlappingState).toBe(false);
+    expect((ep as any).agentSpeechStartedAt).toBeUndefined();
+    expectClose(ep.minDelay, 300);
+  });
+
+  it('test_update_options', () => {
+    let ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    ep.updateOptions({ minDelay: toMs(0.5) });
+    expect(ep.minDelay).toBe(toMs(0.5));
+    expect((ep as any).configuredMinDelay).toBe(toMs(0.5));
+
+    ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    ep.updateOptions({ maxDelay: toMs(2.0) });
+    expect(ep.maxDelay).toBe(toMs(2.0));
+    expect((ep as any).configuredMaxDelay).toBe(toMs(2.0));
+
+    ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    ep.updateOptions({ minDelay: toMs(0.5), maxDelay: toMs(2.0) });
+    expect(ep.minDelay).toBe(toMs(0.5));
+    expect(ep.maxDelay).toBe(toMs(2.0));
+
+    ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+    ep.updateOptions();
+    expect(ep.minDelay).toBe(toMs(0.3));
+    expect(ep.maxDelay).toBe(toMs(1.0));
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 1.0);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(102_000);
+    ep.onStartOfSpeech(105_000);
+
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 1.0);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_100);
+    ep.onStartOfSpeech(100_500);
+
+    expect(ep.maxDelay).toBeGreaterThanOrEqual((ep as any).configuredMinDelay);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    expect((ep as any).agentSpeechStartedAt).toBeDefined();
+
+    ep.onStartOfSpeech(102_000);
+    ep.onEndOfSpeech(103_000, false);
+    expect((ep as any).agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    ep.onStartOfSpeech(100_250, true);
+
+    expect((ep as any).overlappingState).toBe(true);
+    const previous = [ep.minDelay, ep.maxDelay];
+
+    ep.onStartOfSpeech(100_350);
+
+    expect((ep as any).overlappingState).toBe(true);
+    expect([ep.minDelay, ep.maxDelay]).toEqual(previous);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_900);
+    ep.onStartOfSpeech(101_800);
+    ep.onEndOfSpeech(102_000, false);
+
+    expectClose(ep.maxDelay, 0.5 * 900 + 0.5 * 1000);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing(toMs(0.06), toMs(1.0), 1.0);
+
+    ep.onEndOfSpeech(99_000);
+    ep.onStartOfSpeech(100_000);
+
+    ep.onStartOfAgentSpeech(100_200);
+    ep.onStartOfSpeech(100_250, true);
+
+    expectClose((ep as any).utteranceEndedAt, 100_199);
+    expectClose(ep.minDelay, 60);
+    expectClose(ep.maxDelay, 1000);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.updateOptions({ minDelay: toMs(0.6), maxDelay: toMs(2.0) });
+
+    expectClose((ep as any).utterancePause.alpha, 0.5);
+    expectClose((ep as any).turnPause.alpha, 0.5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.updateOptions({ minDelay: toMs(0.5), maxDelay: toMs(2.0) });
+    expect((ep as any).utterancePause.min).toBe(500);
+    expect((ep as any).turnPause.max).toBe(2000);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_200);
+    expectClose(ep.minDelay, 500);
+
+    ep.onEndOfSpeech(101_000);
+    ep.onStartOfAgentSpeech(102_800);
+    ep.onStartOfSpeech(103_500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(101_500, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101_800, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect((ep as any).utteranceStartedAt).toBeUndefined();
+    expect((ep as any).utteranceEndedAt).toBeUndefined();
+    expect((ep as any).overlappingState).toBe(false);
+    expect((ep as any).speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_400, false);
+    ep.onEndOfSpeech(100_600, true);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expectClose(ep.minDelay, expected);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(100_600, true);
+
+    ep.onEndOfSpeech(100_800, true);
+
+    expect((ep as any).utteranceEndedAt).toBe(100_800);
+    expect((ep as any).speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(101_000, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+    ep.onEndOfSpeech(101_500, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect((ep as any).utteranceStartedAt).toBeUndefined();
+    expect((ep as any).utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+
+    ep.onStartOfAgentSpeech(100_000);
+    ep.onStartOfSpeech(100_100, true);
+    expect((ep as any).overlappingState).toBe(true);
+    expect((ep as any).agentSpeechStartedAt).toBe(100_000);
+
+    ep.onEndOfAgentSpeech(101_000);
+
+    expect((ep as any).agentSpeechEndedAt).toBe(101_000);
+    expect((ep as any).agentSpeechStartedAt).toBe(100_000);
+    expect((ep as any).overlappingState).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_900);
+    ep.onStartOfSpeech(101_800, false);
+    ep.onEndOfSpeech(102_000);
+
+    expectClose(ep.maxDelay, 0.5 * 900 + 0.5 * 1000);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0));
+
+    expect((ep as any).speaking).toBe(false);
+    ep.onStartOfSpeech(100_000);
+    expect((ep as any).speaking).toBe(true);
+    ep.onEndOfSpeech(100_500);
+    expect((ep as any).speaking).toBe(false);
+  });
+
+  it.each([
+    ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+    ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+    ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+    ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+    ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+    ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+    ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+    ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+    ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+  ])(
+    'test_all_overlapping_and_should_ignore_combos [%s]',
+    (
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ) => {
+      const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+      ep.onStartOfSpeech(toMs(99.0));
+      ep.onEndOfSpeech(toMs(100.0));
+
+      let userStart: number;
+
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(toMs(100.5));
+        ep.onEndOfAgentSpeech(toMs(101.0));
+        userStart = toMs(101.5);
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(toMs(100.15));
+          userStart = toMs(100.35);
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(toMs(100.2));
+          userStart = toMs(101.5);
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(toMs(100.15));
+          userStart = toMs(100.4);
+        } else {
+          ep.onStartOfAgentSpeech(toMs(100.9));
+          userStart = toMs(101.8);
+        }
+      } else {
+        userStart = toMs(100.4);
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping);
+
+      const previousMin = ep.minDelay;
+      const previousMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + toMs(0.5), shouldIgnore);
+
+      const minChanged = ep.minDelay !== previousMin;
+      const maxChanged = ep.maxDelay !== previousMax;
+
+      expect(minChanged, `[${label}] minDelay ${previousMin} -> ${ep.minDelay}`).toBe(
+        expectMinChange,
+      );
+      expect(maxChanged, `[${label}] maxDelay ${previousMax} -> ${ep.maxDelay}`).toBe(
+        expectMaxChange,
+      );
+      expect((ep as any).speaking, `[${label}] speaking should be false`).toBe(false);
+      expect((ep as any).overlappingState, `[${label}] overlapping should be false`).toBe(false);
+    },
+  );
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing(toMs(0.3), toMs(1.0), 0.5);
+
+    ep.onStartOfSpeech(toMs(100.0));
+    ep.onEndOfSpeech(toMs(101.0));
+
+    ep.onStartOfAgentSpeech(toMs(101.5));
+
+    ep.onStartOfSpeech(toMs(102.5), true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(toMs(102.8), true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(toMs(103.0));
+
+    ep.onStartOfSpeech(toMs(103.5));
+    ep.onEndOfSpeech(toMs(104.0));
+
+    expect((ep as any).speaking).toBe(false);
+    expect((ep as any).agentSpeechStartedAt).toBeUndefined();
+  });
+});

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+const logger = log();
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 7-7 lines
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250; // 0.25s -> 250ms
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-46 lines
+export class BaseEndpointing {
+  protected configuredMinDelay: number;
+  protected configuredMaxDelay: number;
+  protected overlappingState = false;
+
+  constructor(minDelay: number, maxDelay: number) {
+    this.configuredMinDelay = minDelay;
+    this.configuredMaxDelay = maxDelay;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 16-22 lines
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    this.configuredMinDelay = minDelay ?? this.configuredMinDelay;
+    this.configuredMaxDelay = maxDelay ?? this.configuredMaxDelay;
+  }
+
+  get minDelay(): number {
+    return this.configuredMinDelay;
+  }
+
+  get maxDelay(): number {
+    return this.configuredMaxDelay;
+  }
+
+  get overlapping(): boolean {
+    return this.overlappingState;
+  }
+
+  onStartOfSpeech(_startedAt: number, overlapping = false): void {
+    this.overlappingState = overlapping;
+  }
+
+  onEndOfSpeech(_endedAt: number, _shouldIgnore = false): void {
+    this.overlappingState = false;
+  }
+
+  onStartOfAgentSpeech(_startedAt: number): void {}
+
+  onEndOfAgentSpeech(_endedAt: number): void {}
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-303 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private utterancePause: ExpFilter;
+  private turnPause: ExpFilter;
+  private utteranceStartedAt?: number;
+  private utteranceEndedAt?: number;
+  private agentSpeechStartedAt?: number;
+  private agentSpeechEndedAt?: number;
+  private speaking = false;
+
+  constructor(minDelay: number, maxDelay: number, alpha = 0.9) {
+    super(minDelay, maxDelay);
+    this.utterancePause = new ExpFilter(alpha, {
+      initial: minDelay,
+      min: minDelay,
+      max: maxDelay,
+    });
+    this.turnPause = new ExpFilter(alpha, {
+      initial: maxDelay,
+      min: minDelay,
+      max: maxDelay,
+    });
+  }
+
+  get minDelay(): number {
+    return this.utterancePause.value ?? this.configuredMinDelay;
+  }
+
+  get maxDelay(): number {
+    const turnDelay = this.turnPause.value ?? this.configuredMaxDelay;
+    return Math.max(turnDelay, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this.utteranceEndedAt === undefined || this.utteranceStartedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.utteranceStartedAt - this.utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this.agentSpeechStartedAt === undefined || this.utteranceEndedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.agentSpeechStartedAt - this.utteranceEndedAt);
+  }
+
+  get immediateInterruptionDelay(): [number, number] {
+    if (this.utteranceStartedAt === undefined || this.agentSpeechStartedAt === undefined) {
+      return [0, 0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 139-143 lines
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this.agentSpeechStartedAt = startedAt;
+    this.agentSpeechEndedAt = undefined;
+    this.overlappingState = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 144-153 lines
+  override onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this.agentSpeechStartedAt !== undefined &&
+      (this.agentSpeechEndedAt === undefined || this.agentSpeechEndedAt < this.agentSpeechStartedAt)
+    ) {
+      this.agentSpeechEndedAt = endedAt;
+    }
+    this.overlappingState = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 155-177 lines
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this.overlappingState) {
+      return;
+    }
+
+    if (
+      this.utteranceStartedAt !== undefined &&
+      this.utteranceEndedAt !== undefined &&
+      this.agentSpeechStartedAt !== undefined &&
+      this.utteranceEndedAt < this.utteranceStartedAt &&
+      overlapping
+    ) {
+      this.utteranceEndedAt = this.agentSpeechStartedAt - 1; // 1e-3s -> 1ms
+      logger.trace({ utteranceEndedAt: this.utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this.utteranceStartedAt = startedAt;
+    this.overlappingState = overlapping;
+    this.speaking = true;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 179-286 lines
+  override onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    if (shouldIgnore && this.overlappingState) {
+      if (
+        this.utteranceStartedAt !== undefined &&
+        this.agentSpeechStartedAt !== undefined &&
+        Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        logger.trace(
+          {
+            pause: Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true within grace period',
+        );
+      } else {
+        this.overlappingState = false;
+        this.speaking = false;
+        this.utteranceStartedAt = undefined;
+        this.utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    if (
+      this.overlappingState ||
+      (this.agentSpeechStartedAt !== undefined && this.agentSpeechEndedAt === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const pause = this.betweenUtteranceDelay;
+
+      if (
+        interruptionDelay > 0 &&
+        interruptionDelay <= this.minDelay &&
+        turnDelay > 0 &&
+        turnDelay <= this.maxDelay &&
+        pause > 0
+      ) {
+        const previousMinDelay = this.minDelay;
+        this.utterancePause.apply(1, pause);
+        logger.debug(
+          {
+            reason: 'immediate interruption',
+            pause,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${previousMinDelay} -> ${this.minDelay}`,
+        );
+      } else if (this.betweenTurnDelay > 0) {
+        const previousMaxDelay = this.maxDelay;
+        this.turnPause.apply(1, this.betweenTurnDelay);
+        logger.debug(
+          {
+            reason: 'new turn (interruption)',
+            pause: this.betweenTurnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+            betweenUtteranceDelay: this.betweenUtteranceDelay,
+            betweenTurnDelay: this.betweenTurnDelay,
+          },
+          `max endpointing delay updated: ${previousMaxDelay} -> ${this.maxDelay}`,
+        );
+      }
+    } else if (this.betweenTurnDelay > 0) {
+      const previousMaxDelay = this.maxDelay;
+      this.turnPause.apply(1, this.betweenTurnDelay);
+      logger.debug(
+        {
+          reason: 'new turn',
+          pause: this.betweenTurnDelay,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `max endpointing delay updated due to pause: ${previousMaxDelay} -> ${this.maxDelay}`,
+      );
+    } else if (
+      this.betweenUtteranceDelay > 0 &&
+      this.agentSpeechEndedAt === undefined &&
+      this.agentSpeechStartedAt === undefined
+    ) {
+      const previousMinDelay = this.minDelay;
+      this.utterancePause.apply(1, this.betweenUtteranceDelay);
+      logger.debug(
+        {
+          reason: 'pause between utterances',
+          pause: this.betweenUtteranceDelay,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `min endpointing delay updated: ${previousMinDelay} -> ${this.minDelay}`,
+      );
+    }
+
+    this.utteranceEndedAt = endedAt;
+    this.agentSpeechStartedAt = undefined;
+    this.agentSpeechEndedAt = undefined;
+    this.speaking = false;
+    this.overlappingState = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 288-302 lines
+  override updateOptions({
+    minDelay,
+    maxDelay,
+  }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this.configuredMinDelay = minDelay;
+      this.utterancePause.reset({ initial: this.configuredMinDelay, min: this.configuredMinDelay });
+      this.turnPause.reset({ min: this.configuredMinDelay });
+    }
+
+    if (maxDelay !== undefined) {
+      this.configuredMaxDelay = maxDelay;
+      this.turnPause.reset({ initial: this.configuredMaxDelay, max: this.configuredMaxDelay });
+      this.utterancePause.reset({ max: this.configuredMaxDelay });
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  switch (options.mode) {
+    case 'dynamic':
+      return new DynamicEndpointing(options.minDelay, options.maxDelay);
+    case 'fixed':
+    default:
+      return new BaseEndpointing(options.minDelay, options.maxDelay);
+  }
+}


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/109).

Tracking issue: https://github.com/livekit/rosetta/issues/109

## Summary
- port the Python dynamic endpointing runtime into the Node.js voice pipeline and wire it through `AudioRecognition` and `AgentActivity`
- extend the shared `ExpFilter` helper and add parity tests for the ported endpointing behavior, plus target-native regression coverage for runtime integration
- add a changeset for the new voice feature

## Source
- `livekit-agents/livekit/agents/voice/endpointing.py`
- `tests/test_endpointing.py`