### PR TITLE
feat(voice): add dynamic endpointing

### DIFF
--- a/.changeset/dynamic-endpointing-port.md
+++ b/.changeset/dynamic-endpointing-port.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+feat(voice): add dynamic endpointing

--- a/.changeset/rosetta-dynamic-endpointing.md
+++ b/.changeset/rosetta-dynamic-endpointing.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+feat(voice): add dynamic endpointing support

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -351,44 +351,84 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 }
 
 /** @internal */
+// Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-64 lines
 export class ExpFilter {
-  #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  private _alpha: number;
+  private _filtered?: number;
+  private _maxVal?: number;
+  private _minVal?: number;
 
-  constructor(alpha: number, max?: number) {
-    this.#alpha = alpha;
-    this.#max = max;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-20 lines
+  constructor(alpha: number, maxVal?: number, minVal?: number, initial?: number) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
+
+    this._alpha = alpha;
+    this._filtered = initial;
+    this._maxVal = maxVal;
+    this._minVal = minVal;
   }
 
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 21-37 lines
+  reset(alpha?: number, initial?: number, minVal?: number, maxVal?: number) {
+    if (alpha !== undefined) {
+      if (!(alpha > 0 && alpha <= 1)) {
+        throw new Error('alpha must be in (0, 1].');
+      }
+      this._alpha = alpha;
     }
-    this.#filtered = undefined;
+    if (initial !== undefined) {
+      this._filtered = initial;
+    }
+    if (minVal !== undefined) {
+      this._minVal = minVal;
+    }
+    if (maxVal !== undefined) {
+      this._maxVal = maxVal;
+    }
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
-      const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
-    } else {
-      this.#filtered = sample;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 38-57 lines
+  apply(exp: number, sample?: number): number {
+    if (sample === undefined) {
+      sample = this._filtered;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (sample !== undefined && this._filtered === undefined) {
+      this._filtered = sample;
+    } else if (sample !== undefined && this._filtered !== undefined) {
+      const a = this._alpha ** exp;
+      this._filtered = a * this._filtered + (1 - a) * sample;
     }
 
-    return this.#filtered;
+    if (this._filtered === undefined) {
+      throw new Error('sample or initial value must be given.');
+    }
+
+    if (this._maxVal !== undefined && this._filtered > this._maxVal) {
+      this._filtered = this._maxVal;
+    }
+
+    if (this._minVal !== undefined && this._filtered < this._minVal) {
+      this._filtered = this._minVal;
+    }
+
+    return this._filtered;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 59-61 lines
+  get value(): number | undefined {
+    return this._filtered;
   }
 
   get filtered(): number | undefined {
-    return this.#filtered;
+    return this.value;
   }
 
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 63-64 lines
   set alpha(alpha: number) {
-    this.#alpha = alpha;
+    this._alpha = alpha;
   }
 }
 

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -351,44 +351,88 @@ export class AsyncIterableQueue<T> implements AsyncIterableIterator<T> {
 }
 
 /** @internal */
+// Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 5-64 lines
 export class ExpFilter {
-  #alpha: number;
-  #max?: number;
-  #filtered?: number = undefined;
+  _alpha: number;
+  _filtered: number | undefined;
+  _maxVal: number | undefined;
+  _minVal: number | undefined;
 
-  constructor(alpha: number, max?: number) {
-    this.#alpha = alpha;
-    this.#max = max;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 6-20 lines
+  constructor(alpha: number, maxVal?: number, minVal?: number, initial?: number) {
+    if (!(alpha > 0 && alpha <= 1)) {
+      throw new Error('alpha must be in (0, 1].');
+    }
+
+    this._alpha = alpha;
+    this._filtered = initial;
+    this._maxVal = maxVal;
+    this._minVal = minVal;
   }
 
-  reset(alpha?: number) {
-    if (alpha) {
-      this.#alpha = alpha;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 21-37 lines
+  reset(alpha?: number, initial?: number, minVal?: number, maxVal?: number): void {
+    if (alpha !== undefined) {
+      if (!(alpha > 0 && alpha <= 1)) {
+        throw new Error('alpha must be in (0, 1].');
+      }
+      this._alpha = alpha;
     }
-    this.#filtered = undefined;
+    if (initial !== undefined) {
+      this._filtered = initial;
+    }
+    if (minVal !== undefined) {
+      this._minVal = minVal;
+    }
+    if (maxVal !== undefined) {
+      this._maxVal = maxVal;
+    }
   }
 
-  apply(exp: number, sample: number): number {
-    if (this.#filtered) {
-      const a = this.#alpha ** exp;
-      this.#filtered = a * this.#filtered + (1 - a) * sample;
-    } else {
-      this.#filtered = sample;
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 38-57 lines
+  apply(exp: number, sample?: number): number {
+    if (sample === undefined) {
+      sample = this._filtered;
     }
 
-    if (this.#max && this.#filtered > this.#max) {
-      this.#filtered = this.#max;
+    if (sample !== undefined && this._filtered === undefined) {
+      this._filtered = sample;
+    } else if (sample !== undefined && this._filtered !== undefined) {
+      const a = this._alpha ** exp;
+      this._filtered = a * this._filtered + (1 - a) * sample;
     }
 
-    return this.#filtered;
+    if (this._filtered === undefined) {
+      throw new Error('sample or initial value must be given.');
+    }
+
+    if (this._maxVal !== undefined && this._filtered > this._maxVal) {
+      this._filtered = this._maxVal;
+    }
+
+    if (this._minVal !== undefined && this._filtered < this._minVal) {
+      this._filtered = this._minVal;
+    }
+
+    return this._filtered;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 59-61 lines
+  get value(): number | undefined {
+    return this._filtered;
   }
 
   get filtered(): number | undefined {
-    return this.#filtered;
+    return this.value;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/utils/exp_filter.py - 63-64 lines
+  updateBase(alpha: number): void {
+    this._alpha = alpha;
   }
 
   set alpha(alpha: number) {
-    this.#alpha = alpha;
+    this._alpha = alpha;
   }
 }
 

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -127,6 +127,11 @@ export interface AgentOptions<UserData> {
   useTtsAlignedTranscript?: boolean;
   /** @deprecated use turnHandling.turnDetection instead */
   turnDetection?: TurnDetectionMode;
+  // Ref: python livekit-agents/livekit/agents/voice/agent.py - 52-56 lines
+  /** @deprecated use turnHandling.endpointing.minDelay instead */
+  minEndpointingDelay?: number;
+  /** @deprecated use turnHandling.endpointing.maxDelay instead */
+  maxEndpointingDelay?: number;
   /** @deprecated use turnHandling.interruption.enabled instead */
   allowInterruptions?: boolean;
 }
@@ -165,6 +170,8 @@ export class Agent<UserData = any> {
     llm,
     tts,
     allowInterruptions,
+    minEndpointingDelay,
+    maxEndpointingDelay,
     turnHandling,
     minConsecutiveSpeechDelay,
     useTtsAlignedTranscript,
@@ -191,9 +198,12 @@ export class Agent<UserData = any> {
         })
       : ChatContext.empty();
 
+    // Ref: python livekit-agents/livekit/agents/voice/agent.py - 64-73 lines
     const resolvedTurnHandling = migrateTurnHandling({
       turnDetection,
       allowInterruptions,
+      minEndpointingDelay,
+      maxEndpointingDelay,
       turnHandling,
     });
     this._turnHandling =

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -65,6 +65,7 @@ import {
   type RecognitionHooks,
   type STTPipeline,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import {
   AgentSessionEventTypes,
   createErrorEvent,
@@ -88,6 +89,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -188,6 +190,8 @@ export class AgentActivity implements RecognitionHooks {
   private isInterruptionDetectionEnabled: boolean;
   private isInterruptionByAudioActivityEnabled: boolean;
   private isDefaultInterruptionByAudioActivityEnabled: boolean;
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 207-207 lines
+  private interruptionDetected = false;
 
   private readonly onRealtimeGenerationCreated = (ev: GenerationCreatedEvent): void =>
     this.onGenerationCreated(ev);
@@ -206,6 +210,8 @@ export class AgentActivity implements RecognitionHooks {
     this.onError(ev);
 
   private readonly onInterruptionOverlappingSpeech = (ev: OverlappingSpeechEvent): void => {
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1494-1499 lines
+    this.interruptionDetected = ev.isInterruption;
     this.agentSession.emit(AgentSessionEventTypes.OverlappingSpeech, ev);
   };
 
@@ -469,6 +475,11 @@ export class AgentActivity implements RecognitionHooks {
       this.vad.on('metrics_collected', this.onMetricsCollected);
     }
 
+    const endpointingOpts = {
+      ...this.agentSession.sessionOptions.turnHandling.endpointing,
+      ...this.agent.turnHandling?.endpointing,
+    };
+
     this.audioRecognition = new AudioRecognition({
       recognitionHooks: this,
       // Disable stt node if stt is not provided
@@ -477,12 +488,8 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 779-786 lines
+      endpointing: createEndpointing(endpointingOpts),
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -661,20 +668,6 @@ export class AgentActivity implements RecognitionHooks {
     return this.agent.turnHandling ?? this.agentSession.sessionOptions.turnHandling;
   }
 
-  // get minEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.minDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.minDelay
-  //   );
-  // }
-
-  // get maxEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.maxDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay
-  //   );
-  // }
-
   get toolCtx(): ToolContext {
     return this.agent.toolCtx;
   }
@@ -716,9 +709,11 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   updateOptions({
+    endpointing,
     toolChoice,
     turnDetection,
   }: {
+    endpointing?: EndpointingOptions;
     toolChoice?: ToolChoice | null;
     turnDetection?: TurnDetectionMode;
   }): void {
@@ -743,7 +738,11 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (this.audioRecognition) {
-      this.audioRecognition.updateOptions({ turnDetection: this.turnDetectionMode });
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 487-493 lines
+      this.audioRecognition.updateOptions({
+        endpointing: endpointing !== undefined ? createEndpointing(endpointing) : undefined,
+        turnDetection: this.turnDetectionMode,
+      });
     }
   }
 
@@ -921,13 +920,11 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info('onInputSpeechStarted');
 
     if (!this.vad) {
+      const startedAt = Date.now();
       this.agentSession._updateUserState('speaking');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfOverlapSpeech(
-          0,
-          Date.now(),
-          this.agentSession._userSpeakingSpan,
-        );
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1501-1508 lines
+        this.audioRecognition.onStartOfSpeech(startedAt, 0, this.agentSession._userSpeakingSpan);
       }
     }
 
@@ -947,8 +944,10 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
+      const endedAt = Date.now();
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1519-1525 lines
+        this.audioRecognition.onEndOfSpeech(endedAt, this.agentSession._userSpeakingSpan);
       }
       this.agentSession._updateUserState('listening');
     }
@@ -1031,10 +1030,13 @@ export class AgentActivity implements RecognitionHooks {
       otelContext: otelContext.active(),
     });
     if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
+      this.interruptionDetected = false;
+    }
+    if (this.audioRecognition) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1653-1667 lines
+      this.audioRecognition.onStartOfSpeech(
         speechStartTime,
+        ev.speechDuration,
         this.agentSession._userSpeakingSpan,
       );
     }
@@ -1046,11 +1048,12 @@ export class AgentActivity implements RecognitionHooks {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
+    if (this.audioRecognition) {
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1689-1703 lines
+      this.audioRecognition.onEndOfSpeech(
         speechEndTime,
         this.agentSession._userSpeakingSpan,
+        this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
       );
     }
     this.agentSession._updateUserState('listening', {
@@ -1839,8 +1842,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2220-2220 lines
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -1932,10 +1938,13 @@ export class AgentActivity implements RecognitionHooks {
 
     if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2340-2342 lines
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
-      this.restoreInterruptionByAudioActivity();
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
+      }
     }
   }
 
@@ -2123,8 +2132,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2576-2578 lines
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2286,8 +2298,11 @@ export class AgentActivity implements RecognitionHooks {
 
       if (this.agentSession.agentState === 'speaking') {
         this.agentSession._updateAgentState('listening');
-        if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+        if (this.audioRecognition) {
+          // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2711-2713 lines
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        }
+        if (this.isInterruptionDetectionEnabled) {
           this.restoreInterruptionByAudioActivity();
         }
       }
@@ -2329,11 +2344,12 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._updateAgentState('thinking');
     } else if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
-          this.restoreInterruptionByAudioActivity();
-        }
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 3215-3217 lines
+        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+      }
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
       }
     }
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -65,6 +65,7 @@ import {
   type RecognitionHooks,
   type STTPipeline,
 } from './audio_recognition.js';
+import { createEndpointing } from './endpointing.js';
 import {
   AgentSessionEventTypes,
   createErrorEvent,
@@ -88,6 +89,7 @@ import {
 } from './generation.js';
 import type { TimedString } from './io.js';
 import { SpeechHandle } from './speech_handle.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export const agentActivityStorage = new AsyncLocalStorage<AgentActivity>();
@@ -186,6 +188,8 @@ export class AgentActivity implements RecognitionHooks {
   private _preemptiveGenerationCount = 0;
   private interruptionDetector?: AdaptiveInterruptionDetector;
   private isInterruptionDetectionEnabled: boolean;
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 207-207 lines
+  private interruptionDetected = false;
   private isInterruptionByAudioActivityEnabled: boolean;
   private isDefaultInterruptionByAudioActivityEnabled: boolean;
 
@@ -206,6 +210,8 @@ export class AgentActivity implements RecognitionHooks {
     this.onError(ev);
 
   private readonly onInterruptionOverlappingSpeech = (ev: OverlappingSpeechEvent): void => {
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1494-1499 lines
+    this.interruptionDetected = ev.isInterruption;
     this.agentSession.emit(AgentSessionEventTypes.OverlappingSpeech, ev);
   };
 
@@ -477,12 +483,8 @@ export class AgentActivity implements RecognitionHooks {
       turnDetector: typeof this.turnDetection === 'string' ? undefined : this.turnDetection,
       turnDetectionMode: this.turnDetectionMode,
       interruptionDetection: this.interruptionDetector,
-      minEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.minDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay,
-      maxEndpointingDelay:
-        this.agent.turnHandling?.endpointing?.maxDelay ??
-        this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay,
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 779-786 lines
+      endpointing: createEndpointing(this.endpointingOptions),
       rootSpanContext: this.agentSession.rootSpanContext,
       sttModel: this.stt?.label,
       sttProvider: this.getSttProvider(),
@@ -661,19 +663,18 @@ export class AgentActivity implements RecognitionHooks {
     return this.agent.turnHandling ?? this.agentSession.sessionOptions.turnHandling;
   }
 
-  // get minEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.minDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.minDelay
-  //   );
-  // }
+  // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 330-339 lines
+  get endpointingOptions(): EndpointingOptions {
+    const agentEndpointing = this.agent.turnHandling?.endpointing ?? {};
+    const sessionEndpointing = this.agentSession.sessionOptions.turnHandling.endpointing;
 
-  // get maxEndpointingDelay(): number {
-  //   return (
-  //     this.agent.turnHandling?.endpointing?.maxDelay ??
-  //     this.agentSession.sessionOptions.turnHandling.endpointing.maxDelay
-  //   );
-  // }
+    return {
+      mode: agentEndpointing.mode ?? sessionEndpointing.mode,
+      minDelay: agentEndpointing.minDelay ?? sessionEndpointing.minDelay,
+      maxDelay: agentEndpointing.maxDelay ?? sessionEndpointing.maxDelay,
+      alpha: agentEndpointing.alpha ?? sessionEndpointing.alpha,
+    };
+  }
 
   get toolCtx(): ToolContext {
     return this.agent.toolCtx;
@@ -715,13 +716,14 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
-  updateOptions({
-    toolChoice,
-    turnDetection,
-  }: {
+  updateOptions(options: {
     toolChoice?: ToolChoice | null;
-    turnDetection?: TurnDetectionMode;
+    endpointingOpts?: EndpointingOptions;
+    turnDetection?: TurnDetectionMode | null;
   }): void {
+    const { toolChoice, endpointingOpts, turnDetection } = options;
+    const hasTurnDetection = Object.hasOwn(options, 'turnDetection');
+
     if (toolChoice !== undefined) {
       this.toolChoice = toolChoice;
     }
@@ -730,8 +732,10 @@ export class AgentActivity implements RecognitionHooks {
       this.realtimeSession.updateOptions({ toolChoice: this.toolChoice });
     }
 
-    if (turnDetection !== undefined) {
-      this.turnDetectionMode = turnDetection;
+    if (hasTurnDetection) {
+      const updatedTurnDetection = turnDetection ?? undefined;
+      this.turnDetectionMode =
+        typeof updatedTurnDetection === 'string' ? updatedTurnDetection : undefined;
       this.isDefaultInterruptionByAudioActivityEnabled =
         this.turnDetectionMode !== 'manual' && this.turnDetectionMode !== 'realtime_llm';
 
@@ -743,7 +747,13 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (this.audioRecognition) {
-      this.audioRecognition.updateOptions({ turnDetection: this.turnDetectionMode });
+      // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 487-493 lines
+      this.audioRecognition.updateOptions({
+        ...(endpointingOpts !== undefined
+          ? { endpointing: createEndpointing(endpointingOpts) }
+          : {}),
+        ...(hasTurnDetection ? { turnDetection } : {}),
+      });
     }
   }
 
@@ -922,12 +932,9 @@ export class AgentActivity implements RecognitionHooks {
 
     if (!this.vad) {
       this.agentSession._updateUserState('speaking');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfOverlapSpeech(
-          0,
-          Date.now(),
-          this.agentSession._userSpeakingSpan,
-        );
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1501-1508 lines
+        this.audioRecognition.onStartOfSpeech(Date.now(), 0, this.agentSession._userSpeakingSpan);
       }
     }
 
@@ -947,8 +954,9 @@ export class AgentActivity implements RecognitionHooks {
     this.logger.info(ev, 'onInputSpeechStopped');
 
     if (!this.vad) {
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onEndOfOverlapSpeech(Date.now(), this.agentSession._userSpeakingSpan);
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1519-1525 lines
+        this.audioRecognition.onEndOfSpeech(Date.now(), this.agentSession._userSpeakingSpan);
       }
       this.agentSession._updateUserState('listening');
     }
@@ -1030,14 +1038,15 @@ export class AgentActivity implements RecognitionHooks {
       lastSpeakingTime: speechStartTime,
       otelContext: otelContext.active(),
     });
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechStartTime as the absolute startedAt timestamp.
-      this.audioRecognition.onStartOfOverlapSpeech(
-        ev.speechDuration,
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1653-1667 lines
+    if (this.audioRecognition) {
+      this.audioRecognition.onStartOfSpeech(
         speechStartTime,
+        ev.speechDuration,
         this.agentSession._userSpeakingSpan,
       );
     }
+    this.interruptionDetected = false;
   }
 
   onEndOfSpeech(ev: VADEvent): void {
@@ -1046,11 +1055,12 @@ export class AgentActivity implements RecognitionHooks {
       // Subtract both silenceDuration and inferenceDuration to correct for VAD model latency.
       speechEndTime = speechEndTime - ev.silenceDuration - ev.inferenceDuration;
     }
-    if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-      // Pass speechEndTime as the absolute endedAt timestamp.
-      this.audioRecognition.onEndOfOverlapSpeech(
+    // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1689-1703 lines
+    if (this.audioRecognition) {
+      this.audioRecognition.onEndOfSpeech(
         speechEndTime,
         this.agentSession._userSpeakingSpan,
+        this.isInterruptionDetectionEnabled ? this.interruptionDetected : undefined,
       );
     }
     this.agentSession._updateUserState('listening', {
@@ -1117,6 +1127,15 @@ export class AgentActivity implements RecognitionHooks {
       !this._currentSpeech.interrupted &&
       this._currentSpeech.allowInterruptions
     ) {
+      if (
+        this.audioRecognition &&
+        !this.audioRecognition.endpointing.overlapping &&
+        this.agentSession.agentState === 'speaking'
+      ) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 1622-1630 lines
+        this.audioRecognition.onStartOfSpeech(Date.now());
+      }
+
       this.logger.info(
         { 'speech id': this._currentSpeech.id },
         'speech interrupted by audio activity',
@@ -1839,8 +1858,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2214-2222 lines
+        this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -1932,7 +1954,8 @@ export class AgentActivity implements RecognitionHooks {
 
     if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2111-2114 lines
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
       this.restoreInterruptionByAudioActivity();
@@ -2123,8 +2146,11 @@ export class AgentActivity implements RecognitionHooks {
         startTime: startedSpeakingAt,
         otelContext: speechHandle._agentTurnContext,
       });
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        this.audioRecognition.onStartOfAgentSpeech();
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2570-2579 lines
+        this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
+      }
+      if (this.isInterruptionDetectionEnabled) {
         this.isInterruptionByAudioActivityEnabled = false;
       }
     };
@@ -2286,8 +2312,11 @@ export class AgentActivity implements RecognitionHooks {
 
       if (this.agentSession.agentState === 'speaking') {
         this.agentSession._updateAgentState('listening');
-        if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
+        if (this.audioRecognition) {
+          // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2340-2343 lines
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        }
+        if (this.isInterruptionDetectionEnabled) {
           this.restoreInterruptionByAudioActivity();
         }
       }
@@ -2329,11 +2358,12 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._updateAgentState('thinking');
     } else if (this.agentSession.agentState === 'speaking') {
       this.agentSession._updateAgentState('listening');
-      if (this.isInterruptionDetectionEnabled && this.audioRecognition) {
-        {
-          this.audioRecognition.onEndOfAgentSpeech(Date.now());
-          this.restoreInterruptionByAudioActivity();
-        }
+      if (this.audioRecognition) {
+        // Ref: python livekit-agents/livekit/agents/voice/agent_activity.py - 2711-2714 lines
+        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+      }
+      if (this.isInterruptionDetectionEnabled) {
+        this.restoreInterruptionByAudioActivity();
       }
     }
 

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -81,6 +81,7 @@ import {
 import type { UnknownUserData } from './run_context.js';
 import type { SpeechHandle } from './speech_handle.js';
 import { RunResult } from './testing/run_result.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
 import type { InterruptionOptions } from './turn_config/interruption.js';
 import type {
   InternalTurnHandlingOptions,
@@ -920,6 +921,68 @@ export class AgentSession<
 
   async close(): Promise<void> {
     await this.closeImpl(CloseReason.USER_INITIATED);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/agent_session.py - 1016-1073 lines
+  updateOptions(
+    options: {
+      endpointingOpts?: Partial<EndpointingOptions>;
+      turnDetection?: TurnDetectionMode | null;
+      minEndpointingDelay?: number;
+      maxEndpointingDelay?: number;
+    } = {},
+  ): void {
+    const hasMinEndpointingDelay =
+      Object.hasOwn(options, 'minEndpointingDelay') && options.minEndpointingDelay !== undefined;
+    const hasMaxEndpointingDelay =
+      Object.hasOwn(options, 'maxEndpointingDelay') && options.maxEndpointingDelay !== undefined;
+    const hasTurnDetection = Object.hasOwn(options, 'turnDetection');
+    let endpointingOpts = options.endpointingOpts;
+    let hasEndpointingOpts = Object.hasOwn(options, 'endpointingOpts');
+
+    if (hasMinEndpointingDelay || hasMaxEndpointingDelay) {
+      this.logger.warn(
+        'minEndpointingDelay and maxEndpointingDelay are deprecated, use endpointingOpts instead',
+      );
+      endpointingOpts = {
+        mode: this.sessionOptions.turnHandling.endpointing.mode,
+        minDelay: hasMinEndpointingDelay
+          ? options.minEndpointingDelay
+          : this.sessionOptions.turnHandling.endpointing.minDelay,
+        maxDelay: hasMaxEndpointingDelay
+          ? options.maxEndpointingDelay
+          : this.sessionOptions.turnHandling.endpointing.maxDelay,
+      };
+      hasEndpointingOpts = true;
+    }
+
+    if (hasEndpointingOpts && endpointingOpts !== undefined) {
+      if (endpointingOpts.mode !== undefined) {
+        this.sessionOptions.turnHandling.endpointing.mode = endpointingOpts.mode;
+      }
+      if (endpointingOpts.minDelay !== undefined) {
+        this.sessionOptions.turnHandling.endpointing.minDelay = endpointingOpts.minDelay;
+      }
+      if (endpointingOpts.maxDelay !== undefined) {
+        this.sessionOptions.turnHandling.endpointing.maxDelay = endpointingOpts.maxDelay;
+      }
+      if (endpointingOpts.alpha !== undefined) {
+        this.sessionOptions.turnHandling.endpointing.alpha = endpointingOpts.alpha;
+      }
+    }
+
+    if (hasTurnDetection) {
+      this.turnDetection = options.turnDetection ?? undefined;
+    }
+
+    if (this.activity) {
+      this.activity.updateOptions({
+        ...(hasEndpointingOpts
+          ? { endpointingOpts: this.sessionOptions.turnHandling.endpointing }
+          : {}),
+        ...(hasTurnDetection ? { turnDetection: options.turnDetection } : {}),
+      });
+    }
   }
 
   shutdown(options?: { drain?: boolean; reason?: ShutdownReason }): void {

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,6 +35,7 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import type { BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
@@ -138,10 +139,8 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
-  /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
-  /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  /** Endpointing delay controller. */
+  endpointing: BaseEndpointing;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +169,7 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  private _endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -224,8 +222,7 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    this._endpointing = opts.endpointing;
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,8 +272,38 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
-    this.turnDetectionMode = options.turnDetection;
+  get endpointing(): BaseEndpointing {
+    return this._endpointing;
+  }
+
+  /** @internal */
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 193-220 lines
+  updateOptions(options: {
+    endpointing?: BaseEndpointing;
+    turnDetection?: TurnDetectionMode | null;
+    minEndpointingDelay?: number;
+    maxEndpointingDelay?: number;
+  }): void {
+    if (options.endpointing !== undefined) {
+      this._endpointing = options.endpointing;
+    }
+
+    if (Object.hasOwn(options, 'turnDetection')) {
+      const turnDetection = options.turnDetection ?? undefined;
+      this.turnDetector = typeof turnDetection === 'string' ? undefined : turnDetection;
+
+      const mode = typeof turnDetection === 'string' ? turnDetection : undefined;
+      if (this.turnDetectionMode !== mode) {
+        const previousMode = this.turnDetectionMode;
+        this.turnDetectionMode = mode;
+
+        if (this.turnDetectionMode === 'manual' || previousMode === 'manual') {
+          this.bounceEOUTask?.cancel();
+          this.bounceEOUTask = undefined;
+          this.userTurnCommitted = false;
+        }
+      }
+    }
   }
 
   async start(options?: { sttPipeline?: STTPipeline }) {
@@ -311,12 +338,19 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 239-244 lines
+  async onStartOfAgentSpeech(startedAt: number) {
     this.isAgentSpeaking = true;
+    this._endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 246-271 lines
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this._endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -342,6 +376,29 @@ export class AudioRecognition {
       await this.flushHeldTranscripts();
     }
     this.isAgentSpeaking = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 273-290 lines
+  async onStartOfSpeech(startedAt: number, speechDuration = 0, userSpeakingSpan?: Span) {
+    this._endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+    if (!this.isInterruptionEnabled || !this.isAgentSpeaking) {
+      return;
+    }
+    await this.trySendInterruptionSentinel(
+      InterruptionStreamSentinel.overlapSpeechStarted(speechDuration, startedAt, userSpeakingSpan),
+    );
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 292-306 lines
+  async onEndOfSpeech(endedAt: number, userSpeakingSpan?: Span, interruption?: boolean) {
+    if (this.speaking) {
+      this._endpointing.onEndOfSpeech(
+        endedAt,
+        interruption !== undefined && !interruption && this.isAgentSpeaking,
+      );
+    }
+
+    await this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
   }
 
   /** Start interruption inference when agent is speaking and overlap speech starts. */
@@ -805,7 +862,7 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        let endpointingDelay = this._endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +888,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this._endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -35,6 +35,7 @@ import { traceTypes, tracer } from '../telemetry/index.js';
 import { Task, cancelAndWait, delay, readStream, waitForAbort } from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { TurnDetectionMode } from './agent_session.js';
+import { type BaseEndpointing, createEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
@@ -138,10 +139,12 @@ export interface AudioRecognitionOptions {
   /** Turn detection mode. */
   turnDetectionMode?: TurnDetectionMode;
   interruptionDetection?: AdaptiveInterruptionDetector;
+  /** Endpointing delay tracker. */
+  endpointing?: BaseEndpointing;
   /** Minimum endpointing delay in milliseconds. */
-  minEndpointingDelay: number;
+  minEndpointingDelay?: number;
   /** Maximum endpointing delay in milliseconds. */
-  maxEndpointingDelay: number;
+  maxEndpointingDelay?: number;
   /** Root span context for tracing. */
   rootSpanContext?: Context;
   /** STT model name for tracing */
@@ -170,8 +173,7 @@ export class AudioRecognition {
   private vad?: VAD;
   private turnDetector?: _TurnDetector;
   private turnDetectionMode?: TurnDetectionMode;
-  private minEndpointingDelay: number;
-  private maxEndpointingDelay: number;
+  private endpointing: BaseEndpointing;
   private lastLanguage?: LanguageCode;
   private rootSpanContext?: Context;
   private sttModel?: string;
@@ -224,8 +226,15 @@ export class AudioRecognition {
     this.vad = opts.vad;
     this.turnDetector = opts.turnDetector;
     this.turnDetectionMode = opts.turnDetectionMode;
-    this.minEndpointingDelay = opts.minEndpointingDelay;
-    this.maxEndpointingDelay = opts.maxEndpointingDelay;
+    // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 131-146 lines
+    this.endpointing =
+      opts.endpointing ??
+      createEndpointing({
+        mode: 'fixed',
+        minDelay: opts.minEndpointingDelay ?? 0,
+        maxDelay: opts.maxEndpointingDelay ?? 0,
+        alpha: 0.9,
+      });
     this.lastLanguage = undefined;
     this.rootSpanContext = opts.rootSpanContext;
     this.sttModel = opts.sttModel;
@@ -275,8 +284,18 @@ export class AudioRecognition {
   }
 
   /** @internal */
-  updateOptions(options: { turnDetection: TurnDetectionMode | undefined }): void {
-    this.turnDetectionMode = options.turnDetection;
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 193-220 lines
+  updateOptions(options: {
+    endpointing?: BaseEndpointing;
+    turnDetection?: TurnDetectionMode | undefined;
+  }): void {
+    if (options.endpointing !== undefined) {
+      this.endpointing = options.endpointing;
+    }
+
+    if (Object.hasOwn(options, 'turnDetection')) {
+      this.turnDetectionMode = options.turnDetection;
+    }
   }
 
   async start(options?: { sttPipeline?: STTPipeline }) {
@@ -311,12 +330,19 @@ export class AudioRecognition {
     this.interruptionStreamChannel = undefined;
   }
 
-  async onStartOfAgentSpeech() {
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 239-244 lines
+  async onStartOfAgentSpeech(startedAt: number) {
     this.isAgentSpeaking = true;
+    this.endpointing.onStartOfAgentSpeech(startedAt);
     return this.trySendInterruptionSentinel(InterruptionStreamSentinel.agentSpeechStarted());
   }
 
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 246-271 lines
   async onEndOfAgentSpeech(ignoreUserTranscriptUntil: number) {
+    if (this.isAgentSpeaking) {
+      this.endpointing.onEndOfAgentSpeech(Date.now());
+    }
+
     if (!this.isInterruptionEnabled) {
       this.isAgentSpeaking = false;
       return;
@@ -342,6 +368,27 @@ export class AudioRecognition {
       await this.flushHeldTranscripts();
     }
     this.isAgentSpeaking = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 273-290 lines
+  onStartOfSpeech(startedAt: number, speechDuration = 0, userSpeakingSpan?: Span): void {
+    this.endpointing.onStartOfSpeech(startedAt, this.isAgentSpeaking);
+    if (!this.isInterruptionEnabled || !this.isAgentSpeaking) {
+      return;
+    }
+    void this.onStartOfOverlapSpeech(speechDuration, startedAt, userSpeakingSpan);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 292-306 lines
+  onEndOfSpeech(endedAt: number, userSpeakingSpan?: Span, interruption?: boolean): void {
+    if (this.speaking) {
+      this.endpointing.onEndOfSpeech(
+        endedAt,
+        interruption !== undefined && !interruption && this.isAgentSpeaking,
+      );
+    }
+
+    void this.onEndOfOverlapSpeech(endedAt, userSpeakingSpan);
   }
 
   /** Start interruption inference when agent is speaking and overlap speech starts. */
@@ -805,7 +852,8 @@ export class AudioRecognition {
         speechStartTime: number | undefined,
       ) =>
       async (controller: AbortController) => {
-        let endpointingDelay = this.minEndpointingDelay;
+        // Ref: python livekit-agents/livekit/agents/voice/audio_recognition.py - 943-973 lines
+        let endpointingDelay = this.endpointing.minDelay;
 
         const userTurnSpan = this.ensureUserTurnSpan();
         const userTurnCtx = this.userTurnContext(userTurnSpan);
@@ -831,7 +879,7 @@ export class AudioRecognition {
                   );
 
                   if (unlikelyThreshold && endOfTurnProbability < unlikelyThreshold) {
-                    endpointingDelay = this.maxEndpointingDelay;
+                    endpointingDelay = this.endpointing.maxDelay;
                   }
                 } catch (error) {
                   this.logger.error(error, 'Error predicting end of turn');

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -7,6 +7,7 @@ import { ChatContext } from '../llm/chat_context.js';
 import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
 import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
+import { BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function createHooks() {
@@ -45,8 +46,7 @@ function createRecognition(sttNode: STTNode, hooks = createHooks()) {
     recognition: new AudioRecognition({
       recognitionHooks: hooks,
       stt: sttNode,
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing(0, 0),
     }),
   };
 }

--- a/agents/src/voice/audio_recognition_span.test.ts
+++ b/agents/src/voice/audio_recognition_span.test.ts
@@ -22,6 +22,7 @@ import {
   type RecognitionHooks,
   type _TurnDetector,
 } from './audio_recognition.js';
+import { BaseEndpointing } from './endpointing.js';
 import type { STTNode } from './io.js';
 
 function setupInMemoryTracing() {
@@ -145,8 +146,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: undefined,
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'stt',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing(0, 0),
       sttModel: 'deepgram-nova2',
       sttProvider: 'deepgram',
       getLinkedParticipant: () => ({ sid: 'p1', identity: 'bob', kind: ParticipantKind.AGENT }),
@@ -254,8 +254,7 @@ describe('AudioRecognition user_turn span parity', () => {
       vad: new FakeVAD(vadEvents),
       turnDetector: alwaysTrueTurnDetector,
       turnDetectionMode: 'vad',
-      minEndpointingDelay: 0,
-      maxEndpointingDelay: 0,
+      endpointing: new BaseEndpointing(0, 0),
       sttModel: 'stt-model',
       sttProvider: 'stt-provider',
       getLinkedParticipant: () => ({ sid: 'p2', identity: 'alice', kind: ParticipantKind.AGENT }),

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,532 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { initializeLogger } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import { AgentActivity } from './agent_activity.js';
+import { AudioRecognition, type RecognitionHooks } from './audio_recognition.js';
+import { BaseEndpointing, DynamicEndpointing, createEndpointing } from './endpointing.js';
+
+beforeAll(() => {
+  initializeLogger({ pretty: false, level: 'silent' });
+});
+
+function hooks(): RecognitionHooks {
+  return {
+    onInterruption: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onEndOfTurn: vi.fn(async () => true),
+    onPreemptiveGeneration: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+  };
+}
+
+// Ref: python tests/test_endpointing.py - 7-63 lines
+describe('TestExponentialMovingAverage', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    const ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    const emaWithInitial = new ExpFilter(0.5, undefined, undefined, 10.0);
+    expect(emaWithInitial.value).toBe(10.0);
+
+    const emaAlphaOne = new ExpFilter(1.0);
+    expect(emaAlphaOne.value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0.0)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(-0.5)).toThrow(/alpha must be in/);
+    expect(() => new ExpFilter(1.5)).toThrow(/alpha must be in/);
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1.0, 10.0);
+    expect(result).toBe(10.0);
+    expect(ema.value).toBe(10.0);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    const result = ema.apply(1.0, 20.0);
+    expect(result).toBe(15.0);
+    expect(ema.value).toBe(15.0);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    ema.apply(1.0, 20.0);
+    ema.apply(1.0, 20.0);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    let ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    expect(ema.value).toBe(10.0);
+    ema.reset();
+    expect(ema.value).toBe(10.0);
+
+    ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    ema.reset(undefined, 5.0);
+    expect(ema.value).toBe(5.0);
+  });
+});
+
+// Ref: python tests/test_endpointing.py - 64-564 lines
+describe('TestDynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.2);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect((ep as any)._utterancePause._alpha).toBeCloseTo(0.9, 5);
+    expect((ep as any)._turnPause._alpha).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.betweenUtteranceDelay).toBe(0.0);
+    expect(ep.betweenTurnDelay).toBe(0.0);
+    expect(ep.immediateInterruptionDelay).toEqual([0.0, 0.0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    let ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    expect((ep as any)._utteranceEndedAt).toBe(100000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(99900);
+    expect((ep as any)._utteranceEndedAt).toBe(99900);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfSpeech(100000);
+    expect((ep as any)._utteranceStartedAt).toBe(100000);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100000);
+    expect((ep as any)._agentSpeechStartedAt).toBe(100000);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100500);
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(500, 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100800);
+    expect(ep.betweenTurnDelay).toBeCloseTo(800, 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400);
+    ep.onEndOfSpeech(100500, false);
+    expect(ep.minDelay).toBeCloseTo(0.5 * 400 + 0.5 * initialMin, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100600);
+    ep.onStartOfSpeech(101500);
+    ep.onEndOfSpeech(102000, false);
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 600 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    expect((ep as any)._agentSpeechStartedAt).not.toBeUndefined();
+    ep.onStartOfSpeech(100250, true);
+    expect((ep as any)._overlapping).toBe(true);
+    ep.onEndOfSpeech(100500);
+    expect((ep as any)._overlapping).toBe(false);
+    expect((ep as any)._agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(300, 5);
+  });
+
+  it('test_update_options', () => {
+    let ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ minDelay: 500 });
+    expect(ep.minDelay).toBe(500);
+    expect((ep as any)._minDelay).toBe(500);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ maxDelay: 2000 });
+    expect(ep.maxDelay).toBe(2000);
+    expect((ep as any)._maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions();
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(102000);
+    ep.onStartOfSpeech(105000);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100100);
+    ep.onStartOfSpeech(100500);
+    expect(ep.maxDelay).toBeGreaterThanOrEqual((ep as any)._minDelay);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    expect((ep as any)._agentSpeechStartedAt).not.toBeUndefined();
+    ep.onStartOfSpeech(102000);
+    ep.onEndOfSpeech(103000, false);
+    expect((ep as any)._agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+    expect((ep as any)._overlapping).toBe(true);
+    const prevVal = [ep.minDelay, ep.maxDelay];
+    ep.onStartOfSpeech(100350);
+    expect((ep as any)._overlapping).toBe(true);
+    expect(prevVal).toEqual([ep.minDelay, ep.maxDelay]);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800);
+    ep.onEndOfSpeech(102000, false);
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing(60, 1000, 1.0);
+    ep.onEndOfSpeech(99000);
+    ep.onStartOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+    expect((ep as any)._utteranceEndedAt).toBeCloseTo(100199, 5);
+    expect(ep.minDelay).toBeCloseTo(60, 5);
+    expect(ep.maxDelay).toBeCloseTo(1000, 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+    expect((ep as any)._utterancePause._alpha).toBeCloseTo(0.5, 5);
+    expect((ep as any)._turnPause._alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_alpha_in_place', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100200);
+    ep.onEndOfSpeech(101000);
+    const learnedMin = ep.minDelay;
+    ep.updateOptions({ alpha: 0.2 });
+    expect((ep as any)._utterancePause._alpha).toBeCloseTo(0.2, 5);
+    expect((ep as any)._turnPause._alpha).toBeCloseTo(0.2, 5);
+    expect(ep.minDelay).toBeCloseTo(learnedMin, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect((ep as any)._utterancePause._minVal).toBe(500);
+    expect((ep as any)._turnPause._maxVal).toBe(2000);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100200);
+    expect(ep.minDelay).toBeCloseTo(500, 5);
+
+    ep.onEndOfSpeech(101000);
+    ep.onStartOfAgentSpeech(102800);
+    ep.onStartOfSpeech(103500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101500, true);
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+    ep.onEndOfSpeech(101800, true);
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect((ep as any)._utteranceStartedAt).toBeUndefined();
+    expect((ep as any)._utteranceEndedAt).toBeUndefined();
+    expect((ep as any)._overlapping).toBe(false);
+    expect((ep as any)._speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400, false);
+    ep.onEndOfSpeech(100600, true);
+    expect(ep.minDelay).toBeCloseTo(0.5 * 400 + 0.5 * initialMin, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(100600, true);
+    ep.onEndOfSpeech(100800, true);
+    expect((ep as any)._utteranceEndedAt).toBe(100800);
+    expect((ep as any)._speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101000, true);
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+    ep.onEndOfSpeech(101500, true);
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect((ep as any)._utteranceStartedAt).toBeUndefined();
+    expect((ep as any)._utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100000);
+    ep.onStartOfSpeech(100100, true);
+    expect((ep as any)._overlapping).toBe(true);
+    expect((ep as any)._agentSpeechStartedAt).toBe(100000);
+    ep.onEndOfAgentSpeech(101000);
+    expect((ep as any)._agentSpeechEndedAt).toBe(101000);
+    expect((ep as any)._agentSpeechStartedAt).toBe(100000);
+    expect((ep as any)._overlapping).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800, false);
+    ep.onEndOfSpeech(102000);
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect((ep as any)._speaking).toBe(false);
+    ep.onStartOfSpeech(100000);
+    expect((ep as any)._speaking).toBe(true);
+    ep.onEndOfSpeech(100500);
+    expect((ep as any)._speaking).toBe(false);
+  });
+
+  it.each([
+    ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+    ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+    ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+    ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+    ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+    ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+    ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+    ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+    ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+  ])(
+    'test_all_overlapping_and_should_ignore_combos[%s]',
+    (
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ) => {
+      const ep = new DynamicEndpointing(300, 1000, 0.5);
+      ep.onStartOfSpeech(99000);
+      ep.onEndOfSpeech(100000);
+
+      let userStart: number;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100500);
+        ep.onEndOfAgentSpeech(101000);
+        userStart = 101500;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100350;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100200);
+          userStart = 101500;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100400;
+        } else {
+          ep.onStartOfAgentSpeech(100900);
+          userStart = 101800;
+        }
+      } else {
+        userStart = 100400;
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping as boolean);
+      const prevMin = ep.minDelay;
+      const prevMax = ep.maxDelay;
+      ep.onEndOfSpeech(userStart + 500, shouldIgnore as boolean);
+
+      expect(ep.minDelay !== prevMin, `[${label}] min_delay change`).toBe(expectMinChange);
+      expect(ep.maxDelay !== prevMax, `[${label}] max_delay change`).toBe(expectMaxChange);
+      expect((ep as any)._speaking, `[${label}] _speaking should be false`).toBe(false);
+      expect((ep as any)._overlapping, `[${label}] _overlapping should be false`).toBe(false);
+    },
+  );
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onStartOfSpeech(100000);
+    ep.onEndOfSpeech(101000);
+    ep.onStartOfAgentSpeech(101500);
+    ep.onStartOfSpeech(102500, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102800, true);
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+    ep.onEndOfAgentSpeech(103000);
+    ep.onStartOfSpeech(103500);
+    ep.onEndOfSpeech(104000);
+    expect((ep as any)._speaking).toBe(false);
+    expect((ep as any)._agentSpeechStartedAt).toBeUndefined();
+  });
+});
+
+// Ref: python tests/test_endpointing.py - 565-581 lines
+describe('TestCreateEndpointing', () => {
+  it('test_dynamic_mode_wires_alpha', () => {
+    const ep = createEndpointing({ mode: 'dynamic', minDelay: 300, maxDelay: 1000, alpha: 0.7 });
+    expect(ep).toBeInstanceOf(DynamicEndpointing);
+    expect((ep as any)._utterancePause._alpha).toBeCloseTo(0.7, 5);
+    expect((ep as any)._turnPause._alpha).toBeCloseTo(0.7, 5);
+  });
+
+  it('test_fixed_mode_returns_base_endpointing', () => {
+    const ep = createEndpointing({ mode: 'fixed', minDelay: 500, maxDelay: 3000, alpha: 0.9 });
+    expect(ep).toBeInstanceOf(BaseEndpointing);
+    expect(ep).not.toBeInstanceOf(DynamicEndpointing);
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(3000);
+  });
+});
+
+describe('Target dynamic endpointing integration', () => {
+  it('routes no-VAD realtime speech lifecycle into AudioRecognition endpointing hooks', () => {
+    const activity = Object.create(AgentActivity.prototype) as AgentActivity & {
+      audioRecognition: {
+        onStartOfSpeech: ReturnType<typeof vi.fn>;
+        onEndOfSpeech: ReturnType<typeof vi.fn>;
+      };
+      agent: { vad?: unknown };
+      interrupt: ReturnType<typeof vi.fn>;
+      logger: { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+      agentSession: {
+        vad?: unknown;
+        _userSpeakingSpan?: unknown;
+        _updateUserState: ReturnType<typeof vi.fn>;
+        emit: ReturnType<typeof vi.fn>;
+      };
+    };
+    activity.agent = { vad: undefined };
+    activity.audioRecognition = { onStartOfSpeech: vi.fn(), onEndOfSpeech: vi.fn() };
+    activity.interrupt = vi.fn();
+    activity.logger = { info: vi.fn(), error: vi.fn() };
+    activity.agentSession = {
+      vad: undefined,
+      _updateUserState: vi.fn(),
+      emit: vi.fn(),
+    };
+
+    activity.onInputSpeechStarted({} as any);
+    activity.onInputSpeechStopped({ userTranscriptionEnabled: false } as any);
+
+    expect(activity.audioRecognition.onStartOfSpeech).toHaveBeenCalledWith(
+      expect.any(Number),
+      0,
+      undefined,
+    );
+    expect(activity.audioRecognition.onEndOfSpeech).toHaveBeenCalledWith(
+      expect.any(Number),
+      undefined,
+    );
+  });
+
+  it('updates agent speech endpointing even when adaptive interruption is disabled', async () => {
+    const endpointing = new DynamicEndpointing(300, 1000);
+    const recognition = new AudioRecognition({ recognitionHooks: hooks(), endpointing });
+
+    await recognition.onStartOfAgentSpeech(100500);
+    await recognition.onEndOfAgentSpeech(101000);
+
+    expect((endpointing as any)._agentSpeechStartedAt).toBe(100500);
+    expect((endpointing as any)._agentSpeechEndedAt).not.toBeUndefined();
+    await recognition.close();
+  });
+
+  it('replaces endpointing through updateOptions and intentionally resets runtime state', async () => {
+    const first = new DynamicEndpointing(300, 1000);
+    const second = new DynamicEndpointing(500, 2000);
+    const recognition = new AudioRecognition({ recognitionHooks: hooks(), endpointing: first });
+
+    recognition.updateOptions({ endpointing: second });
+
+    expect((recognition as any).endpointing).toBe(second);
+    expect((recognition as any).endpointing).not.toBe(first);
+    await recognition.close();
+  });
+});

--- a/agents/src/voice/endpointing.test.ts
+++ b/agents/src/voice/endpointing.test.ts
@@ -1,0 +1,655 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { initializeLogger } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import { Agent } from './agent.js';
+import { AgentActivity } from './agent_activity.js';
+import { AgentSession } from './agent_session.js';
+import { AudioRecognition, type RecognitionHooks } from './audio_recognition.js';
+import { BaseEndpointing, DynamicEndpointing, createEndpointing } from './endpointing.js';
+import { defaultEndpointingOptions } from './turn_config/endpointing.js';
+import { defaultInterruptionOptions } from './turn_config/interruption.js';
+
+beforeAll(() => {
+  initializeLogger({ pretty: false, level: 'silent' });
+});
+
+function createRecognitionHooks(): RecognitionHooks {
+  return {
+    onInterruption: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onEndOfTurn: vi.fn(async () => true),
+    onPreemptiveGeneration: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+  };
+}
+
+describe('TestExponentialMovingAverage', () => {
+  it('test_initialization_with_valid_alpha', () => {
+    const ema = new ExpFilter(0.5);
+    expect(ema.value).toBeUndefined();
+
+    const emaWithInitial = new ExpFilter(0.5, undefined, undefined, 10.0);
+    expect(emaWithInitial.value).toBe(10.0);
+
+    const emaAlphaOne = new ExpFilter(1.0);
+    expect(emaAlphaOne.value).toBeUndefined();
+  });
+
+  it('test_initialization_with_invalid_alpha', () => {
+    expect(() => new ExpFilter(0.0)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(-0.5)).toThrow('alpha must be in');
+    expect(() => new ExpFilter(1.5)).toThrow('alpha must be in');
+  });
+
+  it('test_update_with_no_initial_value', () => {
+    const ema = new ExpFilter(0.5);
+    const result = ema.apply(1.0, 10.0);
+    expect(result).toBe(10.0);
+    expect(ema.value).toBe(10.0);
+  });
+
+  it('test_update_with_initial_value', () => {
+    const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    const result = ema.apply(1.0, 20.0);
+    expect(result).toBe(15.0);
+    expect(ema.value).toBe(15.0);
+  });
+
+  it('test_update_multiple_times', () => {
+    const ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    ema.apply(1.0, 20.0);
+    ema.apply(1.0, 20.0);
+    expect(ema.value).toBe(17.5);
+  });
+
+  it('test_reset', () => {
+    let ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    expect(ema.value).toBe(10.0);
+    ema.reset();
+    expect(ema.value).toBe(10.0);
+
+    ema = new ExpFilter(0.5, undefined, undefined, 10.0);
+    ema.reset(undefined, 5.0);
+    expect(ema.value).toBe(5.0);
+  });
+});
+
+describe('TestDynamicEndpointing', () => {
+  it('test_initialization', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_with_custom_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.2);
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_initialization_uses_updated_default_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep._utterancePause._alpha).toBeCloseTo(0.9, 5);
+    expect(ep._turnPause._alpha).toBeCloseTo(0.9, 5);
+  });
+
+  it('test_empty_delays', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep.betweenUtteranceDelay).toBe(0.0);
+    expect(ep.betweenTurnDelay).toBe(0.0);
+    expect(ep.immediateInterruptionDelay).toEqual([0.0, 0.0]);
+  });
+
+  it('test_on_utterance_ended', () => {
+    let ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    expect(ep._utteranceEndedAt).toBe(100000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(99900);
+    expect(ep._utteranceEndedAt).toBe(99900);
+  });
+
+  it('test_on_utterance_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfSpeech(100000);
+    expect(ep._utteranceStartedAt).toBe(100000);
+  });
+
+  it('test_on_agent_speech_started', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100000);
+    expect(ep._agentSpeechStartedAt).toBe(100000);
+  });
+
+  it('test_between_utterance_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100500);
+    expect(ep.betweenUtteranceDelay).toBeCloseTo(500, 5);
+  });
+
+  it('test_between_turn_delay_calculation', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100800);
+    expect(ep.betweenTurnDelay).toBeCloseTo(800, 5);
+  });
+
+  it('test_pause_between_utterances_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400);
+    ep.onEndOfSpeech(100500, false);
+    expect(ep.minDelay).toBeCloseTo(0.5 * 400 + 0.5 * initialMin, 5);
+  });
+
+  it('test_new_turn_updates_max_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100600);
+    ep.onStartOfSpeech(101500);
+    ep.onEndOfSpeech(102000, false);
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 600 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_updates_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    expect(ep._agentSpeechStartedAt).toBeDefined();
+    ep.onStartOfSpeech(100250, true);
+    expect(ep._overlapping).toBe(true);
+
+    ep.onEndOfSpeech(100500);
+
+    expect(ep._overlapping).toBe(false);
+    expect(ep._agentSpeechStartedAt).toBeUndefined();
+    expect(ep.minDelay).toBeCloseTo(300, 5);
+  });
+
+  it('test_update_options', () => {
+    let ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ minDelay: 500 });
+    expect(ep.minDelay).toBe(500);
+    expect(ep._minDelay).toBe(500);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ maxDelay: 2000 });
+    expect(ep.maxDelay).toBe(2000);
+    expect(ep._maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(2000);
+
+    ep = new DynamicEndpointing(300, 1000);
+    ep.updateOptions();
+    expect(ep.minDelay).toBe(300);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_configured_max', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(102000);
+    ep.onStartOfSpeech(105000);
+    expect(ep.maxDelay).toBe(1000);
+  });
+
+  it('test_max_delay_clamped_to_min_delay', () => {
+    const ep = new DynamicEndpointing(300, 1000, 1.0);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100100);
+    ep.onStartOfSpeech(100500);
+    expect(ep.maxDelay).toBeGreaterThanOrEqual(ep._minDelay);
+  });
+
+  it('test_non_interruption_clears_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    expect(ep._agentSpeechStartedAt).toBeDefined();
+
+    ep.onStartOfSpeech(102000);
+    ep.onEndOfSpeech(103000, false);
+    expect(ep._agentSpeechStartedAt).toBeUndefined();
+  });
+
+  it('test_consecutive_interruptions_only_track_first', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect(ep._overlapping).toBe(true);
+    const prevVal = [ep.minDelay, ep.maxDelay];
+
+    ep.onStartOfSpeech(100350);
+
+    expect(ep._overlapping).toBe(true);
+    expect(prevVal).toEqual([ep.minDelay, ep.maxDelay]);
+  });
+
+  it('test_delayed_interruption_updates_max_delay_without_crashing', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800);
+    ep.onEndOfSpeech(102000, false);
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_interruption_adjusts_stale_utterance_end_time', () => {
+    const ep = new DynamicEndpointing(60, 1000, 1.0);
+    ep.onEndOfSpeech(99000);
+    ep.onStartOfSpeech(100000);
+
+    ep.onStartOfAgentSpeech(100200);
+    ep.onStartOfSpeech(100250, true);
+
+    expect(ep._utteranceEndedAt).toBeCloseTo(100199, 5);
+    expect(ep.minDelay).toBeCloseTo(60, 5);
+    expect(ep.maxDelay).toBeCloseTo(1000, 5);
+  });
+
+  it('test_update_options_preserves_filter_alpha', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.updateOptions({ minDelay: 600, maxDelay: 2000 });
+    expect(ep._utterancePause._alpha).toBeCloseTo(0.5, 5);
+    expect(ep._turnPause._alpha).toBeCloseTo(0.5, 5);
+  });
+
+  it('test_update_options_updates_alpha_in_place', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100200);
+    ep.onEndOfSpeech(101000);
+    const learnedMin = ep.minDelay;
+
+    ep.updateOptions({ alpha: 0.2 });
+
+    expect(ep._utterancePause._alpha).toBeCloseTo(0.2, 5);
+    expect(ep._turnPause._alpha).toBeCloseTo(0.2, 5);
+    expect(ep.minDelay).toBeCloseTo(learnedMin, 5);
+  });
+
+  it('test_update_options_updates_filter_clamp_bounds', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.updateOptions({ minDelay: 500, maxDelay: 2000 });
+    expect(ep._utterancePause._minVal).toBe(500);
+    expect(ep._turnPause._maxVal).toBe(2000);
+
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100200);
+    expect(ep.minDelay).toBeCloseTo(500, 5);
+
+    ep.onEndOfSpeech(101000);
+    ep.onStartOfAgentSpeech(102800);
+    ep.onStartOfSpeech(103500);
+    expect(ep.maxDelay).toBeGreaterThan(1000);
+    expect(ep.maxDelay).toBeLessThanOrEqual(2000);
+  });
+
+  it('test_should_ignore_skips_filter_update', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101500, true);
+
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+
+    ep.onEndOfSpeech(101800, true);
+
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect(ep._utteranceStartedAt).toBeUndefined();
+    expect(ep._utteranceEndedAt).toBeUndefined();
+    expect(ep._overlapping).toBe(false);
+    expect(ep._speaking).toBe(false);
+  });
+
+  it('test_should_ignore_without_overlapping_still_updates', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    const initialMin = ep.minDelay;
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfSpeech(100400, false);
+    ep.onEndOfSpeech(100600, true);
+
+    expect(ep.minDelay).toBeCloseTo(0.5 * 400 + 0.5 * initialMin, 5);
+  });
+
+  it('test_should_ignore_grace_period_overrides', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(100600, true);
+
+    ep.onEndOfSpeech(100800, true);
+
+    expect(ep._utteranceEndedAt).toBe(100800);
+    expect(ep._speaking).toBe(false);
+  });
+
+  it('test_should_ignore_outside_grace_period', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100500);
+    ep.onStartOfSpeech(101000, true);
+
+    const prevMin = ep.minDelay;
+    const prevMax = ep.maxDelay;
+    ep.onEndOfSpeech(101500, true);
+
+    expect(ep.minDelay).toBe(prevMin);
+    expect(ep.maxDelay).toBe(prevMax);
+    expect(ep._utteranceStartedAt).toBeUndefined();
+    expect(ep._utteranceEndedAt).toBeUndefined();
+  });
+
+  it('test_on_end_of_agent_speech_clears_state', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    ep.onStartOfAgentSpeech(100000);
+    ep.onStartOfSpeech(100100, true);
+    expect(ep._overlapping).toBe(true);
+    expect(ep._agentSpeechStartedAt).toBe(100000);
+
+    ep.onEndOfAgentSpeech(101000);
+
+    expect(ep._agentSpeechEndedAt).toBe(101000);
+    expect(ep._agentSpeechStartedAt).toBe(100000);
+    expect(ep._overlapping).toBe(false);
+  });
+
+  it('test_overlapping_inferred_from_agent_speech', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+    ep.onEndOfSpeech(100000);
+    ep.onStartOfAgentSpeech(100900);
+    ep.onStartOfSpeech(101800, false);
+    ep.onEndOfSpeech(102000);
+
+    expect(ep.maxDelay).toBeCloseTo(0.5 * 900 + 0.5 * 1000, 5);
+  });
+
+  it('test_speaking_flag_set_and_cleared', () => {
+    const ep = new DynamicEndpointing(300, 1000);
+    expect(ep._speaking).toBe(false);
+    ep.onStartOfSpeech(100000);
+    expect(ep._speaking).toBe(true);
+    ep.onEndOfSpeech(100500);
+    expect(ep._speaking).toBe(false);
+  });
+
+  it.each([
+    ['no_agent/no_overlap/no_ignore', 'none', false, false, false, true, false],
+    ['no_agent/no_overlap/ignore', 'none', false, true, false, true, false],
+    ['agent_ended/no_overlap/no_ignore', 'ended', false, false, false, false, true],
+    ['agent_ended/no_overlap/ignore', 'ended', false, true, false, false, true],
+    ['agent_active/no_overlap/no_ignore', 'active', false, false, false, false, true],
+    ['agent_active/no_overlap/ignore', 'active', false, true, false, false, true],
+    ['agent_active/overlap/no_ignore', 'active', true, false, false, true, false],
+    ['agent_active/overlap/ignore/outside_grace', 'active', true, true, false, false, false],
+    ['agent_active/overlap/ignore/inside_grace', 'active', true, true, true, true, false],
+  ])(
+    'test_all_overlapping_and_should_ignore_combos: %s',
+    (
+      label,
+      agentSpeech,
+      overlapping,
+      shouldIgnore,
+      withinGrace,
+      expectMinChange,
+      expectMaxChange,
+    ) => {
+      const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+      ep.onStartOfSpeech(99000);
+      ep.onEndOfSpeech(100000);
+
+      let userStart: number;
+      if (agentSpeech === 'ended') {
+        ep.onStartOfAgentSpeech(100500);
+        ep.onEndOfAgentSpeech(101000);
+        userStart = 101500;
+      } else if (agentSpeech === 'active') {
+        if (withinGrace) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100350;
+        } else if (overlapping && shouldIgnore) {
+          ep.onStartOfAgentSpeech(100200);
+          userStart = 101500;
+        } else if (overlapping) {
+          ep.onStartOfAgentSpeech(100150);
+          userStart = 100400;
+        } else {
+          ep.onStartOfAgentSpeech(100900);
+          userStart = 101800;
+        }
+      } else {
+        userStart = 100400;
+      }
+
+      ep.onStartOfSpeech(userStart, overlapping as boolean);
+
+      const prevMin = ep.minDelay;
+      const prevMax = ep.maxDelay;
+
+      ep.onEndOfSpeech(userStart + 500, shouldIgnore as boolean);
+
+      const minChanged = ep.minDelay !== prevMin;
+      const maxChanged = ep.maxDelay !== prevMax;
+
+      expect(minChanged, `[${label}] min_delay change`).toBe(expectMinChange);
+      expect(maxChanged, `[${label}] max_delay change`).toBe(expectMaxChange);
+      expect(ep._speaking, `[${label}] _speaking should be false`).toBe(false);
+      expect(ep._overlapping, `[${label}] _overlapping should be false`).toBe(false);
+    },
+  );
+
+  it('test_full_conversation_sequence', () => {
+    const ep = new DynamicEndpointing(300, 1000, 0.5);
+
+    ep.onStartOfSpeech(100000);
+    ep.onEndOfSpeech(101000);
+
+    ep.onStartOfAgentSpeech(101500);
+
+    ep.onStartOfSpeech(102500, true);
+    const minBeforeBackchannel = ep.minDelay;
+    const maxBeforeBackchannel = ep.maxDelay;
+    ep.onEndOfSpeech(102800, true);
+
+    expect(ep.minDelay).toBe(minBeforeBackchannel);
+    expect(ep.maxDelay).toBe(maxBeforeBackchannel);
+
+    ep.onEndOfAgentSpeech(103000);
+
+    ep.onStartOfSpeech(103500);
+    ep.onEndOfSpeech(104000);
+
+    expect(ep._speaking).toBe(false);
+    expect(ep._agentSpeechStartedAt).toBeUndefined();
+  });
+});
+
+describe('TestCreateEndpointing', () => {
+  it('test_dynamic_mode_wires_alpha', () => {
+    const ep = createEndpointing({ mode: 'dynamic', minDelay: 300, maxDelay: 1000, alpha: 0.7 });
+
+    expect(ep).toBeInstanceOf(DynamicEndpointing);
+    expect((ep as DynamicEndpointing)._utterancePause._alpha).toBeCloseTo(0.7, 5);
+    expect((ep as DynamicEndpointing)._turnPause._alpha).toBeCloseTo(0.7, 5);
+  });
+
+  it('test_fixed_mode_returns_base_endpointing', () => {
+    const ep = createEndpointing({ mode: 'fixed', minDelay: 500, maxDelay: 3000, alpha: 0.9 });
+
+    expect(ep).not.toBeInstanceOf(DynamicEndpointing);
+    expect(ep).toBeInstanceOf(BaseEndpointing);
+    expect(ep.minDelay).toBe(500);
+    expect(ep.maxDelay).toBe(3000);
+  });
+});
+
+describe('Target dynamic endpointing runtime integration', () => {
+  it('updates session endpointing options and replaces the active runtime endpointing', () => {
+    const session = new AgentSession({});
+    const updateOptions = vi.fn();
+    (session as unknown as { activity?: { updateOptions: typeof updateOptions } }).activity = {
+      updateOptions,
+    };
+
+    session.updateOptions({ endpointingOpts: { mode: 'dynamic', minDelay: 250, alpha: 0.2 } });
+
+    expect(session.sessionOptions.turnHandling.endpointing).toEqual({
+      mode: 'dynamic',
+      minDelay: 250,
+      maxDelay: 3000,
+      alpha: 0.2,
+    });
+    expect(updateOptions).toHaveBeenCalledWith({
+      endpointingOpts: session.sessionOptions.turnHandling.endpointing,
+    });
+  });
+
+  it('replaces AudioRecognition endpointing state on updateOptions', () => {
+    const oldEndpointing = new DynamicEndpointing(300, 1000, 0.5);
+    oldEndpointing.onEndOfSpeech(100000);
+    oldEndpointing.onStartOfSpeech(100450);
+    oldEndpointing.onEndOfSpeech(100700);
+    expect(oldEndpointing.minDelay).toBeGreaterThan(300);
+
+    const recognition = new AudioRecognition({
+      recognitionHooks: createRecognitionHooks(),
+      endpointing: oldEndpointing,
+    });
+    const newEndpointing = createEndpointing({
+      mode: 'dynamic',
+      minDelay: 500,
+      maxDelay: 2000,
+      alpha: 0.2,
+    });
+
+    recognition.updateOptions({ endpointing: newEndpointing });
+
+    expect(recognition.endpointing).toBe(newEndpointing);
+    expect(recognition.endpointing.minDelay).toBe(500);
+  });
+
+  it('preserves agent endpointing override precedence for dynamic mode and alpha', () => {
+    const agent = new Agent({
+      instructions: 'test',
+      turnHandling: {
+        endpointing: { mode: 'dynamic', alpha: 0.4 },
+        interruption: {},
+        preemptiveGeneration: {},
+        turnDetection: undefined,
+      },
+    });
+    const session = {
+      sessionOptions: {
+        turnHandling: {
+          endpointing: defaultEndpointingOptions,
+          interruption: defaultInterruptionOptions,
+        },
+      },
+      turnDetection: undefined,
+      useTtsAlignedTranscript: true,
+      vad: undefined,
+      stt: undefined,
+      llm: undefined,
+      tts: undefined,
+      interruptionDetection: undefined,
+    } as unknown as AgentSession;
+
+    const activity = new AgentActivity(agent, session);
+
+    expect(activity.endpointingOptions).toEqual({
+      mode: 'dynamic',
+      minDelay: 500,
+      maxDelay: 3000,
+      alpha: 0.4,
+    });
+  });
+
+  it('routes realtime no-VAD speech through AudioRecognition endpointing hooks', () => {
+    const activity = Object.create(AgentActivity.prototype) as {
+      agent: Pick<Agent, 'vad' | 'stt' | 'llm' | 'tts'>;
+      agentSession: {
+        _updateUserState: ReturnType<typeof vi.fn>;
+        _userSpeakingSpan: string;
+        emit: ReturnType<typeof vi.fn>;
+      };
+      audioRecognition: {
+        onStartOfSpeech: ReturnType<typeof vi.fn>;
+        onEndOfSpeech: ReturnType<typeof vi.fn>;
+      };
+      interrupt: ReturnType<typeof vi.fn>;
+      logger: { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+    };
+    activity.agent = { vad: undefined, stt: undefined, llm: undefined, tts: undefined };
+    activity.agentSession = {
+      _updateUserState: vi.fn(),
+      _userSpeakingSpan: 'span',
+      emit: vi.fn(),
+    };
+    activity.audioRecognition = {
+      onStartOfSpeech: vi.fn(),
+      onEndOfSpeech: vi.fn(),
+    };
+    activity.interrupt = vi.fn();
+    activity.logger = { info: vi.fn(), error: vi.fn() };
+
+    AgentActivity.prototype.onInputSpeechStarted.call(activity, {});
+    AgentActivity.prototype.onInputSpeechStopped.call(activity, {
+      userTranscriptionEnabled: false,
+    });
+
+    expect(activity.audioRecognition.onStartOfSpeech).toHaveBeenCalledWith(
+      expect.any(Number),
+      0,
+      'span',
+    );
+    expect(activity.audioRecognition.onEndOfSpeech).toHaveBeenCalledWith(
+      expect.any(Number),
+      'span',
+    );
+  });
+
+  it('tracks agent speech for dynamic endpointing even without adaptive interruption', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1000);
+      const endpointing = new DynamicEndpointing(300, 1000, 0.5);
+      const recognition = new AudioRecognition({
+        recognitionHooks: createRecognitionHooks(),
+        endpointing,
+      });
+
+      await recognition.onStartOfAgentSpeech(1000);
+      await recognition.onStartOfSpeech(1100);
+
+      expect(endpointing._agentSpeechStartedAt).toBe(1000);
+      expect(endpointing.overlapping).toBe(true);
+
+      vi.setSystemTime(1300);
+      await recognition.onEndOfAgentSpeech(1300);
+
+      expect(endpointing._agentSpeechEndedAt).toBe(1300);
+      expect(endpointing.overlapping).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,321 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250;
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-47 lines
+export class BaseEndpointing {
+  protected _minDelay: number;
+  protected _maxDelay: number;
+  protected _overlapping = false;
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 11-14 lines
+  constructor(minDelay: number, maxDelay: number) {
+    this._minDelay = minDelay;
+    this._maxDelay = maxDelay;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 16-22 lines
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this._minDelay = minDelay;
+    }
+    if (maxDelay !== undefined) {
+      this._maxDelay = maxDelay;
+    }
+  }
+
+  get minDelay(): number {
+    return this._minDelay;
+  }
+
+  get maxDelay(): number {
+    return this._maxDelay;
+  }
+
+  get overlapping(): boolean {
+    return this._overlapping;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 36-40 lines
+  onStartOfSpeech(startedAt: number, overlapping = false): void {
+    void startedAt;
+    this._overlapping = overlapping;
+  }
+
+  onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    void endedAt;
+    void shouldIgnore;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 42-46 lines
+  onStartOfAgentSpeech(startedAt: number): void {
+    void startedAt;
+  }
+
+  onEndOfAgentSpeech(endedAt: number): void {
+    void endedAt;
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-90 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  private _utterancePause: ExpFilter;
+  private _turnPause: ExpFilter;
+  private _utteranceStartedAt?: number;
+  private _utteranceEndedAt?: number;
+  private _agentSpeechStartedAt?: number;
+  private _agentSpeechEndedAt?: number;
+  private _speaking = false;
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 50-83 lines
+  constructor(minDelay: number, maxDelay: number, alpha = 0.9) {
+    super(minDelay, maxDelay);
+
+    this._utterancePause = new ExpFilter(alpha, maxDelay, minDelay, minDelay);
+    this._turnPause = new ExpFilter(alpha, maxDelay, minDelay, maxDelay);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 91-102 lines
+  override get minDelay(): number {
+    return this._utterancePause.value ?? this._minDelay;
+  }
+
+  override get maxDelay(): number {
+    const turnVal = this._turnPause.value ?? this._maxDelay;
+    return Math.max(turnVal, this.minDelay);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 104-120 lines
+  get betweenUtteranceDelay(): number {
+    if (this._utteranceEndedAt === undefined) {
+      return 0.0;
+    }
+    if (this._utteranceStartedAt === undefined) {
+      return 0.0;
+    }
+
+    return Math.max(0, this._utteranceStartedAt - this._utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this._agentSpeechStartedAt === undefined) {
+      return 0.0;
+    }
+    if (this._utteranceEndedAt === undefined) {
+      return 0.0;
+    }
+
+    return Math.max(0, this._agentSpeechStartedAt - this._utteranceEndedAt);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 122-137 lines
+  get immediateInterruptionDelay(): [number, number] {
+    if (this._utteranceStartedAt === undefined) {
+      return [0.0, 0.0];
+    }
+    if (this._agentSpeechStartedAt === undefined) {
+      return [0.0, 0.0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 139-153 lines
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this._agentSpeechStartedAt = startedAt;
+    this._agentSpeechEndedAt = undefined;
+    this._overlapping = false;
+  }
+
+  override onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this._agentSpeechStartedAt !== undefined &&
+      (this._agentSpeechEndedAt === undefined ||
+        this._agentSpeechEndedAt < this._agentSpeechStartedAt)
+    ) {
+      this._agentSpeechEndedAt = endedAt;
+    }
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 155-178 lines
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this._overlapping) {
+      return;
+    }
+
+    if (
+      this._utteranceStartedAt !== undefined &&
+      this._utteranceEndedAt !== undefined &&
+      this._agentSpeechStartedAt !== undefined &&
+      this._utteranceEndedAt < this._utteranceStartedAt &&
+      overlapping
+    ) {
+      this._utteranceEndedAt = this._agentSpeechStartedAt - 1;
+      log().trace({ utteranceEndedAt: this._utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this._utteranceStartedAt = startedAt;
+    this._overlapping = overlapping;
+    this._speaking = true;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 179-287 lines
+  override onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 180-203 lines
+    if (shouldIgnore && this._overlapping) {
+      if (
+        this._utteranceStartedAt !== undefined &&
+        this._agentSpeechStartedAt !== undefined &&
+        Math.abs(this._utteranceStartedAt - this._agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        log().trace(
+          {
+            delay: Math.abs(this._utteranceStartedAt - this._agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true: user speech started within grace period of agent speech',
+        );
+      } else {
+        this._overlapping = false;
+        this._speaking = false;
+        this._utteranceStartedAt = undefined;
+        this._utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 205-247 lines
+    if (
+      this._overlapping ||
+      (this._agentSpeechStartedAt !== undefined && this._agentSpeechEndedAt === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const utterancePause = this.betweenUtteranceDelay;
+      if (
+        0 < interruptionDelay &&
+        interruptionDelay <= this.minDelay &&
+        0 < turnDelay &&
+        turnDelay <= this.maxDelay &&
+        utterancePause > 0
+      ) {
+        const prevVal = this.minDelay;
+        this._utterancePause.apply(1.0, utterancePause);
+        log().debug(
+          {
+            reason: 'immediate interruption',
+            pause: utterancePause,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${prevVal} -> ${this.minDelay}`,
+        );
+      } else {
+        const turnPause = this.betweenTurnDelay;
+        if (turnPause > 0) {
+          const prevVal = this.maxDelay;
+          this._turnPause.apply(1.0, turnPause);
+          log().debug(
+            {
+              reason: 'new turn (interruption)',
+              pause: turnPause,
+              maxDelay: this.maxDelay,
+              minDelay: this.minDelay,
+              betweenUtteranceDelay: this.betweenUtteranceDelay,
+              betweenTurnDelay: this.betweenTurnDelay,
+            },
+            `max endpointing delay updated: ${prevVal} -> ${this.maxDelay}`,
+          );
+        }
+      }
+    } else {
+      // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 248-280 lines
+      const turnPause = this.betweenTurnDelay;
+      if (turnPause > 0) {
+        const prevVal = this.maxDelay;
+        this._turnPause.apply(1.0, turnPause);
+        log().debug(
+          {
+            reason: 'new turn',
+            pause: turnPause,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `max endpointing delay updated due to pause: ${prevVal} -> ${this.maxDelay}`,
+        );
+      } else {
+        const utterancePause = this.betweenUtteranceDelay;
+        if (
+          utterancePause > 0 &&
+          this._agentSpeechEndedAt === undefined &&
+          this._agentSpeechStartedAt === undefined
+        ) {
+          const prevVal = this.minDelay;
+          this._utterancePause.apply(1.0, utterancePause);
+          log().debug(
+            {
+              reason: 'pause between utterances',
+              pause: utterancePause,
+              maxDelay: this.maxDelay,
+              minDelay: this.minDelay,
+            },
+            `min endpointing delay updated: ${prevVal} -> ${this.minDelay}`,
+          );
+        }
+      }
+    }
+
+    this._utteranceEndedAt = endedAt;
+    this._agentSpeechStartedAt = undefined;
+    this._agentSpeechEndedAt = undefined;
+    this._speaking = false;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 288-307 lines
+  override updateOptions({
+    minDelay,
+    maxDelay,
+    alpha,
+  }: {
+    minDelay?: number;
+    maxDelay?: number;
+    alpha?: number;
+  } = {}): void {
+    if (minDelay !== undefined) {
+      this._minDelay = minDelay;
+      this._utterancePause.reset(undefined, this._minDelay, this._minDelay);
+      this._turnPause.reset(undefined, undefined, this._minDelay);
+    }
+
+    if (maxDelay !== undefined) {
+      this._maxDelay = maxDelay;
+      this._turnPause.reset(undefined, this._maxDelay, undefined, this._maxDelay);
+      this._utterancePause.reset(undefined, undefined, undefined, this._maxDelay);
+    }
+
+    if (alpha !== undefined) {
+      this._utterancePause.reset(alpha);
+      this._turnPause.reset(alpha);
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 310-322 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  switch (options.mode ?? 'fixed') {
+    case 'dynamic':
+      return new DynamicEndpointing(options.minDelay, options.maxDelay, options.alpha);
+    default:
+      return new BaseEndpointing(options.minDelay, options.maxDelay);
+  }
+}

--- a/agents/src/voice/endpointing.ts
+++ b/agents/src/voice/endpointing.ts
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { log } from '../log.js';
+import { ExpFilter } from '../utils.js';
+import type { EndpointingOptions } from './turn_config/endpointing.js';
+
+const AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD = 250;
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 10-47 lines
+export class BaseEndpointing {
+  _minDelay: number;
+  _maxDelay: number;
+  _overlapping = false;
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 11-14 lines
+  constructor(minDelay: number, maxDelay: number) {
+    this._minDelay = minDelay;
+    this._maxDelay = maxDelay;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 16-22 lines
+  updateOptions({ minDelay, maxDelay }: { minDelay?: number; maxDelay?: number } = {}): void {
+    if (minDelay !== undefined) {
+      this._minDelay = minDelay;
+    }
+    if (maxDelay !== undefined) {
+      this._maxDelay = maxDelay;
+    }
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 24-34 lines
+  get minDelay(): number {
+    return this._minDelay;
+  }
+
+  get maxDelay(): number {
+    return this._maxDelay;
+  }
+
+  get overlapping(): boolean {
+    return this._overlapping;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 36-40 lines
+  onStartOfSpeech(startedAt: number, overlapping = false): void {
+    void startedAt;
+    this._overlapping = overlapping;
+  }
+
+  onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    void endedAt;
+    void shouldIgnore;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 42-46 lines
+  onStartOfAgentSpeech(startedAt: number): void {
+    void startedAt;
+  }
+
+  onEndOfAgentSpeech(endedAt: number): void {
+    void endedAt;
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 49-307 lines
+export class DynamicEndpointing extends BaseEndpointing {
+  _utterancePause: ExpFilter;
+  _turnPause: ExpFilter;
+  _utteranceStartedAt: number | undefined;
+  _utteranceEndedAt: number | undefined;
+  _agentSpeechStartedAt: number | undefined;
+  _agentSpeechEndedAt: number | undefined;
+  _speaking = false;
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 50-90 lines
+  constructor(minDelay: number, maxDelay: number, alpha = 0.9) {
+    super(minDelay, maxDelay);
+
+    this._utterancePause = new ExpFilter(alpha, maxDelay, minDelay, minDelay);
+    this._turnPause = new ExpFilter(alpha, maxDelay, minDelay, maxDelay);
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 91-137 lines
+  override get minDelay(): number {
+    return this._utterancePause.value ?? this._minDelay;
+  }
+
+  override get maxDelay(): number {
+    const turnVal = this._turnPause.value ?? this._maxDelay;
+    return Math.max(turnVal, this.minDelay);
+  }
+
+  get betweenUtteranceDelay(): number {
+    if (this._utteranceEndedAt === undefined) {
+      return 0.0;
+    }
+    if (this._utteranceStartedAt === undefined) {
+      return 0.0;
+    }
+
+    return Math.max(0, this._utteranceStartedAt - this._utteranceEndedAt);
+  }
+
+  get betweenTurnDelay(): number {
+    if (this._agentSpeechStartedAt === undefined) {
+      return 0.0;
+    }
+    if (this._utteranceEndedAt === undefined) {
+      return 0.0;
+    }
+
+    return Math.max(0, this._agentSpeechStartedAt - this._utteranceEndedAt);
+  }
+
+  get immediateInterruptionDelay(): [number, number] {
+    if (this._utteranceStartedAt === undefined) {
+      return [0.0, 0.0];
+    }
+    if (this._agentSpeechStartedAt === undefined) {
+      return [0.0, 0.0];
+    }
+
+    return [this.betweenTurnDelay, Math.abs(this.betweenUtteranceDelay - this.betweenTurnDelay)];
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 139-153 lines
+  override onStartOfAgentSpeech(startedAt: number): void {
+    this._agentSpeechStartedAt = startedAt;
+    this._agentSpeechEndedAt = undefined;
+    this._overlapping = false;
+  }
+
+  override onEndOfAgentSpeech(endedAt: number): void {
+    if (
+      this._agentSpeechStartedAt !== undefined &&
+      (this._agentSpeechEndedAt === undefined ||
+        this._agentSpeechEndedAt < this._agentSpeechStartedAt)
+    ) {
+      this._agentSpeechEndedAt = endedAt;
+    }
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 155-178 lines
+  override onStartOfSpeech(startedAt: number, overlapping = false): void {
+    if (this._overlapping) {
+      return;
+    }
+
+    if (
+      this._utteranceStartedAt !== undefined &&
+      this._utteranceEndedAt !== undefined &&
+      this._agentSpeechStartedAt !== undefined &&
+      this._utteranceEndedAt < this._utteranceStartedAt &&
+      overlapping
+    ) {
+      this._utteranceEndedAt = this._agentSpeechStartedAt - 1;
+      log().trace({ utteranceEndedAt: this._utteranceEndedAt }, 'utterance ended at adjusted');
+    }
+
+    this._utteranceStartedAt = startedAt;
+    this._overlapping = overlapping;
+    this._speaking = true;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 179-287 lines
+  override onEndOfSpeech(endedAt: number, shouldIgnore = false): void {
+    if (shouldIgnore && this._overlapping) {
+      if (
+        this._utteranceStartedAt !== undefined &&
+        this._agentSpeechStartedAt !== undefined &&
+        Math.abs(this._utteranceStartedAt - this._agentSpeechStartedAt) <
+          AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD
+      ) {
+        log().trace(
+          {
+            speechOffset: Math.abs(this._utteranceStartedAt - this._agentSpeechStartedAt),
+            gracePeriod: AGENT_SPEECH_LEADING_SILENCE_GRACE_PERIOD,
+          },
+          'ignoring shouldIgnore=true: user speech started within grace period of agent speech',
+        );
+      } else {
+        this._overlapping = false;
+        this._speaking = false;
+        this._utteranceStartedAt = undefined;
+        this._utteranceEndedAt = undefined;
+        return;
+      }
+    }
+
+    if (
+      this._overlapping ||
+      (this._agentSpeechStartedAt !== undefined && this._agentSpeechEndedAt === undefined)
+    ) {
+      const [turnDelay, interruptionDelay] = this.immediateInterruptionDelay;
+      const utterancePause = this.betweenUtteranceDelay;
+      if (
+        0 < interruptionDelay &&
+        interruptionDelay <= this.minDelay &&
+        0 < turnDelay &&
+        turnDelay <= this.maxDelay &&
+        utterancePause > 0
+      ) {
+        const prevVal = this.minDelay;
+        this._utterancePause.apply(1.0, utterancePause);
+        log().debug(
+          {
+            reason: 'immediate interruption',
+            pause: utterancePause,
+            interruptionDelay,
+            turnDelay,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `min endpointing delay updated: ${prevVal} -> ${this.minDelay}`,
+        );
+      } else {
+        const turnPause = this.betweenTurnDelay;
+        if (turnPause > 0) {
+          const prevVal = this.maxDelay;
+          this._turnPause.apply(1.0, turnPause);
+          log().debug(
+            {
+              reason: 'new turn (interruption)',
+              pause: turnPause,
+              maxDelay: this.maxDelay,
+              minDelay: this.minDelay,
+              betweenUtteranceDelay: this.betweenUtteranceDelay,
+              betweenTurnDelay: this.betweenTurnDelay,
+            },
+            `max endpointing delay updated: ${prevVal} -> ${this.maxDelay}`,
+          );
+        }
+      }
+    } else {
+      const turnPause = this.betweenTurnDelay;
+      if (turnPause > 0) {
+        const prevVal = this.maxDelay;
+        this._turnPause.apply(1.0, turnPause);
+        log().debug(
+          {
+            reason: 'new turn',
+            pause: turnPause,
+            maxDelay: this.maxDelay,
+            minDelay: this.minDelay,
+          },
+          `max endpointing delay updated due to pause: ${prevVal} -> ${this.maxDelay}`,
+        );
+      } else {
+        const utterancePause = this.betweenUtteranceDelay;
+        if (
+          utterancePause > 0 &&
+          this._agentSpeechEndedAt === undefined &&
+          this._agentSpeechStartedAt === undefined
+        ) {
+          const prevVal = this.minDelay;
+          this._utterancePause.apply(1.0, utterancePause);
+          log().debug(
+            {
+              reason: 'pause between utterances',
+              pause: utterancePause,
+              maxDelay: this.maxDelay,
+              minDelay: this.minDelay,
+            },
+            `min endpointing delay updated: ${prevVal} -> ${this.minDelay}`,
+          );
+        }
+      }
+    }
+
+    this._utteranceEndedAt = endedAt;
+    this._agentSpeechStartedAt = undefined;
+    this._agentSpeechEndedAt = undefined;
+    this._speaking = false;
+    this._overlapping = false;
+  }
+
+  // Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 288-307 lines
+  override updateOptions({
+    minDelay,
+    maxDelay,
+    alpha,
+  }: {
+    minDelay?: number;
+    maxDelay?: number;
+    alpha?: number;
+  } = {}): void {
+    if (minDelay !== undefined) {
+      this._minDelay = minDelay;
+      this._utterancePause.reset(undefined, this._minDelay, this._minDelay);
+      this._turnPause.reset(undefined, undefined, this._minDelay);
+    }
+
+    if (maxDelay !== undefined) {
+      this._maxDelay = maxDelay;
+      this._turnPause.reset(undefined, this._maxDelay, undefined, this._maxDelay);
+      this._utterancePause.reset(undefined, undefined, undefined, this._maxDelay);
+    }
+
+    if (alpha !== undefined) {
+      this._utterancePause.reset(alpha);
+      this._turnPause.reset(alpha);
+    }
+  }
+}
+
+// Ref: python livekit-agents/livekit/agents/voice/endpointing.py - 310-322 lines
+export function createEndpointing(options: EndpointingOptions): BaseEndpointing {
+  switch (options.mode) {
+    case 'dynamic':
+      return new DynamicEndpointing(options.minDelay, options.maxDelay, options.alpha);
+    default:
+      return new BaseEndpointing(options.minDelay, options.maxDelay);
+  }
+}

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -22,6 +22,7 @@ export {
   RoomSessionTransport,
 } from './remote_session.js';
 export * from './events.js';
+export * from './endpointing.js';
 export { type TimedString } from './io.js';
 export * from './report.js';
 export * from './room_io/index.js';

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -22,6 +22,7 @@ export {
   RoomSessionTransport,
 } from './remote_session.js';
 export * from './events.js';
+export { BaseEndpointing, DynamicEndpointing, createEndpointing } from './endpointing.js';
 export { type TimedString } from './io.js';
 export * from './report.js';
 export * from './room_io/index.js';

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -6,8 +6,8 @@
  */
 export interface EndpointingOptions {
   /**
-   * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on
-   * end-of-utterance prediction.
+   * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on speech
+   * activity.
    * @defaultValue "fixed"
    */
   mode: 'fixed' | 'dynamic';
@@ -24,10 +24,18 @@ export interface EndpointingOptions {
    * @defaultValue 3000
    */
   maxDelay: number;
+  /**
+   * Exponential moving average coefficient for dynamic endpointing. The higher the value, the more
+   * weight is given to the history.
+   * @defaultValue 0.9
+   */
+  alpha: number;
 }
 
+// Ref: python livekit-agents/livekit/agents/voice/turn.py - 47-74 lines
 export const defaultEndpointingOptions = {
   mode: 'fixed',
   minDelay: 500,
   maxDelay: 3000,
+  alpha: 0.9,
 } as const satisfies EndpointingOptions;

--- a/agents/src/voice/turn_config/endpointing.ts
+++ b/agents/src/voice/turn_config/endpointing.ts
@@ -7,7 +7,7 @@
 export interface EndpointingOptions {
   /**
    * Endpointing mode. `"fixed"` uses a fixed delay, `"dynamic"` adjusts delay based on
-   * end-of-utterance prediction.
+   * observed speech activity.
    * @defaultValue "fixed"
    */
   mode: 'fixed' | 'dynamic';
@@ -24,10 +24,19 @@ export interface EndpointingOptions {
    * @defaultValue 3000
    */
   maxDelay: number;
+  /**
+   * Exponential moving average coefficient for dynamic endpointing. Higher values give more weight
+   * to history.
+   * @defaultValue 0.9
+   */
+  // Ref: python livekit-agents/livekit/agents/voice/turn.py - 63-66 lines
+  alpha: number;
 }
 
+// Ref: python livekit-agents/livekit/agents/voice/turn.py - 69-74 lines
 export const defaultEndpointingOptions = {
   mode: 'fixed',
   minDelay: 500,
   maxDelay: 3000,
+  alpha: 0.9,
 } as const satisfies EndpointingOptions;

--- a/agents/src/voice/turn_config/utils.test.ts
+++ b/agents/src/voice/turn_config/utils.test.ts
@@ -84,6 +84,19 @@ describe('migrateLegacyOptions', () => {
 
     expect(result.turnHandling.turnDetection).toBe('vad');
   });
+
+  it('should preserve dynamic endpointing mode and alpha from turnHandling', () => {
+    const { agentSessionOptions: result } = migrateLegacyOptions({
+      turnHandling: {
+        endpointing: { mode: 'dynamic', alpha: 0.3 },
+      },
+    });
+
+    expect(result.turnHandling.endpointing.mode).toBe('dynamic');
+    expect(result.turnHandling.endpointing.alpha).toBe(0.3);
+    expect(result.turnHandling.endpointing.minDelay).toBe(defaultEndpointingOptions.minDelay);
+    expect(result.turnHandling.endpointing.maxDelay).toBe(defaultEndpointingOptions.maxDelay);
+  });
 });
 
 describe('migrateTurnHandling', () => {

--- a/agents/src/voice/turn_config/utils.ts
+++ b/agents/src/voice/turn_config/utils.ts
@@ -128,6 +128,7 @@ export function stripUndefined<T extends object>(obj: T): Partial<T> {
 export function mergeWithDefaults(config: TurnHandlingOptions) {
   return {
     turnDetection: config.turnDetection ?? defaultTurnHandlingOptions.turnDetection,
+    // Ref: python livekit-agents/livekit/agents/voice/turn.py - 186-190 lines
     endpointing: { ...defaultEndpointingOptions, ...stripUndefined(config.endpointing) },
     interruption: { ...defaultInterruptionOptions, ...stripUndefined(config.interruption) },
     preemptiveGeneration: {


### PR DESCRIPTION
## Summary
- Port Python dynamic endpointing runtime to the Node voice pipeline, including EMA-based min/max delay adaptation and endpointing factory wiring.
- Add `mode: 'dynamic'` and `alpha` endpointing options with session and activity update propagation.
- Mirror the Python endpointing contract in Vitest and add Node-specific runtime coverage for no-VAD/realtime hooks and update replacement semantics.

## Tests
- `uv run pytest tests/test_endpointing.py`
- `pnpm test -- agents/src/voice/endpointing.test.ts`
- `pnpm test -- agents/src/utils.test.ts`
- `pnpm test -- agents/src/voice/turn_config/utils.test.ts`
- `pnpm test -- agents/src/voice/audio_recognition_span.test.ts agents/src/voice/audio_recognition_handoff.test.ts`
- `pnpm test -- agents/src/voice/agent.test.ts agents/src/voice/agent_activity.test.ts agents/src/voice/agent_session_handoff.test.ts`
- `pnpm test -- agents/src/voice/interruption_detection.test.ts`
- `pnpm test -- agents/src/voice`
- `pnpm --filter @livekit/agents build`
- `pnpm exec eslint -f unix agents/src/voice/endpointing.ts agents/src/voice/endpointing.test.ts agents/src/voice/audio_recognition.ts agents/src/voice/agent_activity.ts agents/src/voice/agent_session.ts agents/src/voice/agent.ts agents/src/utils.ts` (warnings only, all pre-existing in touched legacy files)
- `git diff --check`

## Notes
- `pnpm --filter @livekit/agents api:check` still fails on the existing API Extractor limitation for `export * as ___` in `dist/index.d.ts`, before it can validate this diff.
- The remote branch already existed, so this PR branch includes a merge commit that preserves the remote history while keeping the verified local tree.