### PR TITLE
Port dynamic endpointing to the Node.js SDK

### DIFF
--- a/.changeset/dynamic-endpointing-port.md
+++ b/.changeset/dynamic-endpointing-port.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': minor
+---
+
+Port dynamic endpointing from the Python SDK, including the adaptive endpointing runtime, test parity, and Node.js voice pipeline wiring.

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -351,44 +351,104 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 }
 
 /** @internal */
+// Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-64 lines
 export class ExpFilter {
-  #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  private _alpha: number;
+  private _filtered: number | undefined;
+  private _max_val: number | undefined;
+  private _min_val: number | undefined;
 
-  constructor(alpha: number, max?: number) {
-    this.#alpha = alpha;
-    this.#max = max;
+  constructor(
+    alpha: number,
+    max?: number,
+    options: {
+      initial?: number;
+      minVal?: number;
+      maxVal?: number;
+    } = {},
+  ) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
+
+    this._alpha = alpha;
+    this._filtered = options.initial;
+    this._max_val = options.maxVal ?? max;
+    this._min_val = options.minVal;
   }
 
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 21-36 lines
+  reset(
+    alphaOrOptions?:
+      | number
+      | {
+          initial?: number;
+          minVal?: number;
+          maxVal?: number;
+          alpha?: number;
+        },
+  ) {
+    const options =
+      typeof alphaOrOptions === 'number' ? { alpha: alphaOrOptions } : alphaOrOptions ?? {};
+
+    if (options.alpha !== undefined) {
+      if (!(options.alpha > 0 && options.alpha <= 1)) {
+        throw new Error('alpha must be in (0, 1].');
+      }
+      this._alpha = options.alpha;
     }
-    this.#filtered = undefined;
+
+    if (Object.hasOwn(options, 'initial')) {
+      this._filtered = options.initial;
+    }
+    if (Object.hasOwn(options, 'minVal')) {
+      this._min_val = options.minVal;
+    }
+    if (Object.hasOwn(options, 'maxVal')) {
+      this._max_val = options.maxVal;
+    }
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
-      const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
-    } else {
-      this.#filtered = sample;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 38-57 lines
+  apply(exp: number, sample: number | undefined = undefined): number {
+    sample ??= this._filtered;
+
+    if (sample !== undefined && this._filtered === undefined) {
+      this._filtered = sample;
+    } else if (sample !== undefined && this._filtered !== undefined) {
+      const a = this._alpha ** exp;
+      this._filtered = a * this._filtered + (1 - a) * sample;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (this._filtered === undefined) {
+      throw new Error('sample or initial value must be given.');
     }
 
-    return this.#filtered;
+    if (this._max_val !== undefined && this._filtered > this._max_val) {
+      this._filtered = this._max_val;
+    }
+
+    if (this._min_val !== undefined && this._filtered < this._min_val) {
+      this._filtered = this._min_val;
+    }
+
+    return this._filtered;
+  }
+
+  get value(): number | undefined {
+    return this._filtered;
   }
 
   get filtered(): number | undefined {
-    return this.#filtered;
+    return this._filtered;
   }
 
   set alpha(alpha: number) {
-    this.#alpha = alpha;
+    this._alpha = alpha;
+  }
+
+  updateBase(alpha: number) {
+    this._alpha = alpha;
   }
 }
 

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -375,3 +375,37 @@ describe('AgentActivity - onPreemptiveGeneration guards', () => {
     expect(cancelPreemptiveGeneration).not.toHaveBeenCalled();
   });
 });
+
+describe('AgentActivity - endpointing wiring', () => {
+  it('forwards realtime speech boundaries into AudioRecognition when VAD is unavailable', () => {
+    const onStartOfSpeech = vi.fn();
+    const onEndOfSpeech = vi.fn();
+    const updateUserState = vi.fn();
+
+    const activity = Object.create(AgentActivity.prototype) as any;
+    activity.agent = { vad: undefined };
+    activity.audioRecognition = { onStartOfSpeech, onEndOfSpeech };
+    activity.agentSession = {
+      vad: undefined,
+      _userSpeakingSpan: undefined,
+      _updateUserState: updateUserState,
+    };
+    activity.isInterruptionDetectionEnabled = true;
+    activity.interruptionDetected = false;
+    activity.interrupt = vi.fn();
+    activity.logger = { info: vi.fn(), error: vi.fn() };
+
+    AgentActivity.prototype.onInputSpeechStarted.call(activity, {} as any);
+    expect(onStartOfSpeech).toHaveBeenCalledTimes(1);
+    expect(typeof onStartOfSpeech.mock.calls[0]?.[0]).toBe('number');
+    expect(onStartOfSpeech.mock.calls[0]?.[1]).toBe(0);
+
+    AgentActivity.prototype.onInputSpeechStopped.call(activity, {
+      userTranscriptionEnabled: false,
+    } as any);
+    expect(onEndOfSpeech).toHaveBeenCalledTimes(1);
+    expect(typeof onEndOfSpeech.mock.calls[0]?.[0]).toBe('number');
+    expect(onEndOfSpeech.mock.calls[0]?.[2]).toBe(false);
+    expect(updateUserState).toHaveBeenCalledTimes(2);
+  });
+});

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -65,6 +65,7 @@ import {
   type RecognitionHooks,
   type STTPipeline,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import {
   AgentSessionEventTypes,
   createErrorEvent,
@@ -88,6 +89,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -188,6 +190,7 @@ export class AgentActivity implements RecognitionHooks {
   private isInterruptionDetectionEnabled: boolean;
   private isInterruptionByAudioActivityEnabled: boolean;
   private isDefaultInterruptionByAudioActivityEnabled: boolean;
+  private interruptionDetected = false;
 
   private readonly onRealtimeGenerationCreated = (ev: GenerationCreatedEvent): void =>
     this.onGenerationCreated(ev);
@@ -477,12 +480,8 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 776-783 lines
+      endpointing: createEndpointing(this.endpointingOptions),
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -661,19 +660,20 @@ export class AgentActivity implements RecognitionHooks {
     return this.agent.turnHandling ?? this.agentSession.sessionOptions.turnHandling;
   }
 
-  // get minEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.minDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.minDelay
-  //   );
-  // }
-
-  // get maxEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.maxDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay
-  //   );
-  // }
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 328-337 lines
+  get endpointingOptions() {
+    return {
+      mode:
+        this.agent.turnHandling?.endpointing?.mode ??
+        this.agentSession.sessionOptions.turnHandling.endpointing.mode,
+      minDelay:
+        this.agent.turnHandling?.endpointing?.minDelay ??
+        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
+      maxDelay:
+        this.agent.turnHandling?.endpointing?.maxDelay ??
+        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+    } as const;
+  }
 
   get toolCtx(): ToolContext {
     return this.agent.toolCtx;
@@ -717,9 +717,11 @@ export class AgentActivity implements RecognitionHooks {
 
   updateOptions({
     toolChoice,
+    endpointingOptions,
     turnDetection,
   }: {
     toolChoice?: ToolChoice | null;
+    endpointingOptions?: EndpointingOptions;
     turnDetection?: TurnDetectionMode;
   }): void {
     if (toolChoice !== undefined) {
@@ -743,7 +745,11 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (this.audioRecognition) {
-      this.audioRecognition.updateOptions({ turnDetection: this.turnDetectionMode });
+      this.audioRecognition.updateOptions({
+        endpointing:
+          endpointingOptions !== undefined ? createEndpointing(endpointingOptions) : undefined,
+        turnDetection: this.turnDetectionMode,
+      });
     }
   }
 
@@ -922,12 +928,9 @@ export class AgentActivity implements RecognitionHooks {
 
     if (!this.vad) {
       this.agentSession._updateUserState('speaking');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfOverlapSpeech(
-          0,
-          Date.now(),
-          this.agentSession._userSpeakingSpan,
-        );
+      this.interruptionDetected = false;
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfSpeech(Date.now(), 0, this.agentSession._userSpeakingSpan);
       }
     }
 
@@ -947,8 +950,12 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
+      if (this.audioRecognition) {
+        this.audioRecognition.onEndOfSpeech(
+          Date.now(),
+          this.agentSession._userSpeakingSpan,
+          this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
+        );
       }
       this.agentSession._updateUserState('listening');
     }
@@ -1026,15 +1033,18 @@ export class AgentActivity implements RecognitionHooks {
       // Subtract both speechDuration and inferenceDuration to correct for VAD model latency.
       speechStartTime = speechStartTime - ev.speechDuration - ev.inferenceDuration;
     }
+
+    this.interruptionDetected = false;
     this.agentSession._updateUserState('speaking', {
       lastSpeakingTime: speechStartTime,
       otelContext: otelContext.active(),
     });
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+
+    if (this.audioRecognition) {
       // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
+      this.audioRecognition.onStartOfSpeech(
         speechStartTime,
+        ev.speechDuration,
         this.agentSession._userSpeakingSpan,
       );
     }
@@ -1046,11 +1056,13 @@ export class AgentActivity implements RecognitionHooks {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+
+    if (this.audioRecognition) {
       // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
+      this.audioRecognition.onEndOfSpeech(
         speechEndTime,
         this.agentSession._userSpeakingSpan,
+        this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
       );
     }
     this.agentSession._updateUserState('listening', {
@@ -1127,6 +1139,7 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   onInterruption(ev: OverlappingSpeechEvent) {
+    this.interruptionDetected = true;
     this.restoreInterruptionByAudioActivity();
     this.interruptByAudioActivity();
     if (this.audioRecognition) {
@@ -1837,8 +1850,10 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
+      }
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -1924,10 +1939,12 @@ export class AgentActivity implements RecognitionHooks {
 
     if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+      if (this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
-      this.restoreInterruptionByAudioActivity();
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
+      }
     }
   }
 
@@ -2113,8 +2130,10 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
+      if (this.audioRecognition) {
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
+      }
       if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2271,8 +2290,10 @@ export class AgentActivity implements RecognitionHooks {
 
       if (this.agentSession.agentState === 'speaking') {
         this.agentSession._updateAgentState('listening');
-        if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+        if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        }
+        if (this.isInterruptionDetectionEnabled) {
           this.restoreInterruptionByAudioActivity();
         }
       }
@@ -2314,11 +2335,11 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._updateAgentState('thinking');
     } else if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
-          this.restoreInterruptionByAudioActivity();
-        }
+      if (this.audioRecognition) {
+        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+      }
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
       }
     }
 

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,6 +35,7 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import { type BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
@@ -138,10 +139,8 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
-  /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  /** Endpointing strategy. */
+  endpointing: BaseEndpointing;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +169,7 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  private endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -224,8 +222,7 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    this.endpointing = opts.endpointing;
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,7 +272,14 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 192-218 lines
+  updateOptions(options: {
+    endpointing?: BaseEndpointing;
+    turnDetection: TurnDetectionMode | undefined;
+  }): void {
+    if (options.endpointing !== undefined) {
+      this.endpointing = options.endpointing;
+    }
     this.turnDetectionMode = options.turnDetection;
   }
 
@@ -311,12 +315,27 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  get adaptiveInterruptionActive(): boolean {
+    return (
+      this.isInterruptionEnabled &&
+      this.interruptionStreamChannel !== undefined &&
+      !this.interruptionStreamChannel.closed
+    );
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-244 lines
+  async onStartOfAgentSpeech(startedAt: number) {
     this.isAgentSpeaking = true;
+    this.endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 245-270 lines
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -342,6 +361,31 @@ export class AudioRecognition {
       await this.flushHeldTranscripts();
     }
     this.isAgentSpeaking = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 272-289 lines
+  async onStartOfSpeech(startedAt: number, speechDuration: number = 0, userSpeakingSpan?: Span) {
+    this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+
+    if (!this.adaptiveInterruptionActive || !this.isAgentSpeaking) {
+      return;
+    }
+
+    this.trySendInterruptionSentinel(
+      InterruptionStreamSentinel.overlapSpeechStarted(speechDuration, startedAt, userSpeakingSpan),
+    );
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-305 lines
+  async onEndOfSpeech(endedAt: number, userSpeakingSpan?: Span, interruption?: boolean) {
+    if (this.speaking) {
+      this.endpointing.onEndOfSpeech(
+        endedAt,
+        interruption !== undefined && !interruption && this.isAgentSpeaking,
+      );
+    }
+
+    this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
   }
 
   /** Start interruption inference when agent is speaking and overlap speech starts. */
@@ -805,7 +849,8 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 931-947 lines
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +876,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');
@@ -1017,7 +1062,8 @@ export class AudioRecognition {
           case VADEventType.START_OF_SPEECH:
             this.logger.debug('VAD task: START_OF_SPEECH');
             {
-              const startTime = Date.now() - ev.speechDuration;
+              // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 870-883 lines
+              const startTime = Date.now() - ev.speechDuration - ev.inferenceDuration;
               const span = this.ensureUserTurnSpan(startTime);
               const ctx = this.userTurnContext(span);
               otelContext.with(ctx, () => this.hooks.onStartOfSpeech(ev));

--- a/agents/src/voice/audio_recognition_endpointing.test.ts
+++ b/agents/src/voice/audio_recognition_endpointing.test.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { AudioRecognition, type RecognitionHooks } from './audio_recognition.js';
+import { DynamicEndpointing, createEndpointing } from './endpointing.js';
+
+function createHooks(): RecognitionHooks {
+  return {
+    onInterruption: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onEndOfTurn: vi.fn(async () => true),
+    onPreemptiveGeneration: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+  };
+}
+
+describe('AudioRecognition endpointing integration', () => {
+  it('tracks agent speech timestamps even when adaptive interruption detection is disabled', async () => {
+    const endpointing = new DynamicEndpointing(300, 1000);
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing,
+    });
+
+    try {
+      await recognition.onStartOfAgentSpeech(100_500);
+      expect((endpointing as any)._agent_speech_started_at).toBe(100_500);
+
+      await recognition.onEndOfAgentSpeech(101_000);
+      expect((endpointing as any)._agent_speech_ended_at).toBeDefined();
+    } finally {
+      await recognition.close();
+    }
+  });
+
+  it('replaces the endpointing strategy on updateOptions instead of preserving learned state', async () => {
+    const original = new DynamicEndpointing(300, 1000, 0.5);
+    original.onEndOfSpeech(100_000);
+    original.onStartOfSpeech(100_400);
+    original.onEndOfSpeech(100_500);
+    expect(original.minDelay).toBeCloseTo(350, 5);
+
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing: original,
+    });
+    const replacement = createEndpointing({ mode: 'dynamic', minDelay: 600, maxDelay: 2000 });
+
+    try {
+      recognition.updateOptions({ endpointing: replacement, turnDetection: undefined });
+
+      expect((recognition as any).endpointing).toBe(replacement);
+      expect(((recognition as any).endpointing as DynamicEndpointing).minDelay).toBe(600);
+    } finally {
+      await recognition.close();
+    }
+  });
+});

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -7,6 +7,7 @@ import { ChatContext } from '../llm/chat_context.js';
 import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function createHooks() {
@@ -45,8 +46,7 @@ function createRecognition(sttNode: STTNode, hooks = createHooks()) {
     recognition: new AudioRecognition({
       recognitionHooks: hooks,
       stt: sttNode,
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
     }),
   };
 }

--- a/agents/src/voice/audio_recognition_span.test.ts
+++ b/agents/src/voice/audio_recognition_span.test.ts
@@ -22,6 +22,7 @@ import {
   type RecognitionHooks,
   type _TurnDetector,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function setupInMemoryTracing() {
@@ -145,8 +146,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: undefined,
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'stt',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
       sttModel: 'deepgram-nova2',
       sttProvider: 'deepgram',
       getLinkedParticipant: () => ({ sid: 'p1', identity: 'bob', kind: ParticipantKind.AGENT }),
@@ -254,8 +254,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: new FakeVAD(vadEvents),
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'vad',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: createEndpointing({ mode: 'fixed', minDelay: 0, maxDelay: 0 }),
       sttModel: 'stt-model',
       sttProvider: 'stt-provider',
       getLinkedParticipant: () => ({ sid: 'p2', identity: 'alice', kind: ParticipantKind.AGENT }),

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,471 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { ExpFilter } from '../utils.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+// Ref: python tests/test_endpointing.py - 7-63 lines
+describe('TestExponentialMovingAverage', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    let ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    const emaWithInitial = new ExpFilter(0.5, undefined, { initial: 10.0 });
+    expect(emaWithInitial.value).toBe(10.0);
+
+    ema = new ExpFilter(1.0);
+    expect(ema.value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0.0)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(-0.5)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(1.5)).toThrow('alpha must be in');
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1.0, 10.0);
+    expect(result).toBe(10.0);
+    expect(ema.value).toBe(10.0);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, undefined, { initial: 10.0 });
+    const result = ema.apply(1.0, 20.0);
+    expect(result).toBe(15.0);
+    expect(ema.value).toBe(15.0);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, undefined, { initial: 10.0 });
+    ema.apply(1.0, 20.0);
+    ema.apply(1.0, 20.0);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    let ema = new ExpFilter(0.5, undefined, { initial: 10.0 });
+    expect(ema.value).toBe(10.0);
+    ema.reset();
+    expect(ema.value).toBe(10.0);
+
+    ema = new ExpFilter(0.5, undefined, { initial: 10.0 });
+    ema.reset({ initial: 5.0 });
+    expect(ema.value).toBe(5.0);
+  });
+});
+
+// Ref: python tests/test_endpointing.py - 64-545 lines
+describe('TestDynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.2);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect((ep as any)._utterance_pause._alpha).toBeCloseTo(0.9, 5);
+    expect((ep as any)._turn_pause._alpha).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toEqual([0, 0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    let ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100_000);
+    expect((ep as any)._utterance_ended_at).toBe(100_000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(99_900);
+    expect((ep as any)._utterance_ended_at).toBe(99_900);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfSpeech(100_000);
+    expect((ep as any)._utterance_started_at).toBe(100_000);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100_000);
+    expect((ep as any)._agent_speech_started_at).toBe(100_000);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_500);
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(500, 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_800);
+    expect(ep.betweenTurnDelay).toBeCloseTo(800, 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_400);
+    ep.onEndOfSpeech(100_500, false);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_600);
+    ep.onStartOfSpeech(101_500);
+    ep.onEndOfSpeech(102_000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 600 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    expect((ep as any)._agent_speech_started_at).toBeDefined();
+    ep.onStartOfSpeech(100_250, true);
+    expect((ep as any)._overlapping).toBe(true);
+
+    ep.onEndOfSpeech(100_500);
+
+    expect((ep as any)._overlapping).toBe(false);
+    expect((ep as any)._agent_speech_started_at).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(300, 5);
+  });
+
+  it('test_update_options', () => {
+    let ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ minDelay: 500 });
+    expect(ep.minDelay).toBe(500);
+    expect((ep as any)._min_delay).toBe(500);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ maxDelay: 2000 });
+    expect(ep.maxDelay).toBe(2000);
+    expect((ep as any)._max_delay).toBe(2000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions();
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(102_000);
+    ep.onStartOfSpeech(105_000);
+
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_100);
+    ep.onStartOfSpeech(100_500);
+
+    expect(ep.maxDelay).toBeGreaterThanOrEqual((ep as any)._min_delay);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    expect((ep as any)._agent_speech_started_at).toBeDefined();
+
+    ep.onStartOfSpeech(102_000);
+    ep.onEndOfSpeech(103_000, false);
+    expect((ep as any)._agent_speech_started_at).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    ep.onStartOfSpeech(100_250, true);
+
+    expect((ep as any)._overlapping).toBe(true);
+    const prevVal = [ep.minDelay, ep.maxDelay];
+
+    ep.onStartOfSpeech(100_350);
+
+    expect((ep as any)._overlapping).toBe(true);
+    expect([ep.minDelay, ep.maxDelay]).toEqual(prevVal);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_900);
+    ep.onStartOfSpeech(101_800);
+    ep.onEndOfSpeech(102_000, false);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing(60, 1000, 1.0);
+
+    ep.onEndOfSpeech(99_000);
+    ep.onStartOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_200);
+    ep.onStartOfSpeech(100_250, true);
+
+    expect((ep as any)._utterance_ended_at).toBeCloseTo(100_199, 0);
+    expect(ep.minDelay).toBeCloseTo(60, 5);
+    expect(ep.maxDelay).toBeCloseTo(1000, 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+
+    expect((ep as any)._utterance_pause._alpha).toBeCloseTo(0.5, 5);
+    expect((ep as any)._turn_pause._alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect((ep as any)._utterance_pause._min_val).toBe(500);
+    expect((ep as any)._turn_pause._max_val).toBe(2000);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_200);
+    expect(ep.minDelay).toBeCloseTo(500, 5);
+
+    ep.onEndOfSpeech(101_000);
+    ep.onStartOfAgentSpeech(102_800);
+    ep.onStartOfSpeech(103_500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(101_500, true);
+
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101_800, true);
+
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect((ep as any)._utterance_started_at).toBeUndefined();
+    expect((ep as any)._utterance_ended_at).toBeUndefined();
+    expect((ep as any)._overlapping).toBe(false);
+    expect((ep as any)._speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfSpeech(100_400, false);
+    ep.onEndOfSpeech(100_600, true);
+
+    const expected = 0.5 * 400 + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(100_600, true);
+
+    ep.onEndOfSpeech(100_800, true);
+
+    expect((ep as any)._utterance_ended_at).toBe(100_800);
+    expect((ep as any)._speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_500);
+    ep.onStartOfSpeech(101_000, true);
+
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+    ep.onEndOfSpeech(101_500, true);
+
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect((ep as any)._utterance_started_at).toBeUndefined();
+    expect((ep as any)._utterance_ended_at).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    ep.onStartOfAgentSpeech(100_000);
+    ep.onStartOfSpeech(100_100, true);
+    expect((ep as any)._overlapping).toBe(true);
+    expect((ep as any)._agent_speech_started_at).toBe(100_000);
+
+    ep.onEndOfAgentSpeech(101_000);
+
+    expect((ep as any)._agent_speech_ended_at).toBe(101_000);
+    expect((ep as any)._agent_speech_started_at).toBe(100_000);
+    expect((ep as any)._overlapping).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100_000);
+    ep.onStartOfAgentSpeech(100_900);
+    ep.onStartOfSpeech(101_800, false);
+    ep.onEndOfSpeech(102_000);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+
+    expect((ep as any)._speaking).toBe(false);
+    ep.onStartOfSpeech(100_000);
+    expect((ep as any)._speaking).toBe(true);
+    ep.onEndOfSpeech(100_500);
+    expect((ep as any)._speaking).toBe(false);
+  });
+
+  it.each([
+    ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+    ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+    ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+    ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+    ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+    ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+    ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+    ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+    ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+  ])(
+    'test_all_overlapping_and_should_ignore_combos %s',
+    (
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ) => {
+      const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+      ep.onStartOfSpeech(99_000);
+      ep.onEndOfSpeech(100_000);
+
+      let userStart: number;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100_500);
+        ep.onEndOfAgentSpeech(101_000);
+        userStart = 101_500;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100_150);
+          userStart = 100_350;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100_200);
+          userStart = 101_500;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100_150);
+          userStart = 100_400;
+        } else {
+          ep.onStartOfAgentSpeech(100_900);
+          userStart = 101_800;
+        }
+      } else {
+        userStart = 100_400;
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping);
+
+      const prevMin = ep.minDelay;
+      const prevMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + 500, shouldIgnore);
+
+      const minChanged = ep.minDelay !== prevMin;
+      const maxChanged = ep.maxDelay !== prevMax;
+
+      expect(minChanged, `[${label}] minDelay change`).toBe(expectMinChange);
+      expect(maxChanged, `[${label}] maxDelay change`).toBe(expectMaxChange);
+      expect((ep as any)._speaking, `[${label}] _speaking should be false`).toBe(false);
+      expect((ep as any)._overlapping, `[${label}] _overlapping should be false`).toBe(false);
+    },
+  );
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onStartOfSpeech(100_000);
+    ep.onEndOfSpeech(101_000);
+
+    ep.onStartOfAgentSpeech(101_500);
+
+    ep.onStartOfSpeech(102_500, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102_800, true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(103_000);
+
+    ep.onStartOfSpeech(103_500);
+    ep.onEndOfSpeech(104_000);
+
+    expect((ep as any)._speaking).toBe(false);
+    expect((ep as any)._agent_speech_started_at).toBeUndefined();
+  });
+});

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,306 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+const logger = log();
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 7-7 lines
+const _AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250; // 0.25s -> 250ms
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-47 lines
+export class BaseEndpointing {
+  protected _min_delay: number;
+  protected _max_delay: number;
+  protected _overlapping: boolean;
+
+  constructor(minDelay: number, maxDelay: number) {
+    this._min_delay = minDelay;
+    this._max_delay = maxDelay;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 16-22 lines
+  updateOptions(options: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (Object.hasOwn(options, 'minDelay')) {
+      this._min_delay = options.minDelay!;
+    }
+    if (Object.hasOwn(options, 'maxDelay')) {
+      this._max_delay = options.maxDelay!;
+    }
+  }
+
+  get minDelay(): number {
+    return this._min_delay;
+  }
+
+  get maxDelay(): number {
+    return this._max_delay;
+  }
+
+  get overlapping(): boolean {
+    return this._overlapping;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 36-40 lines
+  onStartOfSpeech(startedAt: number, overlapping: boolean = false): void {
+    void startedAt;
+    this._overlapping = overlapping;
+  }
+
+  onEndOfSpeech(endedAt: number, shouldIgnore: boolean = false): void {
+    void endedAt;
+    void shouldIgnore;
+    this._overlapping = false;
+  }
+
+  onStartOfAgentSpeech(startedAt: number): void {
+    void startedAt;
+  }
+
+  onEndOfAgentSpeech(endedAt: number): void {
+    void endedAt;
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-303 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private _utterance_pause: ExpFilter;
+  private _turn_pause: ExpFilter;
+
+  private _utterance_started_at: number | undefined;
+  private _utterance_ended_at: number | undefined;
+  private _agent_speech_started_at: number | undefined;
+  private _agent_speech_ended_at: number | undefined;
+  private _speaking: boolean;
+
+  constructor(minDelay: number, maxDelay: number, alpha: number = 0.9) {
+    super(minDelay, maxDelay);
+
+    this._utterance_pause = new ExpFilter(alpha, undefined, {
+      initial: minDelay,
+      minVal: minDelay,
+      maxVal: maxDelay,
+    });
+    this._turn_pause = new ExpFilter(alpha, undefined, {
+      initial: maxDelay,
+      minVal: minDelay,
+      maxVal: maxDelay,
+    });
+
+    this._utterance_started_at = undefined;
+    this._utterance_ended_at = undefined;
+    this._agent_speech_started_at = undefined;
+    this._agent_speech_ended_at = undefined;
+    this._speaking = false;
+  }
+
+  get minDelay(): number {
+    return this._utterance_pause.value ?? this._min_delay;
+  }
+
+  get maxDelay(): number {
+    const turnVal = this._turn_pause.value ?? this._max_delay;
+    return Math.max(turnVal, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this._utterance_ended_at === undefined || this._utterance_started_at === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this._utterance_started_at - this._utterance_ended_at);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this._agent_speech_started_at === undefined || this._utterance_ended_at === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this._agent_speech_started_at - this._utterance_ended_at);
+  }
+
+  get immediateInterruptionDelay(): [number, number] {
+    if (this._utterance_started_at === undefined || this._agent_speech_started_at === undefined) {
+      return [0, 0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 139-142 lines
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this._agent_speech_started_at = startedAt;
+    this._agent_speech_ended_at = undefined;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 144-153 lines
+  override onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this._agent_speech_started_at !== undefined &&
+      (this._agent_speech_ended_at === undefined ||
+        this._agent_speech_ended_at < this._agent_speech_started_at)
+    ) {
+      this._agent_speech_ended_at = endedAt;
+    }
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 155-177 lines
+  override onStartOfSpeech(startedAt: number, overlapping: boolean = false): void {
+    if (this._overlapping) {
+      return;
+    }
+
+    if (
+      this._utterance_started_at !== undefined &&
+      this._utterance_ended_at !== undefined &&
+      this._agent_speech_started_at !== undefined &&
+      this._utterance_ended_at < this._utterance_started_at &&
+      overlapping
+    ) {
+      this._utterance_ended_at = this._agent_speech_started_at - 1;
+      logger.trace({ utteranceEndedAt: this._utterance_ended_at }, 'utterance ended at adjusted');
+    }
+
+    this._utterance_started_at = startedAt;
+    this._overlapping = overlapping;
+    this._speaking = true;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 179-286 lines
+  override onEndOfSpeech(endedAt: number, shouldIgnore: boolean = false): void {
+    if (shouldIgnore && this._overlapping) {
+      if (
+        this._utterance_started_at !== undefined &&
+        this._agent_speech_started_at !== undefined &&
+        Math.abs(this._utterance_started_at - this._agent_speech_started_at) <
+          _AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        logger.trace(
+          {
+            startedAtDelta: Math.abs(this._utterance_started_at - this._agent_speech_started_at),
+            gracePeriod: _AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true within grace period',
+        );
+      } else {
+        this._overlapping = false;
+        this._speaking = false;
+        this._utterance_started_at = undefined;
+        this._utterance_ended_at = undefined;
+        return;
+      }
+    }
+
+    if (
+      this._overlapping ||
+      (this._agent_speech_started_at !== undefined && this._agent_speech_ended_at === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const betweenUtteranceDelay = this.betweenUtteranceDelay;
+
+      if (
+        interruptionDelay > 0 &&
+        interruptionDelay <= this.minDelay &&
+        turnDelay > 0 &&
+        turnDelay <= this.maxDelay &&
+        betweenUtteranceDelay > 0
+      ) {
+        const prevVal = this.minDelay;
+        this._utterance_pause.apply(1.0, betweenUtteranceDelay);
+        logger.debug(
+          {
+            prevVal,
+            reason: 'immediate interruption',
+            pause: betweenUtteranceDelay,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          'min endpointing delay updated',
+        );
+      } else if (this.betweenTurnDelay > 0) {
+        const prevVal = this.maxDelay;
+        this._turn_pause.apply(1.0, this.betweenTurnDelay);
+        logger.debug(
+          {
+            prevVal,
+            reason: 'new turn (interruption)',
+            pause: this.betweenTurnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+            betweenUtteranceDelay: this.betweenUtteranceDelay,
+            betweenTurnDelay: this.betweenTurnDelay,
+          },
+          'max endpointing delay updated',
+        );
+      }
+    } else if (this.betweenTurnDelay > 0) {
+      const prevVal = this.maxDelay;
+      this._turn_pause.apply(1.0, this.betweenTurnDelay);
+      logger.debug(
+        {
+          prevVal,
+          reason: 'new turn',
+          pause: this.betweenTurnDelay,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        'max endpointing delay updated due to pause',
+      );
+    } else if (
+      this.betweenUtteranceDelay > 0 &&
+      this._agent_speech_ended_at === undefined &&
+      this._agent_speech_started_at === undefined
+    ) {
+      const prevVal = this.minDelay;
+      this._utterance_pause.apply(1.0, this.betweenUtteranceDelay);
+      logger.debug(
+        {
+          prevVal,
+          reason: 'pause between utterances',
+          pause: this.betweenUtteranceDelay,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        'min endpointing delay updated',
+      );
+    }
+
+    this._utterance_ended_at = endedAt;
+    this._agent_speech_started_at = undefined;
+    this._agent_speech_ended_at = undefined;
+    this._speaking = false;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 288-302 lines
+  override updateOptions(options: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (Object.hasOwn(options, 'minDelay')) {
+      this._min_delay = options.minDelay!;
+      this._utterance_pause.reset({ initial: this._min_delay, minVal: this._min_delay });
+      this._turn_pause.reset({ minVal: this._min_delay });
+    }
+
+    if (Object.hasOwn(options, 'maxDelay')) {
+      this._max_delay = options.maxDelay!;
+      this._turn_pause.reset({ initial: this._max_delay, maxVal: this._max_delay });
+      this._utterance_pause.reset({ maxVal: this._max_delay });
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  switch (options.mode) {
+    case 'dynamic':
+      return new DynamicEndpointing(options.minDelay, options.maxDelay);
+    default:
+      return new BaseEndpointing(options.minDelay, options.maxDelay);
+  }
+}

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -22,6 +22,7 @@ export {
   RoomSessionTransport,
 } from './remote_session.js';
 export * from './events.js';
+export * from './endpointing.js';
 export { type TimedString } from './io.js';
 export * from './report.js';
 export * from './room_io/index.js';

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -7,7 +7,7 @@
 export interface EndpointingOptions {
   /**
    * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on
-   * end-of-utterance prediction.
+   * observed pauses between utterances, turns, and interruptions.
    * @defaultValue "fixed"
    */
   mode: 'fixed' | 'dynamic';


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/118).

Tracking issue: https://github.com/livekit/rosetta/issues/118

## Summary
- port the Python dynamic endpointing runtime into `@livekit/agents`, including `BaseEndpointing`, `DynamicEndpointing`, `createEndpointing`, and the shared `ExpFilter` behavior it relies on
- wire endpointing strategies through `AudioRecognition` and `AgentActivity`, including realtime/no-VAD paths and endpointing replacement semantics during updates
- port the full Python `tests/test_endpointing.py` contract and add Node-specific regression coverage for runtime wiring and strategy replacement

## Source
- https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/endpointing.py
- https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/audio_recognition.py
- https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/agent_activity.py

## Testing
- `pnpm exec vitest run agents/src/voice/endpointing.test.ts agents/src/voice/audio_recognition_endpointing.test.ts agents/src/voice/audio_recognition_span.test.ts agents/src/voice/audio_recognition_handoff.test.ts agents/src/voice/agent_activity.test.ts agents/src/voice/agent.test.ts`
- `pnpm exec vitest run agents/src/utils.test.ts agents/src/voice/turn_config/utils.test.ts`
- `pnpm --filter @livekit/agents build:types`