### PR TITLE
fix: end Runway realtime sessions on shutdown

### DIFF
--- a/.changeset/proud-dolphins-smile.md
+++ b/.changeset/proud-dolphins-smile.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-runway": patch
+---
+
+fix: end Runway realtime sessions on shutdown

--- a/plugins/runway/src/avatar.ts
+++ b/plugins/runway/src/avatar.ts
@@ -72,6 +72,7 @@ export class AvatarSession extends voice.AvatarSession {
   private avatarParticipantName: string;
   private connOptions: APIConnectOptions;
   private room?: Room;
+  private realtimeSessionId?: string;
   private endSessionPromise?: Promise<void>;
 
   #logger = log();
@@ -197,6 +198,10 @@ export class AvatarSession extends voice.AvatarSession {
             options: { statusCode: response.status, body: { error: text } },
           });
         }
+        const payload = (await response.json()) as { id?: unknown };
+        if (typeof payload.id === 'string') {
+          this.realtimeSessionId = payload.id;
+        }
         return;
       } catch (e) {
         if (e instanceof APIStatusError && !e.retryable) throw e;
@@ -234,28 +239,66 @@ export class AvatarSession extends voice.AvatarSession {
   }
 
   private async endRunwayRealtimeSession(room: Room): Promise<void> {
-    if (!room.isConnected) {
-      this.#logger.warn('could not end Runway realtime session; room is disconnected');
+    // Preferred path: data-channel END_CALL while the room is still connected.
+    // The Runway worker handles this message and shuts the session down through
+    // the normal "user ended call" lifecycle (COMPLETED, not CANCELLED).
+    const localParticipant = room.localParticipant;
+    if (room.isConnected && localParticipant) {
+      try {
+        await localParticipant.publishData(
+          new TextEncoder().encode(JSON.stringify({ type: 'END_CALL' })),
+          {
+            reliable: true,
+            destination_identities: [this.avatarParticipantIdentity],
+          },
+        );
+        this.#logger.debug('sent Runway realtime session end call');
+        return;
+      } catch (error) {
+        this.#logger.warn(
+          { error: String(error) },
+          'error ending Runway realtime session via data channel',
+        );
+      }
+    }
+
+    // Fallback for hard shutdowns where the room is already disconnected
+    // (e.g. aclose() registered as a job shutdown callback runs after
+    // room.disconnect()): cancel the session via API so we don't keep
+    // billing until maxDuration.
+    await this.cancelRunwayRealtimeSession();
+  }
+
+  private async cancelRunwayRealtimeSession(): Promise<void> {
+    const sessionId = this.realtimeSessionId;
+    if (sessionId === undefined) {
+      this.#logger.warn('could not cancel Runway realtime session; no session id available');
       return;
     }
 
     try {
-      const localParticipant = room.localParticipant;
-      if (!localParticipant) {
-        this.#logger.warn('could not end Runway realtime session; room has no local participant');
-        return;
-      }
-
-      await localParticipant.publishData(
-        new TextEncoder().encode(JSON.stringify({ type: 'END_CALL' })),
-        {
-          reliable: true,
-          destination_identities: [this.avatarParticipantIdentity],
+      const response = await fetch(`${this.apiUrl}/v1/realtime_sessions/${sessionId}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'X-Runway-Version': API_VERSION,
+          'User-Agent': USER_AGENT,
         },
-      );
-      this.#logger.debug('sent Runway realtime session end call');
+        signal: AbortSignal.timeout(this.connOptions.timeoutMs),
+      });
+      if (response.ok) {
+        this.#logger.debug({ sessionId }, 'cancelled Runway realtime session');
+      } else {
+        this.#logger.warn(
+          { sessionId, status: response.status, body: await response.text() },
+          'could not cancel Runway realtime session',
+        );
+      }
     } catch (error) {
-      this.#logger.warn({ error: String(error) }, 'error ending Runway realtime session');
+      this.#logger.warn(
+        { sessionId, error: String(error) },
+        'error cancelling Runway realtime session',
+      );
     }
   }
 

--- a/plugins/runway/src/avatar.ts
+++ b/plugins/runway/src/avatar.ts
@@ -6,7 +6,6 @@ import {
   APIConnectionError,
   APIStatusError,
   DEFAULT_API_CONNECT_OPTIONS,
-  getJobContext,
   intervalForRetry,
   voice,
 } from '@livekit/agents';
@@ -72,6 +71,8 @@ export class AvatarSession extends voice.AvatarSession {
   private avatarParticipantIdentity: string;
   private avatarParticipantName: string;
   private connOptions: APIConnectOptions;
+  private room?: Room;
+  private endSessionPromise?: Promise<void>;
 
   #logger = log();
 
@@ -109,6 +110,7 @@ export class AvatarSession extends voice.AvatarSession {
     options: StartOptions = {},
   ): Promise<void> {
     await super.start(agentSession, room);
+    this.room = room;
 
     const livekitUrl = options.livekitUrl || process.env.LIVEKIT_URL;
     const livekitApiKey = options.livekitApiKey || process.env.LIVEKIT_API_KEY;
@@ -139,14 +141,9 @@ export class AvatarSession extends voice.AvatarSession {
     const livekitToken = await at.toJwt();
 
     this.#logger.debug('starting Runway avatar session');
-    const sessionId = await this.createSession(
-      livekitUrl,
-      livekitToken,
-      room.name || '',
-      localParticipantIdentity,
-    );
-    getJobContext(false)?.addShutdownCallback(async () => {
-      await this.cancelRunwayRealtimeSession(sessionId);
+    await this.createSession(livekitUrl, livekitToken, room.name || '', localParticipantIdentity);
+    agentSession.on(voice.AgentSessionEventTypes.Close, () => {
+      void this.ensureEndSessionPromise();
     });
 
     agentSession.output.audio = new voice.DataStreamAudioOutput({
@@ -162,7 +159,7 @@ export class AvatarSession extends voice.AvatarSession {
     livekitToken: string,
     roomName: string,
     agentIdentity: string,
-  ): Promise<string> {
+  ): Promise<void> {
     const body: Record<string, unknown> = {
       model: 'gwm1_avatars',
       avatar: this.avatar,
@@ -200,22 +197,7 @@ export class AvatarSession extends voice.AvatarSession {
             options: { statusCode: response.status, body: { error: text } },
           });
         }
-        const payload = (await response.json()) as unknown;
-        const sessionId =
-          typeof payload === 'object' && payload !== null && 'id' in payload
-            ? payload.id
-            : undefined;
-        if (!sessionId || typeof sessionId !== 'string') {
-          throw new APIStatusError({
-            message: 'Runway API response missing session id',
-            options: {
-              statusCode: response.status,
-              body: { error: JSON.stringify(payload) },
-              retryable: false,
-            },
-          });
-        }
-        return sessionId;
+        return;
       } catch (e) {
         if (e instanceof APIStatusError && !e.retryable) throw e;
 
@@ -238,31 +220,46 @@ export class AvatarSession extends voice.AvatarSession {
     });
   }
 
-  private async cancelRunwayRealtimeSession(sessionId: string): Promise<void> {
-    try {
-      const response = await fetch(`${this.apiUrl}/v1/realtime_sessions/${sessionId}`, {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${this.apiKey}`,
-          'X-Runway-Version': API_VERSION,
-          'User-Agent': USER_AGENT,
-        },
-        signal: AbortSignal.timeout(this.connOptions.timeoutMs),
-      });
-
-      if (response.ok) {
-        this.#logger.debug({ sessionId }, 'cancelled Runway realtime session');
-      } else {
-        this.#logger.warn(
-          { sessionId, status: response.status },
-          'could not cancel Runway realtime session',
-        );
-      }
-    } catch (error) {
-      this.#logger.warn(
-        { sessionId, error: String(error) },
-        'error cancelling Runway realtime session',
-      );
+  private ensureEndSessionPromise(): Promise<void> | undefined {
+    if (this.endSessionPromise !== undefined) {
+      return this.endSessionPromise;
     }
+
+    if (this.room === undefined) {
+      return undefined;
+    }
+
+    this.endSessionPromise = this.endRunwayRealtimeSession(this.room);
+    return this.endSessionPromise;
+  }
+
+  private async endRunwayRealtimeSession(room: Room): Promise<void> {
+    if (!room.isConnected) {
+      this.#logger.warn('could not end Runway realtime session; room is disconnected');
+      return;
+    }
+
+    try {
+      const localParticipant = room.localParticipant;
+      if (!localParticipant) {
+        this.#logger.warn('could not end Runway realtime session; room has no local participant');
+        return;
+      }
+
+      await localParticipant.publishData(
+        new TextEncoder().encode(JSON.stringify({ type: 'END_CALL' })),
+        {
+          reliable: true,
+          destination_identities: [this.avatarParticipantIdentity],
+        },
+      );
+      this.#logger.debug('sent Runway realtime session end call');
+    } catch (error) {
+      this.#logger.warn({ error: String(error) }, 'error ending Runway realtime session');
+    }
+  }
+
+  override async aclose(): Promise<void> {
+    await this.ensureEndSessionPromise();
   }
 }

--- a/plugins/runway/src/avatar.ts
+++ b/plugins/runway/src/avatar.ts
@@ -201,6 +201,11 @@ export class AvatarSession extends voice.AvatarSession {
         const payload = (await response.json()) as { id?: unknown };
         if (typeof payload.id === 'string') {
           this.realtimeSessionId = payload.id;
+        } else {
+          this.#logger.warn(
+            { payload: JSON.stringify(payload) },
+            'Runway API response missing session id; API cancellation fallback will be unavailable',
+          );
         }
         return;
       } catch (e) {


### PR DESCRIPTION
End Runway realtime sessions through the normal LiveKit data-channel lifecycle when the LiveKit job shuts down, so conversations complete cleanly instead of being marked cancelled.

Verify:
- `pnpm --dir /Users/robinandeer/Documents/github/runway/runway-agents-js exec prettier --write plugins/runway/src/avatar.ts .changeset/runway-session-cleanup.md`
- `pnpm --dir /Users/robinandeer/Documents/github/runway/runway-agents-js --filter @livekit/agents-plugin-runway lint`
- `pnpm --dir /Users/robinandeer/Documents/github/runway/runway-agents-js --filter @livekit/agents-plugin-runway build`