### PR TITLE
fix(inference): skip unknown message warning and rename output_timestamps → output_alignment

### DIFF
--- a/.changeset/inference-skip-unknown-rename-alignment.md
+++ b/.changeset/inference-skip-unknown-rename-alignment.md
@@ -1,0 +1,8 @@
+---
+"@livekit/agents": patch
+---
+
+Port livekit/agents#5614:
+
+- **fix(inference/tts): rename `output_timestamps` server event to `output_alignment`** — matches the gateway's renamed message type. The schema literal, `ttsKnownServerEventSchema` discriminated union, the `knownTtsServerEventTypes` set, the recv-loop `switch` case, and the test fixtures all switch from `output_timestamps` to `output_alignment`. The exported type alias `TtsOutputTimestampsEvent` is renamed to `TtsOutputAlignmentEvent` (the previous name was internal — it was not surfaced in the public API extractor report and was not referenced by any plugin or example).
+- **fix(inference/stt, inference/tts): silently drop unknown / unparseable server events** — drops the `"Unexpected message from LiveKit TTS"` and `"Failed to parse STT server event"` `logger.warn` calls in the recv loops so they no longer flood logs when the inference gateway introduces new event types. Behavior matches the Python change in `inference/stt.py` and `inference/tts.py`.

--- a/agents/src/inference/api_protos.test.ts
+++ b/agents/src/inference/api_protos.test.ts
@@ -17,9 +17,9 @@ describe('sttServerEventSchema', () => {
 });
 
 describe('ttsServerEventSchema', () => {
-  it('extracts output_timestamps words payload', () => {
+  it('extracts output_alignment words payload', () => {
     const result = ttsServerEventSchema.safeParse({
-      type: 'output_timestamps',
+      type: 'output_alignment',
       session_id: 's1',
       words: [
         { word: 'hello', start: 0.1, end: 0.4 },
@@ -29,16 +29,16 @@ describe('ttsServerEventSchema', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.type).toBe('output_timestamps');
+      expect(result.data.type).toBe('output_alignment');
       expect(result.data.session_id).toBe('s1');
       expect(result.data.words?.map((w) => w.word)).toEqual(['hello', 'world']);
       expect(result.data.chars).toBeUndefined();
     }
   });
 
-  it('extracts output_timestamps chars payload', () => {
+  it('extracts output_alignment chars payload', () => {
     const result = ttsServerEventSchema.safeParse({
-      type: 'output_timestamps',
+      type: 'output_alignment',
       session_id: 's2',
       chars: [
         { char: 'h', start: 0.1, end: 0.2 },
@@ -48,16 +48,16 @@ describe('ttsServerEventSchema', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.type).toBe('output_timestamps');
+      expect(result.data.type).toBe('output_alignment');
       expect(result.data.session_id).toBe('s2');
       expect(result.data.chars?.map((c) => c.char)).toEqual(['h', 'i']);
       expect(result.data.words).toBeUndefined();
     }
   });
 
-  it('rejects malformed output_timestamps entries', () => {
+  it('rejects malformed output_alignment entries', () => {
     const result = ttsServerEventSchema.safeParse({
-      type: 'output_timestamps',
+      type: 'output_alignment',
       session_id: 's3',
       words: [{ word: 'oops', start: 'bad', end: 0.2 }],
     });

--- a/agents/src/inference/api_protos.ts
+++ b/agents/src/inference/api_protos.ts
@@ -66,8 +66,8 @@ export const ttsCharTimestampSchema = z.object({
   end: z.number(),
 });
 
-export const ttsOutputTimestampsEventSchema = z.object({
-  type: z.literal('output_timestamps'),
+export const ttsOutputAlignmentEventSchema = z.object({
+  type: z.literal('output_alignment'),
   session_id: z.string().optional(),
   words: z.array(ttsWordTimestampSchema).optional(),
   chars: z.array(ttsCharTimestampSchema).optional(),
@@ -83,7 +83,7 @@ export const ttsClientEventSchema = z.discriminatedUnion('type', [
 export const ttsKnownServerEventSchema = z.discriminatedUnion('type', [
   ttsSessionCreatedEventSchema,
   ttsOutputAudioEventSchema,
-  ttsOutputTimestampsEventSchema,
+  ttsOutputAlignmentEventSchema,
   ttsDoneEventSchema,
   ttsSessionClosedEventSchema,
   ttsErrorEventSchema,
@@ -92,7 +92,7 @@ export const ttsKnownServerEventSchema = z.discriminatedUnion('type', [
 const knownTtsServerEventTypes = new Set([
   'session.created',
   'output_audio',
-  'output_timestamps',
+  'output_alignment',
   'done',
   'session.closed',
   'error',
@@ -117,7 +117,7 @@ export type TtsSessionCreatedEvent = z.infer<typeof ttsSessionCreatedEventSchema
 export type TtsOutputAudioEvent = z.infer<typeof ttsOutputAudioEventSchema>;
 export type TtsWordTimestamp = z.infer<typeof ttsWordTimestampSchema>;
 export type TtsCharTimestamp = z.infer<typeof ttsCharTimestampSchema>;
-export type TtsOutputTimestampsEvent = z.infer<typeof ttsOutputTimestampsEventSchema>;
+export type TtsOutputAlignmentEvent = z.infer<typeof ttsOutputAlignmentEventSchema>;
 export type TtsDoneEvent = z.infer<typeof ttsDoneEventSchema>;
 export type TtsSessionClosedEvent = z.infer<typeof ttsSessionClosedEventSchema>;
 export type TtsErrorEvent = z.infer<typeof ttsErrorEventSchema>;

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -557,13 +557,11 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
             if (signal.aborted) return;
             if (result.done) return;
 
-            // Parse and validate with Zod schema
+            // Ref: python livekit-agents/livekit/agents/inference/stt.py - 660-665 lines
+            // Unknown / unexpected messages are silently dropped to avoid noisy warnings
+            // when the gateway introduces new event types.
             const parseResult = await sttServerEventSchema.safeParseAsync(result.value);
             if (!parseResult.success) {
-              this.#logger.warn(
-                { error: parseResult.error, rawData: result.value },
-                'Failed to parse STT server event',
-              );
               continue;
             }
 

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -165,7 +165,7 @@ export function parseTTSModelString(model: string): [string, string | undefined]
  *
  * Mirrors the Python implementation: support is opt-in through the provider's
  * `extra_kwargs` / `modelOptions` payload — the gateway only emits
- * `output_timestamps` events when the provider-specific flag is set.
+ * `output_alignment` events when the provider-specific flag is set.
  */
 export function hasAlignedTranscript(
   model: string | undefined,
@@ -398,7 +398,7 @@ export class TTS<TModel extends TTSModels> extends BaseTTS {
     // `extra` (modelOptions) when the WebSocket is first opened via
     // `session.create`. Pooled sockets keep the old session settings and, for
     // example, would keep reporting `alignedTranscript=true` while the server
-    // never emits `output_timestamps`. Invalidate so the next `stream()` opens
+    // never emits `output_alignment`. Invalidate so the next `stream()` opens
     // a fresh connection with the up-to-date payload.
     if (sessionAffectingChange) {
       this.pool.invalidate();
@@ -704,9 +704,11 @@ export class SynthesizeStream<TModel extends TTSModels> extends BaseSynthesizeSt
           if (signal.aborted) return;
           if (result.done) return;
 
+          // Ref: python livekit-agents/livekit/agents/inference/tts.py - 670-679 lines
+          // Unknown / unexpected messages are silently dropped to avoid noisy warnings
+          // when the gateway introduces new event types.
           const parsedServerEvent = ttsKnownServerEventSchema.safeParse(result.value);
           if (!parsedServerEvent.success) {
-            this.#logger.warn({ serverEvent: result.value }, 'Unexpected message from LiveKit TTS');
             continue;
           }
 
@@ -727,7 +729,8 @@ export class SynthesizeStream<TModel extends TTSModels> extends BaseSynthesizeSt
                 lastFrame = frame;
               }
               break;
-            case 'output_timestamps':
+            // Ref: python livekit-agents/livekit/agents/inference/tts.py - 651 line
+            case 'output_alignment':
               if (serverEvent.words && serverEvent.words.length > 0) {
                 for (const w of serverEvent.words) {
                   pendingTimedTranscripts.push(


### PR DESCRIPTION
## Summary

Automated port of [livekit/agents#5614](https://github.com/livekit/agents/pull/5614) ("fix(inference): skip unknown message warning and rename event name") into agents-js.

cc: @toubatbrian @livekit/agent-devs

> This is an automated Claude Code Routine created by @toubatbrian. Right now it is in experimentation stage.

## Ported changes

### 1. Rename `output_timestamps` → `output_alignment` (TTS)

The inference gateway renamed the per-utterance word/character timing event from `output_timestamps` to `output_alignment`. Without this rename, the JS client would silently drop alignment frames (so `TimedString` word/character timings would never reach the output emitter, breaking aligned-transcript downstream consumers like `SyncedAudioOutput`).

Files touched:

- `agents/src/inference/api_protos.ts`
  - `ttsOutputTimestampsEventSchema` → `ttsOutputAlignmentEventSchema`, with `z.literal('output_timestamps')` → `z.literal('output_alignment')`.
  - Updated entry in `ttsKnownServerEventSchema` discriminated union.
  - Updated entry in the `knownTtsServerEventTypes` set used by `ttsUnknownServerEventSchema`'s `refine`.
  - Renamed exported type alias `TtsOutputTimestampsEvent` → `TtsOutputAlignmentEvent`.
- `agents/src/inference/tts.ts`
  - `case 'output_timestamps':` → `case 'output_alignment':` in the recv loop.
  - Updated doc comment on `hasAlignedTranscript` and the pool-invalidation comment in `updateOptions`.
- `agents/src/inference/api_protos.test.ts`
  - Renamed the three `output_timestamps` test cases to `output_alignment` and updated the fixture payloads / `expect(...).toBe('output_alignment')` assertions.

### 2. Silently drop unknown / unparseable inference server events (STT + TTS)

The Python PR removed the `else: logger.warning("received unexpected message ...")` branches in both `inference/stt.py` and `inference/tts.py`. JS achieves the same shape via Zod `safeParse(Async)` against `sttServerEventSchema` / `ttsKnownServerEventSchema` — when parsing fails we now `continue` without emitting a warning, so the gateway adding new event types no longer floods logs.

Files touched:

- `agents/src/inference/stt.ts` — removed the `'Failed to parse STT server event'` `logger.warn`.
- `agents/src/inference/tts.ts` — removed the `'Unexpected message from LiveKit TTS'` `logger.warn`.

## Implementation nuances (JS vs Python)

- **Strict-vs-lenient parse failures.** The Python recv loops were chained `if/elif/else` on `data.get("type")`, so removing the `else` branch only suppresses the warning for *unknown* event types — malformed but known events would have raised `KeyError`/`TypeError` on the field access. JS validates each event against a Zod discriminated union, so the suppressed `safeParse` failure now also covers the case of a *known* event type with an invalid payload (e.g. wrong types in `words`/`chars`). This is a deliberate over-match — silently dropping a malformed-but-known event matches the spirit of "don't spam warnings" and is consistent with how the Python pre-PR code would have crashed-and-restarted versus the JS schema-validation-no-throw flow that already existed before this port.
- **Renamed type export.** `TtsOutputTimestampsEvent` was an internal type alias (not surfaced via `pnpm api:check`). I renamed it inline rather than introducing a deprecated alias, since there are no external consumers in `agents-js` and the Python rename is a breaking gateway-level change anyway.
- **Python-reference comments.** Per `CLAUDE.md` porting guidelines, added `// Ref: python livekit-agents/livekit/agents/inference/{stt,tts}.py - <line range>` markers above the corresponding JS edits.

## Changeset

Patch-level changeset added at `.changeset/inference-skip-unknown-rename-alignment.md` (no minor/major bump).

## Test plan

- [x] `pnpm build:agents` succeeds.
- [x] `pnpm vitest run agents/src/inference/api_protos.test.ts` — 4/4 passing.
- [x] `pnpm format:check` — clean.
- [x] `grep -rn "output_timestamps\|TtsOutputTimestampsEvent\|ttsOutputTimestampsEventSchema"` — no remaining references in `agents/`, `plugins/`, or `examples/`.
- [ ] Reviewer to manually validate against a live inference gateway that `output_alignment` events arrive and `TimedString` word/character timings are forwarded.

https://claude.ai/code/session_01R2m1bVYPCUyx5kGajhMjdU

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2m1bVYPCUyx5kGajhMjdU)_