### PR TITLE
feat(xai): support model selection in realtime, default to grok-voice-think-fast-1.0

### DIFF
--- a/.changeset/xai-realtime-model-selection.md
+++ b/.changeset/xai-realtime-model-selection.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-xai": patch
+---
+
+feat(xai): support model selection in realtime, default to grok-voice-think-fast-1.0

--- a/plugins/xai/src/realtime/realtime_model.ts
+++ b/plugins/xai/src/realtime/realtime_model.ts
@@ -7,7 +7,8 @@ const { RealtimeModel: OpenAIRealtimeModel } = realtime;
 type OpenAIRealtimeModelOptions = ConstructorParameters<typeof OpenAIRealtimeModel>[0];
 
 const XAI_BASE_URL = 'wss://api.x.ai/v1';
-const DEFAULT_MODEL = 'grok-4-1-fast-non-reasoning';
+// Ref: python livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py - 32 lines
+const DEFAULT_MODEL: GrokRealtimeModels = 'grok-voice-think-fast-1.0';
 const DEFAULT_VOICE = 'ara';
 
 const XAI_DEFAULT_TURN_DETECTION = {
@@ -21,8 +22,11 @@ const XAI_DEFAULT_TURN_DETECTION = {
 
 export type GrokVoices = 'eve' | 'ara' | 'rex' | 'sal' | 'leo';
 
+// Ref: python livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/types.py - 39-42 lines
+export type GrokRealtimeModels = 'grok-voice-think-fast-1.0' | 'grok-voice-fast-1.0';
+
 export interface RealtimeModelOptions extends Omit<OpenAIRealtimeModelOptions, 'model'> {
-  model?: string;
+  model?: GrokRealtimeModels | string;
   voice?: GrokVoices | string;
   apiKey?: string;
 }


### PR DESCRIPTION
Port of livekit/agents#5548 to JS.

x.ai deprecated `grok-voice-fast-1.0` and recommends `grok-voice-think-fast-1.0` as the new flagship voice model, selectable via the `model` query param on the realtime websocket (see https://docs.x.ai/developers/model-capabilities/audio/voice-agent). This patch updates the default `model` in `xai.realtime.RealtimeModel` to `grok-voice-think-fast-1.0`, exposes a `GrokRealtimeModels` literal with both the new and legacy ids, and types the `model` option as `GrokRealtimeModels | string`. The parent OpenAI realtime client already forwards `model` as a ws query param so the resulting URL matches the x.ai docs exactly.

## Summary
- Add `GrokRealtimeModels` type (`'grok-voice-think-fast-1.0' | 'grok-voice-fast-1.0'`)
- Default `RealtimeModel` `model` to `grok-voice-think-fast-1.0`
- Type `RealtimeModelOptions.model` as `GrokRealtimeModels | string`

## Test plan
- [x] `pnpm --filter @livekit/agents-plugin-xai build` succeeds
- [x] `pnpm --filter @livekit/agents-plugin-xai lint` clean (only pre-existing warnings in `_utils.ts`)
- [x] `pnpm format:check` passes
- [x] Manual smoke: instantiating `RealtimeModel` with no args resolves to `grok-voice-think-fast-1.0`; passing `model: 'grok-voice-fast-1.0'` is accepted and forwarded; arbitrary string still accepted via `string` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)