### PR TITLE
feat(voice): port dynamic endpointing from Python SDK

### DIFF
--- a/.changeset/dynamic-endpointing.md
+++ b/.changeset/dynamic-endpointing.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": minor
+---
+
+feat(voice): add dynamic endpointing that adapts min/max turn-detection delays based on observed speech activity

--- a/agents/src/utils.test.ts
+++ b/agents/src/utils.test.ts
@@ -5,7 +5,16 @@ import { AudioFrame } from '@livekit/rtc-node';
 import { ReadableStream } from 'node:stream/web';
 import { describe, expect, it } from 'vitest';
 import { initializeLogger } from '../src/log.js';
-import { Event, Task, TaskResult, dedent, delay, isPending, resampleStream } from '../src/utils.js';
+import {
+  Event,
+  ExpFilter,
+  Task,
+  TaskResult,
+  dedent,
+  delay,
+  isPending,
+  resampleStream,
+} from '../src/utils.js';
 
 describe('utils', () => {
   // initialize logger
@@ -821,6 +830,64 @@ world
       const outputFrames = await streamToArray(outputStream);
 
       expect(outputFrames).toEqual([]);
+    });
+  });
+
+  // Ref: python tests/test_endpointing.py - 7-61 lines
+  describe('ExpFilter', () => {
+    // Ref: python tests/test_endpointing.py - 10-19 lines
+    it('test_initialization_with_valid_alpha', () => {
+      let ema = new ExpFilter(0.5);
+      expect(ema.filtered).toBeUndefined();
+
+      ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+      expect(ema.filtered).toBe(10.0);
+
+      ema = new ExpFilter(1.0);
+      expect(ema.filtered).toBeUndefined();
+    });
+
+    // Ref: python tests/test_endpointing.py - 21-30 lines
+    it('test_initialization_with_invalid_alpha', () => {
+      expect(() => new ExpFilter(0.0)).toThrow(/alpha must be in/);
+      expect(() => new ExpFilter(-0.5)).toThrow(/alpha must be in/);
+      expect(() => new ExpFilter(1.5)).toThrow(/alpha must be in/);
+    });
+
+    // Ref: python tests/test_endpointing.py - 32-37 lines
+    it('test_update_with_no_initial_value', () => {
+      const ema = new ExpFilter(0.5);
+      const result = ema.apply(1.0, 10.0);
+      expect(result).toBe(10.0);
+      expect(ema.filtered).toBe(10.0);
+    });
+
+    // Ref: python tests/test_endpointing.py - 39-44 lines
+    it('test_update_with_initial_value', () => {
+      const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+      const result = ema.apply(1.0, 20.0); // 0.5 * 20 + 0.5 * 10 = 15
+      expect(result).toBe(15.0);
+      expect(ema.filtered).toBe(15.0);
+    });
+
+    // Ref: python tests/test_endpointing.py - 46-51 lines
+    it('test_update_multiple_times', () => {
+      const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+      ema.apply(1.0, 20.0); // 15.0
+      ema.apply(1.0, 20.0); // 0.5 * 20 + 0.5 * 15 = 17.5
+      expect(ema.filtered).toBe(17.5);
+    });
+
+    // Ref: python tests/test_endpointing.py - 53-61 lines
+    it('test_reset', () => {
+      let ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+      expect(ema.filtered).toBe(10.0);
+      ema.reset();
+      expect(ema.filtered).toBe(10.0);
+
+      ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+      ema.reset({ initial: 5.0 });
+      expect(ema.filtered).toBe(5.0);
     });
   });
 });

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -351,44 +351,75 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 }
 
 /** @internal */
+// Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-64 lines
 export class ExpFilter {
-  #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  private _alpha: number;
+  private _max?: number;
+  private _min?: number;
+  private _filtered?: number;
 
-  constructor(alpha: number, max?: number) {
-    this.#alpha = alpha;
-    this.#max = max;
+  constructor(alpha: number, max?: number, min?: number, initial?: number) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
+    this._alpha = alpha;
+    this._max = max;
+    this._min = min;
+    this._filtered = initial;
   }
 
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+  reset(opts?: { alpha?: number; initial?: number; min?: number; max?: number }): void {
+    if (opts?.alpha !== undefined) {
+      if (!(opts.alpha > 0 && opts.alpha <= 1)) {
+        throw new Error('alpha must be in (0, 1].');
+      }
+      this._alpha = opts.alpha;
     }
-    this.#filtered = undefined;
+    if (opts?.initial !== undefined) {
+      this._filtered = opts.initial;
+    }
+    if (opts?.min !== undefined) {
+      this._min = opts.min;
+    }
+    if (opts?.max !== undefined) {
+      this._max = opts.max;
+    }
   }
 
   apply(exp: number, sample: number): number {
-    if (this.#filtered) {
-      const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
+    if (this._filtered !== undefined) {
+      const a = this._alpha ** exp;
+      this._filtered = a * this._filtered + (1 - a) * sample;
     } else {
-      this.#filtered = sample;
+      this._filtered = sample;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (this._max !== undefined && this._filtered > this._max) {
+      this._filtered = this._max;
+    }
+    if (this._min !== undefined && this._filtered < this._min) {
+      this._filtered = this._min;
     }
 
-    return this.#filtered;
+    return this._filtered;
   }
 
+  /** Current filtered value, or `undefined` if `apply` has never been called and no `initial` was provided. */
   get filtered(): number | undefined {
-    return this.#filtered;
+    return this._filtered;
+  }
+
+  /** Alias for `filtered` — mirrors the Python `ExpFilter.value` property. */
+  get value(): number | undefined {
+    return this._filtered;
+  }
+
+  get alpha(): number {
+    return this._alpha;
   }
 
   set alpha(alpha: number) {
-    this.#alpha = alpha;
+    this._alpha = alpha;
   }
 }
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -88,6 +88,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import { type BaseEndpointing, createEndpointing } from './turn_config/dynamic_endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -161,6 +162,8 @@ export class AgentActivity implements RecognitionHooks {
 
   private started = false;
   private audioRecognition?: AudioRecognition;
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 477-482 lines
+  private endpointing?: BaseEndpointing;
   private realtimeSession?: RealtimeSession;
   private realtimeSpans?: Map<string, Span>; // Maps response_id to OTEL span for metrics recording
   private turnDetectionMode?: TurnDetectionMode;
@@ -469,6 +472,12 @@ export class AgentActivity implements RecognitionHooks {
       this.vad.on('metrics_collected', this.onMetricsCollected);
     }
 
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 725-740 lines
+    this.endpointing = createEndpointing({
+      ...this.agentSession.sessionOptions.turnHandling.endpointing,
+      ...this.agent.turnHandling?.endpointing,
+    });
+
     this.audioRecognition = new AudioRecognition({
       recognitionHooks: this,
       // Disable stt node if stt is not provided
@@ -477,12 +486,7 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      endpointing: this.endpointing,
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -660,20 +664,6 @@ export class AgentActivity implements RecognitionHooks {
   get turnHandling() {
     return this.agent.turnHandling ?? this.agentSession.sessionOptions.turnHandling;
   }
-
-  // get minEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.minDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.minDelay
-  //   );
-  // }
-
-  // get maxEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.maxDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay
-  //   );
-  // }
 
   get toolCtx(): ToolContext {
     return this.agent.toolCtx;
@@ -1838,7 +1828,8 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2195-2195 lines
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2114,7 +2105,8 @@ export class AgentActivity implements RecognitionHooks {
         otelContext: speechHandle._agentTurnContext,
       });
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2540-2540 lines
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -36,6 +36,7 @@ import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.j
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
 import type { STTNode } from './io.js';
+import type { BaseEndpointing } from './turn_config/dynamic_endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export interface EndOfTurnInfo {
@@ -138,10 +139,12 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
-  /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  /**
+   * Endpointing strategy. Determines the min/max endpointing delay (in milliseconds) and, when a
+   * {@link DynamicEndpointing} is provided, adapts those delays to observed speech activity.
+   */
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 131-131 lines
+  endpointing: BaseEndpointing;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +173,8 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 146-146 lines
+  private endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -224,8 +227,7 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    this.endpointing = opts.endpointing;
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,8 +277,17 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
-    this.turnDetectionMode = options.turnDetection;
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 192-218 lines
+  updateOptions(options: {
+    turnDetection?: TurnDetectionMode | undefined;
+    endpointing?: BaseEndpointing;
+  }): void {
+    if (options.endpointing !== undefined) {
+      this.endpointing = options.endpointing;
+    }
+    if (options.turnDetection !== undefined) {
+      this.turnDetectionMode = options.turnDetection;
+    }
   }
 
   async start(options?: { sttPipeline?: STTPipeline }) {
@@ -311,12 +322,19 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-243 lines
+  async onStartOfAgentSpeech(startedAt: number) {
     this.isAgentSpeaking = true;
+    this.endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 245-270 lines
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -805,7 +823,8 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 934-934 lines
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +850,8 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 958-958 lines
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');
@@ -1018,6 +1038,8 @@ export class AudioRecognition {
             this.logger.debug('VAD task: START_OF_SPEECH');
             {
               const startTime = Date.now() - ev.speechDuration;
+              // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 278-280 lines
+              this.endpointing.onStartOfSpeech(startTime, this.isAgentSpeaking);
               const span = this.ensureUserTurnSpan(startTime);
               const ctx = this.userTurnContext(span);
               otelContext.with(ctx, () => this.hooks.onStartOfSpeech(ev));
@@ -1047,6 +1069,14 @@ export class AudioRecognition {
           case VADEventType.END_OF_SPEECH:
             this.logger.debug('VAD task: END_OF_SPEECH');
             {
+              // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-303 lines
+              // `shouldIgnore` mirrors the `interruption=NOT_GIVEN` branch of the Python call site
+              // because the JS target does not track a per-turn `interruption_detected` flag; in
+              // that branch Python resolves `should_ignore` to `false`.
+              const endTime = Date.now() - ev.silenceDuration - ev.inferenceDuration;
+              if (this.speaking) {
+                this.endpointing.onEndOfSpeech(endTime, false);
+              }
               const span = this.ensureUserTurnSpan();
               const ctx = this.userTurnContext(span);
               otelContext.with(ctx, () => this.hooks.onEndOfSpeech(ev));

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -8,6 +8,7 @@ import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
 import type { STTNode } from './io.js';
+import { BaseEndpointing } from './turn_config/dynamic_endpointing.js';
 
 function createHooks() {
   const hooks: RecognitionHooks = {
@@ -45,8 +46,7 @@ function createRecognition(sttNode: STTNode, hooks = createHooks()) {
     recognition: new AudioRecognition({
       recognitionHooks: hooks,
       stt: sttNode,
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing({ minDelay: 0, maxDelay: 0 }),
     }),
   };
 }

--- a/agents/src/voice/audio_recognition_span.test.ts
+++ b/agents/src/voice/audio_recognition_span.test.ts
@@ -23,6 +23,7 @@ import {
   type _TurnDetector,
 } from './audio_recognition.js';
 import type { STTNode } from './io.js';
+import { BaseEndpointing } from './turn_config/dynamic_endpointing.js';
 
 function setupInMemoryTracing() {
   const exporter = new InMemorySpanExporter();
@@ -145,8 +146,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: undefined,
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'stt',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing({ minDelay: 0, maxDelay: 0 }),
       sttModel: 'deepgram-nova2',
       sttProvider: 'deepgram',
       getLinkedParticipant: () => ({ sid: 'p1', identity: 'bob', kind: ParticipantKind.AGENT }),
@@ -254,8 +254,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: new FakeVAD(vadEvents),
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'vad',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing({ minDelay: 0, maxDelay: 0 }),
       sttModel: 'stt-model',
       sttProvider: 'stt-provider',
       getLinkedParticipant: () => ({ sid: 'p2', identity: 'alice', kind: ParticipantKind.AGENT }),

--- a/agents/src/voice/turn_config/dynamic_endpointing.test.ts
+++ b/agents/src/voice/turn_config/dynamic_endpointing.test.ts
@@ -1,0 +1,672 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { initializeLogger } from '../../log.js';
+import type { ExpFilter } from '../../utils.js';
+import { BaseEndpointing, DynamicEndpointing, createEndpointing } from './dynamic_endpointing.js';
+
+initializeLogger({ pretty: false, level: 'silent' });
+
+/** Private-field accessor shape for introspecting `DynamicEndpointing` internals from tests. */
+interface DynamicEndpointingInternals {
+  _utterancePause: ExpFilter & { _min?: number; _max?: number };
+  _turnPause: ExpFilter & { _min?: number; _max?: number };
+  _utteranceStartedAt?: number;
+  _utteranceEndedAt?: number;
+  _agentSpeechStartedAt?: number;
+  _agentSpeechEndedAt?: number;
+  _speaking: boolean;
+  _overlapping: boolean;
+  _minDelay: number;
+  _maxDelay: number;
+}
+
+function peek(ep: DynamicEndpointing): DynamicEndpointingInternals {
+  return ep as unknown as DynamicEndpointingInternals;
+}
+
+// Time values in the ported tests are in milliseconds. Python test values (in seconds) are
+// multiplied by 1000: `0.3s → 300ms`, `100.0s → 100000ms`, `0.25s grace → 250ms`. Alpha is
+// unitless so it stays unchanged.
+
+// Ref: python tests/test_endpointing.py - 64-545 lines
+describe('DynamicEndpointing', () => {
+  // Ref: python tests/test_endpointing.py - 67-71 lines
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  // Ref: python tests/test_endpointing.py - 73-77 lines
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.2 });
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  // Ref: python tests/test_endpointing.py - 79-82 lines
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    const any = peek(ep);
+    expect(any._utterancePause.alpha).toBeCloseTo(0.9, 5);
+    expect(any._turnPause.alpha).toBeCloseTo(0.9, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 84-89 lines
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toEqual([0, 0]);
+  });
+
+  // Ref: python tests/test_endpointing.py - 91-98 lines
+  it('test_on_utterance_ended', () => {
+    let ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(100000);
+    expect(peek(ep)._utteranceEndedAt).toBe(100000);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(99900);
+    expect(peek(ep)._utteranceEndedAt).toBe(99900);
+  });
+
+  // Ref: python tests/test_endpointing.py - 100-103 lines
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onStartOfSpeech(100000);
+    expect(peek(ep)._utteranceStartedAt).toBe(100000);
+  });
+
+  // Ref: python tests/test_endpointing.py - 105-108 lines
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onStartOfAgentSpeech(100000);
+    expect(peek(ep)._agentSpeechStartedAt).toBe(100000);
+  });
+
+  // Ref: python tests/test_endpointing.py - 110-117 lines
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100500);
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(500, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 119-126 lines
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100800);
+    expect(ep.betweenTurnDelay).toBeCloseTo(800, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 128-138 lines
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400);
+    ep.onEndOfSpeech(100500, false);
+    // pause = 400; EMA: 0.5 * 400 + 0.5 * 300 = 350
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 140-149 lines
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100600);
+    ep.onStartOfSpeech(101500);
+    ep.onEndOfSpeech(102000, false);
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 600 + 0.5 * 1000, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 151-167 lines
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    expect(peek(ep)._agentSpeechStartedAt).not.toBeUndefined();
+    ep.onStartOfSpeech(100250, true);
+    expect(peek(ep)._overlapping).toBe(true);
+
+    ep.onEndOfSpeech(100500);
+
+    // pause = 250; clamped to max(250, 300) = 300; EMA: 0.5 * 300 + 0.5 * 300 = 300
+    expect(peek(ep)._overlapping).toBe(false);
+    expect(peek(ep)._agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(300, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 169-188 lines
+  it('test_update_options', () => {
+    let ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions({ minDelay: 500 });
+    expect(ep.minDelay).toBe(500);
+    expect(peek(ep)._minDelay).toBe(500);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions({ maxDelay: 2000 });
+    expect(ep.maxDelay).toBe(2000);
+    expect(peek(ep)._maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.updateOptions();
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  // Ref: python tests/test_endpointing.py - 190-198 lines
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 1.0 });
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(102000);
+    ep.onStartOfSpeech(105000);
+    expect(ep.maxDelay).toBe(1000); // pause=2000 clamped to _maxDelay
+  });
+
+  // Ref: python tests/test_endpointing.py - 200-208 lines
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 1.0 });
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100100);
+    ep.onStartOfSpeech(100500);
+    expect(ep.maxDelay).toBeGreaterThanOrEqual(peek(ep)._minDelay);
+  });
+
+  // Ref: python tests/test_endpointing.py - 210-220 lines
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    expect(peek(ep)._agentSpeechStartedAt).not.toBeUndefined();
+
+    ep.onStartOfSpeech(102000);
+    ep.onEndOfSpeech(103000, false);
+    expect(peek(ep)._agentSpeechStartedAt).toBeUndefined();
+  });
+
+  // Ref: python tests/test_endpointing.py - 222-236 lines
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect(peek(ep)._overlapping).toBe(true);
+    const prev = [ep.minDelay, ep.maxDelay];
+
+    ep.onStartOfSpeech(100350);
+
+    expect(peek(ep)._overlapping).toBe(true);
+    expect([ep.minDelay, ep.maxDelay]).toEqual(prev);
+  });
+
+  // Ref: python tests/test_endpointing.py - 238-247 lines
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800);
+    ep.onEndOfSpeech(102000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 249-262 lines
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing({ minDelay: 60, maxDelay: 1000, alpha: 1.0 });
+
+    // Simulate stale ordering where end timestamp still belongs to a previous utterance.
+    ep.onEndOfSpeech(99000);
+    ep.onStartOfSpeech(100000);
+
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect(peek(ep)._utteranceEndedAt).toBeCloseTo(100200, 0);
+    expect(ep.minDelay).toBeCloseTo(60, 5);
+    expect(ep.maxDelay).toBeCloseTo(1000, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 264-271 lines
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+
+    const any = peek(ep);
+    expect(any._utterancePause.alpha).toBeCloseTo(0.5, 5);
+    expect(any._turnPause.alpha).toBeCloseTo(0.5, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 273-290 lines
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    const any = peek(ep);
+    expect(any._utterancePause._min).toBe(500);
+    expect(any._turnPause._max).toBe(2000);
+
+    // minDelay updated from 300 to 500
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100200);
+    expect(ep.minDelay).toBeCloseTo(500, 5);
+
+    // maxDelay updated from 1000 to 2000
+    ep.onEndOfSpeech(101000);
+    ep.onStartOfAgentSpeech(102800);
+    ep.onStartOfSpeech(103500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  // Ref: python tests/test_endpointing.py - 292-313 lines
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    // user starts 1.0s (1000ms) after agent (well outside 250ms grace period)
+    ep.onStartOfSpeech(101500, true);
+
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101800, true);
+
+    // filters should not have been updated
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    // state should be reset
+    const any = peek(ep);
+    expect(any._utteranceStartedAt).toBeUndefined();
+    expect(any._utteranceEndedAt).toBeUndefined();
+    expect(any._overlapping).toBe(false);
+    expect(any._speaking).toBe(false);
+  });
+
+  // Ref: python tests/test_endpointing.py - 315-326 lines
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400, false);
+    ep.onEndOfSpeech(100600, true);
+
+    // shouldIgnore only gates when overlapping, so minDelay should update (case 1)
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 328-342 lines
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    // user starts speaking 100ms after agent (within 250ms grace period)
+    ep.onStartOfSpeech(100600, true);
+
+    ep.onEndOfSpeech(100800, true);
+
+    // grace period should override shouldIgnore, so the interruption path runs
+    // and state is properly cleaned up (not left as undefined)
+    const any = peek(ep);
+    expect(any._utteranceEndedAt).toBe(100800);
+    expect(any._speaking).toBe(false);
+  });
+
+  // Ref: python tests/test_endpointing.py - 344-361 lines
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    // user starts speaking 500ms after agent (outside 250ms grace period)
+    ep.onStartOfSpeech(101000, true);
+
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+    ep.onEndOfSpeech(101500, true);
+
+    // outside grace period, shouldIgnore takes effect — no filter update
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    const any = peek(ep);
+    expect(any._utteranceStartedAt).toBeUndefined();
+    expect(any._utteranceEndedAt).toBeUndefined();
+  });
+
+  // Ref: python tests/test_endpointing.py - 363-378 lines
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+
+    ep.onStartOfAgentSpeech(100000);
+    ep.onStartOfSpeech(100100, true);
+    expect(peek(ep)._overlapping).toBe(true);
+    expect(peek(ep)._agentSpeechStartedAt).toBe(100000);
+
+    ep.onEndOfAgentSpeech(101000);
+
+    const any = peek(ep);
+    expect(any._agentSpeechEndedAt).toBe(101000);
+    // _agentSpeechStartedAt is intentionally preserved so that betweenTurnDelay can be computed
+    // in the normal end-of-speech path
+    expect(any._agentSpeechStartedAt).toBe(100000);
+    expect(any._overlapping).toBe(false);
+  });
+
+  // Ref: python tests/test_endpointing.py - 380-392 lines
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    // overlapping not explicitly set
+    ep.onStartOfSpeech(101800, false);
+    ep.onEndOfSpeech(102000);
+
+    // _agentSpeechStartedAt set → interruption path → case 3 (delayed) updates maxDelay
+    // betweenTurnDelay = 900
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  // Ref: python tests/test_endpointing.py - 394-402 lines
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000 });
+
+    expect(peek(ep)._speaking).toBe(false);
+    ep.onStartOfSpeech(100000);
+    expect(peek(ep)._speaking).toBe(true);
+    ep.onEndOfSpeech(100500);
+    expect(peek(ep)._speaking).toBe(false);
+  });
+
+  // Ref: python tests/test_endpointing.py - 404-509 lines
+  describe('test_all_overlapping_and_should_ignore_combos', () => {
+    type AgentSpeech = 'none' | 'ended' | 'active';
+    interface Case {
+      label: string;
+      agentSpeech: AgentSpeech;
+      overlapping: boolean;
+      shouldIgnore: boolean;
+      withinGrace: boolean;
+      expectMinChange: boolean;
+      expectMaxChange: boolean;
+    }
+
+    const cases: Case[] = [
+      // --- No agent speech ---
+      // Case 1: pause between utterances updates minDelay
+      {
+        label: 'no_agent/no_overlap/no_ignore',
+        agentSpeech: 'none',
+        overlapping: false,
+        shouldIgnore: false,
+        withinGrace: false,
+        expectMinChange: true,
+        expectMaxChange: false,
+      },
+      // shouldIgnore is ignored when not overlapping
+      {
+        label: 'no_agent/no_overlap/ignore',
+        agentSpeech: 'none',
+        overlapping: false,
+        shouldIgnore: true,
+        withinGrace: false,
+        expectMinChange: true,
+        expectMaxChange: false,
+      },
+      // --- Agent speech ended ---
+      // agent finished speaking → normal path, betweenTurnDelay > 0 → case 3 updates max
+      {
+        label: 'agent_ended/no_overlap/no_ignore',
+        agentSpeech: 'ended',
+        overlapping: false,
+        shouldIgnore: false,
+        withinGrace: false,
+        expectMinChange: false,
+        expectMaxChange: true,
+      },
+      {
+        label: 'agent_ended/no_overlap/ignore',
+        agentSpeech: 'ended',
+        overlapping: false,
+        shouldIgnore: true,
+        withinGrace: false,
+        expectMinChange: false,
+        expectMaxChange: true,
+      },
+      // --- Agent speech active ---
+      // Inferred interruption from agentSpeechStartedAt → case 3 (delayed)
+      {
+        label: 'agent_active/no_overlap/no_ignore',
+        agentSpeech: 'active',
+        overlapping: false,
+        shouldIgnore: false,
+        withinGrace: false,
+        expectMinChange: false,
+        expectMaxChange: true,
+      },
+      // shouldIgnore ignored when not overlapping
+      {
+        label: 'agent_active/no_overlap/ignore',
+        agentSpeech: 'active',
+        overlapping: false,
+        shouldIgnore: true,
+        withinGrace: false,
+        expectMinChange: false,
+        expectMaxChange: true,
+      },
+      // Explicit overlapping, immediate → case 2 updates minDelay
+      {
+        label: 'agent_active/overlap/no_ignore',
+        agentSpeech: 'active',
+        overlapping: true,
+        shouldIgnore: false,
+        withinGrace: false,
+        expectMinChange: true,
+        expectMaxChange: false,
+      },
+      // Backchannel: overlapping + shouldIgnore outside grace → skip
+      {
+        label: 'agent_active/overlap/ignore/outside_grace',
+        agentSpeech: 'active',
+        overlapping: true,
+        shouldIgnore: true,
+        withinGrace: false,
+        expectMinChange: false,
+        expectMaxChange: false,
+      },
+      // Grace period override: overlapping + shouldIgnore inside grace → case 2 still runs
+      {
+        label: 'agent_active/overlap/ignore/inside_grace',
+        agentSpeech: 'active',
+        overlapping: true,
+        shouldIgnore: true,
+        withinGrace: true,
+        expectMinChange: true,
+        expectMaxChange: false,
+      },
+    ];
+
+    it.each(cases)(
+      '$label',
+      ({
+        label,
+        agentSpeech,
+        overlapping,
+        shouldIgnore,
+        withinGrace,
+        expectMinChange,
+        expectMaxChange,
+      }) => {
+        const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+        // Previous utterance
+        ep.onStartOfSpeech(99000);
+        ep.onEndOfSpeech(100000);
+
+        // Set up agent speech state
+        let userStart: number;
+        if (agentSpeech === 'ended') {
+          ep.onStartOfAgentSpeech(100500);
+          ep.onEndOfAgentSpeech(101000);
+          userStart = 101500;
+        } else if (agentSpeech === 'active') {
+          if (withinGrace) {
+            // Agent at 100150, user at 100350 (200ms after agent, within 250ms grace)
+            // betweenTurnDelay=150, betweenUtteranceDelay=350
+            // interruptionDelay=|350-150|=200 <= 300 → case 2 triggers
+            // EMA: 0.5*350 + 0.5*300 = 325 → min changes
+            ep.onStartOfAgentSpeech(100150);
+            userStart = 100350;
+          } else if (overlapping && shouldIgnore) {
+            // Outside grace: agent at 100200, user at 101500 (1.3s after agent)
+            // shouldIgnore + overlapping + outside grace → skip
+            ep.onStartOfAgentSpeech(100200);
+            userStart = 101500;
+          } else if (overlapping) {
+            // Agent at 100150, user at 100400 (250ms after agent, at grace boundary)
+            // betweenTurnDelay=150, betweenUtteranceDelay=400
+            // interruptionDelay=|400-150|=250 <= 300 → case 2 triggers
+            // EMA: 0.5*400 + 0.5*300 = 350 → min changes
+            ep.onStartOfAgentSpeech(100150);
+            userStart = 100400;
+          } else {
+            // Delayed: agent spoke but user starts much later (inferred interruption)
+            // betweenTurnDelay=900 → case 3 updates maxDelay
+            ep.onStartOfAgentSpeech(100900);
+            userStart = 101800;
+          }
+        } else {
+          // No agent speech
+          userStart = 100400;
+        }
+
+        ep.onStartOfSpeech(userStart, overlapping);
+
+        const prevMin = ep.minDelay;
+        const prevMax = ep.maxDelay;
+
+        ep.onEndOfSpeech(userStart + 500, shouldIgnore);
+
+        const minChanged = ep.minDelay !== prevMin;
+        const maxChanged = ep.maxDelay !== prevMax;
+
+        expect(
+          minChanged,
+          `[${label}] minDelay change mismatch: ${prevMin} -> ${ep.minDelay}`,
+        ).toBe(expectMinChange);
+        expect(
+          maxChanged,
+          `[${label}] maxDelay change mismatch: ${prevMax} -> ${ep.maxDelay}`,
+        ).toBe(expectMaxChange);
+
+        // State should always be cleaned up after onEndOfSpeech
+        const any = peek(ep);
+        expect(any._speaking, `[${label}] _speaking should be false`).toBe(false);
+        expect(any._overlapping, `[${label}] _overlapping should be false`).toBe(false);
+      },
+    );
+  });
+
+  // Ref: python tests/test_endpointing.py - 511-545 lines
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing({ minDelay: 300, maxDelay: 1000, alpha: 0.5 });
+
+    // Turn 1: user speaks
+    ep.onStartOfSpeech(100000);
+    ep.onEndOfSpeech(101000);
+
+    // Agent responds
+    ep.onStartOfAgentSpeech(101500);
+
+    // Turn 2: user backchannel (ignored) — overlapping with agent, 1.0s after agent start
+    ep.onStartOfSpeech(102500, true);
+    const minBefore = ep.minDelay;
+    const maxBefore = ep.maxDelay;
+    ep.onEndOfSpeech(102800, true);
+
+    // backchannel ignored — delays unchanged
+    expect(ep.minDelay).toBe(minBefore);
+    expect(ep.maxDelay).toBe(maxBefore);
+
+    // Agent finishes
+    ep.onEndOfAgentSpeech(103000);
+
+    // Turn 3: user speaks again (new turn after agent)
+    ep.onStartOfSpeech(103500);
+    ep.onEndOfSpeech(104000);
+
+    const any = peek(ep);
+    expect(any._speaking).toBe(false);
+    expect(any._agentSpeechStartedAt).toBeUndefined();
+  });
+});
+
+// Target-only coverage for the integration seam between DynamicEndpointing and target-only
+// runtime paths (createEndpointing factory, AudioRecognition.updateOptions replacement).
+describe('createEndpointing', () => {
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+  it('returns BaseEndpointing for fixed mode', () => {
+    const ep = createEndpointing({ mode: 'fixed', minDelay: 300, maxDelay: 1000 });
+    expect(ep).toBeInstanceOf(BaseEndpointing);
+    expect(ep).not.toBeInstanceOf(DynamicEndpointing);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('returns DynamicEndpointing for dynamic mode', () => {
+    const ep = createEndpointing({ mode: 'dynamic', minDelay: 300, maxDelay: 1000 });
+    expect(ep).toBeInstanceOf(DynamicEndpointing);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+});
+
+describe('BaseEndpointing', () => {
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-46 lines
+  it('updateOptions updates fixed delays without resetting overlap state', () => {
+    const ep = new BaseEndpointing({ minDelay: 300, maxDelay: 1000 });
+    ep.onStartOfSpeech(100000, true);
+    expect(ep.overlapping).toBe(true);
+
+    ep.updateOptions({ minDelay: 500 });
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(1000);
+    // overlap state preserved across updateOptions
+    expect(ep.overlapping).toBe(true);
+
+    ep.updateOptions({ maxDelay: 2000 });
+    expect(ep.maxDelay).toBe(2000);
+    expect(ep.overlapping).toBe(true);
+
+    ep.onEndOfSpeech(100500);
+    expect(ep.overlapping).toBe(false);
+  });
+
+  it('onStartOfAgentSpeech / onEndOfAgentSpeech are no-ops', () => {
+    const ep = new BaseEndpointing({ minDelay: 300, maxDelay: 1000 });
+    expect(() => ep.onStartOfAgentSpeech(100000)).not.toThrow();
+    expect(() => ep.onEndOfAgentSpeech(100500)).not.toThrow();
+    // base impl doesn't track agent speech state
+    expect(ep.overlapping).toBe(false);
+  });
+});

--- a/agents/src/voice/turn_config/dynamic_endpointing.ts
+++ b/agents/src/voice/turn_config/dynamic_endpointing.ts
@@ -1,0 +1,333 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../../log.js';
+import { ExpFilter } from '../../utils.js';
+import { type EndpointingOptions } from './endpointing.js';
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 7-7 lines
+// 0.25s → 250ms
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD_MS = 250;
+
+/**
+ * Base endpointing that exposes a fixed min/max delay pair with no adaptation.
+ *
+ * All timestamps (`startedAt` / `endedAt`) and delays (`minDelay` / `maxDelay`) are expressed in
+ * milliseconds.
+ */
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-46 lines
+export class BaseEndpointing {
+  protected _minDelay: number;
+  protected _maxDelay: number;
+  protected _overlapping = false;
+
+  constructor({ minDelay, maxDelay }: { minDelay: number; maxDelay: number }) {
+    this._minDelay = minDelay;
+    this._maxDelay = maxDelay;
+  }
+
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this._minDelay = minDelay;
+    }
+    if (maxDelay !== undefined) {
+      this._maxDelay = maxDelay;
+    }
+  }
+
+  get minDelay(): number {
+    return this._minDelay;
+  }
+
+  get maxDelay(): number {
+    return this._maxDelay;
+  }
+
+  get overlapping(): boolean {
+    return this._overlapping;
+  }
+
+  onStartOfSpeech(_startedAt: number, overlapping = false): void {
+    this._overlapping = overlapping;
+  }
+
+  onEndOfSpeech(_endedAt: number, _shouldIgnore = false): void {
+    this._overlapping = false;
+  }
+
+  onStartOfAgentSpeech(_startedAt: number): void {
+    // no-op in the base class
+  }
+
+  onEndOfAgentSpeech(_endedAt: number): void {
+    // no-op in the base class
+  }
+}
+
+/**
+ * Dynamic endpointing that adjusts the min/max delay based on observed speech activity.
+ *
+ * The min delay covers pauses between user utterances and between an utterance and an immediate
+ * user interruption. The max delay covers pauses between a user utterance and the agent's reply.
+ */
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-302 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private _utterancePause: ExpFilter;
+  private _turnPause: ExpFilter;
+  private _utteranceStartedAt?: number;
+  private _utteranceEndedAt?: number;
+  private _agentSpeechStartedAt?: number;
+  private _agentSpeechEndedAt?: number;
+  private _speaking = false;
+  private _logger = log();
+
+  constructor({
+    minDelay,
+    maxDelay,
+    alpha = 0.9,
+  }: {
+    minDelay: number;
+    maxDelay: number;
+    alpha?: number;
+  }) {
+    super({ minDelay, maxDelay });
+
+    this._utterancePause = new ExpFilter(alpha, maxDelay, minDelay, minDelay);
+    this._turnPause = new ExpFilter(alpha, maxDelay, minDelay, maxDelay);
+  }
+
+  override get minDelay(): number {
+    return this._utterancePause.value ?? this._minDelay;
+  }
+
+  override get maxDelay(): number {
+    const turnVal = this._turnPause.value ?? this._maxDelay;
+    return Math.max(turnVal, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this._utteranceEndedAt === undefined || this._utteranceStartedAt === undefined) {
+      return 0;
+    }
+    return Math.max(0, this._utteranceStartedAt - this._utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this._agentSpeechStartedAt === undefined || this._utteranceEndedAt === undefined) {
+      return 0;
+    }
+    return Math.max(0, this._agentSpeechStartedAt - this._utteranceEndedAt);
+  }
+
+  /**
+   * Two pauses describing an immediate interruption:
+   * `[utterance] [turn][interruption] [immediate interruption]`
+   *                    ^                ^
+   *                    turn delay       interruption delay
+   */
+  get immediateInterruptionDelay(): [number, number] {
+    if (this._utteranceStartedAt === undefined || this._agentSpeechStartedAt === undefined) {
+      return [0, 0];
+    }
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this._agentSpeechStartedAt = startedAt;
+    this._agentSpeechEndedAt = undefined;
+    this._overlapping = false;
+  }
+
+  override onEndOfAgentSpeech(endedAt: number): void {
+    // NOTE: intentionally keep _agentSpeechStartedAt so that betweenTurnDelay can be computed in
+    // the normal end-of-speech path
+    // NOTE: also guard against duplicate calls from pipeline reply and pipeline reply done
+    if (
+      this._agentSpeechStartedAt !== undefined &&
+      (this._agentSpeechEndedAt === undefined ||
+        this._agentSpeechEndedAt < this._agentSpeechStartedAt)
+    ) {
+      this._agentSpeechEndedAt = endedAt;
+    }
+    this._overlapping = false;
+  }
+
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this._overlapping) {
+      // duplicate calls from _interrupt_by_audio_activity and on_start_of_speech
+      return;
+    }
+
+    // VAD interrupt by audio activity is triggered before end of speech is detected
+    // adjust the utterance ended time to be just before the agent speech started
+    if (
+      this._utteranceStartedAt !== undefined &&
+      this._utteranceEndedAt !== undefined &&
+      this._agentSpeechStartedAt !== undefined &&
+      this._utteranceEndedAt < this._utteranceStartedAt &&
+      overlapping
+    ) {
+      this._utteranceEndedAt = this._agentSpeechStartedAt - 1e-3;
+      this._logger.trace(
+        { utteranceEndedAt: this._utteranceEndedAt },
+        'utterance ended at adjusted',
+      );
+    }
+
+    this._utteranceStartedAt = startedAt;
+    this._overlapping = overlapping;
+    this._speaking = true;
+  }
+
+  override onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    if (shouldIgnore && this._overlapping) {
+      // If user speech started within the grace period of agent speech, don't ignore —
+      // TTS leading silence can cause the agent speech timestamp to precede actual audible
+      // audio, making this look like a backchannel when it's really the user speaking before
+      // hearing the agent.
+      if (
+        this._utteranceStartedAt !== undefined &&
+        this._agentSpeechStartedAt !== undefined &&
+        Math.abs(this._utteranceStartedAt - this._agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD_MS
+      ) {
+        this._logger.trace(
+          {
+            diff: Math.abs(this._utteranceStartedAt - this._agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD_MS,
+          },
+          'ignoring shouldIgnore=true: user speech started within grace period of agent speech',
+        );
+      } else {
+        // skip update because it might be a backchannel
+        this._overlapping = false;
+        this._speaking = false;
+        this._utteranceStartedAt = undefined;
+        this._utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    if (
+      this._overlapping ||
+      (this._agentSpeechStartedAt !== undefined && this._agentSpeechEndedAt === undefined)
+    ) {
+      // interruption path (agent is still speaking)
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const pauseBetweenUtterances = this.betweenUtteranceDelay;
+      if (
+        interruptionDelay > 0 &&
+        interruptionDelay <= this.minDelay &&
+        turnDelay > 0 &&
+        turnDelay <= this.maxDelay &&
+        pauseBetweenUtterances > 0
+      ) {
+        // immediate interruption → update min delay (case 2)
+        const prevVal = this.minDelay;
+        this._utterancePause.apply(1.0, pauseBetweenUtterances);
+        this._logger.debug(
+          {
+            reason: 'immediate interruption',
+            pause: pauseBetweenUtterances,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${prevVal} -> ${this.minDelay}`,
+        );
+      } else {
+        const pauseBetweenTurns = this.betweenTurnDelay;
+        if (pauseBetweenTurns > 0) {
+          // delayed interruption → update max delay (case 3)
+          const prevVal = this.maxDelay;
+          this._turnPause.apply(1.0, pauseBetweenTurns);
+          this._logger.debug(
+            {
+              reason: 'new turn (interruption)',
+              pause: pauseBetweenTurns,
+              maxDelay: this.maxDelay,
+              minDelay: this.minDelay,
+              betweenUtteranceDelay: this.betweenUtteranceDelay,
+              betweenTurnDelay: this.betweenTurnDelay,
+            },
+            `max endpointing delay updated: ${prevVal} -> ${this.maxDelay}`,
+          );
+        }
+      }
+    } else {
+      // normal end of speech
+      const pauseBetweenTurns = this.betweenTurnDelay;
+      if (pauseBetweenTurns > 0) {
+        const prevVal = this.maxDelay;
+        this._turnPause.apply(1.0, pauseBetweenTurns);
+        this._logger.debug(
+          {
+            reason: 'new turn',
+            pause: pauseBetweenTurns,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `max endpointing delay updated due to pause: ${prevVal} -> ${this.maxDelay}`,
+        );
+      } else {
+        const pauseBetweenUtterances = this.betweenUtteranceDelay;
+        if (
+          pauseBetweenUtterances > 0 &&
+          this._agentSpeechEndedAt === undefined &&
+          this._agentSpeechStartedAt === undefined
+        ) {
+          const prevVal = this.minDelay;
+          this._utterancePause.apply(1.0, pauseBetweenUtterances);
+          this._logger.debug(
+            {
+              reason: 'pause between utterances',
+              pause: pauseBetweenUtterances,
+              maxDelay: this.maxDelay,
+              minDelay: this.minDelay,
+            },
+            `min endpointing delay updated: ${prevVal} -> ${this.minDelay}`,
+          );
+        }
+      }
+    }
+
+    this._utteranceEndedAt = endedAt;
+    this._agentSpeechStartedAt = undefined;
+    this._agentSpeechEndedAt = undefined;
+    this._speaking = false;
+    this._overlapping = false;
+  }
+
+  override updateOptions({
+    minDelay,
+    maxDelay,
+  }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this._minDelay = minDelay;
+      this._utterancePause.reset({ initial: this._minDelay, min: this._minDelay });
+      this._turnPause.reset({ min: this._minDelay });
+    }
+
+    if (maxDelay !== undefined) {
+      this._maxDelay = maxDelay;
+      this._turnPause.reset({ initial: this._maxDelay, max: this._maxDelay });
+      this._utterancePause.reset({ max: this._maxDelay });
+    }
+  }
+}
+
+/**
+ * Create an endpointing instance based on the `mode` field of the provided options.
+ *
+ * - `"dynamic"` → {@link DynamicEndpointing}
+ * - anything else → {@link BaseEndpointing}
+ */
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  const { mode = 'fixed', minDelay, maxDelay } = options;
+  if (mode === 'dynamic') {
+    return new DynamicEndpointing({ minDelay, maxDelay });
+  }
+  return new BaseEndpointing({ minDelay, maxDelay });
+}


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/115).

Tracking issue: https://github.com/livekit/rosetta/issues/115
Source implementation: `livekit-agents/livekit/agents/voice/endpointing.py`

## Summary

Ports the **Dynamic endpointing** feature from the Python `livekit-agents` SDK. Adds two new classes and a factory:

- `BaseEndpointing` — fixed-delay endpointing with `minDelay` / `maxDelay` getters and no-op speech hooks.
- `DynamicEndpointing extends BaseEndpointing` — adjusts the min/max turn-detection delays via exponential-moving-average filters over observed pauses (between utterances, between utterance and agent speech, and immediate interruptions).
- `createEndpointing(options)` — factory dispatched by `EndpointingOptions.mode` (`"dynamic"` → `DynamicEndpointing`, anything else → `BaseEndpointing`).

All new code lives in `agents/src/voice/turn_config/dynamic_endpointing.ts` and is wired through `AudioRecognition` and `AgentActivity`.

## Changes

- **`ExpFilter` (agents/src/utils.ts)** — extended additively with optional `min` / `initial` constructor parameters and an options-object `reset({ alpha?, initial?, min?, max? })`. Added alpha-range validation and a `value` getter mirroring the Python `ExpFilter.value` property. The only existing caller (`plugins/silero/src/vad.ts: new ExpFilter(0.35)`) keeps working unchanged.
- **`AudioRecognition` (agents/src/voice/audio_recognition.ts)** — replaced the raw `minEndpointingDelay` / `maxEndpointingDelay` number options with a single `endpointing: BaseEndpointing` option. Wires endpointing calls into the VAD `START_OF_SPEECH` / `END_OF_SPEECH` handlers and into `onStartOfAgentSpeech` / `onEndOfAgentSpeech`. `onStartOfAgentSpeech` now takes a `startedAt: number` parameter matching the Python signature. Added `updateOptions({ endpointing })` so the endpointing instance can be hot-swapped.
- **`AgentActivity` (agents/src/voice/agent_activity.ts)** — constructs the endpointing instance via `createEndpointing(opts)` at activity start and passes it to `AudioRecognition`. Both `onStartOfAgentSpeech` call sites (`pipelineReply` and `realtimeGeneration`) are updated to pass `startedAt`.

## Test porting

All 36 source tests from `tests/test_endpointing.py` are ported 1:1:

- 6 `TestExponentialMovingAverage` tests → `agents/src/utils.test.ts`
- 30 `TestDynamicEndpointing` tests (including the 9-case `test_all_overlapping_and_should_ignore_combos` parametrization) → `agents/src/voice/turn_config/dynamic_endpointing.test.ts`

Plus target-only regression coverage for the `createEndpointing` factory, `BaseEndpointing.updateOptions`, and the target-idiomatic `AudioRecognition` constructor-option shape.

Time values in the ported tests are in milliseconds to match the target repo's convention (Python seconds × 1000 → TS ms; the `0.25s` grace period becomes `250ms`).

## Needs human review

- `AgentActivity.updateOptions` does not yet accept `endpointing` options, so the Python `agent_activity.update_options(endpointing=create_endpointing(...))` call chain is not wired through at the target `AgentActivity` level. The new `AudioRecognition.updateOptions({ endpointing })` path is in place and used by the unit tests, but plumbing it through `AgentActivity.updateOptions` would expand that method's public API and is left for a follow-up.

## Verification

- `pnpm build` — all 27 packages build.
- `pnpm --filter @livekit/agents exec vitest run` — 736 passed / 2 skipped.
- `pnpm format:check` — clean.
- `pnpm --filter @livekit/agents lint` — 0 errors (warnings unchanged from baseline).