### PR TITLE
feat(endpointing): expose dynamic endpointing alpha parameter

### DIFF
--- a/.changeset/expose-dynamic-endpointing-alpha.md
+++ b/.changeset/expose-dynamic-endpointing-alpha.md
@@ -1,0 +1,9 @@
+---
+"@livekit/agents": patch
+---
+
+feat(endpointing): expose dynamic endpointing alpha parameter
+
+Adds `alpha` (EMA coefficient) to `EndpointingOptions` so callers can
+configure dynamic endpointing smoothing through `turnHandling.endpointing`.
+Default is `0.9`, matching Python parity (livekit/agents#5491).

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -30,6 +30,7 @@ export interface EndpointingOptions {
    * Only applies when {@link EndpointingOptions.mode} is `"dynamic"`.
    * @defaultValue 0.9
    */
+  // Ref: python livekit-agents/livekit/agents/voice/turn.py - 63-66 lines
   alpha: number;
 }
 
@@ -37,5 +38,6 @@ export const defaultEndpointingOptions = {
   mode: 'fixed',
   minDelay: 500,
   maxDelay: 3000,
+  // Ref: python livekit-agents/livekit/agents/voice/turn.py - 73 lines
   alpha: 0.9,
 } as const satisfies EndpointingOptions;

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -24,10 +24,18 @@ export interface EndpointingOptions {
    * @defaultValue 3000
    */
   maxDelay: number;
+  /**
+   * Exponential moving average coefficient for dynamic endpointing.
+   * The higher the value, the more weight is given to the history.
+   * Only applies when {@link EndpointingOptions.mode} is `"dynamic"`.
+   * @defaultValue 0.9
+   */
+  alpha: number;
 }
 
 export const defaultEndpointingOptions = {
   mode: 'fixed',
   minDelay: 500,
   maxDelay: 3000,
+  alpha: 0.9,
 } as const satisfies EndpointingOptions;


### PR DESCRIPTION
## Summary

Port of livekit/agents#5491 (Python) — exposes the `alpha` EMA (exponential moving average) coefficient for dynamic endpointing on the public `EndpointingOptions` config surface.

> This is an automated Claude Code routine port created by @toubatbrian. Currently in experimentation stage.

## What changed in Python (upstream)

The upstream PR adds a new `alpha` field to `EndpointingOptions`:

- Field added to the `EndpointingOptions` TypedDict and `_ENDPOINTING_DEFAULTS` (default `0.9`).
- `DynamicEndpointing.__init__` accepts `alpha` and forwards it to both internal EMA filters (`_utterance_pause`, `_turn_pause`).
- `DynamicEndpointing.update_options(...)` accepts `alpha` and updates the EMA filters in place without resetting their learned state.
- `create_endpointing(options)` reads `options["alpha"]` when constructing a `DynamicEndpointing`.
- `AgentSession.update_options(...)` and `agent_activity.endpointing_opts` plumb `alpha` through from session-level → agent-level overrides.

The `alpha` controls how much weight is given to historical end-of-utterance pauses versus the latest sample (higher → more inertia, more smoothing).

## What this JS PR does

- Adds an `alpha: number` field to the `EndpointingOptions` interface in `agents/src/voice/turn_config/endpointing.ts`.
- Adds the matching default `alpha: 0.9` to `defaultEndpointingOptions`.

## Implementation nuances / parity gap

agents-js does **not** currently ship a `DynamicEndpointing` runtime — only the fixed-delay path is wired through `AudioRecognition` via `minEndpointingDelay` / `maxEndpointingDelay`. There is no JS counterpart yet for:

- `DynamicEndpointing` class with EMA filters (`_utterance_pause`, `_turn_pause`)
- `create_endpointing(options)` factory selecting between fixed and dynamic modes
- `AgentSession.update_options(...)` / `AgentActivity.endpointing_opts` runtime plumbing for endpointing fields

Because of that, this port stops at the **config-surface level**: it makes `alpha` a first-class option on `EndpointingOptions` so:

1. Users who set `turnHandling.endpointing.alpha` today will not get a TypeScript error and the value is plumbed through `mergeWithDefaults` like the other endpointing fields.
2. When the dynamic endpointing runtime is eventually ported to agents-js, the public config field is already in place — no breaking change to the option shape will be needed at that point.

The Python `update_options(alpha=...)` runtime path and the `DynamicEndpointing` test coverage (`test_endpointing.py` additions) are intentionally **not** ported here — they would be dead code without the underlying class, and porting the full dynamic endpointing implementation is out of scope for this small config-parity PR.

## Files touched

- `agents/src/voice/turn_config/endpointing.ts` — added `alpha` to interface + default.

## Test plan

- [ ] `pnpm -w build` succeeds (type-only addition, optional field with default).
- [ ] `turnHandling: { endpointing: { alpha: 0.7 } }` accepted by `AgentSessionOptions` without TS errors.
- [ ] No behavior change for existing fixed-mode users (alpha is unused at runtime today).

## Reviewers

cc @toubatbrian @livekit/agent-devs

---

Linked Python PR: livekit/agents#5491


---
_Generated by [Claude Code](https://claude.ai/code/session_018fHRgnG2Crsr8GPpHkmikg)_