### PR TITLE
feat(elevenlabs): add STT support

### DIFF
--- a/.changeset/elevenlabs-stt-plugin.md
+++ b/.changeset/elevenlabs-stt-plugin.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-elevenlabs': patch
+---
+
+feat(elevenlabs): port ElevenLabs STT support from Python agents

--- a/examples/src/elevenlabs_scribe_v2.ts
+++ b/examples/src/elevenlabs_scribe_v2.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  type JobContext,
+  type JobProcess,
+  ServerOptions,
+  cli,
+  defineAgent,
+  inference,
+  voice,
+} from '@livekit/agents';
+import * as elevenlabs from '@livekit/agents-plugin-elevenlabs';
+import * as silero from '@livekit/agents-plugin-silero';
+import { fileURLToPath } from 'node:url';
+
+export default defineAgent({
+  // Ref: python examples/other/elevenlab_scribe_v2.py - 17-21 lines
+  prewarm: async (proc: JobProcess) => {
+    proc.userData.vad = await silero.VAD.load();
+  },
+  // Ref: python examples/other/elevenlab_scribe_v2.py - 24-49 lines
+  entry: async (ctx: JobContext) => {
+    const stt = new elevenlabs.STT({
+      useRealtime: true,
+      serverVad: {
+        vadSilenceThresholdSecs: 0.5,
+        vadThreshold: 0.5,
+        minSpeechDurationMs: 100,
+        minSilenceDurationMs: 300,
+      },
+      modelId: 'scribe_v2_realtime',
+    });
+
+    const session = new voice.AgentSession({
+      voiceOptions: { allowInterruptions: true },
+      vad: ctx.proc.userData.vad! as silero.VAD,
+      stt,
+      llm: new inference.LLM({ model: 'openai/gpt-4.1-mini' }),
+      tts: new inference.TTS({ model: 'cartesia/sonic-3' }),
+    });
+
+    await session.start({
+      agent: new voice.Agent({ instructions: 'You are a somewhat helpful assistant.' }),
+      room: ctx.room,
+    });
+
+    session.say('Hello, how can I help you?', { allowInterruptions: false });
+  },
+});
+
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/elevenlabs_scribe_v2.ts
+++ b/examples/src/elevenlabs_scribe_v2.ts
@@ -15,11 +15,9 @@ import * as silero from '@livekit/agents-plugin-silero';
 import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
-  // Ref: python examples/other/elevenlab_scribe_v2.py - 17-21 lines
   prewarm: async (proc: JobProcess) => {
     proc.userData.vad = await silero.VAD.load();
   },
-  // Ref: python examples/other/elevenlab_scribe_v2.py - 24-49 lines
   entry: async (ctx: JobContext) => {
     const stt = new elevenlabs.STT({
       useRealtime: true,

--- a/plugins/elevenlabs/src/_utils.ts
+++ b/plugins/elevenlabs/src/_utils.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/_utils.py - 8-37 lines
 export class PeriodicCollector<T> {
   private duration: number;
   private callback: (value: T) => void;

--- a/plugins/elevenlabs/src/_utils.ts
+++ b/plugins/elevenlabs/src/_utils.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/_utils.py - 8-37 lines
+export class PeriodicCollector<T> {
+  private duration: number;
+  private callback: (value: T) => void;
+  private lastFlushTime: number;
+  private total: T | null = null;
+
+  constructor(callback: (value: T) => void, options: { duration: number }) {
+    this.duration = options.duration;
+    this.callback = callback;
+    this.lastFlushTime = performance.now() / 1000;
+  }
+
+  push(value: T): void {
+    if (this.total === null) {
+      this.total = value;
+    } else {
+      this.total = ((this.total as number) + (value as number)) as T;
+    }
+
+    if (performance.now() / 1000 - this.lastFlushTime >= this.duration) {
+      this.flush();
+    }
+  }
+
+  flush(): void {
+    if (this.total !== null) {
+      this.callback(this.total);
+      this.total = null;
+    }
+    this.lastFlushTime = performance.now() / 1000;
+  }
+}

--- a/plugins/elevenlabs/src/index.ts
+++ b/plugins/elevenlabs/src/index.ts
@@ -4,7 +4,6 @@
 import { Plugin } from '@livekit/agents';
 
 export * from './models.js';
-// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/__init__.py - 20-21 lines
 export * from './stt.js';
 export * from './tts.js';
 

--- a/plugins/elevenlabs/src/index.ts
+++ b/plugins/elevenlabs/src/index.ts
@@ -4,6 +4,8 @@
 import { Plugin } from '@livekit/agents';
 
 export * from './models.js';
+// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/__init__.py - 20-21 lines
+export * from './stt.js';
 export * from './tts.js';
 
 class ElevenLabsPlugin extends Plugin {

--- a/plugins/elevenlabs/src/models.ts
+++ b/plugins/elevenlabs/src/models.ts
@@ -24,5 +24,4 @@ export type TTSEncoding =
   | 'pcm_22050'
   | 'pcm_44100';
 
-// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/models.py - 38-45 lines
 export type STTRealtimeSampleRates = 8000 | 16000 | 22050 | 24000 | 44100 | 48000;

--- a/plugins/elevenlabs/src/models.ts
+++ b/plugins/elevenlabs/src/models.ts
@@ -23,3 +23,6 @@ export type TTSEncoding =
   | 'pcm_16000'
   | 'pcm_22050'
   | 'pcm_44100';
+
+// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/models.py - 38-45 lines
+export type STTRealtimeSampleRates = 8000 | 16000 | 22050 | 24000 | 44100 | 48000;

--- a/plugins/elevenlabs/src/stt.test.ts
+++ b/plugins/elevenlabs/src/stt.test.ts
@@ -1,0 +1,415 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { mergeFrames, stt as sttLib } from '@livekit/agents';
+import { AudioFrame, AudioResampler } from '@livekit/rtc-node';
+import { once } from 'node:events';
+import { readFileSync } from 'node:fs';
+import { type RequestListener, type Server, createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { describe, expect, it } from 'vitest';
+import { WebSocketServer } from 'ws';
+import { STT } from './stt.js';
+
+function makeFrame(samplesPerChannel = 800, sampleRate = 16000): AudioFrame {
+  const data = new Int16Array(samplesPerChannel);
+  data.fill(1);
+  return new AudioFrame(data, sampleRate, 1, samplesPerChannel);
+}
+
+async function startHttpServer(handler: RequestListener) {
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind to a port');
+  return { server, baseURL: `http://127.0.0.1:${address.port}` };
+}
+
+async function closeHttpServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function startWebSocketServer() {
+  const wss = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  await once(wss, 'listening');
+  const address = wss.address() as AddressInfo;
+  return { wss, baseURL: `http://127.0.0.1:${address.port}` };
+}
+
+async function closeWebSocketServer(wss: WebSocketServer): Promise<void> {
+  await new Promise<void>((resolve) => wss.close(() => resolve()));
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+async function collectUntilEnd(stream: sttLib.SpeechStream): Promise<sttLib.SpeechEvent[]> {
+  const events: sttLib.SpeechEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+    if (event.type === sttLib.SpeechEventType.END_OF_SPEECH) break;
+  }
+  return events;
+}
+
+const TRANSCRIPT =
+  'It could not have been ten seconds, and yet it seemed a long time that their hands were clasped together.';
+
+function normalizedWords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9' ]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter(Boolean);
+}
+
+function editDistance(left: string[], right: string[]): number {
+  let previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  for (let i = 0; i < left.length; i++) {
+    const current = [i + 1];
+    for (let j = 0; j < right.length; j++) {
+      current[j + 1] = Math.min(
+        current[j]! + 1,
+        previous[j + 1]! + 1,
+        previous[j]! + (left[i] === right[j] ? 0 : 1),
+      );
+    }
+    previous = current;
+  }
+  return previous[right.length] ?? 0;
+}
+
+function wordErrorRate(hypothesis: string, reference: string): number {
+  const referenceWords = normalizedWords(reference);
+  if (referenceWords.length === 0) return 0;
+  return (
+    editDistance(referenceWords, normalizedWords(hypothesis).slice(0, referenceWords.length)) /
+    referenceWords.length
+  );
+}
+
+function makeIntegrationSpeech(): AudioFrame {
+  const sample = readFileSync(new URL('../../test/src/long.wav', import.meta.url));
+  const channels = sample.readUInt16LE(22);
+  const sampleRate = sample.readUInt32LE(24);
+  const pcm = new Int16Array(sample.buffer, sample.byteOffset + 44, (sample.byteLength - 44) / 2);
+  const frame = new AudioFrame(pcm, sampleRate, channels, Math.trunc(pcm.length / channels));
+
+  if (sampleRate === 24000) return frame;
+
+  const resampler = new AudioResampler(sampleRate, 24000, channels);
+  const frames = resampler.push(frame);
+  frames.push(...resampler.flush());
+  resampler.close();
+  return mergeFrames(frames);
+}
+
+const hasElevenLabsApiKey = Boolean(process.env.ELEVEN_API_KEY);
+
+// Ref: python tests/test_stt.py - 121-170 lines
+describe('ElevenLabs STT integration', () => {
+  it.skipIf(!hasElevenLabsApiKey)(
+    'recognizes speech with the real ElevenLabs API',
+    async () => {
+      const eleven = new STT();
+      const event = await eleven.recognize(makeIntegrationSpeech(), {
+        connOptions: { maxRetry: 2, retryIntervalMs: 2000, timeoutMs: 10000 },
+      });
+
+      expect(event.type).toBe(sttLib.SpeechEventType.FINAL_TRANSCRIPT);
+      expect(wordErrorRate(event.alternatives?.[0]?.text ?? '', TRANSCRIPT)).toBeLessThanOrEqual(
+        0.25,
+      );
+    },
+    60_000,
+  );
+});
+
+describe('ElevenLabs STT', () => {
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 117-141 lines
+  it('defaults to Scribe v1 batch recognition', () => {
+    const stt = new STT({ apiKey: 'test-key' });
+
+    expect(stt.model).toBe('scribe_v1');
+    expect(stt.provider).toBe('ElevenLabs');
+    expect(stt.capabilities.streaming).toBe(false);
+    expect(stt.capabilities.interimResults).toBe(true);
+    expect(stt.capabilities.alignedTranscript).toBe(false);
+  });
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 117-141 lines
+  it('maps deprecated useRealtime to realtime model capabilities', () => {
+    const stt = new STT({ apiKey: 'test-key', useRealtime: true, includeTimestamps: true });
+
+    expect(stt.model).toBe('scribe_v2_realtime');
+    expect(stt.capabilities.streaming).toBe(true);
+    expect(stt.capabilities.alignedTranscript).toBe('word');
+  });
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 178-243 lines
+  it('sends batch recognition form fields and maps word metadata', async () => {
+    let request:
+      | {
+          method?: string;
+          url?: string;
+          apiKey?: string | string[];
+          body: string;
+        }
+      | undefined;
+
+    const { server, baseURL } = await startHttpServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        request = {
+          method: req.method,
+          url: req.url,
+          apiKey: req.headers['xi-api-key'],
+          body: Buffer.concat(chunks).toString('utf8'),
+        };
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            text: 'bonjour livekit',
+            language_code: 'fr',
+            words: [
+              { text: 'bonjour', start: 0.2, end: 0.7, speaker_id: 'speaker-a' },
+              { text: 'livekit', start: 0.8, end: 1.1, speaker_id: 'speaker-a' },
+            ],
+          }),
+        );
+      });
+    });
+
+    try {
+      const eleven = new STT({
+        apiKey: 'test-key',
+        baseURL,
+        languageCode: 'en',
+        tagAudioEvents: false,
+        modelId: 'scribe_v2',
+        keyterms: ['LiveKit', 'ElevenLabs'],
+      });
+
+      const event = await eleven.recognize(makeFrame(), {
+        language: 'fr',
+        connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1000 },
+      });
+
+      expect(request?.method).toBe('POST');
+      expect(request?.url).toBe('/speech-to-text');
+      expect(request?.apiKey).toBe('test-key');
+      expect(request?.body).toContain('name="model_id"');
+      expect(request?.body).toContain('scribe_v2');
+      expect(request?.body).toContain('name="tag_audio_events"');
+      expect(request?.body).toContain('false');
+      expect(request?.body).toContain('name="language_code"');
+      expect(request?.body).toContain('fr');
+      expect(request?.body.match(/name="keyterms"/g)).toHaveLength(2);
+
+      expect(event.type).toBe(sttLib.SpeechEventType.FINAL_TRANSCRIPT);
+      expect(event.alternatives?.[0]).toMatchObject({
+        text: 'bonjour livekit',
+        language: 'fr',
+        speakerId: 'speaker-a',
+        startTime: 0.2,
+        endTime: 1.1,
+      });
+      expect(event.alternatives?.[0]?.words?.map((word) => word.text)).toEqual([
+        'bonjour',
+        'livekit',
+      ]);
+    } finally {
+      await closeHttpServer(server);
+    }
+  });
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 531-639 lines
+  it('streams audio and maps realtime speech events', async () => {
+    const { wss, baseURL } = await startWebSocketServer();
+    const receivedMessages: Record<string, unknown>[] = [];
+    let requestUrl = '';
+    let requestApiKey: string | string[] | undefined;
+
+    wss.on('connection', (ws, req) => {
+      requestUrl = req.url ?? '';
+      requestApiKey = req.headers['xi-api-key'];
+      let sentEvents = false;
+      ws.on('message', (raw) => {
+        receivedMessages.push(JSON.parse(raw.toString()) as Record<string, unknown>);
+        if (sentEvents) return;
+        sentEvents = true;
+        ws.send(JSON.stringify({ message_type: 'session_started', session_id: 'session-1' }));
+        ws.send(
+          JSON.stringify({ message_type: 'partial_transcript', text: 'hel', language_code: 'en' }),
+        );
+        ws.send(
+          JSON.stringify({
+            message_type: 'committed_transcript',
+            text: 'hello',
+            language_code: 'en',
+            words: [{ text: 'hello', start: 0.1, end: 0.4 }],
+          }),
+        );
+        ws.send(JSON.stringify({ message_type: 'committed_transcript', text: '' }));
+        setTimeout(() => ws.close(), 20);
+      });
+    });
+
+    try {
+      const eleven = new STT({ apiKey: 'test-key', baseURL, modelId: 'scribe_v2_realtime' });
+      const stream = eleven.stream();
+      stream.startTimeOffset = 1;
+
+      await waitUntil(() => requestUrl !== '');
+
+      stream.pushFrame(makeFrame());
+      stream.flush();
+      stream.endInput();
+
+      const events = await collectUntilEnd(stream);
+      stream.close();
+
+      const url = new URL(`ws://127.0.0.1${requestUrl}`);
+      expect(requestApiKey).toBe('test-key');
+      expect(url.pathname).toBe('/speech-to-text/realtime');
+      expect(url.searchParams.get('model_id')).toBe('scribe_v2_realtime');
+      expect(url.searchParams.get('audio_format')).toBe('pcm_16000');
+      expect(url.searchParams.get('commit_strategy')).toBe('vad');
+      expect(url.searchParams.get('include_language_detection')).toBe('true');
+      expect(receivedMessages[0]).toMatchObject({
+        message_type: 'input_audio_chunk',
+        commit: false,
+        sample_rate: 16000,
+      });
+      expect(typeof receivedMessages[0]?.audio_base_64).toBe('string');
+
+      const speechEvents = events.filter(
+        (event) => event.type !== sttLib.SpeechEventType.RECOGNITION_USAGE,
+      );
+      expect(speechEvents.map((event) => event.type)).toEqual([
+        sttLib.SpeechEventType.START_OF_SPEECH,
+        sttLib.SpeechEventType.INTERIM_TRANSCRIPT,
+        sttLib.SpeechEventType.FINAL_TRANSCRIPT,
+        sttLib.SpeechEventType.END_OF_SPEECH,
+      ]);
+      expect(events.some((event) => event.type === sttLib.SpeechEventType.RECOGNITION_USAGE)).toBe(
+        true,
+      );
+      expect(speechEvents[2]?.alternatives?.[0]).toMatchObject({
+        text: 'hello',
+        language: 'en',
+        startTime: 1.1,
+        endTime: 1.4,
+      });
+      expect(speechEvents[2]?.alternatives?.[0]?.words?.[0]).toMatchObject({
+        text: 'hello',
+        startTime: 1.1,
+        endTime: 1.4,
+        startTimeOffset: 1,
+      });
+    } finally {
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 482-516 lines
+  it('builds realtime query params for language, timestamps, and server VAD', async () => {
+    const { wss, baseURL } = await startWebSocketServer();
+    let requestUrl = '';
+
+    wss.on('connection', (ws, req) => {
+      requestUrl = req.url ?? '';
+      ws.on('message', () => {
+        ws.send(JSON.stringify({ message_type: 'committed_transcript', text: 'ignored' }));
+        ws.send(
+          JSON.stringify({
+            message_type: 'committed_transcript_with_timestamps',
+            text: 'kept',
+            language_code: 'en',
+            words: [{ text: 'kept', start: 0, end: 0.2 }],
+          }),
+        );
+        ws.send(JSON.stringify({ message_type: 'committed_transcript_with_timestamps', text: '' }));
+      });
+    });
+
+    try {
+      const eleven = new STT({
+        apiKey: 'test-key',
+        baseURL,
+        modelId: 'scribe_v2_realtime',
+        languageCode: 'en',
+        includeTimestamps: true,
+        serverVad: {
+          vadSilenceThresholdSecs: 0.5,
+          vadThreshold: 0.4,
+          minSpeechDurationMs: 100,
+          minSilenceDurationMs: 300,
+        },
+      });
+      const stream = eleven.stream();
+
+      await waitUntil(() => requestUrl !== '');
+
+      stream.pushFrame(makeFrame());
+      stream.endInput();
+
+      const events = await collectUntilEnd(stream);
+      stream.close();
+
+      const url = new URL(`ws://127.0.0.1${requestUrl}`);
+      expect(url.searchParams.get('language_code')).toBe('en');
+      expect(url.searchParams.get('include_language_detection')).toBeNull();
+      expect(url.searchParams.get('include_timestamps')).toBe('true');
+      expect(url.searchParams.get('vad_silence_threshold_secs')).toBe('0.5');
+      expect(url.searchParams.get('vad_threshold')).toBe('0.4');
+      expect(url.searchParams.get('min_speech_duration_ms')).toBe('100');
+      expect(url.searchParams.get('min_silence_duration_ms')).toBe('300');
+      expect(
+        events.find((event) => event.type === sttLib.SpeechEventType.FINAL_TRANSCRIPT)
+          ?.alternatives?.[0]?.text,
+      ).toBe('kept');
+    } finally {
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 277-295 lines
+  it('updates server VAD on active streams and reconnects in place', async () => {
+    const { wss, baseURL } = await startWebSocketServer();
+    const urls: string[] = [];
+
+    wss.on('connection', (ws, req) => {
+      urls.push(req.url ?? '');
+      ws.on('message', () => {});
+    });
+
+    try {
+      const eleven = new STT({ apiKey: 'test-key', baseURL, modelId: 'scribe_v2_realtime' });
+      const stream = eleven.stream();
+
+      await waitUntil(() => urls.length === 1);
+      eleven.updateOptions({ serverVad: null });
+      await waitUntil(() => urls.length === 2, 2000);
+      stream.close();
+
+      const first = new URL(`ws://127.0.0.1${urls[0]}`);
+      const second = new URL(`ws://127.0.0.1${urls[1]}`);
+      expect(first.searchParams.get('commit_strategy')).toBe('vad');
+      expect(second.searchParams.get('commit_strategy')).toBe('manual');
+    } finally {
+      await closeWebSocketServer(wss);
+    }
+  });
+});

--- a/plugins/elevenlabs/src/stt.test.ts
+++ b/plugins/elevenlabs/src/stt.test.ts
@@ -116,7 +116,6 @@ function makeIntegrationSpeech(): AudioFrame {
 
 const hasElevenLabsApiKey = Boolean(process.env.ELEVEN_API_KEY);
 
-// Ref: python tests/test_stt.py - 121-170 lines
 describe('ElevenLabs STT integration', () => {
   it.skipIf(!hasElevenLabsApiKey)(
     'recognizes speech with the real ElevenLabs API',
@@ -136,7 +135,6 @@ describe('ElevenLabs STT integration', () => {
 });
 
 describe('ElevenLabs STT', () => {
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 117-141 lines
   it('defaults to Scribe v1 batch recognition', () => {
     const stt = new STT({ apiKey: 'test-key' });
 
@@ -147,7 +145,6 @@ describe('ElevenLabs STT', () => {
     expect(stt.capabilities.alignedTranscript).toBe(false);
   });
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 117-141 lines
   it('maps deprecated useRealtime to realtime model capabilities', () => {
     const stt = new STT({ apiKey: 'test-key', useRealtime: true, includeTimestamps: true });
 
@@ -156,7 +153,6 @@ describe('ElevenLabs STT', () => {
     expect(stt.capabilities.alignedTranscript).toBe('word');
   });
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 178-243 lines
   it('sends batch recognition form fields and maps word metadata', async () => {
     let request:
       | {
@@ -234,7 +230,6 @@ describe('ElevenLabs STT', () => {
     }
   });
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 531-639 lines
   it('streams audio and maps realtime speech events', async () => {
     const { wss, baseURL } = await startWebSocketServer();
     const receivedMessages: Record<string, unknown>[] = [];
@@ -323,7 +318,6 @@ describe('ElevenLabs STT', () => {
     }
   });
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 482-516 lines
   it('builds realtime query params for language, timestamps, and server VAD', async () => {
     const { wss, baseURL } = await startWebSocketServer();
     let requestUrl = '';
@@ -385,7 +379,6 @@ describe('ElevenLabs STT', () => {
     }
   });
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 277-295 lines
   it('updates server VAD on active streams and reconnects in place', async () => {
     const { wss, baseURL } = await startWebSocketServer();
     const urls: string[] = [];

--- a/plugins/elevenlabs/src/stt.ts
+++ b/plugins/elevenlabs/src/stt.ts
@@ -1,0 +1,850 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  type APIConnectOptions,
+  APIConnectionError,
+  APIError,
+  APIStatusError,
+  APITimeoutError,
+  type AudioBuffer,
+  AudioByteStream,
+  DEFAULT_API_CONNECT_OPTIONS,
+  Future,
+  Task,
+  calculateAudioDurationSeconds,
+  createTimedString,
+  delay,
+  intervalForRetry,
+  log,
+  mergeFrames,
+  normalizeLanguage,
+  stt,
+  waitForAbort,
+} from '@livekit/agents';
+import type { AudioFrame } from '@livekit/rtc-node';
+import { type RawData, WebSocket } from 'ws';
+import { PeriodicCollector } from './_utils.js';
+import type { STTRealtimeSampleRates } from './models.js';
+
+const API_BASE_URL_V1 = 'https://api.elevenlabs.io/v1';
+const AUTHORIZATION_HEADER = 'xi-api-key';
+
+// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 51-59 lines
+export interface VADOptions {
+  vadSilenceThresholdSecs?: number | null;
+  vadThreshold?: number | null;
+  minSpeechDurationMs?: number | null;
+  minSilenceDurationMs?: number | null;
+}
+
+// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 62-63 lines
+export type ElevenLabsSTTModels = 'scribe_v1' | 'scribe_v2' | 'scribe_v2_realtime';
+
+export interface STTHTTPSession {
+  fetch?: typeof fetch;
+  wsConnect?: (
+    url: string,
+    options: { headers: Record<string, string>; signal?: AbortSignal; timeoutMs?: number },
+  ) => WebSocket | Promise<WebSocket>;
+}
+
+export interface STTOptions {
+  apiKey?: string;
+  baseURL?: string;
+  languageCode?: string;
+  tagAudioEvents?: boolean;
+  useRealtime?: boolean;
+  sampleRate?: STTRealtimeSampleRates;
+  serverVad?: VADOptions | null;
+  includeTimestamps?: boolean;
+  httpSession?: STTHTTPSession;
+  modelId?: ElevenLabsSTTModels | string;
+  keyterms?: string[];
+}
+
+// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 66-77 lines
+interface ResolvedSTTOptions {
+  modelId: ElevenLabsSTTModels | string;
+  apiKey: string;
+  baseURL: string;
+  languageCode?: string;
+  tagAudioEvents: boolean;
+  includeTimestamps: boolean;
+  sampleRate: STTRealtimeSampleRates;
+  serverVad?: VADOptions | null;
+  keyterms?: string[];
+}
+
+export interface STTRecognizeOptions {
+  language?: string;
+  connOptions?: APIConnectOptions;
+  abortSignal?: AbortSignal;
+}
+
+interface ElevenLabsWord {
+  text?: string;
+  start?: number;
+  end?: number;
+  speaker_id?: string | null;
+}
+
+interface ElevenLabsBatchResponse {
+  text?: string;
+  language_code?: string;
+  words?: ElevenLabsWord[];
+  detail?: string;
+}
+
+interface ElevenLabsStreamEvent {
+  message_type?: string;
+  text?: string;
+  words?: ElevenLabsWord[];
+  language_code?: string;
+  session_id?: string;
+  message?: string;
+  details?: string;
+}
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  return (
+    typeof value === 'object' && value !== null && 'aborted' in value && 'addEventListener' in value
+  );
+}
+
+// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 188-190 lines
+function createWav(frame: AudioFrame): Buffer {
+  const bitsPerSample = 16;
+  const byteRate = (frame.sampleRate * frame.channels * bitsPerSample) / 8;
+  const blockAlign = (frame.channels * bitsPerSample) / 8;
+
+  const header = Buffer.alloc(44);
+  header.write('RIFF', 0);
+  header.writeUInt32LE(36 + frame.data.byteLength, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(frame.channels, 22);
+  header.writeUInt32LE(frame.sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+  header.write('data', 36);
+  header.writeUInt32LE(frame.data.byteLength, 40);
+
+  const pcm = Buffer.from(frame.data.buffer, frame.data.byteOffset, frame.data.byteLength);
+  return Buffer.concat([header, pcm]);
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function asWords(value: unknown): ElevenLabsWord[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((word) => {
+    const record = toRecord(word);
+    return {
+      text: asString(record.text),
+      start: asNumber(record.start),
+      end: asNumber(record.end),
+      speaker_id: asString(record.speaker_id) ?? null,
+    };
+  });
+}
+
+function parseBatchResponse(value: unknown): ElevenLabsBatchResponse {
+  const record = toRecord(value);
+  return {
+    text: asString(record.text),
+    language_code: asString(record.language_code),
+    words: asWords(record.words),
+    detail: asString(record.detail),
+  };
+}
+
+function parseStreamEvent(value: unknown): ElevenLabsStreamEvent {
+  const record = toRecord(value);
+  return {
+    message_type: asString(record.message_type),
+    text: asString(record.text),
+    words: asWords(record.words),
+    language_code: asString(record.language_code),
+    session_id: asString(record.session_id),
+    message: asString(record.message),
+    details: asString(record.details),
+  };
+}
+
+// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 79-310 lines
+export class STT extends stt.STT {
+  #opts: ResolvedSTTOptions;
+  #session: STTHTTPSession;
+  #streams = new Set<WeakRef<SpeechStream>>();
+  #logger = log();
+
+  label = 'elevenlabs.STT';
+
+  constructor(opts: STTOptions = {}) {
+    let modelId = opts.modelId;
+    if (opts.useRealtime !== undefined) {
+      if (modelId !== undefined) {
+        log().warn(
+          'both `useRealtime` and `modelId` parameters are provided. `useRealtime` will be ignored.',
+        );
+      } else {
+        log().warn(
+          '`useRealtime` parameter is deprecated. Specify a realtime modelId to enable streaming. Defaulting modelId to one based on useRealtime parameter.',
+        );
+        modelId = opts.useRealtime ? 'scribe_v2_realtime' : 'scribe_v1';
+      }
+    }
+    modelId = modelId ?? 'scribe_v1';
+    const useRealtime = modelId === 'scribe_v2_realtime';
+
+    if (!useRealtime && opts.serverVad !== undefined) {
+      log().warn('Server-side VAD is only supported for Scribe v2 realtime model');
+    }
+
+    const includeTimestamps = opts.includeTimestamps ?? false;
+    super({
+      streaming: useRealtime,
+      interimResults: true,
+      alignedTranscript: includeTimestamps && useRealtime ? 'word' : false,
+    });
+
+    const apiKey = opts.apiKey ?? process.env.ELEVEN_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        'ElevenLabs API key is required, either as argument or set ELEVEN_API_KEY environmental variable',
+      );
+    }
+
+    this.#opts = {
+      apiKey,
+      baseURL: opts.baseURL ?? API_BASE_URL_V1,
+      languageCode: opts.languageCode ? normalizeLanguage(opts.languageCode) : undefined,
+      tagAudioEvents: opts.tagAudioEvents ?? true,
+      sampleRate: opts.sampleRate ?? 16000,
+      serverVad: opts.serverVad,
+      includeTimestamps,
+      modelId,
+      keyterms: opts.keyterms,
+    };
+    this.#session = opts.httpSession ?? {};
+  }
+
+  get model(): string {
+    return this.#opts.modelId;
+  }
+
+  get provider(): string {
+    return 'ElevenLabs';
+  }
+
+  async recognize(buffer: AudioBuffer, abortSignal?: AbortSignal): Promise<stt.SpeechEvent>;
+  async recognize(buffer: AudioBuffer, options?: STTRecognizeOptions): Promise<stt.SpeechEvent>;
+  async recognize(
+    buffer: AudioBuffer,
+    optionsOrAbortSignal?: AbortSignal | STTRecognizeOptions,
+  ): Promise<stt.SpeechEvent> {
+    const options = isAbortSignal(optionsOrAbortSignal)
+      ? { abortSignal: optionsOrAbortSignal }
+      : optionsOrAbortSignal ?? {};
+    const connOptions = options.connOptions ?? DEFAULT_API_CONNECT_OPTIONS;
+
+    for (let i = 0; i < connOptions.maxRetry + 1; i++) {
+      try {
+        const startTime = process.hrtime.bigint();
+        const event = await this.#recognizeImpl(buffer, options.language, options.abortSignal);
+        const durationMs = Number((process.hrtime.bigint() - startTime) / BigInt(1000000));
+        this.emit('metrics_collected', {
+          type: 'stt_metrics',
+          requestId: event.requestId ?? '',
+          timestamp: Date.now(),
+          durationMs,
+          label: this.label,
+          audioDurationMs: Math.round(calculateAudioDurationSeconds(buffer) * 1000),
+          streamed: false,
+          metadata: {
+            modelProvider: this.provider,
+            modelName: this.model,
+          },
+        });
+        return event;
+      } catch (error) {
+        if (error instanceof APIError) {
+          const retryInterval = intervalForRetry(connOptions, i);
+
+          if (connOptions.maxRetry === 0 || !error.retryable) {
+            this.#emitError(error, false);
+            throw error;
+          } else if (i === connOptions.maxRetry) {
+            this.#emitError(error, false);
+            throw new APIConnectionError({
+              message: `failed to recognize speech after ${connOptions.maxRetry + 1} attempts`,
+              options: { retryable: false },
+            });
+          } else {
+            this.#logger.warn(
+              { stt: this.label, attempt: i + 1, error },
+              `failed to recognize speech, retrying in ${retryInterval}ms`,
+            );
+          }
+
+          if (retryInterval > 0) {
+            await delay(retryInterval);
+          }
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    throw new APIConnectionError({ message: 'failed to recognize speech' });
+  }
+
+  protected async _recognize(
+    buffer: AudioBuffer,
+    abortSignal?: AbortSignal,
+  ): Promise<stt.SpeechEvent> {
+    return this.#recognizeImpl(buffer, undefined, abortSignal);
+  }
+
+  #emitError(error: Error, recoverable: boolean): void {
+    this.emit('error', {
+      type: 'stt_error',
+      timestamp: Date.now(),
+      label: this.label,
+      error,
+      recoverable,
+    });
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 178-243 lines
+  async #recognizeImpl(
+    buffer: AudioBuffer,
+    language?: string,
+    abortSignal?: AbortSignal,
+  ): Promise<stt.SpeechEvent> {
+    if (language !== undefined) {
+      this.#opts.languageCode = normalizeLanguage(language);
+    }
+
+    const wavBytes = createWav(mergeFrames(buffer));
+    const form = new FormData();
+    form.append('file', new Blob([new Uint8Array(wavBytes)], { type: 'audio/x-wav' }), 'audio.wav');
+    form.append('model_id', this.#opts.modelId);
+    form.append('tag_audio_events', String(this.#opts.tagAudioEvents));
+    if (this.#opts.languageCode) {
+      form.append('language_code', this.#opts.languageCode);
+    }
+    if (this.#opts.keyterms !== undefined) {
+      for (const keyterm of this.#opts.keyterms) {
+        form.append('keyterms', keyterm);
+      }
+    }
+
+    try {
+      const fetchFn = this.#session.fetch ?? fetch;
+      const response = await fetchFn(`${this.#opts.baseURL}/speech-to-text`, {
+        method: 'POST',
+        headers: { [AUTHORIZATION_HEADER]: this.#opts.apiKey },
+        body: form,
+        signal: abortSignal ?? null,
+      });
+      const responseJson = parseBatchResponse(await response.json());
+      if (response.status !== 200) {
+        throw new APIStatusError({
+          message: responseJson.detail ?? 'Unknown ElevenLabs error',
+          options: { statusCode: response.status, requestId: null, body: responseJson },
+        });
+      }
+
+      const words = responseJson.words ?? [];
+      const speakerId = words.length > 0 ? words[0]?.speaker_id ?? null : null;
+      const startTime = words.length > 0 ? Math.min(...words.map((word) => word.start ?? 0)) : 0;
+      const endTime = words.length > 0 ? Math.max(...words.map((word) => word.end ?? 0)) : 0;
+      const normalizedLanguage = normalizeLanguage(
+        responseJson.language_code ?? this.#opts.languageCode ?? '',
+      );
+
+      return this.#transcriptionToSpeechEvent(
+        normalizedLanguage,
+        responseJson.text ?? '',
+        startTime,
+        endTime,
+        speakerId,
+        words.length > 0 ? words : undefined,
+      );
+    } catch (error) {
+      if (error instanceof APITimeoutError || error instanceof APIConnectionError) {
+        throw error;
+      }
+      if (error instanceof APIStatusError) {
+        throw new APIConnectionError({ message: error.message });
+      }
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new APITimeoutError({});
+      }
+      throw new APIConnectionError({});
+    }
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 245-275 lines
+  #transcriptionToSpeechEvent(
+    languageCode: string,
+    text: string,
+    startTime: number,
+    endTime: number,
+    speakerId: string | null,
+    words?: ElevenLabsWord[],
+  ): stt.SpeechEvent {
+    return {
+      type: stt.SpeechEventType.FINAL_TRANSCRIPT,
+      alternatives: [
+        {
+          text,
+          language: normalizeLanguage(languageCode),
+          speakerId,
+          startTime,
+          endTime,
+          confidence: 0,
+          words: words?.map((word) =>
+            createTimedString({
+              text: word.text ?? '',
+              startTime: word.start ?? 0,
+              endTime: word.end ?? 0,
+            }),
+          ),
+        },
+      ],
+    };
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 277-295 lines
+  updateOptions(opts: {
+    tagAudioEvents?: boolean;
+    serverVad?: VADOptions | null;
+    keyterms?: string[];
+  }): void {
+    if (opts.tagAudioEvents !== undefined) {
+      this.#opts.tagAudioEvents = opts.tagAudioEvents;
+    }
+
+    if (opts.serverVad !== undefined) {
+      this.#opts.serverVad = opts.serverVad;
+    }
+
+    if (opts.keyterms !== undefined) {
+      this.#opts.keyterms = opts.keyterms;
+    }
+
+    for (const ref of this.#streams) {
+      const stream = ref.deref();
+      if (stream) {
+        stream.updateOptions({ serverVad: opts.serverVad });
+      } else {
+        this.#streams.delete(ref);
+      }
+    }
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 296-310 lines
+  stream(options?: { language?: string; connOptions?: APIConnectOptions }): SpeechStream {
+    const stream = new SpeechStream(
+      this,
+      this.#opts,
+      options?.connOptions ?? DEFAULT_API_CONNECT_OPTIONS,
+      options?.language !== undefined
+        ? normalizeLanguage(options.language)
+        : this.#opts.languageCode,
+      this.#session,
+    );
+    this.#streams.add(new WeakRef(stream));
+    return stream;
+  }
+}
+
+// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 313-639 lines
+export class SpeechStream extends stt.SpeechStream {
+  #opts: ResolvedSTTOptions;
+  #language?: string;
+  #session: STTHTTPSession;
+  #reconnectEvent = new Future<void>();
+  #speaking = false;
+  #audioDurationCollector: PeriodicCollector<number>;
+  #logger = log();
+
+  label = 'elevenlabs.SpeechStream';
+
+  constructor(
+    sttInstance: STT,
+    opts: ResolvedSTTOptions,
+    connOptions: APIConnectOptions,
+    language: string | undefined,
+    httpSession: STTHTTPSession,
+  ) {
+    super(sttInstance, opts.sampleRate, connOptions);
+    this.#opts = opts;
+    this.#language = language;
+    this.#session = httpSession;
+    this.#audioDurationCollector = new PeriodicCollector(
+      (duration) => this.#onAudioDurationReport(duration),
+      { duration: 5.0 },
+    );
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 336-344 lines
+  updateOptions(opts: { serverVad?: VADOptions | null }): void {
+    if (opts.serverVad !== undefined) {
+      this.#opts.serverVad = opts.serverVad;
+      if (!this.#reconnectEvent.done) {
+        this.#reconnectEvent.resolve();
+      }
+    }
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 345-351 lines
+  #onAudioDurationReport(duration: number): void {
+    this.queue.put({
+      type: stt.SpeechEventType.RECOGNITION_USAGE,
+      recognitionUsage: { audioDuration: duration },
+    });
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 353-480 lines
+  protected async run(): Promise<void> {
+    while (!this.closed && !this.input.closed) {
+      let ws: WebSocket | null = null;
+      let closingWs = false;
+      const sessionController = new AbortController();
+
+      try {
+        ws = await this.#connectWs();
+
+        const keepaliveTask = Task.from(async (controller) => {
+          while (!controller.signal.aborted) {
+            await Promise.race([delay(10000), waitForAbort(controller.signal)]);
+            if (controller.signal.aborted || ws?.readyState !== WebSocket.OPEN) return;
+            ws.send(
+              JSON.stringify({
+                message_type: 'input_audio_chunk',
+                audio_base_64: '',
+                commit: false,
+                sample_rate: this.#opts.sampleRate,
+              }),
+            );
+          }
+        }, sessionController);
+
+        const sendTask = Task.from(async (controller) => {
+          const samples50Ms = Math.floor(this.#opts.sampleRate / 20);
+          const audioByteStream = new AudioByteStream(this.#opts.sampleRate, 1, samples50Ms);
+          const abortPromise = waitForAbort(controller.signal);
+          const streamAbortPromise = waitForAbort(this.abortSignal);
+          let hasEnded = false;
+
+          try {
+            while (!this.closed) {
+              const result = await Promise.race([
+                this.input.next(),
+                abortPromise,
+                streamAbortPromise,
+              ]);
+              if (result === undefined) return;
+              if (result.done) break;
+
+              const data = result.value;
+              let frames: AudioFrame[];
+              if (data === SpeechStream.FLUSH_SENTINEL) {
+                frames = audioByteStream.flush();
+                hasEnded = true;
+              } else {
+                frames = audioByteStream.write(data.data);
+              }
+
+              for (const frame of frames) {
+                this.#audioDurationCollector.push(frame.samplesPerChannel / frame.sampleRate);
+                const audioBase64 = Buffer.from(
+                  frame.data.buffer,
+                  frame.data.byteOffset,
+                  frame.data.byteLength,
+                ).toString('base64');
+                ws?.send(
+                  JSON.stringify({
+                    message_type: 'input_audio_chunk',
+                    audio_base_64: audioBase64,
+                    commit: false,
+                    sample_rate: this.#opts.sampleRate,
+                  }),
+                );
+
+                if (hasEnded) {
+                  this.#audioDurationCollector.flush();
+                  hasEnded = false;
+                }
+              }
+            }
+          } finally {
+            closingWs = true;
+          }
+        }, sessionController);
+
+        const recvTask = Task.from(async (controller) => {
+          const receiveMessages = new Promise<void>((resolve, reject) => {
+            const onMessage = (msg: RawData, isBinary: boolean) => {
+              if (isBinary) {
+                this.#logger.warn('unexpected ElevenLabs STT binary message');
+                return;
+              }
+              try {
+                this.#processStreamEvent(parseStreamEvent(JSON.parse(msg.toString())));
+              } catch (error) {
+                this.#logger.error({ error }, 'failed to process ElevenLabs STT message');
+              }
+            };
+            const onClose = (code: number, reason: Buffer) => {
+              sessionController.abort();
+              if (closingWs || this.closed) {
+                resolve();
+                return;
+              }
+              reject(
+                new APIStatusError({
+                  message: 'ElevenLabs STT connection closed unexpectedly',
+                  options: {
+                    statusCode: code || -1,
+                    body: { reason: reason.toString() },
+                  },
+                }),
+              );
+            };
+            const onError = (error: Error) => {
+              sessionController.abort();
+              reject(new APIConnectionError({ message: error.message }));
+            };
+            ws?.on('message', onMessage);
+            ws?.once('close', onClose);
+            ws?.once('error', onError);
+          });
+
+          await Promise.race([receiveMessages, waitForAbort(controller.signal)]);
+        }, sessionController);
+
+        const runResult = await Promise.race([
+          Promise.all([keepaliveTask.result, sendTask.result, recvTask.result]).then(
+            () => 'done' as const,
+          ),
+          this.#reconnectEvent.await.then(() => 'reconnect' as const),
+          waitForAbort(this.abortSignal).then(() => 'abort' as const),
+        ]);
+
+        if (runResult === 'reconnect') {
+          this.#reconnectEvent = new Future<void>();
+          continue;
+        }
+        break;
+      } finally {
+        closingWs = true;
+        sessionController.abort();
+        ws?.close();
+      }
+    }
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 482-529 lines
+  async #connectWs(): Promise<WebSocket> {
+    const commitStrategy = this.#opts.serverVad === null ? 'manual' : 'vad';
+    const params = [
+      `model_id=${this.#opts.modelId}`,
+      `audio_format=pcm_${this.#opts.sampleRate}`,
+      `commit_strategy=${commitStrategy}`,
+    ];
+
+    if (!this.#language) {
+      params.push('include_language_detection=true');
+    }
+
+    if (this.#opts.serverVad) {
+      if (
+        this.#opts.serverVad.vadSilenceThresholdSecs !== undefined &&
+        this.#opts.serverVad.vadSilenceThresholdSecs !== null
+      ) {
+        params.push(`vad_silence_threshold_secs=${this.#opts.serverVad.vadSilenceThresholdSecs}`);
+      }
+      if (
+        this.#opts.serverVad.vadThreshold !== undefined &&
+        this.#opts.serverVad.vadThreshold !== null
+      ) {
+        params.push(`vad_threshold=${this.#opts.serverVad.vadThreshold}`);
+      }
+      if (
+        this.#opts.serverVad.minSpeechDurationMs !== undefined &&
+        this.#opts.serverVad.minSpeechDurationMs !== null
+      ) {
+        params.push(`min_speech_duration_ms=${this.#opts.serverVad.minSpeechDurationMs}`);
+      }
+      if (
+        this.#opts.serverVad.minSilenceDurationMs !== undefined &&
+        this.#opts.serverVad.minSilenceDurationMs !== null
+      ) {
+        params.push(`min_silence_duration_ms=${this.#opts.serverVad.minSilenceDurationMs}`);
+      }
+    }
+
+    if (this.#language) {
+      params.push(`language_code=${this.#language}`);
+    }
+
+    if (this.#opts.includeTimestamps) {
+      params.push('include_timestamps=true');
+    }
+
+    const baseURL = this.#opts.baseURL.replace('https://', 'wss://').replace('http://', 'ws://');
+    const wsUrl = `${baseURL}/speech-to-text/realtime?${params.join('&')}`;
+    const headers = { [AUTHORIZATION_HEADER]: this.#opts.apiKey };
+
+    try {
+      if (this.#session.wsConnect) {
+        return await this.#session.wsConnect(wsUrl, {
+          headers,
+          signal: this.abortSignal,
+          timeoutMs: DEFAULT_API_CONNECT_OPTIONS.timeoutMs,
+        });
+      }
+
+      const ws = new WebSocket(wsUrl, { headers });
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          ws.close();
+          reject(new Error('connect timeout'));
+        }, DEFAULT_API_CONNECT_OPTIONS.timeoutMs);
+        const cleanup = () => {
+          clearTimeout(timeout);
+          this.abortSignal.removeEventListener('abort', onAbort);
+          ws.off('open', onOpen);
+          ws.off('error', onError);
+          ws.off('close', onClose);
+        };
+        const onOpen = () => {
+          cleanup();
+          resolve();
+        };
+        const onError = (error: Error) => {
+          cleanup();
+          reject(error);
+        };
+        const onClose = (code: number) => {
+          cleanup();
+          reject(new Error(`WebSocket returned ${code}`));
+        };
+        const onAbort = () => {
+          cleanup();
+          ws.close();
+          reject(new Error('aborted'));
+        };
+        ws.once('open', onOpen);
+        ws.once('error', onError);
+        ws.once('close', onClose);
+        this.abortSignal.addEventListener('abort', onAbort, { once: true });
+      });
+      return ws;
+    } catch (error) {
+      throw new APIConnectionError({ message: 'Failed to connect to ElevenLabs' });
+    }
+  }
+
+  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 531-639 lines
+  #processStreamEvent(data: ElevenLabsStreamEvent): void {
+    const messageType = data.message_type;
+    const text = data.text ?? '';
+    const words = data.words ?? [];
+    const startTime = words.length > 0 ? words[0]?.start ?? 0 : 0;
+    const endTime = words.length > 0 ? words[words.length - 1]?.end ?? 0 : 0;
+    const languageCode = data.language_code ?? this.#language;
+    const normalizedLanguage = languageCode
+      ? normalizeLanguage(languageCode)
+      : normalizeLanguage('en');
+
+    const speechData: stt.SpeechData = {
+      language: normalizedLanguage,
+      text,
+      startTime: startTime + this.startTimeOffset,
+      endTime: endTime + this.startTimeOffset,
+      confidence: 0,
+    };
+    if (words.length > 0) {
+      speechData.words = words.map((word) =>
+        createTimedString({
+          text: word.text ?? '',
+          startTime: (word.start ?? 0) + this.startTimeOffset,
+          endTime: (word.end ?? 0) + this.startTimeOffset,
+          startTimeOffset: this.startTimeOffset,
+        }),
+      );
+    }
+
+    if (messageType === 'partial_transcript') {
+      this.#logger.debug({ data }, 'Received message type partial_transcript');
+      if (text) {
+        if (!this.#speaking) {
+          this.queue.put({ type: stt.SpeechEventType.START_OF_SPEECH });
+          this.#speaking = true;
+        }
+        this.queue.put({
+          type: stt.SpeechEventType.INTERIM_TRANSCRIPT,
+          alternatives: [speechData],
+        });
+      }
+    } else if (
+      (messageType === 'committed_transcript' && !this.#opts.includeTimestamps) ||
+      (messageType === 'committed_transcript_with_timestamps' && this.#opts.includeTimestamps)
+    ) {
+      if (text) {
+        if (!this.#speaking) {
+          this.queue.put({ type: stt.SpeechEventType.START_OF_SPEECH });
+          this.#speaking = true;
+        }
+        this.queue.put({
+          type: stt.SpeechEventType.FINAL_TRANSCRIPT,
+          alternatives: [speechData],
+        });
+      } else if (this.#speaking) {
+        this.queue.put({ type: stt.SpeechEventType.END_OF_SPEECH });
+        this.#speaking = false;
+      }
+    } else if (messageType === 'committed_transcript') {
+      return;
+    } else if (messageType === 'session_started') {
+      this.#logger.debug(`Session started with ID: ${data.session_id ?? 'unknown'}`);
+    } else if (
+      messageType === 'auth_error' ||
+      messageType === 'quota_exceeded' ||
+      messageType === 'transcriber_error' ||
+      messageType === 'input_error' ||
+      messageType === 'error'
+    ) {
+      const errorMsg = data.message ?? 'Unknown error';
+      const detailsSuffix = data.details ? ` - ${data.details}` : '';
+      this.#logger.error(`ElevenLabs STT error [${messageType}]: ${errorMsg}${detailsSuffix}`);
+      throw new APIConnectionError({ message: `${messageType}: ${errorMsg}${detailsSuffix}` });
+    } else if (
+      messageType === 'committed_transcript_with_timestamps' &&
+      !this.#opts.includeTimestamps
+    ) {
+      return;
+    } else {
+      this.#logger.warn(`ElevenLabs STT unknown message type: ${messageType}, data: ${data}`);
+    }
+  }
+}

--- a/plugins/elevenlabs/src/stt.ts
+++ b/plugins/elevenlabs/src/stt.ts
@@ -30,7 +30,6 @@ import type { STTRealtimeSampleRates } from './models.js';
 const API_BASE_URL_V1 = 'https://api.elevenlabs.io/v1';
 const AUTHORIZATION_HEADER = 'xi-api-key';
 
-// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 51-59 lines
 export interface VADOptions {
   vadSilenceThresholdSecs?: number | null;
   vadThreshold?: number | null;
@@ -38,7 +37,6 @@ export interface VADOptions {
   minSilenceDurationMs?: number | null;
 }
 
-// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 62-63 lines
 export type ElevenLabsSTTModels = 'scribe_v1' | 'scribe_v2' | 'scribe_v2_realtime';
 
 export interface STTHTTPSession {
@@ -63,7 +61,6 @@ export interface STTOptions {
   keyterms?: string[];
 }
 
-// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 66-77 lines
 interface ResolvedSTTOptions {
   modelId: ElevenLabsSTTModels | string;
   apiKey: string;
@@ -112,7 +109,6 @@ function isAbortSignal(value: unknown): value is AbortSignal {
   );
 }
 
-// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 188-190 lines
 function createWav(frame: AudioFrame): Buffer {
   const bitsPerSample = 16;
   const byteRate = (frame.sampleRate * frame.channels * bitsPerSample) / 8;
@@ -185,7 +181,6 @@ function parseStreamEvent(value: unknown): ElevenLabsStreamEvent {
   };
 }
 
-// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 79-310 lines
 export class STT extends stt.STT {
   #opts: ResolvedSTTOptions;
   #session: STTHTTPSession;
@@ -330,7 +325,6 @@ export class STT extends stt.STT {
     });
   }
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 178-243 lines
   async #recognizeImpl(
     buffer: AudioBuffer,
     language?: string,
@@ -400,7 +394,6 @@ export class STT extends stt.STT {
     }
   }
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 245-275 lines
   #transcriptionToSpeechEvent(
     languageCode: string,
     text: string,
@@ -431,7 +424,6 @@ export class STT extends stt.STT {
     };
   }
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 277-295 lines
   updateOptions(opts: {
     tagAudioEvents?: boolean;
     serverVad?: VADOptions | null;
@@ -459,7 +451,6 @@ export class STT extends stt.STT {
     }
   }
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 296-310 lines
   stream(options?: { language?: string; connOptions?: APIConnectOptions }): SpeechStream {
     const stream = new SpeechStream(
       this,
@@ -475,7 +466,6 @@ export class STT extends stt.STT {
   }
 }
 
-// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 313-639 lines
 export class SpeechStream extends stt.SpeechStream {
   #opts: ResolvedSTTOptions;
   #language?: string;
@@ -504,7 +494,6 @@ export class SpeechStream extends stt.SpeechStream {
     );
   }
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 336-344 lines
   updateOptions(opts: { serverVad?: VADOptions | null }): void {
     if (opts.serverVad !== undefined) {
       this.#opts.serverVad = opts.serverVad;
@@ -514,7 +503,6 @@ export class SpeechStream extends stt.SpeechStream {
     }
   }
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 345-351 lines
   #onAudioDurationReport(duration: number): void {
     this.queue.put({
       type: stt.SpeechEventType.RECOGNITION_USAGE,
@@ -522,7 +510,6 @@ export class SpeechStream extends stt.SpeechStream {
     });
   }
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 353-480 lines
   protected async run(): Promise<void> {
     while (!this.closed && !this.input.closed) {
       let ws: WebSocket | null = null;
@@ -662,7 +649,6 @@ export class SpeechStream extends stt.SpeechStream {
     }
   }
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 482-529 lines
   async #connectWs(): Promise<WebSocket> {
     const commitStrategy = this.#opts.serverVad === null ? 'manual' : 'vad';
     const params = [
@@ -764,7 +750,6 @@ export class SpeechStream extends stt.SpeechStream {
     }
   }
 
-  // Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py - 531-639 lines
   #processStreamEvent(data: ElevenLabsStreamEvent): void {
     const messageType = data.message_type;
     const text = data.text ?? '';


### PR DESCRIPTION
## Summary
- Port ElevenLabs Scribe STT from Python agents, including batch `recognize()` and realtime WebSocket `stream()` support.
- Export STT types/sample rates and add a Node example mirroring the Python Scribe v2 realtime example.
- Add REST, realtime event, timestamp, and `updateOptions({ serverVad })` regression coverage.

## Tests
- `pnpm test plugins/elevenlabs/src/stt.test.ts`
- `pnpm test plugins/elevenlabs/src/tts.test.ts`
- `pnpm --filter @livekit/agents-plugin-elevenlabs build`
- `pnpm --filter @livekit/agents-plugin-elevenlabs lint`
- `pnpm format:check`
- `git diff --check`

## Notes
- `pnpm --filter @livekit/agents-plugin-elevenlabs api:check` fails because this package has no checked-in API report folder/file yet; API Extractor also reports existing missing release-tag warnings.
- `pnpm --filter livekit-agents-examples build` fails on missing declaration files for many unbuilt plugin packages; after fixing this example's `AgentSession` options, no ElevenLabs-specific example error remained.