### PR TITLE
chore(openai): remove STT.withGroq constructor

### DIFF
--- a/plugins/openai/src/models.ts
+++ b/plugins/openai/src/models.ts
@@ -112,11 +112,6 @@ export type GroqChatModels =
   | 'gemma-7b-it'
   | 'gemma2-9b-it';
 
-export type GroqAudioModels =
-  | 'whisper-large-v3'
-  | 'distil-whisper-large-v3-en'
-  | 'whisper-large-v3-turbo';
-
 export type DeepSeekChatModels = 'deepseek-coder' | 'deepseek-chat';
 
 export type TogetherChatModels =

--- a/plugins/openai/src/stt.ts
+++ b/plugins/openai/src/stt.ts
@@ -4,7 +4,7 @@
 import { type AudioBuffer, mergeFrames, normalizeLanguage, stt } from '@livekit/agents';
 import type { AudioFrame } from '@livekit/rtc-node';
 import { OpenAI } from 'openai';
-import type { GroqAudioModels, WhisperModels } from './models.js';
+import type { WhisperModels } from './models.js';
 
 export interface STTOptions {
   apiKey?: string;
@@ -66,35 +66,6 @@ export class STT extends stt.STT {
         baseURL: this.#opts.baseURL,
         apiKey: this.#opts.apiKey,
       });
-  }
-
-  /**
-   * Create a new instance of Groq STT.
-   *
-   * @remarks
-   * `apiKey` must be set to your Groq API key, either using the argument or by setting the
-   * `GROQ_API_KEY` environment variable.
-   */
-  static withGroq(
-    opts: Partial<{
-      model: string | GroqAudioModels;
-      apiKey?: string;
-      baseURL?: string;
-      client: OpenAI;
-      language: string;
-      detectLanguage: boolean;
-    }> = {},
-  ): STT {
-    opts.apiKey = opts.apiKey || process.env.GROQ_API_KEY;
-    if (opts.apiKey === undefined) {
-      throw new Error('Groq API key is required, whether as an argument or as $GROQ_API_KEY');
-    }
-
-    return new STT({
-      model: 'whisper-large-v3-turbo',
-      baseURL: 'https://api.groq.com/openai/v1',
-      ...opts,
-    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Port of [livekit/agents#5555](https://github.com/livekit/agents/pull/5555) — *chore(openai): remove STT.with_groq constructor*.

Groq has its own dedicated plugin (`livekit-plugins-groq` on Python; the equivalent `@livekit/agents-plugin-groq` should be the JS migration target for users). The OpenAI plugin's Groq STT shortcut is therefore being removed.

> ⚠️ This is an automated Claude Code Routine PR created by @toubatbrian. Right now it is in experimentation stage.

## Ported changes

- **Remove `STT.withGroq` static constructor** from `plugins/openai/src/stt.ts`. This mirrors the removal of `STT.with_groq` in the Python OpenAI plugin (`livekit/plugins/openai/stt.py`).
- **Drop the now-unused `GroqAudioModels` type** from `plugins/openai/src/models.ts`. This mirrors removal of the `GroqAudioModels` literal in `livekit/plugins/openai/models.py`.
- **Drop the `GroqAudioModels` import** from `stt.ts` (the only consumer).

## Implementation nuances / divergence from the Python PR

The Python PR also removed the `GroqChatModels` literal from `models.py`, which was safe in Python because `LLM.with_groq` had already been deleted in a prior change. **In `agents-js`, `LLM.withGroq` still exists in `plugins/openai/src/llm.ts` and references `GroqChatModels`.** Therefore, this port intentionally keeps `GroqChatModels` and `LLM.withGroq` in place — removing them would be an out-of-scope breaking change for JS users and is not part of upstream PR #5555.

A follow-up port (mirroring whichever earlier Python PR removed `LLM.with_groq`) will be needed to fully reach parity — when that lands, `GroqChatModels` and `LLM.withGroq` can be removed together.

The Python PR also touches `uv.lock`, which is Python-specific and intentionally not ported.

## Breaking change

Calls to `STT.withGroq({ ... })` in user code will need to be migrated to the dedicated Groq plugin.

## Test plan

- [ ] `pnpm -w build` succeeds (no remaining references to `GroqAudioModels` or `STT.withGroq`).
- [ ] `pnpm -w test` passes.
- [ ] Verify no example or doc in this repo still imports `STT.withGroq` or `GroqAudioModels`.

## Reviewers

cc @toubatbrian @livekit/agent-devs

---

🤖 Generated by Claude Code automation. Source PR: livekit/agents#5555.

---
_Generated by [Claude Code](https://claude.ai/code/session_011UeAZ2NQi4fT6XhfvB1MF3)_