### PR TITLE
fix(cartesia): send API key and Cartesia-Version as headers

### DIFF
--- a/plugins/cartesia/src/tts.ts
+++ b/plugins/cartesia/src/tts.ts
@@ -531,12 +531,16 @@ export class SynthesizeStream extends tts.SynthesizeStream {
     };
 
     const wsUrl = this.#opts.baseUrl.replace(/^http/, 'ws');
-    const url = `${wsUrl}/tts/websocket?api_key=${this.#opts.apiKey}&cartesia_version=${this.#opts.apiVersion}`;
+    const url = `${wsUrl}/tts/websocket`;
 
     let ws: WebSocket | undefined;
     try {
       ws = await connectCartesiaWebSocket({
         url,
+        headers: {
+          [AUTHORIZATION_HEADER]: this.#opts.apiKey!,
+          [VERSION_HEADER]: this.#opts.apiVersion,
+        },
         timeoutMs: this.connOptions.timeoutMs,
         abortSignal: this.abortSignal,
       });
@@ -673,15 +677,17 @@ const safeTerminateWebSocket = (ws: WebSocket) => {
 
 const connectCartesiaWebSocket = async ({
   url,
+  headers,
   timeoutMs,
   abortSignal,
 }: {
   url: string;
+  headers: Record<string, string>;
   timeoutMs: number;
   abortSignal: AbortSignal;
 }): Promise<WebSocket> => {
   const connectOnce = async (family?: number): Promise<WebSocket> => {
-    const ws = new WebSocket(url, { handshakeTimeout: timeoutMs, family });
+    const ws = new WebSocket(url, { handshakeTimeout: timeoutMs, family, headers });
     try {
       await waitForWsOpen({ ws, timeoutMs, abortSignal });
       return ws;


### PR DESCRIPTION
## Description

Sends `Cartesia-Version: 2025-04-16; X-Api-Key: <api_key>` rather than `?cartesia_version=2025-04-16&api_key=<api_key>`. This is to avoid putting secrets in the URL, which might be logged by users.

## Changes Made

- Moved WebSocket query params to headers

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [x] **Video demo**: No video, but I promise I tested

## Testing

- [x] All tests pass
- [x] Manual test using Cartesia TTS

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.