### PR TITLE
fix(openai): forward session.update on RealtimeSession.updateOptions

### DIFF
--- a/.changeset/openai-realtime-session-opts-copy.md
+++ b/.changeset/openai-realtime-session-opts-copy.md
@@ -1,0 +1,11 @@
+---
+"@livekit/agents-plugin-openai": patch
+---
+
+fix(openai): forward session.update on RealtimeSession.updateOptions
+
+`RealtimeSession.updateOptions()` compared against the shared `RealtimeModel._options`, but the same call mutated that shared object before forwarding to sessions. The diff always saw "no change" and no `session.update` was sent to OpenAI.
+
+Give each `RealtimeSession` its own `_options` copy so the per-session diff is independent of the model-level state and of any other sessions sharing the same model.
+
+Ports [livekit/agents#5531](https://github.com/livekit/agents/pull/5531).

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { llm } from '@livekit/agents';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type * as api_proto from './api_proto.js';
-import { livekitItemToOpenAIItem } from './realtime_model.js';
+import { RealtimeModel, livekitItemToOpenAIItem } from './realtime_model.js';
 
 describe('livekitItemToOpenAIItem', () => {
   describe('message items', () => {
@@ -240,5 +240,88 @@ describe('livekitItemToOpenAIItem', () => {
       expect(result.call_id).toBe('call-123');
       expect(result.output).toBe('The weather in San Francisco is sunny.');
     });
+  });
+});
+
+describe('RealtimeSession.updateOptions', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const stubTaskRuntime = () => {
+    // Prevent background realtime tasks from opening network connections in unit tests.
+    vi.spyOn(llm, 'RealtimeSession', 'get');
+    const agentsModule = require('@livekit/agents') as typeof import('@livekit/agents'); // eslint-disable-line @typescript-eslint/no-require-imports
+    vi.spyOn(agentsModule.Task, 'from').mockReturnValue({
+      cancel: vi.fn(),
+      done: true,
+      result: Promise.resolve(undefined),
+    } as unknown as import('@livekit/agents').Task<void>);
+  };
+
+  it('emits session.update when toolChoice changes', () => {
+    stubTaskRuntime();
+
+    const model = new RealtimeModel({ apiKey: 'test-key' });
+    const session = model.session() as unknown as { updateOptions: (opts: { toolChoice?: llm.ToolChoice }) => void; sendEvent: (event: api_proto.ClientEvent) => void };
+    const sendEventSpy = vi.spyOn(session, 'sendEvent');
+    sendEventSpy.mockClear();
+
+    session.updateOptions({ toolChoice: 'required' });
+
+    expect(sendEventSpy).toHaveBeenCalledTimes(1);
+    expect(sendEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'session.update',
+        session: expect.objectContaining({
+          type: 'realtime',
+          tool_choice: 'required',
+        }),
+      }),
+    );
+  });
+
+  it('does not emit session.update when toolChoice is unchanged', () => {
+    stubTaskRuntime();
+
+    const model = new RealtimeModel({ apiKey: 'test-key' });
+    const session = model.session() as unknown as { updateOptions: (opts: { toolChoice?: llm.ToolChoice }) => void; sendEvent: (event: api_proto.ClientEvent) => void };
+    const sendEventSpy = vi.spyOn(session, 'sendEvent');
+    sendEventSpy.mockClear();
+
+    session.updateOptions({ toolChoice: 'auto' });
+
+    expect(sendEventSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps toolChoice state isolated across sessions from same model', () => {
+    stubTaskRuntime();
+
+    const model = new RealtimeModel({ apiKey: 'test-key' });
+    const sessionA = model.session() as unknown as {
+      updateOptions: (opts: { toolChoice?: llm.ToolChoice }) => void;
+      sendEvent: (event: api_proto.ClientEvent) => void;
+      _options: { toolChoice?: llm.ToolChoice };
+    };
+    const sessionB = model.session() as unknown as {
+      updateOptions: (opts: { toolChoice?: llm.ToolChoice }) => void;
+      sendEvent: (event: api_proto.ClientEvent) => void;
+      _options: { toolChoice?: llm.ToolChoice };
+    };
+
+    const sendEventSpyA = vi.spyOn(sessionA, 'sendEvent');
+    const sendEventSpyB = vi.spyOn(sessionB, 'sendEvent');
+    sendEventSpyA.mockClear();
+    sendEventSpyB.mockClear();
+
+    sessionA.updateOptions({ toolChoice: 'required' });
+
+    expect(sessionA._options.toolChoice).toBe('required');
+    expect(sessionB._options.toolChoice).toBe('auto');
+    expect(sendEventSpyA).toHaveBeenCalledTimes(1);
+    expect(sendEventSpyB).toHaveBeenCalledTimes(0);
+
+    sessionB.updateOptions({ toolChoice: 'required' });
+    expect(sendEventSpyB).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -263,7 +263,10 @@ describe('RealtimeSession.updateOptions', () => {
     stubTaskRuntime();
 
     const model = new RealtimeModel({ apiKey: 'test-key' });
-    const session = model.session() as unknown as { updateOptions: (opts: { toolChoice?: llm.ToolChoice }) => void; sendEvent: (event: api_proto.ClientEvent) => void };
+    const session = model.session() as unknown as {
+      updateOptions: (opts: { toolChoice?: llm.ToolChoice }) => void;
+      sendEvent: (event: api_proto.ClientEvent) => void;
+    };
     const sendEventSpy = vi.spyOn(session, 'sendEvent');
     sendEventSpy.mockClear();
 
@@ -285,7 +288,10 @@ describe('RealtimeSession.updateOptions', () => {
     stubTaskRuntime();
 
     const model = new RealtimeModel({ apiKey: 'test-key' });
-    const session = model.session() as unknown as { updateOptions: (opts: { toolChoice?: llm.ToolChoice }) => void; sendEvent: (event: api_proto.ClientEvent) => void };
+    const session = model.session() as unknown as {
+      updateOptions: (opts: { toolChoice?: llm.ToolChoice }) => void;
+      sendEvent: (event: api_proto.ClientEvent) => void;
+    };
     const sendEventSpy = vi.spyOn(session, 'sendEvent');
     sendEventSpy.mockClear();
 

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -251,7 +251,7 @@ describe('RealtimeSession.updateOptions', () => {
   const stubTaskRuntime = () => {
     // Prevent background realtime tasks from opening network connections in unit tests.
     vi.spyOn(llm, 'RealtimeSession', 'get');
-    const agentsModule = require('@livekit/agents') as typeof import('@livekit/agents'); // eslint-disable-line @typescript-eslint/no-require-imports
+    const agentsModule = require('@livekit/agents') as typeof import('@livekit/agents'); // eslint-disable-line @typescript-eslint/no-var-requires
     vi.spyOn(agentsModule.Task, 'from').mockReturnValue({
       cancel: vi.fn(),
       done: true,

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -415,6 +415,10 @@ export class RealtimeSession extends llm.RealtimeSession {
   private inputResampler?: AudioResampler;
   private instructions?: string;
   private oaiRealtimeModel: RealtimeModel;
+  // Ref: python livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py - 795-797 lines
+  // per-session copy of options so updateOptions can diff against the session's
+  // own state instead of the shared model-level state.
+  private _options: RealtimeOptions;
   private currentGeneration?: ResponseGeneration;
   private responseCreatedFutures: { [id: string]: CreateResponseHandle } = {};
 
@@ -443,6 +447,12 @@ export class RealtimeSession extends llm.RealtimeSession {
     super(realtimeModel);
 
     this.oaiRealtimeModel = realtimeModel;
+    // Ref: python livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py - 796-797 lines
+    // Shallow copy (equivalent to Python's `dataclasses.replace`) so each
+    // session has independent option state. Without this, updateOptions would
+    // mutate the shared model._options before computing its diff, causing the
+    // diff to always see "no change" and never send session.update.
+    this._options = { ...realtimeModel._options };
 
     this.#task = Task.from(({ signal }) => this.#mainTask(signal));
 
@@ -460,7 +470,7 @@ export class RealtimeSession extends llm.RealtimeSession {
   }
 
   private createSessionUpdateEvent(): api_proto.SessionUpdateEvent {
-    const opts = this.oaiRealtimeModel._options;
+    const opts = this._options;
     const maxOutputTokens =
       opts.maxResponseOutputTokens === Infinity ? 'inf' : opts.maxResponseOutputTokens;
 
@@ -722,13 +732,12 @@ export class RealtimeSession extends llm.RealtimeSession {
       }
     }
 
-    const isLegacyAzure =
-      this.oaiRealtimeModel._options.isAzure && !!this.oaiRealtimeModel._options.apiVersion;
+    const isLegacyAzure = this._options.isAzure && !!this._options.apiVersion;
     return {
       type: 'session.update',
       session: {
         ...(!isLegacyAzure && { type: 'realtime' }),
-        model: this.oaiRealtimeModel._options.model,
+        model: this._options.model,
         tools: oaiTools,
       },
       event_id: shortuuid('tools_update_'),
@@ -736,8 +745,7 @@ export class RealtimeSession extends llm.RealtimeSession {
   }
 
   async updateInstructions(_instructions: string): Promise<void> {
-    const isLegacyAzure =
-      this.oaiRealtimeModel._options.isAzure && !!this.oaiRealtimeModel._options.apiVersion;
+    const isLegacyAzure = this._options.isAzure && !!this._options.apiVersion;
     const eventId = shortuuid('instructions_update_');
     this.sendEvent({
       type: 'session.update',
@@ -751,20 +759,19 @@ export class RealtimeSession extends llm.RealtimeSession {
   }
 
   updateOptions({ toolChoice }: { toolChoice?: llm.ToolChoice }): void {
-    const currentToolChoice = toOaiToolChoice(this.oaiRealtimeModel._options.toolChoice);
+    const currentToolChoice = toOaiToolChoice(this._options.toolChoice);
     const nextToolChoice = toOaiToolChoice(toolChoice);
     if (currentToolChoice === nextToolChoice) {
-      this.oaiRealtimeModel._options.toolChoice = toolChoice;
+      this._options.toolChoice = toolChoice;
       return;
     }
 
-    const isLegacyAzure =
-      this.oaiRealtimeModel._options.isAzure && !!this.oaiRealtimeModel._options.apiVersion;
+    const isLegacyAzure = this._options.isAzure && !!this._options.apiVersion;
     const options: api_proto.SessionUpdateEvent['session'] = {
       ...(!isLegacyAzure && { type: 'realtime' }),
     };
 
-    this.oaiRealtimeModel._options.toolChoice = toolChoice;
+    this._options.toolChoice = toolChoice;
     options.tool_choice = toOaiToolChoice(toolChoice);
 
     // TODO(brian): add other options here
@@ -889,32 +896,32 @@ export class RealtimeSession extends llm.RealtimeSession {
       'User-Agent': 'LiveKit-Agents-JS',
     };
 
-    if (this.oaiRealtimeModel._options.isAzure) {
+    if (this._options.isAzure) {
       // Microsoft API has two ways of authentication
       // 1. Entra token set as `Bearer` token
       // 2. API key set as `api_key` header (also accepts query string)
-      if (this.oaiRealtimeModel._options.entraToken) {
-        headers.Authorization = `Bearer ${this.oaiRealtimeModel._options.entraToken}`;
-      } else if (this.oaiRealtimeModel._options.apiKey) {
-        headers['api-key'] = this.oaiRealtimeModel._options.apiKey;
+      if (this._options.entraToken) {
+        headers.Authorization = `Bearer ${this._options.entraToken}`;
+      } else if (this._options.apiKey) {
+        headers['api-key'] = this._options.apiKey;
       } else {
         throw new Error('Microsoft API key or entraToken is required');
       }
     } else {
-      if (!this.oaiRealtimeModel._options.apiKey) {
+      if (!this._options.apiKey) {
         throw new Error(
           'OpenAI API key is required but not set. Check OPENAI_API_KEY environment variable.',
         );
       }
-      headers.Authorization = `Bearer ${this.oaiRealtimeModel._options.apiKey}`;
+      headers.Authorization = `Bearer ${this._options.apiKey}`;
     }
 
     const url = processBaseURL({
-      baseURL: this.oaiRealtimeModel._options.baseURL,
-      model: this.oaiRealtimeModel._options.model,
-      isAzure: this.oaiRealtimeModel._options.isAzure,
-      apiVersion: this.oaiRealtimeModel._options.apiVersion,
-      azureDeployment: this.oaiRealtimeModel._options.azureDeployment,
+      baseURL: this._options.baseURL,
+      model: this._options.model,
+      isAzure: this._options.isAzure,
+      apiVersion: this._options.apiVersion,
+      azureDeployment: this._options.azureDeployment,
     });
 
     if (lkOaiDebug) {
@@ -928,7 +935,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       const timeout = setTimeout(() => {
         ws.close();
         reject(new Error('WebSocket connection timeout'));
-      }, this.oaiRealtimeModel._options.connOptions.timeoutMs);
+      }, this._options.connOptions.timeoutMs);
 
       ws.once('open', () => {
         if (!waiting) return;
@@ -950,12 +957,12 @@ export class RealtimeSession extends llm.RealtimeSession {
     let reconnecting = false;
     let numRetries = 0;
     let wsConn: WebSocket | null = null;
-    const maxRetries = this.oaiRealtimeModel._options.connOptions.maxRetry;
+    const maxRetries = this._options.connOptions.maxRetry;
 
     const reconnect = async () => {
       this.#logger.debug(
         {
-          maxSessionDuration: this.oaiRealtimeModel._options.maxSessionDuration,
+          maxSessionDuration: this._options.maxSessionDuration,
         },
         'Reconnecting to OpenAI Realtime API',
       );
@@ -1005,7 +1012,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       try {
         for (const ev of events) {
           this.emit('openai_client_event_queued', ev);
-          if (this.oaiRealtimeModel._options.isAzure && this.oaiRealtimeModel._options.apiVersion) {
+          if (this._options.isAzure && this._options.apiVersion) {
             normalizeAzureClientEvent(ev as unknown as Record<string, unknown>);
           }
           wsConn!.send(JSON.stringify(ev));
@@ -1063,7 +1070,7 @@ export class RealtimeSession extends llm.RealtimeSession {
         const retryInterval =
           numRetries === 0
             ? DEFAULT_FIRST_RETRY_INTERVAL_MS
-            : this.oaiRealtimeModel._options.connOptions.retryIntervalMs;
+            : this._options.connOptions.retryIntervalMs;
         this.#logger.warn(
           {
             attempt: numRetries,
@@ -1098,7 +1105,7 @@ export class RealtimeSession extends llm.RealtimeSession {
           }
 
           this.emit('openai_client_event_queued', event);
-          if (this.oaiRealtimeModel._options.isAzure && this.oaiRealtimeModel._options.apiVersion) {
+          if (this._options.isAzure && this._options.apiVersion) {
             normalizeAzureClientEvent(event as unknown as Record<string, unknown>);
           }
           wsConn.send(JSON.stringify(event));
@@ -1214,7 +1221,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     });
 
     const waitReconnectTask = Task.from(async ({ signal }) => {
-      await delay(this.oaiRealtimeModel._options.maxSessionDuration, { signal });
+      await delay(this._options.maxSessionDuration, { signal });
       return new APIConnectionError({
         message: 'OpenAI Realtime API connection timeout',
       });
@@ -1269,7 +1276,7 @@ export class RealtimeSession extends llm.RealtimeSession {
         gen.textChannel.close();
         gen.audioChannel.close();
         if (!gen.modalities.done) {
-          gen.modalities.resolve(this.oaiRealtimeModel._options.modalities);
+          gen.modalities.resolve(this._options.modalities);
         }
       }
       this.currentGeneration.messages.clear();
@@ -1295,7 +1302,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     _event: api_proto.InputAudioBufferSpeechStoppedEvent,
   ): void {
     this.emit('input_speech_stopped', {
-      userTranscriptionEnabled: this.oaiRealtimeModel._options.inputAudioTranscription !== null,
+      userTranscriptionEnabled: this._options.inputAudioTranscription !== null,
     } as llm.InputSpeechStoppedEvent);
   }
 
@@ -1644,7 +1651,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       itemGeneration.audioChannel.close();
       if (!itemGeneration.modalities.done) {
         // In case message modalities is not set, this shouldn't happen
-        itemGeneration.modalities.resolve(this.oaiRealtimeModel._options.modalities);
+        itemGeneration.modalities.resolve(this._options.modalities);
       }
     }
   }
@@ -1670,7 +1677,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       generation.textChannel.close();
       generation.audioChannel.close();
       if (!generation.modalities.done) {
-        generation.modalities.resolve(this.oaiRealtimeModel._options.modalities);
+        generation.modalities.resolve(this._options.modalities);
       }
     }
 


### PR DESCRIPTION
## Summary

Ports [livekit/agents#5531](https://github.com/livekit/agents/pull/5531) ("fix(openai): forward session.update on RealtimeModel.update_options") from the Python repo.

### Upstream bug

`RealtimeSession.updateOptions()` compared the incoming options against `RealtimeModel._options` and then mutated that same object before forwarding the update. Because both sides of the diff read from the same mutable object, the diff always saw "no change" and no `session.update` event was ever sent to OpenAI — so the realtime session never actually applied the new options.

The shared-state problem is additionally harmful with multiple sessions attached to the same `RealtimeModel`: one session's `updateOptions` would silently overwrite another session's options.

### Fix

Give each `RealtimeSession` its own shallow copy of `RealtimeOptions`, populated from the model's options at construction time. All reads/writes inside `RealtimeSession` now go through `this._options` instead of `this.oaiRealtimeModel._options`, so:

- `updateOptions` compares against — and mutates — per-session state, so its diff is meaningful and the `session.update` event is emitted.
- Sessions no longer stomp on each other when they share a model.

## Ported changes

- `plugins/openai/src/realtime/realtime_model.ts`
  - New private field `RealtimeSession._options: RealtimeOptions`.
  - Constructor initializes it via a shallow spread: `this._options = { ...realtimeModel._options }`.
  - Mechanically rewrote every `this.oaiRealtimeModel._options` reference inside `RealtimeSession` to `this._options` (connection headers, URL building, Azure branching, session-update construction, tool-update event, `updateOptions`, max-session-duration timeout, modalities resolution, etc.).
  - All references inside `RealtimeModel` itself are untouched — only `RealtimeSession` now reads from a local copy.
- `.changeset/openai-realtime-session-opts-copy.md` (patch bump for `@livekit/agents-plugin-openai`).

Per-line `// Ref: python …` comments are added at the two structural change sites (the new field and the constructor copy), matching the repo convention in `CLAUDE.md` for Python ports.

## Implementation nuances / notes on parity

- **Shallow copy choice.** Python uses `dataclasses.replace(realtime_model._opts)`, which produces a new dataclass instance with the same field values (shallow). In TS, `{ ...realtimeModel._options }` is the direct equivalent — we copy the top-level field references. Nested objects (`connOptions`, `turnDetection`, `inputAudioTranscription`, etc.) are still shared by reference, which matches Python's `dataclasses.replace` semantics exactly. This is deliberate: `updateOptions` replaces whole option fields rather than mutating nested ones, so shared nested references don't reintroduce the bug.
- **Scope of `updateOptions` differs from Python.** The JS `updateOptions` currently only accepts `toolChoice` (see the existing `TODO(brian): add other options here`), whereas the Python version diffs many more options (`voice`, `turn_detection`, `input_audio_transcription`, `input_audio_noise_reduction`, `speed`, `tracing`, `truncation`, `max_response_output_tokens`). We ported the **root-cause structural fix** (per-session `_options` copy), so when additional options are added to JS's `updateOptions` in the future, they will automatically inherit the correct diff semantics. Porting the additional option branches themselves is left out of this PR to keep the change minimal and 1:1 with the upstream fix's intent.
- **`RealtimeModel._options` unchanged.** The model-level options still reflect constructor inputs and are what new sessions copy from. This matches Python: `RealtimeModel._opts` is the template, each `RealtimeSession` gets an independent snapshot.
- **No behavior change at the model level.** Callers who only use one session per model get identical observable behavior plus the `session.update` fix. Callers who reuse a model across sessions get the additional correctness improvement of isolated per-session state.

## Test plan

- [x] `pnpm build:agents` — passes.
- [x] `pnpm --filter=@livekit/agents-plugin-openai build` — passes (types + tsup).
- [x] `pnpm test -- plugins/openai` — all 12 `realtime_model.test.ts` tests pass. (Unrelated `ws/llm.test.ts` failure requires `OPENAI_API_KEY` and predates this change.)
- [x] `pnpm --filter=@livekit/agents-plugin-openai lint` — no new errors/warnings introduced by this change (remaining warnings are pre-existing `no-explicit-any` / tsdoc items).
- [ ] Manual verification in Agent Playground: call `session.updateOptions({ toolChoice: ... })` mid-session and confirm a `session.update` frame is emitted.

---

cc @toubatbrian @livekit/agent-devs

🤖 This PR was generated by an automated Claude Code routine that ports merged `livekit/agents` plugin / core runtime PRs into `livekit/agents-js`. Experimental — please review the ported logic and the nuances noted above carefully.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMabbgaksL9ErAXjqyQfaY)_