### PR TITLE
Port dynamic endpointing to the Node.js voice SDK

### DIFF
--- a/.changeset/dynamic-endpointing.md
+++ b/.changeset/dynamic-endpointing.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': minor
+---
+
+feat(voice): add dynamic endpointing support

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -352,43 +352,86 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 
 /** @internal */
 export class ExpFilter {
-  #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  private _alpha: number;
+  private _maxVal: number | undefined;
+  private _minVal: number | undefined;
+  private _filtered: number | undefined;
 
-  constructor(alpha: number, max?: number) {
-    this.#alpha = alpha;
-    this.#max = max;
-  }
-
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+  constructor(alpha: number, opts?: number | { max?: number; min?: number; initial?: number }) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
     }
-    this.#filtered = undefined;
+
+    this._alpha = alpha;
+    this._maxVal = typeof opts === 'number' ? opts : opts?.max;
+    this._minVal = typeof opts === 'number' ? undefined : opts?.min;
+    this._filtered = typeof opts === 'number' ? undefined : opts?.initial;
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
-      const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
+  reset(opts?: number | { alpha?: number; initial?: number; min?: number; max?: number }) {
+    if (typeof opts === 'number') {
+      if (!(opts > 0 && opts <= 1)) {
+        throw new Error('alpha must be in (0, 1].');
+      }
+      this._alpha = opts;
+      this._filtered = undefined;
+      return;
+    }
+
+    if (opts?.alpha !== undefined) {
+      if (!(opts.alpha > 0 && opts.alpha <= 1)) {
+        throw new Error('alpha must be in (0, 1].');
+      }
+      this._alpha = opts.alpha;
+    }
+    if (opts && Object.hasOwn(opts, 'initial')) {
+      this._filtered = opts.initial;
+    }
+    if (opts && Object.hasOwn(opts, 'min')) {
+      this._minVal = opts.min;
+    }
+    if (opts && Object.hasOwn(opts, 'max')) {
+      this._maxVal = opts.max;
+    }
+  }
+
+  apply(exp: number, sample?: number): number {
+    const resolvedSample = sample ?? this._filtered;
+
+    if (resolvedSample === undefined) {
+      throw new Error('sample or initial value must be given.');
+    }
+
+    if (this._filtered === undefined) {
+      this._filtered = resolvedSample;
     } else {
-      this.#filtered = sample;
+      const a = this._alpha ** exp;
+      this._filtered = a * this._filtered + (1 - a) * resolvedSample;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (this._maxVal !== undefined && this._filtered > this._maxVal) {
+      this._filtered = this._maxVal;
+    }
+    if (this._minVal !== undefined && this._filtered < this._minVal) {
+      this._filtered = this._minVal;
     }
 
-    return this.#filtered;
+    return this._filtered;
   }
 
   get filtered(): number | undefined {
-    return this.#filtered;
+    return this._filtered;
+  }
+
+  get value(): number | undefined {
+    return this._filtered;
   }
 
   set alpha(alpha: number) {
-    this.#alpha = alpha;
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
+    this._alpha = alpha;
   }
 }
 

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -352,29 +352,33 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 
 /** @internal */
 export class ExpFilter {
-  private _alpha: number;
-  private _maxVal: number | undefined;
-  private _minVal: number | undefined;
-  private _filtered: number | undefined;
+  #alpha: number;
+  #maxVal: number | undefined;
+  #minVal: number | undefined;
+  #filtered: number | undefined;
 
+  constructor(alpha: number, max?: number);
+  constructor(alpha: number, opts?: { max?: number; min?: number; initial?: number });
   constructor(alpha: number, opts?: number | { max?: number; min?: number; initial?: number }) {
     if (!(alpha > 0 && alpha <= 1)) {
       throw new Error('alpha must be in (0, 1].');
     }
 
-    this._alpha = alpha;
-    this._maxVal = typeof opts === 'number' ? opts : opts?.max;
-    this._minVal = typeof opts === 'number' ? undefined : opts?.min;
-    this._filtered = typeof opts === 'number' ? undefined : opts?.initial;
+    this.#alpha = alpha;
+    this.#maxVal = typeof opts === 'number' ? opts : opts?.max;
+    this.#minVal = typeof opts === 'number' ? undefined : opts?.min;
+    this.#filtered = typeof opts === 'number' ? undefined : opts?.initial;
   }
 
+  reset(alpha?: number): void;
+  reset(opts?: { alpha?: number; initial?: number; min?: number; max?: number }): void;
   reset(opts?: number | { alpha?: number; initial?: number; min?: number; max?: number }) {
     if (typeof opts === 'number') {
       if (!(opts > 0 && opts <= 1)) {
         throw new Error('alpha must be in (0, 1].');
       }
-      this._alpha = opts;
-      this._filtered = undefined;
+      this.#alpha = opts;
+      this.#filtered = undefined;
       return;
     }
 
@@ -382,56 +386,70 @@ export class ExpFilter {
       if (!(opts.alpha > 0 && opts.alpha <= 1)) {
         throw new Error('alpha must be in (0, 1].');
       }
-      this._alpha = opts.alpha;
+      this.#alpha = opts.alpha;
     }
     if (opts && Object.hasOwn(opts, 'initial')) {
-      this._filtered = opts.initial;
+      this.#filtered = opts.initial;
     }
     if (opts && Object.hasOwn(opts, 'min')) {
-      this._minVal = opts.min;
+      this.#minVal = opts.min;
     }
     if (opts && Object.hasOwn(opts, 'max')) {
-      this._maxVal = opts.max;
+      this.#maxVal = opts.max;
     }
   }
 
+  apply(exp: number, sample: number): number;
+  apply(exp: number, sample?: number): number;
   apply(exp: number, sample?: number): number {
-    const resolvedSample = sample ?? this._filtered;
+    const resolvedSample = sample ?? this.#filtered;
 
     if (resolvedSample === undefined) {
       throw new Error('sample or initial value must be given.');
     }
 
-    if (this._filtered === undefined) {
-      this._filtered = resolvedSample;
+    if (this.#filtered === undefined) {
+      this.#filtered = resolvedSample;
     } else {
-      const a = this._alpha ** exp;
-      this._filtered = a * this._filtered + (1 - a) * resolvedSample;
+      const a = this.#alpha ** exp;
+      this.#filtered = a * this.#filtered + (1 - a) * resolvedSample;
     }
 
-    if (this._maxVal !== undefined && this._filtered > this._maxVal) {
-      this._filtered = this._maxVal;
+    if (this.#maxVal !== undefined && this.#filtered > this.#maxVal) {
+      this.#filtered = this.#maxVal;
     }
-    if (this._minVal !== undefined && this._filtered < this._minVal) {
-      this._filtered = this._minVal;
+    if (this.#minVal !== undefined && this.#filtered < this.#minVal) {
+      this.#filtered = this.#minVal;
     }
 
-    return this._filtered;
+    return this.#filtered;
   }
 
   get filtered(): number | undefined {
-    return this._filtered;
+    return this.#filtered;
   }
 
   get value(): number | undefined {
-    return this._filtered;
+    return this.#filtered;
+  }
+
+  get _alpha(): number {
+    return this.#alpha;
+  }
+
+  get _maxVal(): number | undefined {
+    return this.#maxVal;
+  }
+
+  get _minVal(): number | undefined {
+    return this.#minVal;
   }
 
   set alpha(alpha: number) {
     if (!(alpha > 0 && alpha <= 1)) {
       throw new Error('alpha must be in (0, 1].');
     }
-    this._alpha = alpha;
+    this.#alpha = alpha;
   }
 }
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -208,6 +208,7 @@ export class AgentActivity implements RecognitionHooks {
   private readonly onModelError = (ev: RealtimeModelError | STTError | TTSError | LLMError): void =>
     this.onError(ev);
 
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1484-1488 lines
   private readonly onInterruptionOverlappingSpeech = (ev: OverlappingSpeechEvent): void => {
     this.interruptionDetected = ev.isInterruption;
     this.agentSession.emit(AgentSessionEventTypes.OverlappingSpeech, ev);

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -493,6 +493,12 @@ export class AgentActivity implements RecognitionHooks {
           this.agent.turnHandling?.endpointing?.maxDelay ??
           this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
       }),
+      minEndpointingDelay:
+        this.agent.turnHandling?.endpointing?.minDelay ??
+        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
+      maxEndpointingDelay:
+        this.agent.turnHandling?.endpointing?.maxDelay ??
+        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -726,9 +732,25 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 431-482 lines
+  updateOptions({
+    toolChoice,
+    turnDetection,
+  }: {
+    toolChoice?: ToolChoice | null;
+    turnDetection?: TurnDetectionMode | undefined;
+  }): void;
+  updateOptions({
+    toolChoice,
+    turnDetection,
+    endpointing,
+  }: {
+    toolChoice?: ToolChoice | null;
+    turnDetection?: TurnDetectionMode | undefined;
+    endpointing?: EndpointingOptions;
+  }): void;
   updateOptions(options: {
     toolChoice?: ToolChoice | null;
-    turnDetection?: TurnDetectionMode;
+    turnDetection?: TurnDetectionMode | undefined;
     endpointing?: EndpointingOptions;
   }): void {
     const { toolChoice, turnDetection, endpointing } = options;

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -65,6 +65,7 @@ import {
   type RecognitionHooks,
   type STTPipeline,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import {
   AgentSessionEventTypes,
   createErrorEvent,
@@ -88,6 +89,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -185,6 +187,7 @@ export class AgentActivity implements RecognitionHooks {
   private _preemptiveGeneration?: PreemptiveGeneration;
   private _preemptiveGenerationCount = 0;
   private interruptionDetector?: AdaptiveInterruptionDetector;
+  private interruptionDetected = false;
   private isInterruptionDetectionEnabled: boolean;
   private isInterruptionByAudioActivityEnabled: boolean;
   private isDefaultInterruptionByAudioActivityEnabled: boolean;
@@ -206,6 +209,7 @@ export class AgentActivity implements RecognitionHooks {
     this.onError(ev);
 
   private readonly onInterruptionOverlappingSpeech = (ev: OverlappingSpeechEvent): void => {
+    this.interruptionDetected = ev.isInterruption;
     this.agentSession.emit(AgentSessionEventTypes.OverlappingSpeech, ev);
   };
 
@@ -477,12 +481,18 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 768-778 lines
+      endpointing: createEndpointing({
+        mode:
+          this.agent.turnHandling?.endpointing?.mode ??
+          this.agentSession.sessionOptions.turnHandling.endpointing.mode,
+        minDelay:
+          this.agent.turnHandling?.endpointing?.minDelay ??
+          this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
+        maxDelay:
+          this.agent.turnHandling?.endpointing?.maxDelay ??
+          this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      }),
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -715,13 +725,14 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
-  updateOptions({
-    toolChoice,
-    turnDetection,
-  }: {
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 431-482 lines
+  updateOptions(options: {
     toolChoice?: ToolChoice | null;
     turnDetection?: TurnDetectionMode;
+    endpointing?: EndpointingOptions;
   }): void {
+    const { toolChoice, turnDetection, endpointing } = options;
+
     if (toolChoice !== undefined) {
       this.toolChoice = toolChoice;
     }
@@ -730,7 +741,7 @@ export class AgentActivity implements RecognitionHooks {
       this.realtimeSession.updateOptions({ toolChoice: this.toolChoice });
     }
 
-    if (turnDetection !== undefined) {
+    if (Object.hasOwn(options, 'turnDetection')) {
       this.turnDetectionMode = turnDetection;
       this.isDefaultInterruptionByAudioActivityEnabled =
         this.turnDetectionMode !== 'manual' && this.turnDetectionMode !== 'realtime_llm';
@@ -743,7 +754,12 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (this.audioRecognition) {
-      this.audioRecognition.updateOptions({ turnDetection: this.turnDetectionMode });
+      this.audioRecognition.updateOptions({
+        ...(endpointing ? { endpointing: createEndpointing(endpointing) } : {}),
+        ...(Object.hasOwn(options, 'turnDetection')
+          ? { turnDetection: this.turnDetectionMode }
+          : {}),
+      });
     }
   }
 
@@ -917,17 +933,14 @@ export class AgentActivity implements RecognitionHooks {
 
   // -- Realtime Session events --
 
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1490-1517 lines
   onInputSpeechStarted(_ev: InputSpeechStartedEvent): void {
     this.logger.info('onInputSpeechStarted');
 
     if (!this.vad) {
       this.agentSession._updateUserState('speaking');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfOverlapSpeech(
-          0,
-          Date.now(),
-          this.agentSession._userSpeakingSpan,
-        );
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfSpeech(Date.now(), 0, this.agentSession._userSpeakingSpan);
       }
     }
 
@@ -943,12 +956,13 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1508-1521 lines
   onInputSpeechStopped(ev: InputSpeechStoppedEvent): void {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
+      if (this.audioRecognition) {
+        this.audioRecognition.onEndOfSpeech(Date.now(), this.agentSession._userSpeakingSpan);
       }
       this.agentSession._updateUserState('listening');
     }
@@ -1020,6 +1034,7 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   // recognition hooks
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1645-1658 lines
   onStartOfSpeech(ev: VADEvent): void {
     let speechStartTime = Date.now();
     if (ev) {
@@ -1030,27 +1045,28 @@ export class AgentActivity implements RecognitionHooks {
       lastSpeakingTime: speechStartTime,
       otelContext: otelContext.active(),
     });
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
+    if (this.audioRecognition) {
+      this.audioRecognition.onStartOfSpeech(
         speechStartTime,
+        ev.speechDuration,
         this.agentSession._userSpeakingSpan,
       );
     }
+    this.interruptionDetected = false;
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1665-1693 lines
   onEndOfSpeech(ev: VADEvent): void {
     let speechEndTime = Date.now();
     if (ev) {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
+    if (this.audioRecognition) {
+      this.audioRecognition.onEndOfSpeech(
         speechEndTime,
         this.agentSession._userSpeakingSpan,
+        this.interruptionDetected,
       );
     }
     this.agentSession._updateUserState('listening', {
@@ -1072,6 +1088,7 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1565-1637 lines
   private interruptByAudioActivity(): void {
     if (!this.isInterruptionByAudioActivityEnabled) {
       return;
@@ -1117,6 +1134,14 @@ export class AgentActivity implements RecognitionHooks {
       !this._currentSpeech.interrupted &&
       this._currentSpeech.allowInterruptions
     ) {
+      if (
+        this.audioRecognition &&
+        !this.audioRecognition.overlapping &&
+        this.agentSession.agentState === 'speaking'
+      ) {
+        this.audioRecognition.onStartOfSpeech(Date.now());
+      }
+
       this.logger.info(
         { 'speech id': this._currentSpeech.id },
         'speech interrupted by audio activity',
@@ -1126,6 +1151,7 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1721-1731 lines
   onInterruption(ev: OverlappingSpeechEvent) {
     this.restoreInterruptionByAudioActivity();
     this.interruptByAudioActivity();
@@ -1838,7 +1864,7 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2114,7 +2140,7 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -142,10 +142,10 @@ export interface AudioRecognitionOptions {
   /** Endpointing strategy. */
   endpointing?: BaseEndpointing;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** @deprecated Prefer `endpointing`. Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay?: number;
-  /** @deprecated Prefer `endpointing`. Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay?: number;
+  /** Minimum endpointing delay in milliseconds. */
+  minEndpointingDelay: number;
+  /** Maximum endpointing delay in milliseconds. */
+  maxEndpointingDelay: number;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -175,6 +175,8 @@ export class AudioRecognition {
   private _endpointing: BaseEndpointing;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
+  private minEndpointingDelay: number;
+  private maxEndpointingDelay: number;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -225,12 +227,14 @@ export class AudioRecognition {
     this.hooks = opts.recognitionHooks;
     this.stt = opts.stt;
     this.vad = opts.vad;
+    this.minEndpointingDelay = opts.minEndpointingDelay;
+    this.maxEndpointingDelay = opts.maxEndpointingDelay;
     this._endpointing =
       opts.endpointing ??
       createEndpointing({
         mode: defaultEndpointingOptions.mode,
-        minDelay: opts.minEndpointingDelay ?? defaultEndpointingOptions.minDelay,
-        maxDelay: opts.maxEndpointingDelay ?? defaultEndpointingOptions.maxDelay,
+        minDelay: this.minEndpointingDelay ?? defaultEndpointingOptions.minDelay,
+        maxDelay: this.maxEndpointingDelay ?? defaultEndpointingOptions.maxDelay,
       });
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
@@ -295,6 +299,8 @@ export class AudioRecognition {
   }): void {
     if (Object.hasOwn(options, 'endpointing') && options.endpointing !== undefined) {
       this._endpointing = options.endpointing;
+      this.minEndpointingDelay = options.endpointing.minDelay;
+      this.maxEndpointingDelay = options.endpointing.maxDelay;
     }
 
     if (Object.hasOwn(options, 'turnDetection')) {
@@ -417,7 +423,7 @@ export class AudioRecognition {
   /** Start interruption inference when agent is speaking and overlap speech starts. */
   async onStartOfOverlapSpeech(speechDuration: number, startedAt: number, userSpeakingSpan?: Span) {
     if (this.isAgentSpeaking) {
-      return this.trySendInterruptionSentinel(
+      await this.trySendInterruptionSentinel(
         InterruptionStreamSentinel.overlapSpeechStarted(
           speechDuration,
           startedAt,
@@ -427,6 +433,7 @@ export class AudioRecognition {
     }
   }
 
+  /** End interruption inference when overlap speech ends. */
   // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 307-329 lines
   async onEndOfOverlapSpeech(endedAt: number, userSpeakingSpan?: Span) {
     if (!this.isInterruptionEnabled) {

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,7 +35,9 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import { type BaseEndpointing, createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
+import { defaultEndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export interface EndOfTurnInfo {
@@ -137,11 +139,13 @@ export interface AudioRecognitionOptions {
   turnDetector?: _TurnDetector;
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
+  /** Endpointing strategy. */
+  endpointing?: BaseEndpointing;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
-  /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  /** @deprecated Prefer `endpointing`. Minimum endpointing delay in milliseconds. */
+  minEndpointingDelay?: number;
+  /** @deprecated Prefer `endpointing`. Maximum endpointing delay in milliseconds. */
+  maxEndpointingDelay?: number;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -168,10 +172,9 @@ export class AudioRecognition {
   private stt?: STTNode;
   private sttPipeline?: STTPipeline;
   private vad?: VAD;
+  private _endpointing: BaseEndpointing;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -222,10 +225,15 @@ export class AudioRecognition {
     this.hooks = opts.recognitionHooks;
     this.stt = opts.stt;
     this.vad = opts.vad;
+    this._endpointing =
+      opts.endpointing ??
+      createEndpointing({
+        mode: defaultEndpointingOptions.mode,
+        minDelay: opts.minEndpointingDelay ?? defaultEndpointingOptions.minDelay,
+        maxDelay: opts.maxEndpointingDelay ?? defaultEndpointingOptions.maxDelay,
+      });
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,8 +283,38 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
-    this.turnDetectionMode = options.turnDetection;
+  get overlapping() {
+    return this._endpointing.overlapping;
+  }
+
+  /** @internal */
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 192-219 lines
+  updateOptions(options: {
+    endpointing?: BaseEndpointing;
+    turnDetection?: TurnDetectionMode | undefined;
+  }): void {
+    if (Object.hasOwn(options, 'endpointing') && options.endpointing !== undefined) {
+      this._endpointing = options.endpointing;
+    }
+
+    if (Object.hasOwn(options, 'turnDetection')) {
+      const turnDetection = options.turnDetection;
+      this.turnDetector = typeof turnDetection === 'string' ? undefined : turnDetection;
+
+      const mode = typeof turnDetection === 'string' ? turnDetection : undefined;
+      if (this.turnDetectionMode !== mode) {
+        const previousMode = this.turnDetectionMode;
+        this.turnDetectionMode = mode;
+
+        if (this.turnDetectionMode === 'manual' || previousMode === 'manual') {
+          if (this.bounceEOUTask && !this.bounceEOUTask.done) {
+            this.bounceEOUTask.cancel();
+          }
+          this.bounceEOUTask = undefined;
+          this.userTurnCommitted = false;
+        }
+      }
+    }
   }
 
   async start(options?: { sttPipeline?: STTPipeline }) {
@@ -311,12 +349,19 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-243 lines
+  async onStartOfAgentSpeech(startedAt: number) {
     this.isAgentSpeaking = true;
+    this._endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 245-270 lines
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this._endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -344,10 +389,35 @@ export class AudioRecognition {
     this.isAgentSpeaking = false;
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 272-289 lines
+  onStartOfSpeech(startedAt: number, speechDuration = 0, userSpeakingSpan?: Span): void {
+    this._endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+
+    if (!this.isInterruptionEnabled || !this.isAgentSpeaking) {
+      return;
+    }
+
+    void this.trySendInterruptionSentinel(
+      InterruptionStreamSentinel.overlapSpeechStarted(speechDuration, startedAt, userSpeakingSpan),
+    );
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-329 lines
+  onEndOfSpeech(endedAt: number, userSpeakingSpan?: Span, interruption?: boolean): void {
+    if (this.speaking) {
+      this._endpointing.onEndOfSpeech(
+        endedAt,
+        interruption !== undefined && !interruption && this.isAgentSpeaking,
+      );
+    }
+
+    void this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
+  }
+
   /** Start interruption inference when agent is speaking and overlap speech starts. */
   async onStartOfOverlapSpeech(speechDuration: number, startedAt: number, userSpeakingSpan?: Span) {
     if (this.isAgentSpeaking) {
-      this.trySendInterruptionSentinel(
+      return this.trySendInterruptionSentinel(
         InterruptionStreamSentinel.overlapSpeechStarted(
           speechDuration,
           startedAt,
@@ -357,7 +427,7 @@ export class AudioRecognition {
     }
   }
 
-  /** End interruption inference when overlap speech ends. */
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 307-329 lines
   async onEndOfOverlapSpeech(endedAt: number, userSpeakingSpan?: Span) {
     if (!this.isInterruptionEnabled) {
       return;
@@ -805,7 +875,7 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        let endpointingDelay = this._endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +901,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this._endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');

--- a/agents/src/voice/audio_recognition_endpointing.test.ts
+++ b/agents/src/voice/audio_recognition_endpointing.test.ts
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { initializeLogger } from '../log.js';
+import { AudioRecognition, type RecognitionHooks } from './audio_recognition.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+type AudioRecognitionState = AudioRecognition & {
+  _endpointing: DynamicEndpointing;
+  speaking: boolean;
+};
+
+function state(recognition: AudioRecognition): AudioRecognitionState {
+  return recognition as unknown as AudioRecognitionState;
+}
+
+initializeLogger({ pretty: false, level: 'silent' });
+
+function createHooks(): RecognitionHooks {
+  return {
+    onInterruption: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onEndOfTurn: vi.fn(async () => true),
+    onPreemptiveGeneration: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+  };
+}
+
+describe('AudioRecognition dynamic endpointing', () => {
+  it('applies updated dynamic min delay to subsequent speech callbacks', () => {
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing: new DynamicEndpointing(300, 1000, 0.5),
+    });
+
+    state(recognition).speaking = true;
+    recognition.onStartOfSpeech(99000);
+    recognition.onEndOfSpeech(100000);
+
+    state(recognition).speaking = true;
+    recognition.onStartOfSpeech(100400);
+    recognition.onEndOfSpeech(100900);
+
+    const endpointing = state(recognition)._endpointing;
+    expect(endpointing.minDelay).toBeCloseTo(350, 5);
+  });
+
+  it('applies dynamic max delay updates from agent-speech interruptions', async () => {
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing: new DynamicEndpointing(300, 1000, 0.5),
+    });
+
+    state(recognition).speaking = true;
+    recognition.onStartOfSpeech(99000);
+    recognition.onEndOfSpeech(100000);
+
+    await recognition.onStartOfAgentSpeech(100600);
+
+    state(recognition).speaking = true;
+    recognition.onStartOfSpeech(101500);
+    recognition.onEndOfSpeech(102000);
+
+    const endpointing = state(recognition)._endpointing;
+    expect(endpointing.maxDelay).toBeCloseTo(800, 5);
+  });
+
+  it('replaces endpointing state on updateOptions', () => {
+    const original = new DynamicEndpointing(300, 1000, 0.5);
+    original.onEndOfSpeech(100000);
+    original.onStartOfSpeech(100400);
+    original.onEndOfSpeech(100500, false);
+    expect(original.minDelay).toBeCloseTo(350, 5);
+
+    const replacement = new DynamicEndpointing(500, 2000, 0.5);
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing: original,
+    });
+
+    recognition.updateOptions({ endpointing: replacement });
+
+    expect(state(recognition)._endpointing).toBe(replacement);
+    expect(state(recognition)._endpointing.minDelay).toBe(500);
+  });
+});

--- a/agents/src/voice/audio_recognition_endpointing.test.ts
+++ b/agents/src/voice/audio_recognition_endpointing.test.ts
@@ -37,6 +37,8 @@ describe('AudioRecognition dynamic endpointing', () => {
     const recognition = new AudioRecognition({
       recognitionHooks: createHooks(),
       endpointing: new DynamicEndpointing(300, 1000, 0.5),
+      minEndpointingDelay: 300,
+      maxEndpointingDelay: 1000,
     });
 
     state(recognition).speaking = true;
@@ -55,6 +57,8 @@ describe('AudioRecognition dynamic endpointing', () => {
     const recognition = new AudioRecognition({
       recognitionHooks: createHooks(),
       endpointing: new DynamicEndpointing(300, 1000, 0.5),
+      minEndpointingDelay: 300,
+      maxEndpointingDelay: 1000,
     });
 
     state(recognition).speaking = true;
@@ -82,6 +86,8 @@ describe('AudioRecognition dynamic endpointing', () => {
     const recognition = new AudioRecognition({
       recognitionHooks: createHooks(),
       endpointing: original,
+      minEndpointingDelay: 300,
+      maxEndpointingDelay: 1000,
     });
 
     recognition.updateOptions({ endpointing: replacement });

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,491 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { ExpFilter } from '../utils.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+type ExpFilterState = ExpFilter & {
+  _alpha: number;
+  _maxVal?: number;
+  _minVal?: number;
+};
+
+type DynamicEndpointingState = DynamicEndpointing & {
+  _agentSpeechEndedAt?: number;
+  _agentSpeechStartedAt?: number;
+  _maxDelay: number;
+  _minDelay: number;
+  _overlapping: boolean;
+  _speaking: boolean;
+  _turnPause: ExpFilterState;
+  _utteranceEndedAt?: number;
+  _utterancePause: ExpFilterState;
+  _utteranceStartedAt?: number;
+};
+
+function state(ep: DynamicEndpointing): DynamicEndpointingState {
+  return ep as unknown as DynamicEndpointingState;
+}
+
+describe('ExpFilter', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    let ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    ema = new ExpFilter(0.5, { initial: 10 });
+    expect(ema.value).toBe(10);
+
+    ema = new ExpFilter(1.0);
+    expect(ema.value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0.0)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(-0.5)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(1.5)).toThrow('alpha must be in');
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1.0, 10.0);
+    expect(result).toBe(10.0);
+    expect(ema.value).toBe(10.0);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    const result = ema.apply(1.0, 20.0);
+    expect(result).toBe(15.0);
+    expect(ema.value).toBe(15.0);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    ema.apply(1.0, 20.0);
+    ema.apply(1.0, 20.0);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    let ema = new ExpFilter(0.5, { initial: 10.0 });
+    expect(ema.value).toBe(10.0);
+    ema.reset();
+    expect(ema.value).toBe(10.0);
+
+    ema = new ExpFilter(0.5, { initial: 10.0 });
+    ema.reset({ initial: 5.0 });
+    expect(ema.value).toBe(5.0);
+  });
+});
+
+describe('DynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.2);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(state(ep)._utterancePause._alpha).toBeCloseTo(0.9, 5);
+    expect(state(ep)._turnPause._alpha).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toEqual([0, 0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    let ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    expect(state(ep)._utteranceEndedAt).toBe(100000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(99900);
+    expect(state(ep)._utteranceEndedAt).toBe(99900);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfSpeech(100000);
+    expect(state(ep)._utteranceStartedAt).toBe(100000);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100000);
+    expect(state(ep)._agentSpeechStartedAt).toBe(100000);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100500);
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(500, 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100800);
+    expect(ep.betweenTurnDelay).toBeCloseTo(800, 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400);
+    ep.onEndOfSpeech(100500, false);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100600);
+    ep.onStartOfSpeech(101500);
+    ep.onEndOfSpeech(102000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 600 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    expect(state(ep)._agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(100250, true);
+    expect(state(ep)._overlapping).toBe(true);
+
+    ep.onEndOfSpeech(100500);
+
+    expect(state(ep)._overlapping).toBe(false);
+    expect(state(ep)._agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(300, 5);
+  });
+
+  it('test_update_options', () => {
+    let ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ minDelay: 500 });
+    expect(ep.minDelay).toBe(500);
+    expect(state(ep)._minDelay).toBe(500);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ maxDelay: 2000 });
+    expect(ep.maxDelay).toBe(2000);
+    expect(state(ep)._maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions();
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(102000);
+    ep.onStartOfSpeech(105000);
+
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100100);
+    ep.onStartOfSpeech(100500);
+
+    expect(ep.maxDelay).toBeGreaterThanOrEqual(state(ep)._minDelay);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    expect(state(ep)._agentSpeechStartedAt).toBeDefined();
+
+    ep.onStartOfSpeech(102000);
+    ep.onEndOfSpeech(103000, false);
+    expect(state(ep)._agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect(state(ep)._overlapping).toBe(true);
+    const previous = [ep.minDelay, ep.maxDelay];
+
+    ep.onStartOfSpeech(100350);
+
+    expect(state(ep)._overlapping).toBe(true);
+    expect([ep.minDelay, ep.maxDelay]).toEqual(previous);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800);
+    ep.onEndOfSpeech(102000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing(60, 1000, 1.0);
+
+    ep.onEndOfSpeech(99000);
+    ep.onStartOfSpeech(100000);
+
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect(state(ep)._utteranceEndedAt).toBeCloseTo(100199, 3);
+    expect(ep.minDelay).toBeCloseTo(60, 5);
+    expect(ep.maxDelay).toBeCloseTo(1000, 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+
+    expect(state(ep)._utterancePause._alpha).toBeCloseTo(0.5, 5);
+    expect(state(ep)._turnPause._alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(state(ep)._utterancePause._minVal).toBe(500);
+    expect(state(ep)._turnPause._maxVal).toBe(2000);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100200);
+    expect(ep.minDelay).toBeCloseTo(500, 5);
+
+    ep.onEndOfSpeech(101000);
+    ep.onStartOfAgentSpeech(102800);
+    ep.onStartOfSpeech(103500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101500, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101800, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect(state(ep)._utteranceStartedAt).toBeUndefined();
+    expect(state(ep)._utteranceEndedAt).toBeUndefined();
+    expect(state(ep)._overlapping).toBe(false);
+    expect(state(ep)._speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400, false);
+    ep.onEndOfSpeech(100600, true);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(100600, true);
+
+    ep.onEndOfSpeech(100800, true);
+
+    expect(state(ep)._utteranceEndedAt).toBe(100800);
+    expect(state(ep)._speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101000, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+    ep.onEndOfSpeech(101500, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect(state(ep)._utteranceStartedAt).toBeUndefined();
+    expect(state(ep)._utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    ep.onStartOfAgentSpeech(100000);
+    ep.onStartOfSpeech(100100, true);
+    expect(state(ep)._overlapping).toBe(true);
+    expect(state(ep)._agentSpeechStartedAt).toBe(100000);
+
+    ep.onEndOfAgentSpeech(101000);
+
+    expect(state(ep)._agentSpeechEndedAt).toBe(101000);
+    expect(state(ep)._agentSpeechStartedAt).toBe(100000);
+    expect(state(ep)._overlapping).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800, false);
+    ep.onEndOfSpeech(102000);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    expect(state(ep)._speaking).toBe(false);
+    ep.onStartOfSpeech(100000);
+    expect(state(ep)._speaking).toBe(true);
+    ep.onEndOfSpeech(100500);
+    expect(state(ep)._speaking).toBe(false);
+  });
+
+  it.each([
+    ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+    ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+    ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+    ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+    ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+    ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+    ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+    ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+    ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+  ])(
+    'test_all_overlapping_and_should_ignore_combos (%s)',
+    (
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ) => {
+      const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+      ep.onStartOfSpeech(99000);
+      ep.onEndOfSpeech(100000);
+
+      let userStart = 100400;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100500);
+        ep.onEndOfAgentSpeech(101000);
+        userStart = 101500;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100350;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100200);
+          userStart = 101500;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100400;
+        } else {
+          ep.onStartOfAgentSpeech(100900);
+          userStart = 101800;
+        }
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping);
+
+      const previousMin = ep.minDelay;
+      const previousMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + 500, shouldIgnore);
+
+      const minChanged = ep.minDelay !== previousMin;
+      const maxChanged = ep.maxDelay !== previousMax;
+
+      expect(minChanged, `[${label}] minDelay`).toBe(expectMinChange);
+      expect(maxChanged, `[${label}] maxDelay`).toBe(expectMaxChange);
+      expect(state(ep)._speaking, `[${label}] _speaking`).toBe(false);
+      expect(state(ep)._overlapping, `[${label}] _overlapping`).toBe(false);
+    },
+  );
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onStartOfSpeech(100000);
+    ep.onEndOfSpeech(101000);
+
+    ep.onStartOfAgentSpeech(101500);
+
+    ep.onStartOfSpeech(102500, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102800, true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(103000);
+
+    ep.onStartOfSpeech(103500);
+    ep.onEndOfSpeech(104000);
+
+    expect(state(ep)._speaking).toBe(false);
+    expect(state(ep)._agentSpeechStartedAt).toBeUndefined();
+  });
+});

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+const logger = log();
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 7-7 lines
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250; // 0.25s -> 250ms
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-46 lines
+export class BaseEndpointing {
+  protected _minDelay: number;
+  protected _maxDelay: number;
+  protected _overlapping: boolean;
+
+  constructor(minDelay: number, maxDelay: number) {
+    this._minDelay = minDelay;
+    this._maxDelay = maxDelay;
+    this._overlapping = false;
+  }
+
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this._minDelay = minDelay;
+    }
+    if (maxDelay !== undefined) {
+      this._maxDelay = maxDelay;
+    }
+  }
+
+  get minDelay(): number {
+    return this._minDelay;
+  }
+
+  get maxDelay(): number {
+    return this._maxDelay;
+  }
+
+  get overlapping(): boolean {
+    return this._overlapping;
+  }
+
+  onStartOfSpeech(_startedAt: number, overlapping = false): void {
+    this._overlapping = overlapping;
+  }
+
+  onEndOfSpeech(_endedAt: number, _shouldIgnore = false): void {
+    this._overlapping = false;
+  }
+
+  onStartOfAgentSpeech(_startedAt: number): void {
+    void _startedAt;
+  }
+
+  onEndOfAgentSpeech(_endedAt: number): void {
+    void _endedAt;
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-302 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private _utterancePause: ExpFilter;
+  private _turnPause: ExpFilter;
+  private _utteranceStartedAt: number | undefined;
+  private _utteranceEndedAt: number | undefined;
+  private _agentSpeechStartedAt: number | undefined;
+  private _agentSpeechEndedAt: number | undefined;
+  private _speaking: boolean;
+
+  constructor(minDelay: number, maxDelay: number, alpha = 0.9) {
+    super(minDelay, maxDelay);
+
+    this._utterancePause = new ExpFilter(alpha, {
+      initial: minDelay,
+      min: minDelay,
+      max: maxDelay,
+    });
+    this._turnPause = new ExpFilter(alpha, {
+      initial: maxDelay,
+      min: minDelay,
+      max: maxDelay,
+    });
+
+    this._utteranceStartedAt = undefined;
+    this._utteranceEndedAt = undefined;
+    this._agentSpeechStartedAt = undefined;
+    this._agentSpeechEndedAt = undefined;
+    this._speaking = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 91-102 lines
+  override get minDelay(): number {
+    return this._utterancePause.value ?? super.minDelay;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 91-102 lines
+  override get maxDelay(): number {
+    const turnValue = this._turnPause.value ?? super.maxDelay;
+    return Math.max(turnValue, this.minDelay);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 104-111 lines
+  get betweenUtteranceDelay(): number {
+    if (this._utteranceEndedAt === undefined || this._utteranceStartedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this._utteranceStartedAt - this._utteranceEndedAt);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 113-120 lines
+  get betweenTurnDelay(): number {
+    if (this._agentSpeechStartedAt === undefined || this._utteranceEndedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this._agentSpeechStartedAt - this._utteranceEndedAt);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 122-137 lines
+  get immediateInterruptionDelay(): [number, number] {
+    if (this._utteranceStartedAt === undefined || this._agentSpeechStartedAt === undefined) {
+      return [0, 0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 139-142 lines
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this._agentSpeechStartedAt = startedAt;
+    this._agentSpeechEndedAt = undefined;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 144-153 lines
+  override onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this._agentSpeechStartedAt !== undefined &&
+      (this._agentSpeechEndedAt === undefined ||
+        this._agentSpeechEndedAt < this._agentSpeechStartedAt)
+    ) {
+      this._agentSpeechEndedAt = endedAt;
+    }
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 155-177 lines
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this.overlapping) {
+      return;
+    }
+
+    if (
+      this._utteranceStartedAt !== undefined &&
+      this._utteranceEndedAt !== undefined &&
+      this._agentSpeechStartedAt !== undefined &&
+      this._utteranceEndedAt < this._utteranceStartedAt &&
+      overlapping
+    ) {
+      this._utteranceEndedAt = this._agentSpeechStartedAt - 1;
+      logger.trace({ utteranceEndedAt: this._utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this._utteranceStartedAt = startedAt;
+    this._overlapping = overlapping;
+    this._speaking = true;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 179-286 lines
+  override onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    if (shouldIgnore && this.overlapping) {
+      if (
+        this._utteranceStartedAt !== undefined &&
+        this._agentSpeechStartedAt !== undefined &&
+        Math.abs(this._utteranceStartedAt - this._agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        logger.trace(
+          {
+            overlapSinceAgentStart: Math.abs(this._utteranceStartedAt - this._agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true within grace period',
+        );
+      } else {
+        this._overlapping = false;
+        this._speaking = false;
+        this._utteranceStartedAt = undefined;
+        this._utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    if (
+      this.overlapping ||
+      (this._agentSpeechStartedAt !== undefined && this._agentSpeechEndedAt === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const utterancePause = this.betweenUtteranceDelay;
+
+      if (
+        interruptionDelay > 0 &&
+        interruptionDelay <= this.minDelay &&
+        turnDelay > 0 &&
+        turnDelay <= this.maxDelay &&
+        utterancePause > 0
+      ) {
+        const previousValue = this.minDelay;
+        this._utterancePause.apply(1, utterancePause);
+        logger.debug(
+          {
+            reason: 'immediate interruption',
+            previousValue,
+            minDelay: this.minDelay,
+            maxDelay: this.maxDelay,
+            pause: utterancePause,
+            interruptionDelay,
+            turnDelay,
+          },
+          'min endpointing delay updated',
+        );
+      } else {
+        const turnPause = this.betweenTurnDelay;
+        if (turnPause > 0) {
+          const previousValue = this.maxDelay;
+          this._turnPause.apply(1, turnPause);
+          logger.debug(
+            {
+              reason: 'new turn (interruption)',
+              previousValue,
+              minDelay: this.minDelay,
+              maxDelay: this.maxDelay,
+              pause: turnPause,
+              betweenUtteranceDelay: this.betweenUtteranceDelay,
+              betweenTurnDelay: this.betweenTurnDelay,
+            },
+            'max endpointing delay updated',
+          );
+        }
+      }
+    } else {
+      const turnPause = this.betweenTurnDelay;
+      if (turnPause > 0) {
+        const previousValue = this.maxDelay;
+        this._turnPause.apply(1, turnPause);
+        logger.debug(
+          {
+            reason: 'new turn',
+            previousValue,
+            minDelay: this.minDelay,
+            maxDelay: this.maxDelay,
+            pause: turnPause,
+          },
+          'max endpointing delay updated due to pause',
+        );
+      } else {
+        const utterancePause = this.betweenUtteranceDelay;
+        if (
+          utterancePause > 0 &&
+          this._agentSpeechEndedAt === undefined &&
+          this._agentSpeechStartedAt === undefined
+        ) {
+          const previousValue = this.minDelay;
+          this._utterancePause.apply(1, utterancePause);
+          logger.debug(
+            {
+              reason: 'pause between utterances',
+              previousValue,
+              minDelay: this.minDelay,
+              maxDelay: this.maxDelay,
+              pause: utterancePause,
+            },
+            'min endpointing delay updated',
+          );
+        }
+      }
+    }
+
+    this._utteranceEndedAt = endedAt;
+    this._agentSpeechStartedAt = undefined;
+    this._agentSpeechEndedAt = undefined;
+    this._speaking = false;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 288-302 lines
+  override updateOptions({
+    minDelay,
+    maxDelay,
+  }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this._minDelay = minDelay;
+      this._utterancePause.reset({ initial: this._minDelay, min: this._minDelay });
+      this._turnPause.reset({ min: this._minDelay });
+    }
+
+    if (maxDelay !== undefined) {
+      this._maxDelay = maxDelay;
+      this._turnPause.reset({ initial: this._maxDelay, max: this._maxDelay });
+      this._utterancePause.reset({ max: this._maxDelay });
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  switch (options.mode) {
+    case 'dynamic':
+      return new DynamicEndpointing(options.minDelay, options.maxDelay);
+    default:
+      return new BaseEndpointing(options.minDelay, options.maxDelay);
+  }
+}

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -22,6 +22,7 @@ export {
   RoomSessionTransport,
 } from './remote_session.js';
 export * from './events.js';
+export * from './endpointing.js';
 export { type TimedString } from './io.js';
 export * from './report.js';
 export * from './room_io/index.js';


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/113).

Tracks: https://github.com/livekit/rosetta/issues/113

## Summary
- port the Python `DynamicEndpointing` and `create_endpointing` runtime into `@livekit/agents`
- wire dynamic endpointing through `AudioRecognition` and `AgentActivity`, including overlap handling and endpointing replacement updates
- port `tests/test_endpointing.py` to Vitest and add `AudioRecognition` regression coverage for the target-specific runtime paths

## Source
- https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/endpointing.py
- https://github.com/livekit/agents/blob/main/tests/test_endpointing.py