### PR TITLE
Revert "chore(openai): remove STT.withGroq constructor (#1321)"

### DIFF
--- a/.changeset/revert-remove-stt-withgroq.md
+++ b/.changeset/revert-remove-stt-withgroq.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+Revert "chore(openai): remove STT.withGroq constructor" (#1321)

--- a/plugins/openai/src/models.ts
+++ b/plugins/openai/src/models.ts
@@ -105,6 +105,8 @@ export type GroqChatModels =
   | 'openai/gpt-oss-120b'
   | 'openai/gpt-oss-20b';
 
+export type GroqAudioModels = 'whisper-large-v3' | 'whisper-large-v3-turbo';
+
 export type DeepSeekChatModels = 'deepseek-coder' | 'deepseek-chat';
 
 export type TogetherChatModels =

--- a/plugins/openai/src/stt.ts
+++ b/plugins/openai/src/stt.ts
@@ -4,7 +4,7 @@
 import { type AudioBuffer, mergeFrames, normalizeLanguage, stt } from '@livekit/agents';
 import type { AudioFrame } from '@livekit/rtc-node';
 import { OpenAI } from 'openai';
-import type { WhisperModels } from './models.js';
+import type { GroqAudioModels, WhisperModels } from './models.js';
 
 export interface STTOptions {
   apiKey?: string;
@@ -66,6 +66,35 @@ export class STT extends stt.STT {
         baseURL: this.#opts.baseURL,
         apiKey: this.#opts.apiKey,
       });
+  }
+
+  /**
+   * Create a new instance of Groq STT.
+   *
+   * @remarks
+   * `apiKey` must be set to your Groq API key, either using the argument or by setting the
+   * `GROQ_API_KEY` environment variable.
+   */
+  static withGroq(
+    opts: Partial<{
+      model: string | GroqAudioModels;
+      apiKey?: string;
+      baseURL?: string;
+      client: OpenAI;
+      language: string;
+      detectLanguage: boolean;
+    }> = {},
+  ): STT {
+    opts.apiKey = opts.apiKey || process.env.GROQ_API_KEY;
+    if (opts.apiKey === undefined) {
+      throw new Error('Groq API key is required, whether as an argument or as $GROQ_API_KEY');
+    }
+
+    return new STT({
+      model: 'whisper-large-v3-turbo',
+      baseURL: 'https://api.groq.com/openai/v1',
+      ...opts,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Reverts #1321 ("chore(openai): remove STT.withGroq constructor"), restoring:

- The `STT.withGroq` static constructor in `plugins/openai/src/stt.ts`
- The `GroqAudioModels` type in `plugins/openai/src/models.ts`
- The `GroqAudioModels` import in `stt.ts`

This re-introduces the Groq STT shortcut on the OpenAI plugin that was removed in #1321.

A changeset (`@livekit/agents-plugin-openai: patch`) is included.

## Test plan

- [ ] `pnpm -w build` succeeds with `STT.withGroq` and `GroqAudioModels` restored
- [ ] `pnpm -w test` passes
- [ ] No remaining references that conflict with the restored API

https://claude.ai/code/session_011UeAZ2NQi4fT6XhfvB1MF3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYM4WzNihvykYqFCeTFL9x)_