### PR TITLE
feat(inference): add inferenceClass option to LLM for priority routing

### DIFF
--- a/.changeset/inference-class-priority-routing.md
+++ b/.changeset/inference-class-priority-routing.md
@@ -1,5 +1,5 @@
 ---
-"@livekit/agents": minor
+"@livekit/agents": patch
 ---
 
 feat(inference): add inferenceClass option to LLM for priority routing

--- a/.changeset/inference-class-priority-routing.md
+++ b/.changeset/inference-class-priority-routing.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": minor
+---
+
+feat(inference): add inferenceClass option to LLM for priority routing

--- a/agents/src/inference/index.ts
+++ b/agents/src/inference/index.ts
@@ -10,6 +10,7 @@ export {
   LLMStream,
   type ChatCompletionOptions,
   type GatewayOptions,
+  type InferenceClass,
   type InferenceLLMOptions,
   type LLMModels,
   type XAIModels,

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -9,6 +9,8 @@ import { DEFAULT_API_CONNECT_OPTIONS } from '../types.js';
 import { type Expand, toError } from '../utils.js';
 import {
   type AnyString,
+  HEADER_INFERENCE_PRIORITY,
+  HEADER_INFERENCE_PROVIDER,
   buildMetadataHeaders,
   createAccessToken,
   getDefaultInferenceUrl,
@@ -98,6 +100,9 @@ export type LLMModels =
   | XAIModels
   | AnyString;
 
+// Ref: python livekit-agents/livekit/agents/inference/llm.py - 140 lines
+export type InferenceClass = 'priority' | 'standard';
+
 const REASONING_UNSUPPORTED_PARAMS = new Set([
   'temperature',
   'top_p',
@@ -156,6 +161,8 @@ export interface InferenceLLMOptions {
   baseURL: string;
   apiKey: string;
   apiSecret: string;
+  // Ref: python livekit-agents/livekit/agents/inference/llm.py - 183 lines
+  inferenceClass?: InferenceClass;
   modelOptions: ChatCompletionOptions;
   strictToolSchema?: boolean;
 }
@@ -178,6 +185,8 @@ export class LLM extends llm.LLM {
     baseURL?: string;
     apiKey?: string;
     apiSecret?: string;
+    // Ref: python livekit-agents/livekit/agents/inference/llm.py - 196 lines
+    inferenceClass?: InferenceClass;
     modelOptions?: InferenceLLMOptions['modelOptions'];
     strictToolSchema?: boolean;
   }) {
@@ -189,6 +198,7 @@ export class LLM extends llm.LLM {
       baseURL,
       apiKey,
       apiSecret,
+      inferenceClass,
       modelOptions,
       strictToolSchema = false,
     } = opts;
@@ -211,6 +221,8 @@ export class LLM extends llm.LLM {
       baseURL: lkBaseURL,
       apiKey: lkApiKey,
       apiSecret: lkApiSecret,
+      // Ref: python livekit-agents/livekit/agents/inference/llm.py - 229 lines
+      inferenceClass,
       modelOptions: modelOptions || {},
       strictToolSchema,
     };
@@ -244,6 +256,7 @@ export class LLM extends llm.LLM {
     parallelToolCalls,
     toolChoice,
     // TODO(AJS-270): Add response_format parameter support
+    inferenceClass,
     extraKwargs,
   }: {
     chatCtx: llm.ChatContext;
@@ -252,6 +265,8 @@ export class LLM extends llm.LLM {
     parallelToolCalls?: boolean;
     toolChoice?: llm.ToolChoice;
     // TODO(AJS-270): Add responseFormat parameter
+    // Ref: python livekit-agents/livekit/agents/inference/llm.py - 272 lines
+    inferenceClass?: InferenceClass;
     extraKwargs?: Record<string, unknown>;
   }): LLMStream {
     let modelOptions: Record<string, unknown> = { ...(extraKwargs || {}) };
@@ -278,9 +293,14 @@ export class LLM extends llm.LLM {
 
     modelOptions = { ...modelOptions, ...this.opts.modelOptions };
 
+    // Ref: python livekit-agents/livekit/agents/inference/llm.py - 306-308 lines
+    const effectiveInferenceClass =
+      inferenceClass !== undefined ? inferenceClass : this.opts.inferenceClass;
+
     return new LLMStream(this, {
       model: this.opts.model,
       provider: this.opts.provider,
+      inferenceClass: effectiveInferenceClass,
       client: this.client,
       chatCtx,
       toolCtx,
@@ -298,6 +318,8 @@ export class LLM extends llm.LLM {
 export class LLMStream extends llm.LLMStream {
   private model: LLMModels;
   private provider?: string;
+  // Ref: python livekit-agents/livekit/agents/inference/llm.py - 344 lines
+  private inferenceClass?: InferenceClass;
   private providerFmt: llm.ProviderFormat;
   private client: OpenAI;
   private modelOptions: Record<string, unknown>;
@@ -315,6 +337,7 @@ export class LLMStream extends llm.LLMStream {
     {
       model,
       provider,
+      inferenceClass,
       client,
       chatCtx,
       toolCtx,
@@ -326,6 +349,8 @@ export class LLMStream extends llm.LLMStream {
     }: {
       model: LLMModels;
       provider?: string;
+      // Ref: python livekit-agents/livekit/agents/inference/llm.py - 332 lines
+      inferenceClass?: InferenceClass;
       client: OpenAI;
       chatCtx: llm.ChatContext;
       toolCtx?: llm.ToolContext;
@@ -340,6 +365,7 @@ export class LLMStream extends llm.LLMStream {
     this.client = client;
     this.gatewayOptions = gatewayOptions;
     this.provider = provider;
+    this.inferenceClass = inferenceClass;
     this.providerFmt = providerFmt || 'openai';
     this.modelOptions = modelOptions;
     this.model = model;
@@ -403,7 +429,12 @@ export class LLMStream extends llm.LLMStream {
         ...((requestOptions.extra_headers as Record<string, string> | undefined) ?? {}),
       };
       if (this.provider) {
-        extraHeaders['X-LiveKit-Inference-Provider'] = this.provider;
+        // Ref: python livekit-agents/livekit/agents/inference/llm.py - 386 lines
+        extraHeaders[HEADER_INFERENCE_PROVIDER] = this.provider;
+      }
+      // Ref: python livekit-agents/livekit/agents/inference/llm.py - 387-388 lines
+      if (this.inferenceClass) {
+        extraHeaders[HEADER_INFERENCE_PRIORITY] = this.inferenceClass;
       }
       delete requestOptions.extra_headers;
 

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -100,7 +100,6 @@ export type LLMModels =
   | XAIModels
   | AnyString;
 
-// Ref: python livekit-agents/livekit/agents/inference/llm.py - 140 lines
 export type InferenceClass = 'priority' | 'standard';
 
 const REASONING_UNSUPPORTED_PARAMS = new Set([
@@ -161,7 +160,6 @@ export interface InferenceLLMOptions {
   baseURL: string;
   apiKey: string;
   apiSecret: string;
-  // Ref: python livekit-agents/livekit/agents/inference/llm.py - 183 lines
   inferenceClass?: InferenceClass;
   modelOptions: ChatCompletionOptions;
   strictToolSchema?: boolean;
@@ -185,7 +183,6 @@ export class LLM extends llm.LLM {
     baseURL?: string;
     apiKey?: string;
     apiSecret?: string;
-    // Ref: python livekit-agents/livekit/agents/inference/llm.py - 196 lines
     inferenceClass?: InferenceClass;
     modelOptions?: InferenceLLMOptions['modelOptions'];
     strictToolSchema?: boolean;
@@ -221,7 +218,6 @@ export class LLM extends llm.LLM {
       baseURL: lkBaseURL,
       apiKey: lkApiKey,
       apiSecret: lkApiSecret,
-      // Ref: python livekit-agents/livekit/agents/inference/llm.py - 229 lines
       inferenceClass,
       modelOptions: modelOptions || {},
       strictToolSchema,
@@ -265,7 +261,6 @@ export class LLM extends llm.LLM {
     parallelToolCalls?: boolean;
     toolChoice?: llm.ToolChoice;
     // TODO(AJS-270): Add responseFormat parameter
-    // Ref: python livekit-agents/livekit/agents/inference/llm.py - 272 lines
     inferenceClass?: InferenceClass;
     extraKwargs?: Record<string, unknown>;
   }): LLMStream {
@@ -293,7 +288,6 @@ export class LLM extends llm.LLM {
 
     modelOptions = { ...modelOptions, ...this.opts.modelOptions };
 
-    // Ref: python livekit-agents/livekit/agents/inference/llm.py - 306-308 lines
     const effectiveInferenceClass =
       inferenceClass !== undefined ? inferenceClass : this.opts.inferenceClass;
 
@@ -318,7 +312,6 @@ export class LLM extends llm.LLM {
 export class LLMStream extends llm.LLMStream {
   private model: LLMModels;
   private provider?: string;
-  // Ref: python livekit-agents/livekit/agents/inference/llm.py - 344 lines
   private inferenceClass?: InferenceClass;
   private providerFmt: llm.ProviderFormat;
   private client: OpenAI;
@@ -349,7 +342,6 @@ export class LLMStream extends llm.LLMStream {
     }: {
       model: LLMModels;
       provider?: string;
-      // Ref: python livekit-agents/livekit/agents/inference/llm.py - 332 lines
       inferenceClass?: InferenceClass;
       client: OpenAI;
       chatCtx: llm.ChatContext;
@@ -429,10 +421,8 @@ export class LLMStream extends llm.LLMStream {
         ...((requestOptions.extra_headers as Record<string, string> | undefined) ?? {}),
       };
       if (this.provider) {
-        // Ref: python livekit-agents/livekit/agents/inference/llm.py - 386 lines
         extraHeaders[HEADER_INFERENCE_PROVIDER] = this.provider;
       }
-      // Ref: python livekit-agents/livekit/agents/inference/llm.py - 387-388 lines
       if (this.inferenceClass) {
         extraHeaders[HEADER_INFERENCE_PRIORITY] = this.inferenceClass;
       }

--- a/agents/src/inference/utils.ts
+++ b/agents/src/inference/utils.ts
@@ -16,6 +16,10 @@ export const DEFAULT_INFERENCE_URL = 'https://agent-gateway.livekit.cloud/v1';
 /** Staging inference URL */
 export const STAGING_INFERENCE_URL = 'https://agent-gateway.staging.livekit.cloud/v1';
 
+// Ref: python livekit-agents/livekit/agents/inference/_utils.py - 17-18 lines
+export const HEADER_INFERENCE_PROVIDER = 'X-LiveKit-Inference-Provider';
+export const HEADER_INFERENCE_PRIORITY = 'X-LiveKit-Inference-Priority';
+
 /**
  * Get the default inference URL based on the environment.
  *

--- a/agents/src/inference/utils.ts
+++ b/agents/src/inference/utils.ts
@@ -16,7 +16,6 @@ export const DEFAULT_INFERENCE_URL = 'https://agent-gateway.livekit.cloud/v1';
 /** Staging inference URL */
 export const STAGING_INFERENCE_URL = 'https://agent-gateway.staging.livekit.cloud/v1';
 
-// Ref: python livekit-agents/livekit/agents/inference/_utils.py - 17-18 lines
 export const HEADER_INFERENCE_PROVIDER = 'X-LiveKit-Inference-Provider';
 export const HEADER_INFERENCE_PRIORITY = 'X-LiveKit-Inference-Priority';
 


### PR DESCRIPTION
## Summary

Ports [livekit/agents#5517](https://github.com/livekit/agents/pull/5517) to `agents-js`.

Adds an optional `inferenceClass` argument to `livekit.agents.inference.LLM` on both the constructor and `LLM.chat(...)`. Callers can opt into the LiveKit inference priority tier either globally for an instance or per call. When set, the value is forwarded to the inference gateway via the `X-LiveKit-Inference-Priority` header. **Per-call value takes precedence over the instance default.**

This is a LiveKit-gateway routing hint, independent of OpenAI's request-body `service_tier`.

## Changes

- `agents/src/inference/utils.ts`: add `HEADER_INFERENCE_PROVIDER` and `HEADER_INFERENCE_PRIORITY` header-name constants.
- `agents/src/inference/llm.ts`:
  - new `InferenceClass = 'priority' | 'standard'` type alias
  - `inferenceClass` added to `InferenceLLMOptions`, `LLM` constructor opts, `LLM.chat()` opts, and `LLMStream` constructor opts
  - per-call value wins over instance default via `effectiveInferenceClass = chatArg ?? this.opts.inferenceClass`
  - emit `X-LiveKit-Inference-Priority` header in `LLMStream.run()`; switch the existing provider emission to the new constant
- `agents/src/inference/index.ts`: re-export `type InferenceClass`.
- `.changeset/inference-class-priority-routing.md`: minor bump for `@livekit/agents`.

## Implementation notes / language-difference caveats

1. **Per-call "not given" sentinel.** Python uses `NotGivenOr[InferenceClass] = NOT_GIVEN` with an `is_given(...)` helper to distinguish "user passed nothing" from "user explicitly passed `None`". TypeScript's idiomatic equivalent for this code path is `inferenceClass?: InferenceClass`, i.e. `undefined` means "fall back to instance default". This preserves the intended semantics (per-call overrides instance default; explicit `undefined` behaves like "not given"), though it does not allow a caller to explicitly pass "unset" to override a configured instance default back to `undefined` — which matches typical JS conventions and mirrors how `parallelToolCalls` / `toolChoice` are already handled in `LLM.chat` here.

2. **Naming.** Python identifier is snake_case (`inference_class`); JS follows camelCase (`inferenceClass`), consistent with the rest of this codebase.

3. **Header constants.** Python lives in `inference/_utils.py`; JS lives in `inference/utils.ts` (this repo has no leading-underscore convention for internal modules). Header string values are identical.

4. **No test file.** The Python PR description mentioned `tests/test_inference_llm_class.py` but that file was not included in the merged commit. To stay at feature parity, this port also does not add a new unit test. The header emission path is covered by visual inspection of the diff and the existing typecheck / build / lint passes.

## Cross-reference comments

Every new/changed block carries a `// Ref: python livekit-agents/livekit/agents/inference/<file>.py - <lines>` comment per the porting convention in `CLAUDE.md`.

## Validation

- `pnpm --filter @livekit/agents exec tsc --noEmit` → clean
- `pnpm --filter @livekit/agents exec prettier --check` on modified files → clean
- `pnpm --filter @livekit/agents lint` → no new warnings in modified files
- `pnpm --filter @livekit/agents build` → success

## Reviewers

cc @toubatbrian @livekit/agent-devs

---

🤖 This PR was opened by an automated Claude Code routine created by @toubatbrian (experimental). Source PR: livekit/agents#5517.

---
_Generated by [Claude Code](https://claude.ai/code/session_016df65m8m1WhSQirs1MK5gA)_