### PR TITLE
Port dynamic endpointing to Node agents

### DIFF
--- a/.changeset/dynamic-endpointing.md
+++ b/.changeset/dynamic-endpointing.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Port dynamic endpointing support for voice turn handling.

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -370,6 +370,8 @@ export class ExpFilter {
   #maxVal?: number;
   #minVal?: number;
 
+  constructor(alpha: number, max?: number);
+  constructor(alpha: number, options?: ExpFilterOptions);
   constructor(alpha: number, maxOrOptions?: number | ExpFilterOptions) {
     if (!(alpha > 0 && alpha <= 1)) {
       throw new RangeError('alpha must be in (0, 1].');
@@ -387,6 +389,8 @@ export class ExpFilter {
   }
 
   // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 21-36 lines
+  reset(alpha?: number): void;
+  reset(options?: ExpFilterResetOptions): void;
   reset(options: number | ExpFilterResetOptions = {}): void {
     const resetOptions = typeof options === 'number' ? { alpha: options } : options;
 
@@ -408,6 +412,8 @@ export class ExpFilter {
   }
 
   // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 38-57 lines
+  apply(exp: number, sample: number): number;
+  apply(exp: number, sample?: number): number;
   apply(exp: number, sample?: number): number {
     const nextSample = sample ?? this.#filtered;
 

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -351,35 +351,89 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 }
 
 /** @internal */
+export interface ExpFilterOptions {
+  maxVal?: number;
+  minVal?: number;
+  initial?: number;
+}
+
+/** @internal */
+export interface ExpFilterResetOptions extends ExpFilterOptions {
+  alpha?: number;
+}
+
+// Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-64 lines
+/** @internal */
 export class ExpFilter {
   #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  #filtered?: number;
+  #maxVal?: number;
+  #minVal?: number;
 
-  constructor(alpha: number, max?: number) {
+  constructor(alpha: number, maxOrOptions?: number | ExpFilterOptions) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new RangeError('alpha must be in (0, 1].');
+    }
+
     this.#alpha = alpha;
-    this.#max = max;
-  }
 
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
-    }
-    this.#filtered = undefined;
-  }
-
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
-      const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
+    if (typeof maxOrOptions === 'number') {
+      this.#maxVal = maxOrOptions;
     } else {
-      this.#filtered = sample;
+      this.#maxVal = maxOrOptions?.maxVal;
+      this.#minVal = maxOrOptions?.minVal;
+      this.#filtered = maxOrOptions?.initial;
+    }
+  }
+
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 21-36 lines
+  reset(options: number | ExpFilterResetOptions = {}): void {
+    const resetOptions = typeof options === 'number' ? { alpha: options } : options;
+
+    if (resetOptions.alpha !== undefined) {
+      if (!(resetOptions.alpha > 0 && resetOptions.alpha <= 1)) {
+        throw new RangeError('alpha must be in (0, 1].');
+      }
+      this.#alpha = resetOptions.alpha;
+    }
+    if (resetOptions.initial !== undefined) {
+      this.#filtered = resetOptions.initial;
+    }
+    if (resetOptions.minVal !== undefined) {
+      this.#minVal = resetOptions.minVal;
+    }
+    if (resetOptions.maxVal !== undefined) {
+      this.#maxVal = resetOptions.maxVal;
+    }
+  }
+
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 38-57 lines
+  apply(exp: number, sample?: number): number {
+    const nextSample = sample ?? this.#filtered;
+
+    if (nextSample !== undefined && this.#filtered === undefined) {
+      this.#filtered = nextSample;
+    } else if (nextSample !== undefined && this.#filtered !== undefined) {
+      const a = this.#alpha ** exp;
+      this.#filtered = a * this.#filtered + (1 - a) * nextSample;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (this.#filtered === undefined) {
+      throw new Error('sample or initial value must be given.');
     }
 
+    if (this.#maxVal !== undefined && this.#filtered > this.#maxVal) {
+      this.#filtered = this.#maxVal;
+    }
+
+    if (this.#minVal !== undefined && this.#filtered < this.#minVal) {
+      this.#filtered = this.#minVal;
+    }
+
+    return this.#filtered;
+  }
+
+  get value(): number | undefined {
     return this.#filtered;
   }
 
@@ -387,7 +441,22 @@ export class ExpFilter {
     return this.#filtered;
   }
 
+  get alpha(): number {
+    return this.#alpha;
+  }
+
+  get maxVal(): number | undefined {
+    return this.#maxVal;
+  }
+
+  get minVal(): number | undefined {
+    return this.#minVal;
+  }
+
   set alpha(alpha: number) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new RangeError('alpha must be in (0, 1].');
+    }
     this.#alpha = alpha;
   }
 }

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -375,3 +375,107 @@ describe('AgentActivity - onPreemptiveGeneration guards', () => {
     expect(cancelPreemptiveGeneration).not.toHaveBeenCalled();
   });
 });
+
+type AgentActivityEndpointingMethods = {
+  onInputSpeechStarted: (this: unknown, ev: unknown) => void;
+  onInputSpeechStopped: (this: unknown, ev: unknown) => void;
+  onStartOfSpeech: (this: unknown, ev: unknown) => void;
+  onEndOfSpeech: (this: unknown, ev: unknown) => void;
+  onPipelineReplyDone: (this: unknown) => void;
+};
+
+const agentActivityEndpointingMethods =
+  AgentActivity.prototype as unknown as AgentActivityEndpointingMethods;
+
+describe('AgentActivity - endpointing integration', () => {
+  it('feeds realtime no-VAD speech starts and stops into AudioRecognition endpointing', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    const userSpeakingSpan = {};
+    const audioRecognition = {
+      onStartOfSpeech: vi.fn(),
+      onEndOfSpeech: vi.fn(),
+    };
+    const fakeActivity = {
+      vad: undefined,
+      agentSession: {
+        _updateUserState: vi.fn(),
+        _userSpeakingSpan: userSpeakingSpan,
+        emit: vi.fn(),
+      },
+      audioRecognition,
+      interruptionDetected: false,
+      isInterruptionDetectionEnabled: true,
+      interrupt: vi.fn(),
+      logger: { info: vi.fn(), error: vi.fn() },
+    };
+
+    try {
+      agentActivityEndpointingMethods.onInputSpeechStarted.call(fakeActivity, {});
+      expect(audioRecognition.onStartOfSpeech).toHaveBeenCalledWith(10_000, 0, userSpeakingSpan);
+
+      agentActivityEndpointingMethods.onInputSpeechStopped.call(fakeActivity, {
+        userTranscriptionEnabled: false,
+      });
+      expect(audioRecognition.onEndOfSpeech).toHaveBeenCalledWith(10_000, userSpeakingSpan, false);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it('passes adaptive interruption results through VAD speech end handling', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    const userSpeakingSpan = {};
+    const audioRecognition = {
+      onStartOfSpeech: vi.fn(),
+      onEndOfSpeech: vi.fn(),
+    };
+    const fakeActivity = {
+      agentSession: {
+        _updateUserState: vi.fn(),
+        _userSpeakingSpan: userSpeakingSpan,
+      },
+      audioRecognition,
+      interruptionDetected: false,
+      isInterruptionDetectionEnabled: true,
+    };
+    const vadEvent = {
+      speechDuration: 100,
+      inferenceDuration: 25,
+      silenceDuration: 50,
+    };
+
+    try {
+      agentActivityEndpointingMethods.onStartOfSpeech.call(fakeActivity, vadEvent);
+      expect(audioRecognition.onStartOfSpeech).toHaveBeenCalledWith(9_875, 100, userSpeakingSpan);
+      expect(fakeActivity.interruptionDetected).toBe(false);
+
+      fakeActivity.interruptionDetected = true;
+      agentActivityEndpointingMethods.onEndOfSpeech.call(fakeActivity, vadEvent);
+      expect(audioRecognition.onEndOfSpeech).toHaveBeenCalledWith(9_925, userSpeakingSpan, true);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it('notifies endpointing when pipeline speech drains to listening', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(12_345);
+    const audioRecognition = { onEndOfAgentSpeech: vi.fn() };
+    const fakeActivity = {
+      speechQueue: { peek: vi.fn(() => undefined) },
+      _currentSpeech: undefined,
+      agentSession: { _updateAgentState: vi.fn() },
+      audioRecognition,
+      isInterruptionDetectionEnabled: true,
+      restoreInterruptionByAudioActivity: vi.fn(),
+    };
+
+    try {
+      agentActivityEndpointingMethods.onPipelineReplyDone.call(fakeActivity);
+      expect(fakeActivity.agentSession._updateAgentState).toHaveBeenCalledWith('listening');
+      expect(audioRecognition.onEndOfAgentSpeech).toHaveBeenCalledWith(12_345);
+      expect(fakeActivity.restoreInterruptionByAudioActivity).toHaveBeenCalled();
+    } finally {
+      now.mockRestore();
+    }
+  });
+});

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -88,6 +88,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import { type EndpointingOptions, createEndpointing } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -186,6 +187,8 @@ export class AgentActivity implements RecognitionHooks {
   private _preemptiveGenerationCount = 0;
   private interruptionDetector?: AdaptiveInterruptionDetector;
   private isInterruptionDetectionEnabled: boolean;
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 202-206 lines
+  private interruptionDetected = false;
   private isInterruptionByAudioActivityEnabled: boolean;
   private isDefaultInterruptionByAudioActivityEnabled: boolean;
 
@@ -206,6 +209,8 @@ export class AgentActivity implements RecognitionHooks {
     this.onError(ev);
 
   private readonly onInterruptionOverlappingSpeech = (ev: OverlappingSpeechEvent): void => {
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1491-1496 lines
+    this.interruptionDetected = ev.isInterruption;
     this.agentSession.emit(AgentSessionEventTypes.OverlappingSpeech, ev);
   };
 
@@ -477,12 +482,8 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 776-786 lines
+      endpointing: createEndpointing(this.endpointingOptions),
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -661,19 +662,17 @@ export class AgentActivity implements RecognitionHooks {
     return this.agent.turnHandling ?? this.agentSession.sessionOptions.turnHandling;
   }
 
-  // get minEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.minDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.minDelay
-  //   );
-  // }
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 329-337 lines
+  get endpointingOptions(): EndpointingOptions {
+    const agentEndpointing = this.agent.turnHandling?.endpointing;
+    const sessionEndpointing = this.agentSession.sessionOptions.turnHandling.endpointing;
 
-  // get maxEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.maxDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay
-  //   );
-  // }
+    return {
+      mode: agentEndpointing?.mode ?? sessionEndpointing.mode,
+      minDelay: agentEndpointing?.minDelay ?? sessionEndpointing.minDelay,
+      maxDelay: agentEndpointing?.maxDelay ?? sessionEndpointing.maxDelay,
+    };
+  }
 
   get toolCtx(): ToolContext {
     return this.agent.toolCtx;
@@ -921,14 +920,10 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info('onInputSpeechStarted');
 
     if (!this.vad) {
+      const startedAt = Date.now();
       this.agentSession._updateUserState('speaking');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfOverlapSpeech(
-          0,
-          Date.now(),
-          this.agentSession._userSpeakingSpan,
-        );
-      }
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1498-1505 lines
+      this.audioRecognition?.onStartOfSpeech(startedAt, 0, this.agentSession._userSpeakingSpan);
     }
 
     // this.interrupt() is going to raise when allow_interruptions is False,
@@ -947,9 +942,12 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
-      }
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1516-1524 lines
+      this.audioRecognition?.onEndOfSpeech(
+        Date.now(),
+        this.agentSession._userSpeakingSpan,
+        this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
+      );
       this.agentSession._updateUserState('listening');
     }
 
@@ -1030,14 +1028,13 @@ export class AgentActivity implements RecognitionHooks {
       lastSpeakingTime: speechStartTime,
       otelContext: otelContext.active(),
     });
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
-        speechStartTime,
-        this.agentSession._userSpeakingSpan,
-      );
-    }
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1650-1664 lines
+    this.audioRecognition?.onStartOfSpeech(
+      speechStartTime,
+      ev.speechDuration,
+      this.agentSession._userSpeakingSpan,
+    );
+    this.interruptionDetected = false;
   }
 
   onEndOfSpeech(ev: VADEvent): void {
@@ -1046,13 +1043,12 @@ export class AgentActivity implements RecognitionHooks {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
-        speechEndTime,
-        this.agentSession._userSpeakingSpan,
-      );
-    }
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1686-1700 lines
+    this.audioRecognition?.onEndOfSpeech(
+      speechEndTime,
+      this.agentSession._userSpeakingSpan,
+      this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
+    );
     this.agentSession._updateUserState('listening', {
       lastSpeakingTime: speechEndTime,
       otelContext: otelContext.active(),
@@ -1121,6 +1117,14 @@ export class AgentActivity implements RecognitionHooks {
         { 'speech id': this._currentSpeech.id },
         'speech interrupted by audio activity',
       );
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1621-1627 lines
+      if (
+        this.audioRecognition &&
+        !this.audioRecognition.endpointing.overlapping &&
+        this.agentSession.agentState === 'speaking'
+      ) {
+        this.audioRecognition.onStartOfSpeech(Date.now());
+      }
       this.realtimeSession?.interrupt();
       this._currentSpeech.interrupt();
     }
@@ -1130,6 +1134,7 @@ export class AgentActivity implements RecognitionHooks {
     this.restoreInterruptionByAudioActivity();
     this.interruptByAudioActivity();
     if (this.audioRecognition) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1737-1747 lines
       this.audioRecognition.onEndOfAgentSpeech(ev.overlapStartedAt || ev.detectedAt);
     }
   }
@@ -1621,6 +1626,11 @@ export class AgentActivity implements RecognitionHooks {
   private onPipelineReplyDone(): void {
     if (!this.speechQueue.peek() && (!this._currentSpeech || this._currentSpeech.done())) {
       this.agentSession._updateAgentState('listening');
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2104-2112 lines
+      this.audioRecognition?.onEndOfAgentSpeech(Date.now());
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
+      }
     }
   }
 
@@ -1837,8 +1847,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2193-2213 lines
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -1924,10 +1937,13 @@ export class AgentActivity implements RecognitionHooks {
 
     if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2323-2330 lines
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
-      this.restoreInterruptionByAudioActivity();
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
+      }
     }
   }
 
@@ -2113,8 +2129,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2530-2558 lines
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2271,8 +2290,11 @@ export class AgentActivity implements RecognitionHooks {
 
       if (this.agentSession.agentState === 'speaking') {
         this.agentSession._updateAgentState('listening');
-        if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+        if (this.audioRecognition) {
+          // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2682-2691 lines
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        }
+        if (this.isInterruptionDetectionEnabled) {
           this.restoreInterruptionByAudioActivity();
         }
       }
@@ -2314,11 +2336,12 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._updateAgentState('thinking');
     } else if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
-          this.restoreInterruptionByAudioActivity();
-        }
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2682-2691 lines
+        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+      }
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
       }
     }
 
@@ -2524,10 +2547,18 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     const onFirstFrame = (startedSpeakingAt?: number) => {
+      const agentStartedSpeakingAt = startedSpeakingAt ?? Date.now();
       this.agentSession._updateAgentState('speaking', {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2988-3008 lines
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
+        this.isInterruptionByAudioActivityEnabled = false;
+      }
     };
 
     const readMessages = async (
@@ -2771,6 +2802,17 @@ export class AgentActivity implements RecognitionHooks {
       speechHandle._markGenerationDone();
       await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
 
+      if (this.agentSession.agentState === 'speaking') {
+        this.agentSession._updateAgentState('listening');
+        if (this.audioRecognition) {
+          // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 3175-3185 lines
+          this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        }
+        if (this.isInterruptionDetectionEnabled) {
+          this.restoreInterruptionByAudioActivity();
+        }
+      }
+
       // TODO(brian): close tees
       return;
     }
@@ -2805,6 +2847,13 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._updateAgentState('thinking');
     } else if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 3175-3185 lines
+        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+      }
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
+      }
     }
 
     if (toolOutput.output.length === 0) {

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -36,6 +36,7 @@ import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.j
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
 import type { STTNode } from './io.js';
+import type { BaseEndpointing } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export interface EndOfTurnInfo {
@@ -138,10 +139,8 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
-  /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  /** Endpointing state machine used to decide end-of-turn delays. */
+  endpointing: BaseEndpointing;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +169,9 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 146-146 lines
+  /** @internal */
+  endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -224,8 +224,7 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    this.endpointing = opts.endpointing;
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,8 +274,17 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
-    this.turnDetectionMode = options.turnDetection;
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 192-219 lines
+  updateOptions(options: {
+    endpointing?: BaseEndpointing;
+    turnDetection?: TurnDetectionMode | undefined;
+  }): void {
+    if (options.endpointing !== undefined) {
+      this.endpointing = options.endpointing;
+    }
+    if ('turnDetection' in options) {
+      this.turnDetectionMode = options.turnDetection;
+    }
   }
 
   async start(options?: { sttPipeline?: STTPipeline }) {
@@ -311,43 +319,74 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 238-243 lines
+  onStartOfAgentSpeech(startedAt: number): void {
     this.isAgentSpeaking = true;
-    return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
+    this.endpointing.onStartOfAgentSpeech(startedAt);
+    void this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
-  async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 245-270 lines
+  onEndOfAgentSpeech(ignoreUserTranscriptUntil: number): void {
+    const wasAgentSpeaking = this.isAgentSpeaking;
+    if (wasAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
     }
 
+    this.isAgentSpeaking = false;
+    void this.finishAgentSpeech(ignoreUserTranscriptUntil, wasAgentSpeaking);
+  }
+
+  private async finishAgentSpeech(
+    ignoreUserTranscriptUntil: number,
+    wasAgentSpeaking: boolean,
+  ): Promise<void> {
     const inputOpen = await this.trySendInterruptionSentinel(
       InterruptionStreamSentinel.agentSpeechEnded(),
     );
     if (!inputOpen) {
-      this.isAgentSpeaking = false;
       return;
     }
 
-    if (this.isAgentSpeaking) {
+    if (wasAgentSpeaking) {
       if (this.ignoreUserTranscriptUntil === undefined) {
-        this.onEndOfOverlapSpeech(Date.now());
+        await this.sendOverlapSpeechEnded(Date.now());
       }
       this.ignoreUserTranscriptUntil = this.ignoreUserTranscriptUntil
         ? Math.min(ignoreUserTranscriptUntil, this.ignoreUserTranscriptUntil)
         : ignoreUserTranscriptUntil;
 
-      // flush held transcripts if possible
       await this.flushHeldTranscripts();
     }
-    this.isAgentSpeaking = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 272-289 lines
+  onStartOfSpeech(startedAt: number, speechDuration = 0, userSpeakingSpan?: Span): void {
+    this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+    this.onStartOfOverlapSpeech(speechDuration, startedAt, userSpeakingSpan);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 291-305 lines
+  onEndOfSpeech(endedAt: number, userSpeakingSpan?: Span, interruption?: boolean): void {
+    if (this.speaking) {
+      this.endpointing.onEndOfSpeech(
+        endedAt,
+        interruption !== undefined && !interruption && this.isAgentSpeaking,
+      );
+    }
+
+    this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
   }
 
   /** Start interruption inference when agent is speaking and overlap speech starts. */
-  async onStartOfOverlapSpeech(speechDuration: number, startedAt: number, userSpeakingSpan?: Span) {
-    if (this.isAgentSpeaking) {
-      this.trySendInterruptionSentinel(
+  onStartOfOverlapSpeech(speechDuration: number, startedAt: number, userSpeakingSpan?: Span): void {
+    if (this.isInterruptionEnabled && this.isAgentSpeaking) {
+      void this.trySendInterruptionSentinel(
         InterruptionStreamSentinel.overlapSpeechStarted(
           speechDuration,
           startedAt,
@@ -358,10 +397,15 @@ export class AudioRecognition {
   }
 
   /** End interruption inference when overlap speech ends. */
-  async onEndOfOverlapSpeech(endedAt: number, userSpeakingSpan?: Span) {
-    if (!this.isInterruptionEnabled) {
+  onEndOfOverlapSpeech(endedAt: number, userSpeakingSpan?: Span): void {
+    if (!this.isInterruptionEnabled || !this.isAgentSpeaking) {
       return;
     }
+
+    void this.sendOverlapSpeechEnded(endedAt, userSpeakingSpan);
+  }
+
+  private async sendOverlapSpeechEnded(endedAt: number, userSpeakingSpan?: Span): Promise<boolean> {
     if (userSpeakingSpan && userSpeakingSpan.isRecording()) {
       userSpeakingSpan.setAttribute(traceTypes.ATTR_IS_INTERRUPTION, 'false');
     }
@@ -805,7 +849,8 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 937-962 lines
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +876,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');

--- a/agents/src/voice/audio_recognition_endpointing.test.ts
+++ b/agents/src/voice/audio_recognition_endpointing.test.ts
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { initializeLogger } from '../log.js';
+import { AudioRecognition, type RecognitionHooks } from './audio_recognition.js';
+import { DynamicEndpointing } from './turn_config/endpointing.js';
+
+const ms = (seconds: number) => seconds * 1000;
+
+type RecognitionState = {
+  speaking: boolean;
+};
+
+type EndpointingState = {
+  utteranceStartedAt?: number;
+  utteranceEndedAt?: number;
+};
+
+function markSpeaking(recognition: AudioRecognition): void {
+  (recognition as unknown as RecognitionState).speaking = true;
+}
+
+function endpointingState(endpointing: DynamicEndpointing): EndpointingState {
+  return endpointing as unknown as EndpointingState;
+}
+
+function createHooks(): RecognitionHooks {
+  return {
+    onInterruption: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onEndOfTurn: vi.fn(async () => true),
+    onPreemptiveGeneration: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+  };
+}
+
+describe('AudioRecognition endpointing integration', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('updates dynamic endpointing from recognition speech lifecycle', () => {
+    const endpointing = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing,
+    });
+
+    recognition.onStartOfSpeech(ms(99.0));
+    markSpeaking(recognition);
+    recognition.onEndOfSpeech(ms(100.0));
+    recognition.onStartOfSpeech(ms(100.4));
+    markSpeaking(recognition);
+    recognition.onEndOfSpeech(ms(100.6));
+
+    expect(endpointing.minDelay).toBeCloseTo(ms(0.35), 5);
+  });
+
+  it('replaces endpointing state through updateOptions', () => {
+    const endpointing = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing,
+    });
+
+    recognition.onStartOfSpeech(ms(99.0));
+    markSpeaking(recognition);
+    recognition.onEndOfSpeech(ms(100.0));
+    recognition.onStartOfSpeech(ms(100.4));
+    markSpeaking(recognition);
+    recognition.onEndOfSpeech(ms(100.6));
+    expect(endpointing.minDelay).toBeCloseTo(ms(0.35), 5);
+
+    const replacement = new DynamicEndpointing(ms(0.4), ms(1.2), 0.5);
+    recognition.updateOptions({ endpointing: replacement });
+
+    expect(recognition.endpointing).toBe(replacement);
+    expect(recognition.endpointing.minDelay).toBe(ms(0.4));
+    expect(endpointing.minDelay).toBeCloseTo(ms(0.35), 5);
+  });
+
+  it('passes false adaptive interruption results to shouldIgnore', () => {
+    const endpointing = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing,
+    });
+
+    recognition.onEndOfSpeech(ms(100.0));
+    recognition.onStartOfAgentSpeech(ms(100.5));
+    recognition.onStartOfSpeech(ms(101.5));
+    markSpeaking(recognition);
+
+    const prevMin = endpointing.minDelay;
+    const prevMax = endpointing.maxDelay;
+    recognition.onEndOfSpeech(ms(101.8), undefined, false);
+
+    expect(endpointing.minDelay).toBe(prevMin);
+    expect(endpointing.maxDelay).toBe(prevMax);
+    expect(endpointingState(endpointing).utteranceStartedAt).toBeUndefined();
+    expect(endpointingState(endpointing).utteranceEndedAt).toBeUndefined();
+  });
+});

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -8,6 +8,7 @@ import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
 import type { STTNode } from './io.js';
+import { BaseEndpointing } from './turn_config/endpointing.js';
 
 function createHooks() {
   const hooks: RecognitionHooks = {
@@ -45,8 +46,7 @@ function createRecognition(sttNode: STTNode, hooks = createHooks()) {
     recognition: new AudioRecognition({
       recognitionHooks: hooks,
       stt: sttNode,
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing(0, 0),
     }),
   };
 }

--- a/agents/src/voice/audio_recognition_span.test.ts
+++ b/agents/src/voice/audio_recognition_span.test.ts
@@ -23,6 +23,7 @@ import {
   type _TurnDetector,
 } from './audio_recognition.js';
 import type { STTNode } from './io.js';
+import { BaseEndpointing } from './turn_config/endpointing.js';
 
 function setupInMemoryTracing() {
   const exporter = new InMemorySpanExporter();
@@ -145,8 +146,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: undefined,
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'stt',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing(0, 0),
       sttModel: 'deepgram-nova2',
       sttProvider: 'deepgram',
       getLinkedParticipant: () => ({ sid: 'p1', identity: 'bob', kind: ParticipantKind.AGENT }),
@@ -254,8 +254,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: new FakeVAD(vadEvents),
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'vad',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing(0, 0),
       sttModel: 'stt-model',
       sttProvider: 'stt-provider',
       getLinkedParticipant: () => ({ sid: 'p2', identity: 'alice', kind: ParticipantKind.AGENT }),

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -27,3 +27,5 @@ export * from './report.js';
 export * from './room_io/index.js';
 export { RunContext } from './run_context.js';
 export * as testing from './testing/index.js';
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-316 lines
+export * from './turn_config/endpointing.js';

--- a/agents/src/voice/turn_config/endpointing.test.ts
+++ b/agents/src/voice/turn_config/endpointing.test.ts
@@ -1,0 +1,444 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { initializeLogger } from '../../log.js';
+import { ExpFilter } from '../../utils.js';
+import { DynamicEndpointing } from './endpointing.js';
+
+const ms = (seconds: number) => seconds * 1000;
+
+type DynamicEndpointingState = {
+  configuredMinDelay: number;
+  configuredMaxDelay: number;
+  overlappingValue: boolean;
+  utterancePause: ExpFilter;
+  turnPause: ExpFilter;
+  utteranceStartedAt?: number;
+  utteranceEndedAt?: number;
+  agentSpeechStartedAt?: number;
+  agentSpeechEndedAt?: number;
+  speaking: boolean;
+};
+
+function state(ep: DynamicEndpointing): DynamicEndpointingState {
+  return ep as unknown as DynamicEndpointingState;
+}
+
+// Ref: python tests/test_endpointing.py - 7-62 lines
+describe('ExpFilter', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    const ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    const emaWithInitial = new ExpFilter(0.5, { initial: 10 });
+    expect(emaWithInitial.value).toBe(10);
+
+    const emaAlphaOne = new ExpFilter(1.0);
+    expect(emaAlphaOne.value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0.0)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(-0.5)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(1.5)).toThrow(/alpha must be in/);
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1, 10);
+    expect(result).toBe(10);
+    expect(ema.value).toBe(10);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, { initial: 10 });
+    const result = ema.apply(1, 20);
+    expect(result).toBe(15);
+    expect(ema.value).toBe(15);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, { initial: 10 });
+    ema.apply(1, 20);
+    ema.apply(1, 20);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    let ema = new ExpFilter(0.5, { initial: 10 });
+    expect(ema.value).toBe(10);
+    ema.reset();
+    expect(ema.value).toBe(10);
+
+    ema = new ExpFilter(0.5, { initial: 10 });
+    ema.reset({ initial: 5 });
+    expect(ema.value).toBe(5);
+  });
+});
+
+// Ref: python tests/test_endpointing.py - 64-545 lines
+describe('DynamicEndpointing', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    expect(ep.minDelay).toBe(ms(0.3));
+    expect(ep.maxDelay).toBe(ms(1.0));
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.2);
+    expect(ep.minDelay).toBe(ms(0.3));
+    expect(ep.maxDelay).toBe(ms(1.0));
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    expect(state(ep).utterancePause.alpha).toBeCloseTo(0.9, 5);
+    expect(state(ep).turnPause.alpha).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    expect(ep.betweenUtteranceDelay).toBe(0);
+    expect(ep.betweenTurnDelay).toBe(0);
+    expect(ep.immediateInterruptionDelay).toEqual([0, 0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    let ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.onEndOfSpeech(ms(100.0));
+    expect(state(ep).utteranceEndedAt).toBe(ms(100.0));
+
+    ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.onEndOfSpeech(ms(99.9));
+    expect(state(ep).utteranceEndedAt).toBe(ms(99.9));
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.onStartOfSpeech(ms(100.0));
+    expect(state(ep).utteranceStartedAt).toBe(ms(100.0));
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.onStartOfAgentSpeech(ms(100.0));
+    expect(state(ep).agentSpeechStartedAt).toBe(ms(100.0));
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfSpeech(ms(100.5));
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(ms(0.5), 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.8));
+    expect(ep.betweenTurnDelay).toBeCloseTo(ms(0.8), 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    const initialMin = ep.minDelay;
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfSpeech(ms(100.4));
+    ep.onEndOfSpeech(ms(100.5), false);
+    const expected = 0.5 * ms(0.4) + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.6));
+    ep.onStartOfSpeech(ms(101.5));
+    ep.onEndOfSpeech(ms(102.0), false);
+    expect(ep.maxDelay).toBeCloseTo(0.5 * ms(0.6) + 0.5 * ms(1.0), 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.2));
+    expect(state(ep).agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(ms(100.25), true);
+    expect(ep.overlapping).toBe(true);
+    ep.onEndOfSpeech(ms(100.5));
+    expect(ep.overlapping).toBe(false);
+    expect(state(ep).agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(ms(0.3), 5);
+  });
+
+  it('test_update_options', () => {
+    let ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.updateOptions({ minDelay: ms(0.5) });
+    expect(ep.minDelay).toBe(ms(0.5));
+    expect(state(ep).configuredMinDelay).toBe(ms(0.5));
+
+    ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.updateOptions({ maxDelay: ms(2.0) });
+    expect(ep.maxDelay).toBe(ms(2.0));
+    expect(state(ep).configuredMaxDelay).toBe(ms(2.0));
+
+    ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.updateOptions({ minDelay: ms(0.5), maxDelay: ms(2.0) });
+    expect(ep.minDelay).toBe(ms(0.5));
+    expect(ep.maxDelay).toBe(ms(2.0));
+
+    ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.updateOptions();
+    expect(ep.minDelay).toBe(ms(0.3));
+    expect(ep.maxDelay).toBe(ms(1.0));
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 1.0);
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(102.0));
+    ep.onStartOfSpeech(ms(105.0));
+    expect(ep.maxDelay).toBe(ms(1.0));
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 1.0);
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.1));
+    ep.onStartOfSpeech(ms(100.5));
+    expect(ep.maxDelay).toBeGreaterThanOrEqual(state(ep).configuredMinDelay);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.5));
+    expect(state(ep).agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(ms(102.0));
+    ep.onEndOfSpeech(ms(103.0), false);
+    expect(state(ep).agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.2));
+    ep.onStartOfSpeech(ms(100.25), true);
+    expect(ep.overlapping).toBe(true);
+    const prevVal = [ep.minDelay, ep.maxDelay];
+    ep.onStartOfSpeech(ms(100.35));
+    expect(ep.overlapping).toBe(true);
+    expect(prevVal).toEqual([ep.minDelay, ep.maxDelay]);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.9));
+    ep.onStartOfSpeech(ms(101.8));
+    ep.onEndOfSpeech(ms(102.0), false);
+    expect(ep.maxDelay).toBeCloseTo(0.5 * ms(0.9) + 0.5 * ms(1.0), 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing(ms(0.06), ms(1.0), 1.0);
+    ep.onEndOfSpeech(ms(99.0));
+    ep.onStartOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.2));
+    ep.onStartOfSpeech(ms(100.25), true);
+    expect(state(ep).utteranceEndedAt).toBeCloseTo(ms(100.2) - 1, 5);
+    expect(ep.minDelay).toBeCloseTo(ms(0.06), 5);
+    expect(ep.maxDelay).toBeCloseTo(ms(1.0), 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.updateOptions({ minDelay: ms(0.6), maxDelay: ms(2.0) });
+    expect(state(ep).utterancePause.alpha).toBeCloseTo(0.5, 5);
+    expect(state(ep).turnPause.alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.updateOptions({ minDelay: ms(0.5), maxDelay: ms(2.0) });
+    expect(state(ep).utterancePause.minVal).toBe(ms(0.5));
+    expect(state(ep).turnPause.maxVal).toBe(ms(2.0));
+
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfSpeech(ms(100.2));
+    expect(ep.minDelay).toBeCloseTo(ms(0.5), 5);
+
+    ep.onEndOfSpeech(ms(101.0));
+    ep.onStartOfAgentSpeech(ms(102.8));
+    ep.onStartOfSpeech(ms(103.5));
+    expect(ep.maxDelay).toBeGreaterThan(ms(1.0));
+    expect(ep.maxDelay).toBeLessThanOrEqual(ms(2.0));
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.5));
+    ep.onStartOfSpeech(ms(101.5), true);
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+    ep.onEndOfSpeech(ms(101.8), true);
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect(state(ep).utteranceStartedAt).toBeUndefined();
+    expect(state(ep).utteranceEndedAt).toBeUndefined();
+    expect(ep.overlapping).toBe(false);
+    expect(state(ep).speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    const initialMin = ep.minDelay;
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfSpeech(ms(100.4), false);
+    ep.onEndOfSpeech(ms(100.6), true);
+    const expected = 0.5 * ms(0.4) + 0.5 * initialMin;
+    expect(ep.minDelay).toBeCloseTo(expected, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.5));
+    ep.onStartOfSpeech(ms(100.6), true);
+    ep.onEndOfSpeech(ms(100.8), true);
+    expect(state(ep).utteranceEndedAt).toBe(ms(100.8));
+    expect(state(ep).speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.5));
+    ep.onStartOfSpeech(ms(101.0), true);
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+    ep.onEndOfSpeech(ms(101.5), true);
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect(state(ep).utteranceStartedAt).toBeUndefined();
+    expect(state(ep).utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    ep.onStartOfAgentSpeech(ms(100.0));
+    ep.onStartOfSpeech(ms(100.1), true);
+    expect(ep.overlapping).toBe(true);
+    expect(state(ep).agentSpeechStartedAt).toBe(ms(100.0));
+    ep.onEndOfAgentSpeech(ms(101.0));
+    expect(state(ep).agentSpeechEndedAt).toBe(ms(101.0));
+    expect(state(ep).agentSpeechStartedAt).toBe(ms(100.0));
+    expect(ep.overlapping).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.onEndOfSpeech(ms(100.0));
+    ep.onStartOfAgentSpeech(ms(100.9));
+    ep.onStartOfSpeech(ms(101.8), false);
+    ep.onEndOfSpeech(ms(102.0));
+    expect(ep.maxDelay).toBeCloseTo(0.5 * ms(0.9) + 0.5 * ms(1.0), 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0));
+    expect(state(ep).speaking).toBe(false);
+    ep.onStartOfSpeech(ms(100.0));
+    expect(state(ep).speaking).toBe(true);
+    ep.onEndOfSpeech(ms(100.5));
+    expect(state(ep).speaking).toBe(false);
+  });
+
+  it.each([
+    ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+    ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+    ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+    ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+    ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+    ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+    ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+    ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+    ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+  ] as const)(
+    'test_all_overlapping_and_should_ignore_combos %s',
+    (
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ) => {
+      const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+      ep.onStartOfSpeech(ms(99.0));
+      ep.onEndOfSpeech(ms(100.0));
+
+      let userStart: number;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(ms(100.5));
+        ep.onEndOfAgentSpeech(ms(101.0));
+        userStart = ms(101.5);
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(ms(100.15));
+          userStart = ms(100.35);
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(ms(100.2));
+          userStart = ms(101.5);
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(ms(100.15));
+          userStart = ms(100.4);
+        } else {
+          ep.onStartOfAgentSpeech(ms(100.9));
+          userStart = ms(101.8);
+        }
+      } else {
+        userStart = ms(100.4);
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping);
+      const prevMin = ep.minDelay;
+      const prevMax = ep.maxDelay;
+      ep.onEndOfSpeech(userStart + ms(0.5), shouldIgnore);
+      const minChanged = ep.minDelay !== prevMin;
+      const maxChanged = ep.maxDelay !== prevMax;
+
+      expect(minChanged, `[${label}] min_delay change`).toBe(expectMinChange);
+      expect(maxChanged, `[${label}] max_delay change`).toBe(expectMaxChange);
+      expect(state(ep).speaking, `[${label}] speaking`).toBe(false);
+      expect(ep.overlapping, `[${label}] overlapping`).toBe(false);
+    },
+  );
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing(ms(0.3), ms(1.0), 0.5);
+    ep.onStartOfSpeech(ms(100.0));
+    ep.onEndOfSpeech(ms(101.0));
+
+    ep.onStartOfAgentSpeech(ms(101.5));
+    ep.onStartOfSpeech(ms(102.5), true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(ms(102.8), true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(ms(103.0));
+    ep.onStartOfSpeech(ms(103.5));
+    ep.onEndOfSpeech(ms(104.0));
+
+    expect(state(ep).speaking).toBe(false);
+    expect(state(ep).agentSpeechStartedAt).toBeUndefined();
+  });
+});

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -10,7 +10,8 @@ import { ExpFilter } from '../../utils.js';
 export interface EndpointingOptions {
   /**
    * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on
-   * pauses between user and agent speech.
+   * end-of-utterance prediction.
+   * Dynamic mode also adapts delay bounds from pauses between user and agent speech.
    * @defaultValue "fixed"
    */
   mode: 'fixed' | 'dynamic';

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -1,13 +1,16 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { log } from '../../log.js';
+import { ExpFilter } from '../../utils.js';
+
 /**
  * Configuration for endpointing, which determines when the user's turn is complete.
  */
 export interface EndpointingOptions {
   /**
    * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on
-   * end-of-utterance prediction.
+   * pauses between user and agent speech.
    * @defaultValue "fixed"
    */
   mode: 'fixed' | 'dynamic';
@@ -31,3 +34,296 @@ export const defaultEndpointingOptions = {
   minDelay: 500,
   maxDelay: 3000,
 } as const satisfies EndpointingOptions;
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 7-7 lines
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250; // 0.25s → 250ms
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-47 lines
+export class BaseEndpointing {
+  protected configuredMinDelay: number;
+  protected configuredMaxDelay: number;
+  protected overlappingValue = false;
+
+  constructor(minDelay: number, maxDelay: number) {
+    this.configuredMinDelay = minDelay;
+    this.configuredMaxDelay = maxDelay;
+  }
+
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    this.configuredMinDelay = minDelay ?? this.configuredMinDelay;
+    this.configuredMaxDelay = maxDelay ?? this.configuredMaxDelay;
+  }
+
+  get minDelay(): number {
+    return this.configuredMinDelay;
+  }
+
+  get maxDelay(): number {
+    return this.configuredMaxDelay;
+  }
+
+  get overlapping(): boolean {
+    return this.overlappingValue;
+  }
+
+  onStartOfSpeech(startedAt: number, overlapping = false): void {
+    void startedAt;
+    this.overlappingValue = overlapping;
+  }
+
+  onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    void endedAt;
+    void shouldIgnore;
+    this.overlappingValue = false;
+  }
+
+  onStartOfAgentSpeech(startedAt: number): void {
+    void startedAt;
+  }
+
+  onEndOfAgentSpeech(endedAt: number): void {
+    void endedAt;
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-303 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private utterancePause: ExpFilter;
+  private turnPause: ExpFilter;
+  private utteranceStartedAt?: number;
+  private utteranceEndedAt?: number;
+  private agentSpeechStartedAt?: number;
+  private agentSpeechEndedAt?: number;
+  private speaking = false;
+
+  constructor(minDelay: number, maxDelay: number, alpha = 0.9) {
+    super(minDelay, maxDelay);
+
+    this.utterancePause = new ExpFilter(alpha, {
+      initial: minDelay,
+      minVal: minDelay,
+      maxVal: maxDelay,
+    });
+    this.turnPause = new ExpFilter(alpha, {
+      initial: maxDelay,
+      minVal: minDelay,
+      maxVal: maxDelay,
+    });
+  }
+
+  get minDelay(): number {
+    return this.utterancePause.value ?? this.configuredMinDelay;
+  }
+
+  get maxDelay(): number {
+    const turnVal = this.turnPause.value ?? this.configuredMaxDelay;
+    return Math.max(turnVal, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this.utteranceEndedAt === undefined) {
+      return 0;
+    }
+    if (this.utteranceStartedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.utteranceStartedAt - this.utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this.agentSpeechStartedAt === undefined) {
+      return 0;
+    }
+    if (this.utteranceEndedAt === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, this.agentSpeechStartedAt - this.utteranceEndedAt);
+  }
+
+  get immediateInterruptionDelay(): [number, number] {
+    if (this.utteranceStartedAt === undefined) {
+      return [0, 0];
+    }
+    if (this.agentSpeechStartedAt === undefined) {
+      return [0, 0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 139-153 lines
+  onStartOfAgentSpeech(startedAt: number): void {
+    this.agentSpeechStartedAt = startedAt;
+    this.agentSpeechEndedAt = undefined;
+    this.overlappingValue = false;
+  }
+
+  onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this.agentSpeechStartedAt !== undefined &&
+      (this.agentSpeechEndedAt === undefined || this.agentSpeechEndedAt < this.agentSpeechStartedAt)
+    ) {
+      this.agentSpeechEndedAt = endedAt;
+    }
+    this.overlappingValue = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 155-178 lines
+  onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this.overlappingValue) {
+      return;
+    }
+
+    if (
+      this.utteranceStartedAt !== undefined &&
+      this.utteranceEndedAt !== undefined &&
+      this.agentSpeechStartedAt !== undefined &&
+      this.utteranceEndedAt < this.utteranceStartedAt &&
+      overlapping
+    ) {
+      this.utteranceEndedAt = this.agentSpeechStartedAt - 1; // 1e-3s → 1ms
+      log().trace({ utteranceEndedAt: this.utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this.utteranceStartedAt = startedAt;
+    this.overlappingValue = overlapping;
+    this.speaking = true;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 179-286 lines
+  onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    if (shouldIgnore && this.overlappingValue) {
+      if (
+        this.utteranceStartedAt !== undefined &&
+        this.agentSpeechStartedAt !== undefined &&
+        Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        log().trace(
+          {
+            delta: Math.abs(this.utteranceStartedAt - this.agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true: user speech started within grace period of agent speech',
+        );
+      } else {
+        this.overlappingValue = false;
+        this.speaking = false;
+        this.utteranceStartedAt = undefined;
+        this.utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    if (
+      this.overlappingValue ||
+      (this.agentSpeechStartedAt !== undefined && this.agentSpeechEndedAt === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const pause = this.betweenUtteranceDelay;
+      if (
+        0 < interruptionDelay &&
+        interruptionDelay <= this.minDelay &&
+        0 < turnDelay &&
+        turnDelay <= this.maxDelay &&
+        pause > 0
+      ) {
+        const prevVal = this.minDelay;
+        this.utterancePause.apply(1, pause);
+        log().debug(
+          {
+            reason: 'immediate interruption',
+            pause,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${prevVal} -> ${this.minDelay}`,
+        );
+      } else if (this.betweenTurnDelay > 0) {
+        const prevVal = this.maxDelay;
+        const turnPause = this.betweenTurnDelay;
+        this.turnPause.apply(1, turnPause);
+        log().debug(
+          {
+            reason: 'new turn (interruption)',
+            pause: turnPause,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+            betweenUtteranceDelay: this.betweenUtteranceDelay,
+            betweenTurnDelay: this.betweenTurnDelay,
+          },
+          `max endpointing delay updated: ${prevVal} -> ${this.maxDelay}`,
+        );
+      }
+    } else if (this.betweenTurnDelay > 0) {
+      const prevVal = this.maxDelay;
+      const pause = this.betweenTurnDelay;
+      this.turnPause.apply(1, pause);
+      log().debug(
+        {
+          reason: 'new turn',
+          pause,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `max endpointing delay updated due to pause: ${prevVal} -> ${this.maxDelay}`,
+      );
+    } else if (
+      this.betweenUtteranceDelay > 0 &&
+      this.agentSpeechEndedAt === undefined &&
+      this.agentSpeechStartedAt === undefined
+    ) {
+      const prevVal = this.minDelay;
+      const pause = this.betweenUtteranceDelay;
+      this.utterancePause.apply(1, pause);
+      log().debug(
+        {
+          reason: 'pause between utterances',
+          pause,
+          maxDelay: this.maxDelay,
+          minDelay: this.minDelay,
+        },
+        `min endpointing delay updated: ${prevVal} -> ${this.minDelay}`,
+      );
+    }
+
+    this.utteranceEndedAt = endedAt;
+    this.agentSpeechStartedAt = undefined;
+    this.agentSpeechEndedAt = undefined;
+    this.speaking = false;
+    this.overlappingValue = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 288-302 lines
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this.configuredMinDelay = minDelay;
+      this.utterancePause.reset({
+        initial: this.configuredMinDelay,
+        minVal: this.configuredMinDelay,
+      });
+      this.turnPause.reset({ minVal: this.configuredMinDelay });
+    }
+
+    if (maxDelay !== undefined) {
+      this.configuredMaxDelay = maxDelay;
+      this.turnPause.reset({ initial: this.configuredMaxDelay, maxVal: this.configuredMaxDelay });
+      this.utterancePause.reset({ maxVal: this.configuredMaxDelay });
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-316 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  switch (options.mode ?? 'fixed') {
+    case 'dynamic':
+      return new DynamicEndpointing(options.minDelay, options.maxDelay);
+    case 'fixed':
+    default:
+      return new BaseEndpointing(options.minDelay, options.maxDelay);
+  }
+}


### PR DESCRIPTION
This PR was created by [Rosetta](https://github.com/livekit/rosetta/issues/118).

Tracking issue: https://github.com/livekit/rosetta/issues/118

## Summary
- Ports the Python SDK dynamic endpointing state machine to the Node voice turn handling runtime.
- Reuses and extends the shared `ExpFilter` helper, wires endpointing through VAD, STT, realtime, and agent-speech lifecycle paths.
- Ports the source endpointing parity suite and adds target integration regressions for recognition and AgentActivity seams.

## Source
- https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/endpointing.py
- https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/utils/exp_filter.py
- https://github.com/livekit/agents/blob/main/tests/test_endpointing.py

## Validation
- `pnpm test agents/src/voice/turn_config/endpointing.test.ts agents/src/voice/audio_recognition_endpointing.test.ts agents/src/voice/agent_activity.test.ts agents/src/voice/audio_recognition_handoff.test.ts agents/src/voice/audio_recognition_span.test.ts`
- `pnpm test agents/src/utils.test.ts agents/src/voice/turn_config/utils.test.ts agents/src/voice/agent.test.ts`
- `pnpm test agents/src/voice/agent_activity_handoff.test.ts agents/src/voice/interruption_detection.test.ts agents/src/voice/agent_session_handoff.test.ts`
- `pnpm --filter @livekit/agents build`
- `pnpm --filter @livekit/agents-plugin-silero build`
- `pnpm exec eslint -f unix "agents/src/**/*.ts" --quiet`
- `pnpm exec prettier --check ...touched files...`

## Notes
- `pnpm --filter @livekit/agents api:check` currently fails on the repository's existing API Extractor limitation for `export * as ___` syntax in `dist/index.d.ts`.