### PR TITLE
feat(deepgram): add speed option to TTS

### DIFF
--- a/.changeset/deepgram-tts-speed.md
+++ b/.changeset/deepgram-tts-speed.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-deepgram': patch
+---
+
+Add `speed` option to Deepgram TTS (0.7–1.5).

--- a/plugins/deepgram/src/tts.ts
+++ b/plugins/deepgram/src/tts.ts
@@ -22,6 +22,7 @@ export interface TTSOptions {
   model: TTSModels | string;
   encoding: TTSEncoding;
   sampleRate: number;
+  speed?: number;
   apiKey?: string;
   baseUrl?: string;
   sentenceTokenizer: tokenize.SentenceTokenizer;
@@ -69,6 +70,10 @@ export class TTS extends tts.TTS {
         'Deepgram API key is required, whether as an argument or as $DEEPGRAM_API_KEY',
       );
     }
+
+    if (this.opts.speed !== undefined && (this.opts.speed < 0.7 || this.opts.speed > 1.5)) {
+      throw new Error(`Deepgram TTS speed must be between 0.7 and 1.5, got ${this.opts.speed}`);
+    }
   }
 
   synthesize(
@@ -110,6 +115,9 @@ export class ChunkedStream extends tts.ChunkedStream {
     url.searchParams.append('sample_rate', this.opts.sampleRate.toString());
     url.searchParams.append('model', this.opts.model);
     url.searchParams.append('encoding', this.opts.encoding);
+    if (this.opts.speed !== undefined) {
+      url.searchParams.append('speed', this.opts.speed.toString());
+    }
 
     await new Promise<void>((resolve, reject) => {
       let settled = false;
@@ -262,6 +270,9 @@ export class SynthesizeStream extends tts.SynthesizeStream {
     url.searchParams.append('sample_rate', this.opts.sampleRate.toString());
     url.searchParams.append('model', this.opts.model);
     url.searchParams.append('encoding', this.opts.encoding);
+    if (this.opts.speed !== undefined) {
+      url.searchParams.append('speed', this.opts.speed.toString());
+    }
 
     const ws = new WebSocket(url, {
       headers: {


### PR DESCRIPTION
## Summary
- Add `speed?: number` to the Deepgram `TTSOptions`, validated to Deepgram's documented 0.7–1.5 range in the constructor.
- Forward it as the `speed` query param on both the chunked HTTP `/v1/speak` request and the streaming WebSocket URL.

## Test plan
- [x] `pnpm --filter @livekit/agents-plugin-deepgram build`
- [x] `pnpm --filter @livekit/agents-plugin-deepgram lint` (no new warnings)
- [x] `prettier --check`
- [x] Manual smoke test against a real Deepgram key with `speed=0.9` and `speed=1.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)