### PR TITLE
feat(voice): add dynamic endpointing

### DIFF
--- a/.changeset/dynamic-endpointing-node.md
+++ b/.changeset/dynamic-endpointing-node.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Add dynamic endpointing support to voice turn handling.

--- a/agents/src/types.ts
+++ b/agents/src/types.ts
@@ -7,6 +7,13 @@
  */
 export const USERDATA_TIMED_TRANSCRIPT = 'lk.timed_transcripts';
 
+// Ref: python livekit-agents/livekit/agents/types.py - 54-71 lines
+export const NOT_GIVEN = Symbol('NOT_GIVEN');
+
+// Ref: python livekit-agents/livekit/agents/types.py - 70-71 lines
+export type NotGiven = typeof NOT_GIVEN;
+export type NotGivenOr<T> = T | NotGiven;
+
 /**
  * Connection options for API calls, controlling retry and timeout behavior.
  */

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -16,6 +16,7 @@ import type { ReadableStream } from 'node:stream/web';
 import { TransformStream, type TransformStreamDefaultController } from 'node:stream/web';
 import { v4 as uuidv4 } from 'uuid';
 import { log } from './log.js';
+import { NOT_GIVEN, type NotGivenOr } from './types.js';
 
 /**
  * Recursively expands all nested properties of a type,
@@ -38,6 +39,11 @@ export type Expand<T> = T extends Function
 export type AudioBuffer = AudioFrame[] | AudioFrame;
 
 export const noop = () => {};
+
+// Ref: python livekit-agents/livekit/agents/utils/misc.py - 26-27 lines
+export function isGiven<T>(obj: NotGivenOr<T>): obj is T {
+  return obj !== NOT_GIVEN;
+}
 
 export const isPending = async (promise: Promise<unknown>): Promise<Throws<boolean, Error>> => {
   const sentinel = Symbol('sentinel');
@@ -352,43 +358,92 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 
 /** @internal */
 export class ExpFilter {
-  #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  private _alpha: number;
+  private _filtered: NotGivenOr<number>;
+  private _maxVal: NotGivenOr<number>;
+  private _minVal: NotGivenOr<number>;
 
-  constructor(alpha: number, max?: number) {
-    this.#alpha = alpha;
-    this.#max = max;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-20 lines
+  constructor(
+    alpha: number,
+    maxVal: NotGivenOr<number> = NOT_GIVEN,
+    minVal: NotGivenOr<number> = NOT_GIVEN,
+    initial: NotGivenOr<number> = NOT_GIVEN,
+  ) {
+    if (!(0 < alpha && alpha <= 1)) {
+      throw new RangeError('alpha must be in (0, 1].');
+    }
+
+    this._alpha = alpha;
+    this._filtered = initial;
+    this._maxVal = maxVal;
+    this._minVal = minVal;
   }
 
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 21-36 lines
+  reset(
+    alpha: NotGivenOr<number> = NOT_GIVEN,
+    initial: NotGivenOr<number> = NOT_GIVEN,
+    minVal: NotGivenOr<number> = NOT_GIVEN,
+    maxVal: NotGivenOr<number> = NOT_GIVEN,
+  ) {
+    if (isGiven(alpha)) {
+      if (!(0 < alpha && alpha <= 1)) {
+        throw new RangeError('alpha must be in (0, 1].');
+      }
+      this._alpha = alpha;
     }
-    this.#filtered = undefined;
+    if (isGiven(initial)) {
+      this._filtered = initial;
+    }
+    if (isGiven(minVal)) {
+      this._minVal = minVal;
+    }
+    if (isGiven(maxVal)) {
+      this._maxVal = maxVal;
+    }
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
-      const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
-    } else {
-      this.#filtered = sample;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 38-57 lines
+  apply(exp: number, sample: NotGivenOr<number> = NOT_GIVEN): number {
+    if (!isGiven(sample)) {
+      sample = this._filtered;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (isGiven(sample) && !isGiven(this._filtered)) {
+      this._filtered = sample;
+    } else if (isGiven(sample) && isGiven(this._filtered)) {
+      const a = this._alpha ** exp;
+      this._filtered = a * this._filtered + (1 - a) * sample;
     }
 
-    return this.#filtered;
+    if (!isGiven(this._filtered)) {
+      throw new Error('sample or initial value must be given.');
+    }
+
+    if (isGiven(this._maxVal) && this._filtered > this._maxVal) {
+      this._filtered = this._maxVal;
+    }
+
+    if (isGiven(this._minVal) && this._filtered < this._minVal) {
+      this._filtered = this._minVal;
+    }
+
+    return this._filtered;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 59-61 lines
+  get value(): number | undefined {
+    return isGiven(this._filtered) ? this._filtered : undefined;
   }
 
   get filtered(): number | undefined {
-    return this.#filtered;
+    return this.value;
   }
 
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 63-64 lines
   set alpha(alpha: number) {
-    this.#alpha = alpha;
+    this._alpha = alpha;
   }
 }
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -47,7 +47,8 @@ import { STT, type STTError, type SpeechEvent } from '../stt/stt.js';
 import { recordRealtimeMetrics, traceTypes, tracer } from '../telemetry/index.js';
 import { splitWords } from '../tokenize/basic/word.js';
 import { TTS, type TTSError } from '../tts/tts.js';
-import { Future, Task, cancelAndWait, isDevMode, isHosted, waitFor } from '../utils.js';
+import { NOT_GIVEN, type NotGivenOr } from '../types.js';
+import { Future, Task, cancelAndWait, isDevMode, isGiven, isHosted, waitFor } from '../utils.js';
 import { VAD, type VADEvent } from '../vad.js';
 import type { Agent, ModelSettings } from './agent.js';
 import {
@@ -88,6 +89,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import { type EndpointingOptions, createEndpointing } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -188,6 +190,7 @@ export class AgentActivity implements RecognitionHooks {
   private isInterruptionDetectionEnabled: boolean;
   private isInterruptionByAudioActivityEnabled: boolean;
   private isDefaultInterruptionByAudioActivityEnabled: boolean;
+  private interruptionDetected = false;
 
   private readonly onRealtimeGenerationCreated = (ev: GenerationCreatedEvent): void =>
     this.onGenerationCreated(ev);
@@ -206,6 +209,8 @@ export class AgentActivity implements RecognitionHooks {
     this.onError(ev);
 
   private readonly onInterruptionOverlappingSpeech = (ev: OverlappingSpeechEvent): void => {
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1494-1499 lines
+    this.interruptionDetected = ev.isInterruption;
     this.agentSession.emit(AgentSessionEventTypes.OverlappingSpeech, ev);
   };
 
@@ -477,12 +482,8 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 779-786 lines
+      endpointing: createEndpointing(this.endpointingOptions),
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -661,19 +662,13 @@ export class AgentActivity implements RecognitionHooks {
     return this.agent.turnHandling ?? this.agentSession.sessionOptions.turnHandling;
   }
 
-  // get minEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.minDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.minDelay
-  //   );
-  // }
-
-  // get maxEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.maxDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay
-  //   );
-  // }
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 455-464 lines
+  get endpointingOptions(): EndpointingOptions {
+    return {
+      ...this.agentSession.sessionOptions.turnHandling.endpointing,
+      ...this.agent.turnHandling?.endpointing,
+    };
+  }
 
   get toolCtx(): ToolContext {
     return this.agent.toolCtx;
@@ -717,11 +712,14 @@ export class AgentActivity implements RecognitionHooks {
 
   updateOptions({
     toolChoice,
-    turnDetection,
+    endpointingOpts = NOT_GIVEN,
+    turnDetection = NOT_GIVEN,
   }: {
     toolChoice?: ToolChoice | null;
-    turnDetection?: TurnDetectionMode;
+    endpointingOpts?: NotGivenOr<EndpointingOptions>;
+    turnDetection?: NotGivenOr<TurnDetectionMode | undefined>;
   }): void {
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 466-493 lines
     if (toolChoice !== undefined) {
       this.toolChoice = toolChoice;
     }
@@ -730,12 +728,11 @@ export class AgentActivity implements RecognitionHooks {
       this.realtimeSession.updateOptions({ toolChoice: this.toolChoice });
     }
 
-    if (turnDetection !== undefined) {
-      this.turnDetectionMode = turnDetection;
+    if (isGiven(turnDetection)) {
+      this.turnDetectionMode = typeof turnDetection === 'string' ? turnDetection : undefined;
       this.isDefaultInterruptionByAudioActivityEnabled =
         this.turnDetectionMode !== 'manual' && this.turnDetectionMode !== 'realtime_llm';
 
-      // sync live flag immediately when not speaking so the change takes effect right away
       if (this.agentSession.agentState !== 'speaking') {
         this.isInterruptionByAudioActivityEnabled =
           this.isDefaultInterruptionByAudioActivityEnabled;
@@ -743,7 +740,10 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (this.audioRecognition) {
-      this.audioRecognition.updateOptions({ turnDetection: this.turnDetectionMode });
+      this.audioRecognition.updateOptions({
+        endpointing: isGiven(endpointingOpts) ? createEndpointing(endpointingOpts) : NOT_GIVEN,
+        turnDetection,
+      });
     }
   }
 
@@ -921,13 +921,11 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info('onInputSpeechStarted');
 
     if (!this.vad) {
+      const startedAt = Date.now();
       this.agentSession._updateUserState('speaking');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfOverlapSpeech(
-          0,
-          Date.now(),
-          this.agentSession._userSpeakingSpan,
-        );
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1501-1508 lines
+        this.audioRecognition.onStartOfSpeech(startedAt, 0, this.agentSession._userSpeakingSpan);
       }
     }
 
@@ -947,8 +945,10 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
+      const endedAt = Date.now();
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1519-1525 lines
+        this.audioRecognition.onEndOfSpeech(endedAt, this.agentSession._userSpeakingSpan);
       }
       this.agentSession._updateUserState('listening');
     }
@@ -1030,11 +1030,12 @@ export class AgentActivity implements RecognitionHooks {
       lastSpeakingTime: speechStartTime,
       otelContext: otelContext.active(),
     });
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
+    this.interruptionDetected = false;
+    if (this.audioRecognition) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1653-1664 lines
+      this.audioRecognition.onStartOfSpeech(
         speechStartTime,
+        ev.speechDuration,
         this.agentSession._userSpeakingSpan,
       );
     }
@@ -1046,11 +1047,12 @@ export class AgentActivity implements RecognitionHooks {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
+    if (this.audioRecognition) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1689-1703 lines
+      this.audioRecognition.onEndOfSpeech(
         speechEndTime,
         this.agentSession._userSpeakingSpan,
+        this.isInterruptionDetectionEnabled ? this.interruptionDetected : NOT_GIVEN,
       );
     }
     this.agentSession._updateUserState('listening', {
@@ -1839,8 +1841,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2214-2222 lines
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -1932,7 +1937,8 @@ export class AgentActivity implements RecognitionHooks {
 
     if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2337-2344 lines
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
       this.restoreInterruptionByAudioActivity();
@@ -2123,8 +2129,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2571-2578 lines
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2286,8 +2295,11 @@ export class AgentActivity implements RecognitionHooks {
 
       if (this.agentSession.agentState === 'speaking') {
         this.agentSession._updateAgentState('listening');
-        if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+        if (this.audioRecognition) {
+          // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2708-2714 lines
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        }
+        if (this.isInterruptionDetectionEnabled) {
           this.restoreInterruptionByAudioActivity();
         }
       }
@@ -2329,11 +2341,12 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._updateAgentState('thinking');
     } else if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
-          this.restoreInterruptionByAudioActivity();
-        }
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 3212-3219 lines
+        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+      }
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
       }
     }
 

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -32,10 +32,12 @@ import { mergeReadableStreams } from '../stream/merge_readable_streams.js';
 import { type StreamChannel, createStreamChannel } from '../stream/stream_channel.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { traceTypes, tracer } from '../telemetry/index.js';
-import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
+import { NOT_GIVEN, type NotGivenOr } from '../types.js';
+import { Task, cancelAndWait, delay, isGiven, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
 import type { STTNode } from './io.js';
+import { BaseEndpointing } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export interface EndOfTurnInfo {
@@ -138,10 +140,12 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
+  /** Endpointing delay tracker. */
+  endpointing?: BaseEndpointing;
   /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
+  minEndpointingDelay?: number;
   /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  maxEndpointingDelay?: number;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +174,7 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  private endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -224,8 +227,10 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 131-146 lines
+    this.endpointing =
+      opts.endpointing ??
+      new BaseEndpointing(opts.minEndpointingDelay ?? 500, opts.maxEndpointingDelay ?? 3000);
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,8 +280,22 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
-    this.turnDetectionMode = options.turnDetection;
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 193-220 lines
+  updateOptions({
+    endpointing = NOT_GIVEN,
+    turnDetection = NOT_GIVEN,
+  }: {
+    endpointing?: NotGivenOr<BaseEndpointing>;
+    turnDetection?: NotGivenOr<TurnDetectionMode | undefined>;
+  } = {}): void {
+    if (isGiven(endpointing)) {
+      this.endpointing = endpointing;
+    }
+
+    if (isGiven(turnDetection)) {
+      this.turnDetector = typeof turnDetection === 'string' ? undefined : turnDetection;
+      this.turnDetectionMode = typeof turnDetection === 'string' ? turnDetection : undefined;
+    }
   }
 
   async start(options?: { sttPipeline?: STTPipeline }) {
@@ -311,12 +330,19 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 239-244 lines
+  onStartOfAgentSpeech(startedAt: number): void {
     this.isAgentSpeaking = true;
-    return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
+    this.endpointing.onStartOfAgentSpeech(startedAt);
+    void this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 246-271 lines
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -344,17 +370,31 @@ export class AudioRecognition {
     this.isAgentSpeaking = false;
   }
 
-  /** Start interruption inference when agent is speaking and overlap speech starts. */
-  async onStartOfOverlapSpeech(speechDuration: number, startedAt: number, userSpeakingSpan?: Span) {
-    if (this.isAgentSpeaking) {
-      this.trySendInterruptionSentinel(
-        InterruptionStreamSentinel.overlapSpeechStarted(
-          speechDuration,
-          startedAt,
-          userSpeakingSpan,
-        ),
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 273-290 lines
+  onStartOfSpeech(startedAt: number, speechDuration = 0.0, userSpeakingSpan?: Span): void {
+    this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+    if (!this.isInterruptionEnabled || !this.isAgentSpeaking) {
+      return;
+    }
+    void this.trySendInterruptionSentinel(
+      InterruptionStreamSentinel.overlapSpeechStarted(speechDuration, startedAt, userSpeakingSpan),
+    );
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 292-306 lines
+  onEndOfSpeech(
+    endedAt: number,
+    userSpeakingSpan?: Span,
+    interruption: NotGivenOr<boolean> = NOT_GIVEN,
+  ): void {
+    if (this.speaking) {
+      this.endpointing.onEndOfSpeech(
+        endedAt,
+        isGiven(interruption) && !interruption && this.isAgentSpeaking,
       );
     }
+
+    void this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
   }
 
   /** End interruption inference when overlap speech ends. */
@@ -805,7 +845,8 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 949-949 lines
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +872,8 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 969-973 lines
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -27,3 +27,11 @@ export * from './report.js';
 export * from './room_io/index.js';
 export { RunContext } from './run_context.js';
 export * as testing from './testing/index.js';
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-322 lines
+export {
+  BaseEndpointing,
+  DynamicEndpointing,
+  createEndpointing,
+  defaultEndpointingOptions,
+  type EndpointingOptions,
+} from './turn_config/endpointing.js';

--- a/agents/src/voice/turn_config/endpointing.test.ts
+++ b/agents/src/voice/turn_config/endpointing.test.ts
@@ -1,0 +1,565 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../../llm/chat_context.js';
+import { initializeLogger } from '../../log.js';
+import { ExpFilter } from '../../utils.js';
+import { AudioRecognition, type RecognitionHooks } from '../audio_recognition.js';
+import { BaseEndpointing, DynamicEndpointing, createEndpointing } from './endpointing.js';
+
+const approx = (actual: number, expected: number) => expect(actual).toBeCloseTo(expected, 5);
+
+function createHooks(): RecognitionHooks {
+  return {
+    onInterruption: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onEndOfTurn: vi.fn(async () => true),
+    onPreemptiveGeneration: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+  };
+}
+
+beforeAll(() => {
+  initializeLogger({ pretty: false, level: 'silent' });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ExpFilter', () => {
+  it('initializes with valid alpha', () => {
+    const ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    const emaWithInitial = new ExpFilter(0.5, undefined, undefined, 10.0);
+    expect(emaWithInitial.value).toBe(10.0);
+
+    const alphaOne = new ExpFilter(1.0);
+    expect(alphaOne.value).toBeUndefined();
+  });
+
+  it('rejects invalid alpha values', () => {
+    expect(() => new ExpFilter(0.0)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(-0.5)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(1.5)).toThrow(/alpha must be in/);
+  });
+
+  it('sets the first update directly when there is no initial value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1.0, 10.0);
+    expect(result).toBe(10.0);
+    expect(ema.value).toBe(10.0);
+  });
+
+  it('applies EMA formula when an initial value exists', () => {
+    const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    const result = ema.apply(1.0, 20.0);
+    expect(result).toBe(15.0);
+    expect(ema.value).toBe(15.0);
+  });
+
+  it('calculates multiple updates correctly', () => {
+    const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    ema.apply(1.0, 20.0);
+    ema.apply(1.0, 20.0);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('resets selected filter fields in place', () => {
+    const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    expect(ema.value).toBe(10.0);
+    ema.reset();
+    expect(ema.value).toBe(10.0);
+
+    const emaWithReset = new ExpFilter(0.5, undefined, undefined, 10.0);
+    emaWithReset.reset(undefined, 5.0);
+    expect(emaWithReset.value).toBe(5.0);
+  });
+});
+
+describe('DynamicEndpointing', () => {
+  it('initializes with min and max delay', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('initializes with custom alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.2);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('uses the updated default alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    approx((ep as any)._utterancePause._alpha, 0.9);
+    approx((ep as any)._turnPause._alpha, 0.9);
+  });
+
+  it('returns empty delays before speech is recorded', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.betweenUtteranceDelay).toBe(0.0);
+    expect(ep.betweenTurnDelay).toBe(0.0);
+    expect(ep.immediateInterruptionDelay).toEqual([0.0, 0.0]);
+  });
+
+  it('records utterance end timestamps', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    expect((ep as any)._utteranceEndedAt).toBe(100000);
+
+    const second = new DynamicEndpointing(300, 1000);
+    second.onEndOfSpeech(99900);
+    expect((second as any)._utteranceEndedAt).toBe(99900);
+  });
+
+  it('records utterance start timestamps', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfSpeech(100000);
+    expect((ep as any)._utteranceStartedAt).toBe(100000);
+  });
+
+  it('records agent speech start timestamps', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100000);
+    expect((ep as any)._agentSpeechStartedAt).toBe(100000);
+  });
+
+  it('calculates delay between utterances', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100500);
+    approx(ep.betweenUtteranceDelay, 500);
+  });
+
+  it('calculates delay between turns', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100800);
+    approx(ep.betweenTurnDelay, 800);
+  });
+
+  it('updates min delay for pauses between utterances', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400);
+    ep.onEndOfSpeech(100500, false);
+
+    approx(ep.minDelay, 0.5 * 400 + 0.5 * initialMin);
+  });
+
+  it('updates max delay for new turns', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100600);
+    ep.onStartOfSpeech(101500);
+    ep.onEndOfSpeech(102000, false);
+
+    approx(ep.maxDelay, 0.5 * 600 + 0.5 * 1000);
+  });
+
+  it('updates min delay for immediate interruptions', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    expect((ep as any)._agentSpeechStartedAt).not.toBeUndefined();
+    ep.onStartOfSpeech(100250, true);
+    expect((ep as any)._overlapping).toBe(true);
+
+    ep.onEndOfSpeech(100500);
+
+    expect((ep as any)._overlapping).toBe(false);
+    expect((ep as any)._agentSpeechStartedAt).toBeUndefined();
+    approx(ep.minDelay, 300);
+  });
+
+  it('updates options', () => {
+    const minOnly = new DynamicEndpointing(300, 1000);
+    minOnly.updateOptions({ minDelay: 500 });
+    expect(minOnly.minDelay).toBe(500);
+    expect((minOnly as any)._minDelay).toBe(500);
+
+    const maxOnly = new DynamicEndpointing(300, 1000);
+    maxOnly.updateOptions({ maxDelay: 2000 });
+    expect(maxOnly.maxDelay).toBe(2000);
+    expect((maxOnly as any)._maxDelay).toBe(2000);
+
+    const both = new DynamicEndpointing(300, 1000);
+    both.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(both.minDelay).toBe(500);
+    expect(both.maxDelay).toBe(2000);
+
+    const unchanged = new DynamicEndpointing(300, 1000);
+    unchanged.updateOptions();
+    expect(unchanged.minDelay).toBe(300);
+    expect(unchanged.maxDelay).toBe(1000);
+  });
+
+  it('clamps max delay to the configured max', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(102000);
+    ep.onStartOfSpeech(105000);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('clamps max delay to at least min delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100100);
+    ep.onStartOfSpeech(100500);
+    expect(ep.maxDelay).toBeGreaterThanOrEqual((ep as any)._minDelay);
+  });
+
+  it('clears agent speech for non-interruption utterance end', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    expect((ep as any)._agentSpeechStartedAt).not.toBeUndefined();
+
+    ep.onStartOfSpeech(102000);
+    ep.onEndOfSpeech(103000, false);
+    expect((ep as any)._agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('only tracks the first consecutive interruption', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect((ep as any)._overlapping).toBe(true);
+    const prevVal = [ep.minDelay, ep.maxDelay];
+
+    ep.onStartOfSpeech(100350);
+
+    expect((ep as any)._overlapping).toBe(true);
+    expect(prevVal).toEqual([ep.minDelay, ep.maxDelay]);
+  });
+
+  it('updates max delay for delayed interruptions without crashing', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800);
+    ep.onEndOfSpeech(102000, false);
+    approx(ep.maxDelay, 0.5 * 900 + 0.5 * 1000);
+  });
+
+  it('adjusts stale utterance end time on interruption', () => {
+    const ep = new DynamicEndpointing(60, 1000, 1.0);
+    ep.onEndOfSpeech(99000);
+    ep.onStartOfSpeech(100000);
+
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect((ep as any)._utteranceEndedAt).toBe(100199);
+    approx(ep.minDelay, 60);
+    approx(ep.maxDelay, 1000);
+  });
+
+  it('preserves filter alpha when updating delays', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+
+    approx((ep as any)._utterancePause._alpha, 0.5);
+    approx((ep as any)._turnPause._alpha, 0.5);
+  });
+
+  it('updates alpha in place without resetting learned state', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100200);
+    ep.onEndOfSpeech(101000);
+    const learnedMin = ep.minDelay;
+
+    ep.updateOptions({ alpha: 0.2 });
+
+    approx((ep as any)._utterancePause._alpha, 0.2);
+    approx((ep as any)._turnPause._alpha, 0.2);
+    approx(ep.minDelay, learnedMin);
+  });
+
+  it('updates filter clamp bounds', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect((ep as any)._utterancePause._minVal).toBe(500);
+    expect((ep as any)._turnPause._maxVal).toBe(2000);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100200);
+    approx(ep.minDelay, 500);
+
+    ep.onEndOfSpeech(101000);
+    ep.onStartOfAgentSpeech(102800);
+    ep.onStartOfSpeech(103500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('skips filter updates when shouldIgnore is true during overlap', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101500, true);
+
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101800, true);
+
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect((ep as any)._utteranceStartedAt).toBeUndefined();
+    expect((ep as any)._utteranceEndedAt).toBeUndefined();
+    expect((ep as any)._overlapping).toBe(false);
+    expect((ep as any)._speaking).toBe(false);
+  });
+
+  it('still updates when shouldIgnore is true without overlap', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400, false);
+    ep.onEndOfSpeech(100600, true);
+
+    approx(ep.minDelay, 0.5 * 400 + 0.5 * initialMin);
+  });
+
+  it('overrides shouldIgnore within the agent speech grace period', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(100600, true);
+
+    ep.onEndOfSpeech(100800, true);
+
+    expect((ep as any)._utteranceEndedAt).toBe(100800);
+    expect((ep as any)._speaking).toBe(false);
+  });
+
+  it('applies shouldIgnore outside the grace period', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101000, true);
+
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+    ep.onEndOfSpeech(101500, true);
+
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect((ep as any)._utteranceStartedAt).toBeUndefined();
+    expect((ep as any)._utteranceEndedAt).toBeUndefined();
+  });
+
+  it('sets agent speech ended state and clears overlap', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100000);
+    ep.onStartOfSpeech(100100, true);
+    expect((ep as any)._overlapping).toBe(true);
+    expect((ep as any)._agentSpeechStartedAt).toBe(100000);
+
+    ep.onEndOfAgentSpeech(101000);
+
+    expect((ep as any)._agentSpeechEndedAt).toBe(101000);
+    expect((ep as any)._agentSpeechStartedAt).toBe(100000);
+    expect((ep as any)._overlapping).toBe(false);
+  });
+
+  it('infers overlap from active agent speech', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800, false);
+    ep.onEndOfSpeech(102000);
+
+    approx(ep.maxDelay, 0.5 * 900 + 0.5 * 1000);
+  });
+
+  it('sets and clears speaking flag', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect((ep as any)._speaking).toBe(false);
+    ep.onStartOfSpeech(100000);
+    expect((ep as any)._speaking).toBe(true);
+    ep.onEndOfSpeech(100500);
+    expect((ep as any)._speaking).toBe(false);
+  });
+
+  it.each([
+    ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+    ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+    ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+    ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+    ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+    ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+    ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+    ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+    ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+  ])(
+    'handles overlapping and shouldIgnore combo %s',
+    (
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ) => {
+      const ep = new DynamicEndpointing(300, 1000, 0.5);
+      ep.onStartOfSpeech(99000);
+      ep.onEndOfSpeech(100000);
+
+      let userStart: number;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100500);
+        ep.onEndOfAgentSpeech(101000);
+        userStart = 101500;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100350;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100200);
+          userStart = 101500;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100400;
+        } else {
+          ep.onStartOfAgentSpeech(100900);
+          userStart = 101800;
+        }
+      } else {
+        userStart = 100400;
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping as boolean);
+
+      const prevMin = ep.minDelay;
+      const prevMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + 500, shouldIgnore as boolean);
+
+      expect(ep.minDelay !== prevMin, `[${label}] minDelay change`).toBe(expectMinChange);
+      expect(ep.maxDelay !== prevMax, `[${label}] maxDelay change`).toBe(expectMaxChange);
+      expect((ep as any)._speaking, `[${label}] _speaking`).toBe(false);
+      expect((ep as any)._overlapping, `[${label}] _overlapping`).toBe(false);
+    },
+  );
+
+  it('handles a full conversation sequence with ignored backchannel', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onStartOfSpeech(100000);
+    ep.onEndOfSpeech(101000);
+
+    ep.onStartOfAgentSpeech(101500);
+
+    ep.onStartOfSpeech(102500, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102800, true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(103000);
+
+    ep.onStartOfSpeech(103500);
+    ep.onEndOfSpeech(104000);
+
+    expect((ep as any)._speaking).toBe(false);
+    expect((ep as any)._agentSpeechStartedAt).toBeUndefined();
+  });
+});
+
+describe('createEndpointing', () => {
+  it('wires alpha into dynamic endpointing filters', () => {
+    const ep = createEndpointing({ mode: 'dynamic', minDelay: 300, maxDelay: 1000, alpha: 0.7 });
+
+    expect(ep).toBeInstanceOf(DynamicEndpointing);
+    approx((ep as any)._utterancePause._alpha, 0.7);
+    approx((ep as any)._turnPause._alpha, 0.7);
+  });
+
+  it('returns base endpointing for fixed mode', () => {
+    const ep = createEndpointing({ mode: 'fixed', minDelay: 500, maxDelay: 3000, alpha: 0.9 });
+
+    expect(ep).not.toBeInstanceOf(DynamicEndpointing);
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(3000);
+  });
+});
+
+describe('AudioRecognition endpointing integration', () => {
+  it('preserves learned endpointing state when only turn detection changes', () => {
+    const endpointing = new DynamicEndpointing(300, 1000, 0.5);
+    const recognition = new AudioRecognition({ recognitionHooks: createHooks(), endpointing });
+
+    (recognition as any).speaking = true;
+    recognition.onEndOfSpeech(100000);
+    recognition.onStartOfSpeech(100400);
+    (recognition as any).speaking = true;
+    recognition.onEndOfSpeech(100600);
+    const learnedMin = endpointing.minDelay;
+
+    recognition.updateOptions({ turnDetection: 'manual' });
+
+    expect((recognition as any).endpointing).toBe(endpointing);
+    approx(endpointing.minDelay, learnedMin);
+  });
+
+  it('replaces endpointing state only when a new endpointing object is provided', () => {
+    const initial = new DynamicEndpointing(300, 1000, 0.5);
+    const replacement = new BaseEndpointing(500, 3000);
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      endpointing: initial,
+    });
+
+    recognition.updateOptions({ endpointing: replacement });
+
+    expect((recognition as any).endpointing).toBe(replacement);
+  });
+
+  it('updates endpointing on realtime/no-VAD speech callbacks', () => {
+    const endpointing = new DynamicEndpointing(300, 1000, 0.5);
+    const recognition = new AudioRecognition({ recognitionHooks: createHooks(), endpointing });
+
+    recognition.onStartOfSpeech(100000, 0);
+    (recognition as any).speaking = true;
+    recognition.onEndOfSpeech(100500);
+
+    expect((endpointing as any)._utteranceStartedAt).toBe(100000);
+    expect((endpointing as any)._utteranceEndedAt).toBe(100500);
+  });
+
+  it('updates agent speech endpointing when interruption detection is disabled', async () => {
+    vi.useFakeTimers();
+    const endpointing = new DynamicEndpointing(300, 1000, 0.5);
+    const recognition = new AudioRecognition({ recognitionHooks: createHooks(), endpointing });
+
+    recognition.onStartOfAgentSpeech(100000);
+    vi.setSystemTime(101000);
+    await recognition.onEndOfAgentSpeech(101000);
+
+    expect((endpointing as any)._agentSpeechStartedAt).toBe(100000);
+    expect((endpointing as any)._agentSpeechEndedAt).toBe(101000);
+  });
+});

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -1,21 +1,28 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { log } from '../../log.js';
+import { NOT_GIVEN, type NotGivenOr } from '../../types.js';
+import { ExpFilter, isGiven } from '../../utils.js';
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 7-7 lines
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250;
+
+// Ref: python livekit-agents/livekit/agents/voice/turn.py - 47-66 lines
 /**
  * Configuration for endpointing, which determines when the user's turn is complete.
  */
 export interface EndpointingOptions {
   /**
-   * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on
-   * end-of-utterance prediction.
+   * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on speech
+   * activity.
    * @defaultValue "fixed"
    */
   mode: 'fixed' | 'dynamic';
   /**
    * Minimum time in milliseconds since the last detected speech before the agent declares the user's
    * turn complete. In VAD mode this effectively behaves like `max(VAD silence, minDelay)`;
-   * in STT mode it is applied after the STT end-of-speech signal, so it can be additive with
-   * the STT provider's endpointing delay.
+   * in STT mode it is applied after the STT provider's endpointing delay.
    * @defaultValue 500
    */
   minDelay: number;
@@ -24,10 +31,347 @@ export interface EndpointingOptions {
    * @defaultValue 3000
    */
   maxDelay: number;
+  /**
+   * Exponential moving average coefficient for dynamic endpointing.
+   * @defaultValue 0.9
+   */
+  alpha: number;
 }
 
+// Ref: python livekit-agents/livekit/agents/voice/turn.py - 69-74 lines
 export const defaultEndpointingOptions = {
   mode: 'fixed',
   minDelay: 500,
   maxDelay: 3000,
+  alpha: 0.9,
 } as const satisfies EndpointingOptions;
+
+type BaseEndpointingUpdateOptions = {
+  minDelay?: NotGivenOr<number>;
+  maxDelay?: NotGivenOr<number>;
+};
+
+type DynamicEndpointingUpdateOptions = BaseEndpointingUpdateOptions & {
+  alpha?: NotGivenOr<number>;
+};
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-47 lines
+export class BaseEndpointing {
+  protected _minDelay: number;
+  protected _maxDelay: number;
+  protected _overlapping = false;
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 11-14 lines
+  constructor(minDelay: number, maxDelay: number) {
+    this._minDelay = minDelay;
+    this._maxDelay = maxDelay;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 16-22 lines
+  updateOptions({
+    minDelay = NOT_GIVEN,
+    maxDelay = NOT_GIVEN,
+  }: BaseEndpointingUpdateOptions = {}): void {
+    if (isGiven(minDelay)) {
+      this._minDelay = minDelay;
+    }
+    if (isGiven(maxDelay)) {
+      this._maxDelay = maxDelay;
+    }
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 24-30 lines
+  get minDelay(): number {
+    return this._minDelay;
+  }
+
+  get maxDelay(): number {
+    return this._maxDelay;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 32-34 lines
+  get overlapping(): boolean {
+    return this._overlapping;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 36-40 lines
+  onStartOfSpeech(startedAt: number, overlapping = false): void {
+    void startedAt;
+    this._overlapping = overlapping;
+  }
+
+  onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    void endedAt;
+    void shouldIgnore;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 42-46 lines
+  onStartOfAgentSpeech(startedAt: number): void {
+    void startedAt;
+  }
+
+  onEndOfAgentSpeech(endedAt: number): void {
+    void endedAt;
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-90 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private _utterancePause: ExpFilter;
+  private _turnPause: ExpFilter;
+  private _utteranceStartedAt: number | undefined;
+  private _utteranceEndedAt: number | undefined;
+  private _agentSpeechStartedAt: number | undefined;
+  private _agentSpeechEndedAt: number | undefined;
+  private _speaking = false;
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 50-90 lines
+  constructor(minDelay: number, maxDelay: number, alpha = 0.9) {
+    super(minDelay, maxDelay);
+
+    this._utterancePause = new ExpFilter(alpha, maxDelay, minDelay, minDelay);
+    this._turnPause = new ExpFilter(alpha, maxDelay, minDelay, maxDelay);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 91-102 lines
+  override get minDelay(): number {
+    return this._utterancePause.value ?? this._minDelay;
+  }
+
+  override get maxDelay(): number {
+    const turnVal = this._turnPause.value ?? this._maxDelay;
+    return Math.max(turnVal, this.minDelay);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 104-120 lines
+  get betweenUtteranceDelay(): number {
+    if (this._utteranceEndedAt === undefined) {
+      return 0.0;
+    }
+    if (this._utteranceStartedAt === undefined) {
+      return 0.0;
+    }
+
+    return Math.max(0, this._utteranceStartedAt - this._utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this._agentSpeechStartedAt === undefined) {
+      return 0.0;
+    }
+    if (this._utteranceEndedAt === undefined) {
+      return 0.0;
+    }
+
+    return Math.max(0, this._agentSpeechStartedAt - this._utteranceEndedAt);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 122-137 lines
+  get immediateInterruptionDelay(): [number, number] {
+    if (this._utteranceStartedAt === undefined) {
+      return [0.0, 0.0];
+    }
+    if (this._agentSpeechStartedAt === undefined) {
+      return [0.0, 0.0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 139-153 lines
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this._agentSpeechStartedAt = startedAt;
+    this._agentSpeechEndedAt = undefined;
+    this._overlapping = false;
+  }
+
+  override onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this._agentSpeechStartedAt !== undefined &&
+      (this._agentSpeechEndedAt === undefined ||
+        this._agentSpeechEndedAt < this._agentSpeechStartedAt)
+    ) {
+      this._agentSpeechEndedAt = endedAt;
+    }
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 155-178 lines
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 156-158 lines
+    if (this._overlapping) {
+      return;
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 160-173 lines
+    if (
+      this._utteranceStartedAt !== undefined &&
+      this._utteranceEndedAt !== undefined &&
+      this._agentSpeechStartedAt !== undefined &&
+      this._utteranceEndedAt < this._utteranceStartedAt &&
+      overlapping
+    ) {
+      this._utteranceEndedAt = this._agentSpeechStartedAt - 1;
+      log().trace({ utteranceEndedAt: this._utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this._utteranceStartedAt = startedAt;
+    this._overlapping = overlapping;
+    this._speaking = true;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 179-287 lines
+  override onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 180-203 lines
+    if (shouldIgnore && this._overlapping) {
+      if (
+        this._utteranceStartedAt !== undefined &&
+        this._agentSpeechStartedAt !== undefined &&
+        Math.abs(this._utteranceStartedAt - this._agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        log().trace(
+          {
+            delay: Math.abs(this._utteranceStartedAt - this._agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true: user speech started within grace period of agent speech',
+        );
+      } else {
+        this._overlapping = false;
+        this._speaking = false;
+        this._utteranceStartedAt = undefined;
+        this._utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 205-247 lines
+    if (
+      this._overlapping ||
+      (this._agentSpeechStartedAt !== undefined && this._agentSpeechEndedAt === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const pause = this.betweenUtteranceDelay;
+      // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 208-229 lines
+      if (
+        0 < interruptionDelay &&
+        interruptionDelay <= this.minDelay &&
+        0 < turnDelay &&
+        turnDelay <= this.maxDelay &&
+        pause > 0
+      ) {
+        const prevVal = this.minDelay;
+        this._utterancePause.apply(1.0, pause);
+        log().debug(
+          {
+            reason: 'immediate interruption',
+            pause,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${prevVal} -> ${this.minDelay}`,
+        );
+      } else {
+        // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 230-246 lines
+        const turnPause = this.betweenTurnDelay;
+        if (turnPause > 0) {
+          const prevVal = this.maxDelay;
+          this._turnPause.apply(1.0, turnPause);
+          log().debug(
+            {
+              reason: 'new turn (interruption)',
+              pause: turnPause,
+              maxDelay: this.maxDelay,
+              minDelay: this.minDelay,
+              betweenUtteranceDelay: this.betweenUtteranceDelay,
+              betweenTurnDelay: this.betweenTurnDelay,
+            },
+            `max endpointing delay updated: ${prevVal} -> ${this.maxDelay}`,
+          );
+        }
+      }
+    } else {
+      // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 248-280 lines
+      const turnPause = this.betweenTurnDelay;
+      const utterancePause = this.betweenUtteranceDelay;
+      if (turnPause > 0) {
+        const prevVal = this.maxDelay;
+        this._turnPause.apply(1.0, turnPause);
+        log().debug(
+          {
+            reason: 'new turn',
+            pause: turnPause,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `max endpointing delay updated due to pause: ${prevVal} -> ${this.maxDelay}`,
+        );
+      } else if (
+        utterancePause > 0 &&
+        this._agentSpeechEndedAt === undefined &&
+        this._agentSpeechStartedAt === undefined
+      ) {
+        const prevVal = this.minDelay;
+        this._utterancePause.apply(1.0, utterancePause);
+        log().debug(
+          {
+            reason: 'pause between utterances',
+            pause: utterancePause,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${prevVal} -> ${this.minDelay}`,
+        );
+      }
+    }
+
+    this._utteranceEndedAt = endedAt;
+    this._agentSpeechStartedAt = undefined;
+    this._agentSpeechEndedAt = undefined;
+    this._speaking = false;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 288-307 lines
+  override updateOptions({
+    minDelay = NOT_GIVEN,
+    maxDelay = NOT_GIVEN,
+    alpha = NOT_GIVEN,
+  }: DynamicEndpointingUpdateOptions = {}): void {
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 295-299 lines
+    if (isGiven(minDelay)) {
+      this._minDelay = minDelay;
+      this._utterancePause.reset(NOT_GIVEN, this._minDelay, this._minDelay);
+      this._turnPause.reset(NOT_GIVEN, NOT_GIVEN, this._minDelay);
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 300-303 lines
+    if (isGiven(maxDelay)) {
+      this._maxDelay = maxDelay;
+      this._turnPause.reset(NOT_GIVEN, this._maxDelay, NOT_GIVEN, this._maxDelay);
+      this._utterancePause.reset(NOT_GIVEN, NOT_GIVEN, NOT_GIVEN, this._maxDelay);
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 305-307 lines
+    if (isGiven(alpha)) {
+      this._utterancePause.reset(alpha);
+      this._turnPause.reset(alpha);
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 310-322 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  switch (options.mode) {
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 312-317 lines
+    case 'dynamic':
+      return new DynamicEndpointing(options.minDelay, options.maxDelay, options.alpha);
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 318-322 lines
+    default:
+      return new BaseEndpointing(options.minDelay, options.maxDelay);
+  }
+}


### PR DESCRIPTION
## Summary
- Port Python dynamic endpointing to the Node voice runtime with fixed/dynamic endpointing classes, NOT_GIVEN sentinel handling, and ExpFilter parity.
- Wire endpointing through AudioRecognition/AgentActivity for VAD, STT, realtime/no-VAD, agent speech, and runtime update paths.
- Port the Python endpointing tests 1:1 and add Node runtime regression coverage for updateOptions and no-interruption agent speech paths.

## Source Test Parity
- Ported `tests/test_endpointing.py` ExpFilter, DynamicEndpointing, parametrized overlap/should_ignore, and create_endpointing cases.
- Added target-only AudioRecognition endpointing integration tests for state preservation/replacement and realtime/no-VAD callbacks.

## Verification
- `pnpm test "agents/src/voice/turn_config/endpointing.test.ts" "agents/src/voice/turn_config/utils.test.ts" "agents/src/utils.test.ts" "agents/src/voice/audio_recognition_handoff.test.ts" "agents/src/voice/audio_recognition_span.test.ts" "agents/src/voice/agent_activity.test.ts" "agents/src/voice/agent_activity_handoff.test.ts" "agents/src/voice/agent.test.ts" "agents/src/voice/report.test.ts"`
- `pnpm --filter @livekit/agents build`
- `pnpm format:check`
- `pnpm --filter @livekit/agents lint` (passes with existing repo warnings)
- `pnpm --filter @livekit/agents api:check` is blocked by existing API Extractor limitation: `export * as ___` in `agents/dist/index.d.ts` is not supported.