### PR TITLE
Port dynamic endpointing to the Node SDK

### DIFF
--- a/.changeset/dynamic-endpointing-port.md
+++ b/.changeset/dynamic-endpointing-port.md
@@ -2,4 +2,6 @@
 "@livekit/agents": patch
 ---
 
-fix(voice): port dynamic endpointing runtime behavior from Python
+fix(voice): port dynamic endpointing runtime behavior from Python.
+
+This brings the Node voice pipeline and runtime hooks in line with the Python SDK's dynamic endpointing behavior.

--- a/.changeset/dynamic-endpointing-port.md
+++ b/.changeset/dynamic-endpointing-port.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(voice): port dynamic endpointing runtime behavior from Python

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -350,45 +350,123 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
   }
 }
 
+type ExpFilterOptions = {
+  max?: number;
+  min?: number;
+  initial?: number;
+};
+
+type ExpFilterResetOptions = ExpFilterOptions & {
+  alpha?: number;
+};
+
 /** @internal */
+// Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-64 lines
 export class ExpFilter {
-  #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  private alphaValue: number;
+  private maxValue?: number;
+  private minValue?: number;
+  private filteredValue?: number;
 
-  constructor(alpha: number, max?: number) {
-    this.#alpha = alpha;
-    this.#max = max;
+  constructor(alpha: number, max?: number);
+  constructor(alpha: number, options?: ExpFilterOptions);
+  constructor(alpha: number, maxOrOptions?: number | ExpFilterOptions) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
+
+    this.alphaValue = alpha;
+    this.filteredValue = undefined;
+
+    if (typeof maxOrOptions === 'number') {
+      this.maxValue = maxOrOptions;
+      return;
+    }
+
+    this.maxValue = maxOrOptions?.max;
+    this.minValue = maxOrOptions?.min;
+    this.filteredValue = maxOrOptions?.initial;
   }
 
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 21-37 lines
+  reset(alpha?: number): void;
+  reset(options?: ExpFilterResetOptions): void;
+  reset(alphaOrOptions?: number | ExpFilterResetOptions): void {
+    if (typeof alphaOrOptions === 'number') {
+      if (!(alphaOrOptions > 0 && alphaOrOptions <= 1)) {
+        throw new Error('alpha must be in (0, 1].');
+      }
+
+      this.alphaValue = alphaOrOptions;
+      return;
     }
-    this.#filtered = undefined;
+
+    if (alphaOrOptions?.alpha !== undefined) {
+      if (!(alphaOrOptions.alpha > 0 && alphaOrOptions.alpha <= 1)) {
+        throw new Error('alpha must be in (0, 1].');
+      }
+
+      this.alphaValue = alphaOrOptions.alpha;
+    }
+
+    if (alphaOrOptions?.initial !== undefined) {
+      this.filteredValue = alphaOrOptions.initial;
+    }
+
+    if (alphaOrOptions?.min !== undefined) {
+      this.minValue = alphaOrOptions.min;
+    }
+
+    if (alphaOrOptions?.max !== undefined) {
+      this.maxValue = alphaOrOptions.max;
+    }
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
-      const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
-    } else {
-      this.#filtered = sample;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 38-57 lines
+  apply(exp: number, sample?: number): number {
+    const nextSample = sample ?? this.filteredValue;
+
+    if (nextSample !== undefined && this.filteredValue === undefined) {
+      this.filteredValue = nextSample;
+    } else if (nextSample !== undefined && this.filteredValue !== undefined) {
+      const a = this.alphaValue ** exp;
+      this.filteredValue = a * this.filteredValue + (1 - a) * nextSample;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (this.filteredValue === undefined) {
+      throw new Error('sample or initial value must be given.');
     }
 
-    return this.#filtered;
+    if (this.maxValue !== undefined && this.filteredValue > this.maxValue) {
+      this.filteredValue = this.maxValue;
+    }
+
+    if (this.minValue !== undefined && this.filteredValue < this.minValue) {
+      this.filteredValue = this.minValue;
+    }
+
+    return this.filteredValue;
   }
 
   get filtered(): number | undefined {
-    return this.#filtered;
+    return this.filteredValue;
+  }
+
+  get value(): number | undefined {
+    return this.filteredValue;
   }
 
   set alpha(alpha: number) {
-    this.#alpha = alpha;
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
+
+    this.alphaValue = alpha;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 63-64 lines
+  updateBase(alpha: number): void {
+    this.alpha = alpha;
   }
 }
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -65,6 +65,7 @@ import {
   type RecognitionHooks,
   type STTPipeline,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import {
   AgentSessionEventTypes,
   createErrorEvent,
@@ -88,6 +89,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -184,6 +186,7 @@ export class AgentActivity implements RecognitionHooks {
   private toolChoice: ToolChoice | null = null;
   private _preemptiveGeneration?: PreemptiveGeneration;
   private _preemptiveGenerationCount = 0;
+  private interruptionDetected = false;
   private interruptionDetector?: AdaptiveInterruptionDetector;
   private isInterruptionDetectionEnabled: boolean;
   private isInterruptionByAudioActivityEnabled: boolean;
@@ -206,6 +209,7 @@ export class AgentActivity implements RecognitionHooks {
     this.onError(ev);
 
   private readonly onInterruptionOverlappingSpeech = (ev: OverlappingSpeechEvent): void => {
+    this.interruptionDetected = ev.isInterruption;
     this.agentSession.emit(AgentSessionEventTypes.OverlappingSpeech, ev);
   };
 
@@ -471,18 +475,13 @@ export class AgentActivity implements RecognitionHooks {
 
     this.audioRecognition = new AudioRecognition({
       recognitionHooks: this,
+      endpointing: createEndpointing(this.endpointingOptions),
       // Disable stt node if stt is not provided
       stt: this.stt ? (...args) => this.agent.sttNode(...args) : undefined,
       vad: this.vad,
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -648,6 +647,17 @@ export class AgentActivity implements RecognitionHooks {
     );
   }
 
+  get endpointingOptions(): EndpointingOptions {
+    const agentEndpointing = this.agent.turnHandling?.endpointing ?? {};
+    const sessionEndpointing = this.agentSession.sessionOptions.turnHandling.endpointing;
+
+    return {
+      mode: agentEndpointing.mode ?? sessionEndpointing.mode,
+      minDelay: agentEndpointing.minDelay ?? sessionEndpointing.minDelay,
+      maxDelay: agentEndpointing.maxDelay ?? sessionEndpointing.maxDelay,
+    };
+  }
+
   get useTtsAlignedTranscript(): boolean {
     // Agent setting takes precedence over session setting
     return this.agent.useTtsAlignedTranscript ?? this.agentSession.useTtsAlignedTranscript;
@@ -715,23 +725,37 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
-  updateOptions({
-    toolChoice,
-    turnDetection,
-  }: {
+  updateOptions(options: {
     toolChoice?: ToolChoice | null;
+    endpointingOpts?: EndpointingOptions;
     turnDetection?: TurnDetectionMode;
+    minEndpointingDelay?: number;
+    maxEndpointingDelay?: number;
   }): void {
-    if (toolChoice !== undefined) {
-      this.toolChoice = toolChoice;
+    let { toolChoice, endpointingOpts, turnDetection, minEndpointingDelay, maxEndpointingDelay } =
+      options;
+
+    if (minEndpointingDelay !== undefined || maxEndpointingDelay !== undefined) {
+      this.logger.warn(
+        'minEndpointingDelay and maxEndpointingDelay are deprecated, use endpointingOpts instead',
+      );
+      endpointingOpts = {
+        mode: this.endpointingOptions.mode,
+        minDelay: minEndpointingDelay ?? this.endpointingOptions.minDelay,
+        maxDelay: maxEndpointingDelay ?? this.endpointingOptions.maxDelay,
+      };
+    }
+
+    if (Object.hasOwn(options, 'toolChoice')) {
+      this.toolChoice = toolChoice ?? null;
     }
 
     if (this.realtimeSession) {
       this.realtimeSession.updateOptions({ toolChoice: this.toolChoice });
     }
 
-    if (turnDetection !== undefined) {
-      this.turnDetectionMode = turnDetection;
+    if (Object.hasOwn(options, 'turnDetection')) {
+      this.turnDetectionMode = typeof turnDetection === 'string' ? turnDetection : undefined;
       this.isDefaultInterruptionByAudioActivityEnabled =
         this.turnDetectionMode !== 'manual' && this.turnDetectionMode !== 'realtime_llm';
 
@@ -743,7 +767,13 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (this.audioRecognition) {
-      this.audioRecognition.updateOptions({ turnDetection: this.turnDetectionMode });
+      const liveEndpointing =
+        endpointingOpts !== undefined ? createEndpointing(endpointingOpts) : undefined;
+
+      this.audioRecognition.updateOptions({
+        ...(liveEndpointing ? { endpointing: liveEndpointing } : {}),
+        ...(Object.hasOwn(options, 'turnDetection') ? { turnDetection } : {}),
+      });
     }
   }
 
@@ -922,13 +952,11 @@ export class AgentActivity implements RecognitionHooks {
 
     if (!this.vad) {
       this.agentSession._updateUserState('speaking');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfOverlapSpeech(
-          0,
-          Date.now(),
-          this.agentSession._userSpeakingSpan,
-        );
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfSpeech(Date.now(), 0, this.agentSession._userSpeakingSpan);
       }
+
+      this.interruptionDetected = false;
     }
 
     // this.interrupt() is going to raise when allow_interruptions is False,
@@ -947,8 +975,12 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
+      if (this.audioRecognition) {
+        this.audioRecognition.onEndOfSpeech(
+          Date.now(),
+          this.agentSession._userSpeakingSpan,
+          this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
+        );
       }
       this.agentSession._updateUserState('listening');
     }
@@ -1030,14 +1062,15 @@ export class AgentActivity implements RecognitionHooks {
       lastSpeakingTime: speechStartTime,
       otelContext: otelContext.active(),
     });
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
+    if (this.audioRecognition) {
+      this.audioRecognition.onStartOfSpeech(
         speechStartTime,
+        ev.speechDuration,
         this.agentSession._userSpeakingSpan,
       );
     }
+
+    this.interruptionDetected = false;
   }
 
   onEndOfSpeech(ev: VADEvent): void {
@@ -1046,11 +1079,11 @@ export class AgentActivity implements RecognitionHooks {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
+    if (this.audioRecognition) {
+      this.audioRecognition.onEndOfSpeech(
         speechEndTime,
         this.agentSession._userSpeakingSpan,
+        this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
       );
     }
     this.agentSession._updateUserState('listening', {
@@ -1837,8 +1870,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
+      }
+
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -1924,10 +1960,13 @@ export class AgentActivity implements RecognitionHooks {
 
     if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+      if (this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
-      this.restoreInterruptionByAudioActivity();
+
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
+      }
     }
   }
 
@@ -2113,8 +2152,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
+      }
+
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2271,8 +2313,11 @@ export class AgentActivity implements RecognitionHooks {
 
       if (this.agentSession.agentState === 'speaking') {
         this.agentSession._updateAgentState('listening');
-        if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+        if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        }
+
+        if (this.isInterruptionDetectionEnabled) {
           this.restoreInterruptionByAudioActivity();
         }
       }
@@ -2314,11 +2359,12 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._updateAgentState('thinking');
     } else if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
-          this.restoreInterruptionByAudioActivity();
-        }
+      if (this.audioRecognition) {
+        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+      }
+
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
       }
     }
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -732,8 +732,8 @@ export class AgentActivity implements RecognitionHooks {
     minEndpointingDelay?: number;
     maxEndpointingDelay?: number;
   }): void {
-    let { toolChoice, endpointingOpts, turnDetection, minEndpointingDelay, maxEndpointingDelay } =
-      options;
+    const { toolChoice, turnDetection, minEndpointingDelay, maxEndpointingDelay } = options;
+    let endpointingOpts = options.endpointingOpts;
 
     if (minEndpointingDelay !== undefined || maxEndpointingDelay !== undefined) {
       this.logger.warn(

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,6 +35,7 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import { type BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
@@ -129,6 +130,8 @@ export interface _TurnDetector {
 export interface AudioRecognitionOptions {
   /** Hooks for recognition events. */
   recognitionHooks: RecognitionHooks;
+  /** Endpointing behavior. */
+  endpointing: BaseEndpointing;
   /** Speech-to-text node. */
   stt?: STTNode;
   /** Voice activity detection. */
@@ -138,10 +141,6 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
-  /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -165,13 +164,12 @@ export interface ParticipantLike {
 // TODO add ability to update stt/vad/interruption-detection
 export class AudioRecognition {
   private hooks: RecognitionHooks;
+  private endpointing: BaseEndpointing;
   private stt?: STTNode;
   private sttPipeline?: STTPipeline;
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -220,12 +218,11 @@ export class AudioRecognition {
 
   constructor(opts: AudioRecognitionOptions) {
     this.hooks = opts.recognitionHooks;
+    this.endpointing = opts.endpointing;
     this.stt = opts.stt;
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,8 +272,37 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
-    this.turnDetectionMode = options.turnDetection;
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 192-219 lines
+  updateOptions(options: {
+    endpointing?: BaseEndpointing;
+    turnDetection?: TurnDetectionMode;
+    minEndpointingDelay?: number;
+    maxEndpointingDelay?: number;
+  }): void {
+    const { endpointing, turnDetection, minEndpointingDelay, maxEndpointingDelay } = options;
+
+    void minEndpointingDelay;
+    void maxEndpointingDelay;
+
+    if (Object.hasOwn(options, 'endpointing') && endpointing !== undefined) {
+      this.endpointing = endpointing;
+    }
+
+    if (Object.hasOwn(options, 'turnDetection')) {
+      this.turnDetector = typeof turnDetection === 'string' ? undefined : turnDetection;
+
+      const mode = typeof turnDetection === 'string' ? turnDetection : undefined;
+      if (this.turnDetectionMode !== mode) {
+        const previousMode = this.turnDetectionMode;
+        this.turnDetectionMode = mode;
+
+        if (this.turnDetectionMode === 'manual' || previousMode === 'manual') {
+          this.bounceEOUTask?.cancel();
+          this.bounceEOUTask = undefined;
+          this.userTurnCommitted = false;
+        }
+      }
+    }
   }
 
   async start(options?: { sttPipeline?: STTPipeline }) {
@@ -311,12 +337,19 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-243 lines
+  async onStartOfAgentSpeech(startedAt: number) {
     this.isAgentSpeaking = true;
+    this.endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 245-270 lines
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -342,6 +375,31 @@ export class AudioRecognition {
       await this.flushHeldTranscripts();
     }
     this.isAgentSpeaking = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 272-289 lines
+  onStartOfSpeech(startedAt: number, speechDuration = 0, userSpeakingSpan?: Span): void {
+    this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+
+    if (!this.isInterruptionEnabled || !this.isAgentSpeaking) {
+      return;
+    }
+
+    void this.trySendInterruptionSentinel(
+      InterruptionStreamSentinel.overlapSpeechStarted(speechDuration, startedAt, userSpeakingSpan),
+    );
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-305 lines
+  onEndOfSpeech(endedAt: number, userSpeakingSpan?: Span, interruption?: boolean): void {
+    if (this.speaking) {
+      this.endpointing.onEndOfSpeech(
+        endedAt,
+        interruption !== undefined && !interruption && this.isAgentSpeaking,
+      );
+    }
+
+    void this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
   }
 
   /** Start interruption inference when agent is speaking and overlap speech starts. */
@@ -704,13 +762,14 @@ export class AudioRecognition {
       case SpeechEventType.START_OF_SPEECH:
         if (this.turnDetectionMode !== 'stt') break;
         {
+          const startedAt = Date.now();
           const span = this.ensureUserTurnSpan(Date.now());
           const ctx = this.userTurnContext(span);
           otelContext.with(ctx, () => {
             this.hooks.onStartOfSpeech({
               type: VADEventType.START_OF_SPEECH,
               samplesIndex: 0,
-              timestamp: Date.now(),
+              timestamp: startedAt,
               speechDuration: 0,
               silenceDuration: 0,
               frames: [],
@@ -721,9 +780,14 @@ export class AudioRecognition {
               rawAccumulatedSpeech: 0,
             });
           });
+
+          if (this.speechStartTime === undefined) {
+            this.speechStartTime = startedAt;
+          }
+
+          this.lastSpeakingTime = startedAt;
         }
         this.speaking = true;
-        this.lastSpeakingTime = Date.now();
 
         this.bounceEOUTask?.cancel();
         break;
@@ -805,7 +869,7 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +895,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');

--- a/agents/src/voice/audio_recognition_endpointing.test.ts
+++ b/agents/src/voice/audio_recognition_endpointing.test.ts
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { AgentActivity } from './agent_activity.js';
+import { AudioRecognition, type RecognitionHooks } from './audio_recognition.js';
+import { DynamicEndpointing, createEndpointing } from './endpointing.js';
+
+function createHooks(): RecognitionHooks {
+  return {
+    onInterruption: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onEndOfTurn: vi.fn(async () => true),
+    onPreemptiveGeneration: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('endpointing runtime integration', () => {
+  it('replaces learned dynamic endpointing state when updateOptions swaps endpointing', () => {
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing: new DynamicEndpointing(300, 1000, 0.5),
+    });
+
+    const learned = (recognition as any).endpointing as DynamicEndpointing;
+    learned.onEndOfSpeech(100000);
+    learned.onStartOfSpeech(100400);
+    learned.onEndOfSpeech(100600);
+    expect(learned.minDelay).toBeCloseTo(350, 5);
+
+    recognition.updateOptions({
+      endpointing: createEndpointing({ mode: 'dynamic', minDelay: 300, maxDelay: 1000 }),
+    });
+
+    const replaced = (recognition as any).endpointing as DynamicEndpointing;
+    expect(replaced).not.toBe(learned);
+    expect(replaced.minDelay).toBe(300);
+    expect(replaced.maxDelay).toBe(1000);
+  });
+
+  it('routes VAD speech callbacks through audioRecognition public endpointing hooks', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+
+    const audioRecognition = {
+      onStartOfSpeech: vi.fn(),
+      onEndOfSpeech: vi.fn(),
+    };
+
+    const fakeActivity = {
+      agentSession: {
+        _updateUserState: vi.fn(),
+        _userSpeakingSpan: undefined,
+      },
+      audioRecognition,
+      interruptionDetected: true,
+      isInterruptionDetectionEnabled: true,
+    };
+
+    const onStartOfSpeech = (AgentActivity.prototype as any).onStartOfSpeech as (
+      this: unknown,
+      ev: { speechDuration: number; inferenceDuration: number },
+    ) => void;
+    const onEndOfSpeech = (AgentActivity.prototype as any).onEndOfSpeech as (
+      this: unknown,
+      ev: { silenceDuration: number; inferenceDuration: number },
+    ) => void;
+
+    onStartOfSpeech.call(fakeActivity, { speechDuration: 100, inferenceDuration: 20 });
+    expect(audioRecognition.onStartOfSpeech).toHaveBeenCalledWith(880, 100, undefined);
+
+    vi.setSystemTime(1600);
+    onEndOfSpeech.call(fakeActivity, { silenceDuration: 50, inferenceDuration: 20 });
+    expect(audioRecognition.onEndOfSpeech).toHaveBeenCalledWith(1530, undefined, false);
+  });
+
+  it('routes realtime no-vad speech callbacks through audioRecognition public endpointing hooks', () => {
+    vi.useFakeTimers();
+
+    const audioRecognition = {
+      onStartOfSpeech: vi.fn(),
+      onEndOfSpeech: vi.fn(),
+    };
+
+    const fakeActivity = {
+      logger: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+      vad: undefined,
+      agentSession: {
+        _updateUserState: vi.fn(),
+        _userSpeakingSpan: undefined,
+        emit: vi.fn(),
+      },
+      audioRecognition,
+      interruptionDetected: false,
+      isInterruptionDetectionEnabled: true,
+      interrupt: vi.fn(),
+    };
+
+    const onInputSpeechStarted = (AgentActivity.prototype as any).onInputSpeechStarted as (
+      this: unknown,
+      ev: Record<string, never>,
+    ) => void;
+    const onInputSpeechStopped = (AgentActivity.prototype as any).onInputSpeechStopped as (
+      this: unknown,
+      ev: { userTranscriptionEnabled: boolean },
+    ) => void;
+
+    vi.setSystemTime(1000);
+    onInputSpeechStarted.call(fakeActivity, {});
+    expect(audioRecognition.onStartOfSpeech).toHaveBeenCalledWith(1000, 0, undefined);
+
+    fakeActivity.interruptionDetected = true;
+    vi.setSystemTime(1400);
+    onInputSpeechStopped.call(fakeActivity, { userTranscriptionEnabled: false });
+    expect(audioRecognition.onEndOfSpeech).toHaveBeenCalledWith(1400, undefined, true);
+  });
+
+  it('forwards endpointingOpts into the live audioRecognition instance', () => {
+    const audioRecognition = {
+      updateOptions: vi.fn(),
+    };
+
+    const fakeActivity = {
+      toolChoice: null,
+      logger: {
+        warn: vi.fn(),
+      },
+      realtimeSession: undefined,
+      turnDetectionMode: 'vad',
+      isDefaultInterruptionByAudioActivityEnabled: true,
+      isInterruptionByAudioActivityEnabled: true,
+      agentSession: {
+        agentState: 'listening',
+      },
+      audioRecognition,
+      endpointingOptions: {
+        mode: 'fixed',
+        minDelay: 300,
+        maxDelay: 1000,
+      },
+    };
+
+    const updateOptions = (AgentActivity.prototype as any).updateOptions as (
+      this: unknown,
+      options: Record<string, unknown>,
+    ) => void;
+
+    updateOptions.call(fakeActivity, {
+      endpointingOpts: {
+        mode: 'dynamic',
+        minDelay: 500,
+        maxDelay: 2000,
+      },
+    });
+
+    expect(audioRecognition.updateOptions).toHaveBeenCalledTimes(1);
+    const [{ endpointing }] = audioRecognition.updateOptions.mock.calls[0];
+    expect(endpointing).toBeInstanceOf(DynamicEndpointing);
+    expect(endpointing.minDelay).toBe(500);
+    expect(endpointing.maxDelay).toBe(2000);
+  });
+});

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -7,6 +7,7 @@ import { ChatContext } from '../llm/chat_context.js';
 import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function createHooks() {
@@ -45,8 +46,7 @@ function createRecognition(sttNode: STTNode, hooks = createHooks()) {
     recognition: new AudioRecognition({
       recognitionHooks: hooks,
       stt: sttNode,
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
     }),
   };
 }

--- a/agents/src/voice/audio_recognition_span.test.ts
+++ b/agents/src/voice/audio_recognition_span.test.ts
@@ -22,6 +22,7 @@ import {
   type RecognitionHooks,
   type _TurnDetector,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function setupInMemoryTracing() {
@@ -141,12 +142,11 @@ describe('AudioRecognition user_turn span parity', () => {
 
     const ar = new AudioRecognition({
       recognitionHooks: hooks,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
       stt: sttNode,
       vad: undefined,
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'stt',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
       sttModel: 'deepgram-nova2',
       sttProvider: 'deepgram',
       getLinkedParticipant: () => ({ sid: 'p1', identity: 'bob', kind: ParticipantKind.AGENT }),
@@ -250,12 +250,11 @@ describe('AudioRecognition user_turn span parity', () => {
 
     const ar = new AudioRecognition({
       recognitionHooks: hooks,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
       stt: sttNode,
       vad: new FakeVAD(vadEvents),
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'vad',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
       sttModel: 'stt-model',
       sttProvider: 'stt-provider',
       getLinkedParticipant: () => ({ sid: 'p2', identity: 'alice', kind: ParticipantKind.AGENT }),

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,473 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { ExpFilter } from '../utils.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+describe('ExpFilter', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    const ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    const emaWithInitial = new ExpFilter(0.5, { initial: 10.0 });
+    expect(emaWithInitial.value).toBe(10.0);
+
+    const emaAtOne = new ExpFilter(1.0);
+    expect(emaAtOne.value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0.0)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(-0.5)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(1.5)).toThrow(/alpha must be in/);
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1.0, 10.0);
+    expect(result).toBe(10.0);
+    expect(ema.value).toBe(10.0);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    const result = ema.apply(1.0, 20.0);
+    expect(result).toBe(15.0);
+    expect(ema.value).toBe(15.0);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    ema.apply(1.0, 20.0);
+    ema.apply(1.0, 20.0);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    const ema = new ExpFilter(0.5, { initial: 10.0 });
+    expect(ema.value).toBe(10.0);
+    ema.reset();
+    expect(ema.value).toBe(10.0);
+
+    const emaWithInitial = new ExpFilter(0.5, { initial: 10.0 });
+    emaWithInitial.reset({ initial: 5.0 });
+    expect(emaWithInitial.value).toBe(5.0);
+  });
+});
+
+describe('DynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.2);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000) as any;
+    expect(ep.utterancePause.alphaValue).toBeCloseTo(0.9, 5);
+    expect(ep.turnPause.alphaValue).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toEqual([0, 0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    const ep = new DynamicEndpointing(300, 1000) as any;
+    ep.onEndOfSpeech(100000);
+    expect(ep.utteranceEndedAt).toBe(100000);
+
+    const second = new DynamicEndpointing(300, 1000) as any;
+    second.onEndOfSpeech(99900);
+    expect(second.utteranceEndedAt).toBe(99900);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing(300, 1000) as any;
+    ep.onStartOfSpeech(100000);
+    expect(ep.utteranceStartedAt).toBe(100000);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing(300, 1000) as any;
+    ep.onStartOfAgentSpeech(100000);
+    expect(ep.agentSpeechStartedAt).toBe(100000);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100500);
+
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(500, 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100800);
+
+    expect(ep.betweenTurnDelay).toBeCloseTo(800, 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400);
+    ep.onEndOfSpeech(100500, false);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100600);
+    ep.onStartOfSpeech(101500);
+    ep.onEndOfSpeech(102000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 600 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5) as any;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    expect(ep.agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(100250, true);
+    expect(ep.overlapping).toBe(true);
+
+    ep.onEndOfSpeech(100500);
+
+    expect(ep.overlapping).toBe(false);
+    expect(ep.agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(300, 5);
+  });
+
+  it('test_update_options', () => {
+    const ep = new DynamicEndpointing(300, 1000) as any;
+    ep.updateOptions({ minDelay: 500 });
+    expect(ep.minDelay).toBe(500);
+    expect(ep.minDelayValue).toBe(500);
+
+    const maxOnly = new DynamicEndpointing(300, 1000) as any;
+    maxOnly.updateOptions({ maxDelay: 2000 });
+    expect(maxOnly.maxDelay).toBe(2000);
+    expect(maxOnly.maxDelayValue).toBe(2000);
+
+    const both = new DynamicEndpointing(300, 1000);
+    both.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(both.minDelay).toBe(500);
+    expect(both.maxDelay).toBe(2000);
+
+    const unchanged = new DynamicEndpointing(300, 1000);
+    unchanged.updateOptions();
+    expect(unchanged.minDelay).toBe(300);
+    expect(unchanged.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(102000);
+    ep.onStartOfSpeech(105000);
+
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0) as any;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100100);
+    ep.onStartOfSpeech(100500);
+
+    expect(ep.maxDelay).toBeGreaterThanOrEqual(ep.minDelayValue);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000) as any;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    expect(ep.agentSpeechStartedAt).toBeDefined();
+
+    ep.onStartOfSpeech(102000);
+    ep.onEndOfSpeech(103000, false);
+    expect(ep.agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5) as any;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect(ep.overlapping).toBe(true);
+    const previous = [ep.minDelay, ep.maxDelay];
+
+    ep.onStartOfSpeech(100350);
+
+    expect(ep.overlapping).toBe(true);
+    expect([ep.minDelay, ep.maxDelay]).toEqual(previous);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800);
+    ep.onEndOfSpeech(102000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing(60, 1000, 1.0) as any;
+
+    ep.onEndOfSpeech(99000);
+    ep.onStartOfSpeech(100000);
+
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect(ep.utteranceEndedAt).toBe(100199);
+    expect(ep.minDelay).toBeCloseTo(60, 5);
+    expect(ep.maxDelay).toBeCloseTo(1000, 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5) as any;
+
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+
+    expect(ep.utterancePause.alphaValue).toBeCloseTo(0.5, 5);
+    expect(ep.turnPause.alphaValue).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5) as any;
+
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(ep.utterancePause.minValue).toBe(500);
+    expect(ep.turnPause.maxValue).toBe(2000);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100200);
+    expect(ep.minDelay).toBeCloseTo(500, 5);
+
+    ep.onEndOfSpeech(101000);
+    ep.onStartOfAgentSpeech(102800);
+    ep.onStartOfSpeech(103500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5) as any;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101500, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101800, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect(ep.utteranceStartedAt).toBeUndefined();
+    expect(ep.utteranceEndedAt).toBeUndefined();
+    expect(ep.overlapping).toBe(false);
+    expect(ep.speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400, false);
+    ep.onEndOfSpeech(100600, true);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5) as any;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(100600, true);
+
+    ep.onEndOfSpeech(100800, true);
+
+    expect(ep.utteranceEndedAt).toBe(100800);
+    expect(ep.speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5) as any;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101000, true);
+
+    const previousMin = ep.minDelay;
+    const previousMax = ep.maxDelay;
+    ep.onEndOfSpeech(101500, true);
+
+    expect(ep.minDelay).toBe(previousMin);
+    expect(ep.maxDelay).toBe(previousMax);
+    expect(ep.utteranceStartedAt).toBeUndefined();
+    expect(ep.utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing(300, 1000) as any;
+
+    ep.onStartOfAgentSpeech(100000);
+    ep.onStartOfSpeech(100100, true);
+    expect(ep.overlapping).toBe(true);
+    expect(ep.agentSpeechStartedAt).toBe(100000);
+
+    ep.onEndOfAgentSpeech(101000);
+
+    expect(ep.agentSpeechEndedAt).toBe(101000);
+    expect(ep.agentSpeechStartedAt).toBe(100000);
+    expect(ep.overlapping).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800, false);
+    ep.onEndOfSpeech(102000);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing(300, 1000) as any;
+
+    expect(ep.speaking).toBe(false);
+    ep.onStartOfSpeech(100000);
+    expect(ep.speaking).toBe(true);
+
+    ep.onEndOfSpeech(100500);
+    expect(ep.speaking).toBe(false);
+  });
+
+  it.each([
+    ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+    ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+    ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+    ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+    ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+    ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+    ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+    ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+    ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+  ])(
+    'test_all_overlapping_and_should_ignore_combos %s',
+    (
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ) => {
+      const ep = new DynamicEndpointing(300, 1000, 0.5) as any;
+
+      ep.onStartOfSpeech(99000);
+      ep.onEndOfSpeech(100000);
+
+      let userStart = 100400;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100500);
+        ep.onEndOfAgentSpeech(101000);
+        userStart = 101500;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100350;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100200);
+          userStart = 101500;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100400;
+        } else {
+          ep.onStartOfAgentSpeech(100900);
+          userStart = 101800;
+        }
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping);
+
+      const previousMin = ep.minDelay;
+      const previousMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + 500, shouldIgnore);
+
+      const minChanged = ep.minDelay !== previousMin;
+      const maxChanged = ep.maxDelay !== previousMax;
+
+      expect(minChanged, `[${label}] minDelay mismatch`).toBe(expectMinChange);
+      expect(maxChanged, `[${label}] maxDelay mismatch`).toBe(expectMaxChange);
+      expect(ep.speaking, `[${label}] speaking should be false`).toBe(false);
+      expect(ep.overlapping, `[${label}] overlapping should be false`).toBe(false);
+    },
+  );
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5) as any;
+
+    ep.onStartOfSpeech(100000);
+    ep.onEndOfSpeech(101000);
+
+    ep.onStartOfAgentSpeech(101500);
+
+    ep.onStartOfSpeech(102500, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102800, true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(103000);
+
+    ep.onStartOfSpeech(103500);
+    ep.onEndOfSpeech(104000);
+
+    expect(ep.speaking).toBe(false);
+    expect(ep.agentSpeechStartedAt).toBeUndefined();
+  });
+});

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 7-7 lines
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250; // 0.25s -> 250ms
+
+const logger = log();
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-46 lines
+export class BaseEndpointing {
+  protected minDelayValue: number;
+  protected maxDelayValue: number;
+  protected overlapping = false;
+
+  constructor(minDelay: number, maxDelay: number) {
+    this.minDelayValue = minDelay;
+    this.maxDelayValue = maxDelay;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 16-22 lines
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this.minDelayValue = minDelay;
+    }
+
+    if (maxDelay !== undefined) {
+      this.maxDelayValue = maxDelay;
+    }
+  }
+
+  get minDelay(): number {
+    return this.minDelayValue;
+  }
+
+  get maxDelay(): number {
+    return this.maxDelayValue;
+  }
+
+  get isOverlapping(): boolean {
+    return this.overlapping;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 36-37 lines
+  onStartOfSpeech(_startedAt: number, overlapping = false): void {
+    this.overlapping = overlapping;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 39-40 lines
+  onEndOfSpeech(_endedAt: number, _shouldIgnore = false): void {
+    this.overlapping = false;
+  }
+
+  onStartOfAgentSpeech(_startedAt: number): void {}
+
+  onEndOfAgentSpeech(_endedAt: number): void {}
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-304 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private utterancePause: ExpFilter;
+  private turnPause: ExpFilter;
+  private utteranceStartedAt?: number;
+  private utteranceEndedAt?: number;
+  private agentSpeechStartedAt?: number;
+  private agentSpeechEndedAt?: number;
+  private speaking = false;
+
+  constructor(minDelay: number, maxDelay: number, alpha = 0.9) {
+    super(minDelay, maxDelay);
+
+    this.utterancePause = new ExpFilter(alpha, {
+      initial: minDelay,
+      min: minDelay,
+      max: maxDelay,
+    });
+    this.turnPause = new ExpFilter(alpha, {
+      initial: maxDelay,
+      min: minDelay,
+      max: maxDelay,
+    });
+  }
+
+  get minDelay(): number {
+    return this.utterancePause.value ?? this.minDelayValue;
+  }
+
+  get maxDelay(): number {
+    const turnValue = this.turnPause.value ?? this.maxDelayValue;
+    return Math.max(turnValue, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this.utteranceEndedAt === undefined || this.utteranceStartedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.utteranceStartedAt - this.utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this.agentSpeechStartedAt === undefined || this.utteranceEndedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.agentSpeechStartedAt - this.utteranceEndedAt);
+  }
+
+  get immediateInterruptionDelay(): [number, number] {
+    if (this.utteranceStartedAt === undefined || this.agentSpeechStartedAt === undefined) {
+      return [0, 0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 139-142 lines
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this.agentSpeechStartedAt = startedAt;
+    this.agentSpeechEndedAt = undefined;
+    this.overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 144-153 lines
+  override onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this.agentSpeechStartedAt !== undefined &&
+      (this.agentSpeechEndedAt === undefined || this.agentSpeechEndedAt < this.agentSpeechStartedAt)
+    ) {
+      this.agentSpeechEndedAt = endedAt;
+    }
+
+    this.overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 155-177 lines
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this.overlapping) {
+      return;
+    }
+
+    if (
+      this.utteranceStartedAt !== undefined &&
+      this.utteranceEndedAt !== undefined &&
+      this.agentSpeechStartedAt !== undefined &&
+      this.utteranceEndedAt < this.utteranceStartedAt &&
+      overlapping
+    ) {
+      this.utteranceEndedAt = this.agentSpeechStartedAt - 1; // 1e-3s -> 1ms
+      logger.trace({ utteranceEndedAt: this.utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this.utteranceStartedAt = startedAt;
+    this.overlapping = overlapping;
+    this.speaking = true;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 179-286 lines
+  override onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    if (shouldIgnore && this.overlapping) {
+      if (
+        this.utteranceStartedAt !== undefined &&
+        this.agentSpeechStartedAt !== undefined &&
+        Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        logger.trace(
+          {
+            overlapDelay: Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true: user speech started within grace period of agent speech',
+        );
+      } else {
+        this.overlapping = false;
+        this.speaking = false;
+        this.utteranceStartedAt = undefined;
+        this.utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    if (
+      this.overlapping ||
+      (this.agentSpeechStartedAt !== undefined && this.agentSpeechEndedAt === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const pause = this.betweenUtteranceDelay;
+
+      if (
+        interruptionDelay > 0 &&
+        interruptionDelay <= this.minDelay &&
+        turnDelay > 0 &&
+        turnDelay <= this.maxDelay &&
+        pause > 0
+      ) {
+        const previousValue = this.minDelay;
+        this.utterancePause.apply(1, pause);
+        logger.debug(
+          {
+            reason: 'immediate interruption',
+            pause,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${previousValue} -> ${this.minDelay}`,
+        );
+      } else if (this.betweenTurnDelay > 0) {
+        const previousValue = this.maxDelay;
+        this.turnPause.apply(1, this.betweenTurnDelay);
+        logger.debug(
+          {
+            reason: 'new turn (interruption)',
+            pause: this.betweenTurnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+            betweenUtteranceDelay: this.betweenUtteranceDelay,
+            betweenTurnDelay: this.betweenTurnDelay,
+          },
+          `max endpointing delay updated: ${previousValue} -> ${this.maxDelay}`,
+        );
+      }
+    } else if (this.betweenTurnDelay > 0) {
+      const previousValue = this.maxDelay;
+      this.turnPause.apply(1, this.betweenTurnDelay);
+      logger.debug(
+        {
+          reason: 'new turn',
+          pause: this.betweenTurnDelay,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `max endpointing delay updated due to pause: ${previousValue} -> ${this.maxDelay}`,
+      );
+    } else if (
+      this.betweenUtteranceDelay > 0 &&
+      this.agentSpeechEndedAt === undefined &&
+      this.agentSpeechStartedAt === undefined
+    ) {
+      const previousValue = this.minDelay;
+      this.utterancePause.apply(1, this.betweenUtteranceDelay);
+      logger.debug(
+        {
+          reason: 'pause between utterances',
+          pause: this.betweenUtteranceDelay,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `min endpointing delay updated: ${previousValue} -> ${this.minDelay}`,
+      );
+    }
+
+    this.utteranceEndedAt = endedAt;
+    this.agentSpeechStartedAt = undefined;
+    this.agentSpeechEndedAt = undefined;
+    this.speaking = false;
+    this.overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 288-302 lines
+  override updateOptions({
+    minDelay,
+    maxDelay,
+  }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this.minDelayValue = minDelay;
+      this.utterancePause.reset({ initial: this.minDelayValue, min: this.minDelayValue });
+      this.turnPause.reset({ min: this.minDelayValue });
+    }
+
+    if (maxDelay !== undefined) {
+      this.maxDelayValue = maxDelay;
+      this.turnPause.reset({ initial: this.maxDelayValue, max: this.maxDelayValue });
+      this.utterancePause.reset({ max: this.maxDelayValue });
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  switch (options.mode ?? 'fixed') {
+    case 'dynamic':
+      return new DynamicEndpointing(options.minDelay, options.maxDelay);
+    default:
+      return new BaseEndpointing(options.minDelay, options.maxDelay);
+  }
+}


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/115).

Tracking issue: https://github.com/livekit/rosetta/issues/115

## Summary
- port the Python dynamic endpointing state machine into the Node voice runtime and reuse the shared `ExpFilter` helper instead of fixed min/max delay fields
- wire the endpointing lifecycle through `AgentActivity` and `AudioRecognition`, including live option updates and realtime/no-VAD hook coverage
- port the Python endpointing test contract and add target-specific regression coverage for runtime forwarding and endpointing replacement semantics

## Source
- Python implementation: https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/endpointing.py
- Python tests: https://github.com/livekit/agents/blob/main/tests/test_endpointing.py

## Verification
- `pnpm --filter @livekit/agents exec vitest run src/utils.test.ts src/voice/endpointing.test.ts src/voice/audio_recognition_endpointing.test.ts src/voice/audio_recognition_span.test.ts src/voice/audio_recognition_handoff.test.ts src/voice/agent_activity.test.ts src/voice/agent_activity_handoff.test.ts src/voice/agent.test.ts src/voice/turn_config/utils.test.ts`
- `pnpm --filter @livekit/agents build`
