### PR TITLE
fix(tts): unsubscribe StreamAdapter listeners on close

### DIFF
--- a/agents/src/tts/stream_adapter.ts
+++ b/agents/src/tts/stream_adapter.ts
@@ -2,18 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
+import type { TTSMetrics } from '../metrics/base.js';
 import type { SentenceStream, SentenceTokenizer } from '../tokenize/index.js';
 import type { APIConnectOptions } from '../types.js';
 import { USERDATA_TIMED_TRANSCRIPT } from '../types.js';
 import { Task } from '../utils.js';
 import { createTimedString } from '../voice/io.js';
-import type { ChunkedStream } from './tts.js';
+import type { ChunkedStream, TTSError } from './tts.js';
 import { SynthesizeStream, TTS } from './tts.js';
 
 export class StreamAdapter extends TTS {
   #tts: TTS;
   #sentenceTokenizer: SentenceTokenizer;
   label: string;
+
+  #forwardMetrics = (metrics: TTSMetrics) => {
+    this.emit('metrics_collected', metrics);
+  };
+
+  #forwardError = (error: TTSError) => {
+    this.emit('error', error);
+  };
 
   constructor(tts: TTS, sentenceTokenizer: SentenceTokenizer) {
     super(tts.sampleRate, tts.numChannels, { streaming: true, alignedTranscript: true });
@@ -22,12 +31,14 @@ export class StreamAdapter extends TTS {
     this.label = this.#tts.label;
     this.label = `tts.StreamAdapter<${this.#tts.label}>`;
 
-    this.#tts.on('metrics_collected', (metrics) => {
-      this.emit('metrics_collected', metrics);
-    });
-    this.#tts.on('error', (error) => {
-      this.emit('error', error);
-    });
+    this.#tts.on('metrics_collected', this.#forwardMetrics);
+    this.#tts.on('error', this.#forwardError);
+  }
+
+  async close(): Promise<void> {
+    this.#tts.off('metrics_collected', this.#forwardMetrics);
+    this.#tts.off('error', this.#forwardError);
+    await super.close();
   }
 
   synthesize(

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -485,6 +485,9 @@ export class Agent<UserData = any> {
         if (cleaned) return;
         cleaned = true;
         stream.close();
+        if (wrappedTts !== activity.tts) {
+          wrappedTts.close();
+        }
       };
 
       return new ReadableStream({


### PR DESCRIPTION
## Summary
- `StreamAdapter` wired anonymous `metrics_collected`/`error` handlers on the wrapped TTS in the constructor and never removed them, leaking subscriptions for the lifetime of the inner instance.
- Hoist the handlers into named fields (`#forwardMetrics`, `#forwardError`) and add a `close()` override that `.off()`s them and chains `super.close()`. The wrapped TTS is caller-owned, so `close()` does not close it.

## Test plan
- [x] `pnpm --filter @livekit/agents exec tsc --noEmit`
- [x] `pnpm test -- --run agents/src/tts`