### PR TITLE
feat(agents): expose interrupted speech data on SpeechHandle

### DIFF
--- a/.changeset/expose-interrupted-speech-data.md
+++ b/.changeset/expose-interrupted-speech-data.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+feat(agents): expose `generatedText` and `spokenText` on `SpeechHandle` for interrupted speeches, allowing apps to recover undelivered content

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2249,6 +2249,8 @@ export class AgentActivity implements RecognitionHooks {
         }
       }
 
+      speechHandle._setInterruptionData(textOut?.text || '', forwardedText);
+
       if (forwardedText) {
         hasSpeechMessage = true;
         const message = ChatMessage.create({
@@ -2749,6 +2751,8 @@ export class AgentActivity implements RecognitionHooks {
             audioTranscript: forwardedText,
           });
         }
+
+        speechHandle._setInterruptionData(textOut?.text || '', forwardedText);
 
         if (forwardedText && addToChatCtx) {
           const message = ChatMessage.create({

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2718,10 +2718,14 @@ export class AgentActivity implements RecognitionHooks {
       replyAbortController.abort();
       await cancelAndWait(tasks, AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
 
+      let generatedText = '';
+      let forwardedText = '';
+
       if (messageOutputs.length > 0) {
         // there should be only one message
         const [msgId, textOut, audioOut, msgModalities] = messageOutputs[0]!;
-        let forwardedText = textOut?.text || '';
+        generatedText = textOut?.text || '';
+        forwardedText = generatedText;
 
         if (audioOutput) {
           audioOutput.clearBuffer();
@@ -2752,8 +2756,6 @@ export class AgentActivity implements RecognitionHooks {
           });
         }
 
-        speechHandle._setInterruptionData(textOut?.text || '', forwardedText);
-
         if (forwardedText && addToChatCtx) {
           const message = ChatMessage.create({
             role: 'assistant',
@@ -2771,9 +2773,9 @@ export class AgentActivity implements RecognitionHooks {
           { speech_id: speechHandle.id, message: forwardedText },
           'playout completed with interrupt',
         );
-      } else {
-        speechHandle._setInterruptionData('', '');
       }
+
+      speechHandle._setInterruptionData(generatedText, forwardedText);
       speechHandle._markGenerationDone();
       await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2771,6 +2771,8 @@ export class AgentActivity implements RecognitionHooks {
           { speech_id: speechHandle.id, message: forwardedText },
           'playout completed with interrupt',
         );
+      } else {
+        speechHandle._setInterruptionData('', '');
       }
       speechHandle._markGenerationDone();
       await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2249,7 +2249,7 @@ export class AgentActivity implements RecognitionHooks {
         }
       }
 
-      speechHandle._setInterruptionData(textOut?.text || '', forwardedText);
+      speechHandle._setInterruptionData(llmGenData.generatedText, forwardedText);
 
       if (forwardedText) {
         hasSpeechMessage = true;

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -69,6 +69,8 @@ export class SpeechHandle {
   private doneFut = new Future<void>();
   private generations: Future<void>[] = [];
   private _chatItems: ChatItem[] = [];
+  private _generatedText: string | null = null;
+  private _spokenText: string | null = null;
 
   /** @internal */
   _tasks: Task<void>[] = [];
@@ -157,6 +159,22 @@ export class SpeechHandle {
 
   get chatItems(): ChatItem[] {
     return this._chatItems;
+  }
+
+  /** Full text the model generated before the speech was interrupted. Null if not interrupted or no text was generated. */
+  get generatedText(): string | null {
+    return this._generatedText;
+  }
+
+  /** Text that was actually spoken (heard by the listener) before interruption. Null if not interrupted. */
+  get spokenText(): string | null {
+    return this._spokenText;
+  }
+
+  /** @internal */
+  _setInterruptionData(generatedText: string, spokenText: string): void {
+    this._generatedText = generatedText;
+    this._spokenText = spokenText;
   }
 
   /**

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -173,8 +173,8 @@ export class SpeechHandle {
 
   /** @internal */
   _setInterruptionData(generatedText: string, spokenText: string): void {
-    this._generatedText = generatedText;
-    this._spokenText = spokenText;
+    this._generatedText = generatedText || null;
+    this._spokenText = spokenText || null;
   }
 
   /**

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -166,7 +166,7 @@ export class SpeechHandle {
     return this._generatedText;
   }
 
-  /** Text that was actually spoken (heard by the listener) before interruption. Null if not interrupted. */
+  /** Text that was actually spoken (heard by the listener) before interruption. Null if not interrupted or nothing was spoken. */
   get spokenText(): string | null {
     return this._spokenText;
   }


### PR DESCRIPTION
## Summary

Expose two new getters on `SpeechHandle` so application code can recover from agent interruptions:

- `generatedText` — full text the model produced before the speech was interrupted (`null` if not interrupted or no text was generated).
- `spokenText` — text that was actually heard by the listener before interruption (`null` if not interrupted).

## Motivation

When an agent is interrupted mid-response (especially while delivering a tool result), the caller may have heard nothing or only a fragment. Today the SDK correctly truncates the server-side conversation, but `SpeechHandle.chatItems` only retains the spoken portion — the full generated text is discarded, so application code has no way to detect *what was lost* and re-state it on the next turn.

This data already exists internally in `agent_activity.ts` at the moment of interruption (`textOut.text` = full model output, `playbackEv.synchronizedTranscript` = what was spoken). This PR just plumbs it onto the handle.

## Changes

- `agents/src/voice/speech_handle.ts` — add `_generatedText` / `_spokenText` private fields, `generatedText` / `spokenText` public getters, and an internal `_setInterruptionData(generatedText, spokenText)` setter (marked `@internal`, matching `_markDone`, `_itemAdded`, etc.).
- `agents/src/voice/agent_activity.ts` — populate the fields in both `_pipelineReplyTaskImpl` (traditional STT→LLM→TTS) and `_realtimeGenerationTaskImpl` (realtime / multimodal) at the point where `forwardedText` is finalized, so non-interrupted speeches incur no overhead and both pipelines behave the same.

## Usage

```ts
session.on(AgentSessionEventTypes.SpeechCreated, (ev) => {
  ev.speechHandle.addDoneCallback(() => {
    if (ev.speechHandle.interrupted) {
      const generated = ev.speechHandle.generatedText; // "Yes, we rent skid steers. We have mini, medium, and large units."
      const spoken = ev.speechHandle.spokenText;       // "Yes," (or "" if nothing was heard)
      // Application can now implement recovery logic
    }
  });
});
```

## Test plan

- [ ] `pnpm build` succeeds
- [ ] `pnpm api:check` succeeds (or `pnpm api:update` is run if the public API report needs regenerating)
- [ ] `pnpm test` passes existing voice/agent_activity tests
- [ ] Manual: run an agent (e.g. `examples/src/basic_agent.ts`), interrupt it mid-utterance, and verify `generatedText` / `spokenText` reflect the model's full output and the truncated heard portion respectively
- [ ] Verify both traditional pipeline and a realtime plugin (e.g. `openai/realtime`) populate the fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)