### PR TITLE
Block preemptive generation during tool execution

### DIFF
--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -274,6 +274,7 @@ function buildPreemptiveRunner(opts: Partial<PreemptiveOpts> = {}) {
     _preemptiveGenerationCount: 0,
     _preemptiveGeneration: undefined,
     _currentSpeech: undefined as SpeechHandle | undefined,
+    _backgroundSpeeches: new Set<SpeechHandle>(),
     schedulingPaused: false,
     llm: new FakePreemptiveLLM(),
     tools: {},
@@ -373,5 +374,25 @@ describe('AgentActivity - onPreemptiveGeneration guards', () => {
     expect(fakeActivity._preemptiveGenerationCount).toBe(0);
     expect(generateReply).not.toHaveBeenCalled();
     expect(cancelPreemptiveGeneration).not.toHaveBeenCalled();
+  });
+
+  it('skips preemption while a tool execution is still running in the background', () => {
+    const { fakeActivity, generateReply, cancelPreemptiveGeneration, call } =
+      buildPreemptiveRunner();
+
+    fakeActivity._backgroundSpeeches.add(SpeechHandle.create());
+
+    call();
+
+    expect(fakeActivity._preemptiveGenerationCount).toBe(0);
+    expect(generateReply).not.toHaveBeenCalled();
+    expect(cancelPreemptiveGeneration).not.toHaveBeenCalled();
+
+    fakeActivity._backgroundSpeeches.clear();
+
+    call();
+
+    expect(fakeActivity._preemptiveGenerationCount).toBe(1);
+    expect(generateReply).toHaveBeenCalledTimes(1);
   });
 });

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1294,6 +1294,7 @@ export class AgentActivity implements RecognitionHooks {
       !preemptiveOpts.enabled ||
       this.schedulingPaused ||
       (this._currentSpeech !== undefined && !this._currentSpeech.interrupted) ||
+      this._backgroundSpeeches.size > 0 ||
       !(this.llm instanceof LLM)
     ) {
       return;


### PR DESCRIPTION
## Summary

Prevents preemptive generation from starting while a previous speech handle is still executing function tools in the background.

`_currentSpeech` is cleared after the assistant generation/playout phase, before tool execution finishes. During that window a user EOU could previously start a preemptive reply from stale chat context, before the tool result had been inserted. The existing `_backgroundSpeeches` set already tracks that exact interval, so the preemptive guard now treats it as active work.

Fixes #1365.

## Validation

- `pnpm vitest run agents/src/voice/agent_activity.test.ts`
- `pnpm exec prettier --check agents/src/voice/agent_activity.ts agents/src/voice/agent_activity.test.ts`
- `pnpm exec eslint -f unix agents/src/voice/agent_activity.ts agents/src/voice/agent_activity.test.ts` (existing warnings only)
- `pnpm --filter @livekit/agents build`
- `git diff --check`
