### PR TITLE
fix(silero): bump onnxruntime-node to 1.24.3 to fix libc++abi mutex abort (#1375)

### DIFF
--- a/.changeset/silero-onnxruntime-1.24-mutex-abort.md
+++ b/.changeset/silero-onnxruntime-1.24-mutex-abort.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-silero": patch
+---
+
+Bump `onnxruntime-node` (and `onnxruntime-common`) to `1.24.3` to fix a libc++abi mutex abort during process shutdown on macOS arm64. The crash fired in `~unique_ptr<OrtEnv>` inside `libonnxruntime.1.21.0.dylib` when `silero.VAD.load()` had been called and the process exited while LiveKit's tokio runtime threads were still alive — a static-destructor race present in `onnxruntime-node@1.21.0..1.23.2` and fixed upstream in `onnxruntime-node@1.24.1`. Verified the bump resolves the crash for the minimal repro in #1375.

--- a/plugins/silero/package.json
+++ b/plugins/silero/package.json
@@ -38,12 +38,12 @@
     "@livekit/rtc-node": "catalog:",
     "@microsoft/api-extractor": "^7.35.0",
     "@types/ws": "catalog:",
-    "onnxruntime-common": "1.21.0",
+    "onnxruntime-common": "1.24.3",
     "tsup": "^8.3.5",
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "onnxruntime-node": "1.21.0",
+    "onnxruntime-node": "1.24.3",
     "ws": "catalog:"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@livekit/rtc-node':
       specifier: ^0.13.27
       version: 0.13.27
+    '@types/ws':
+      specifier: ^8.5.10
+      version: 8.18.1
     ws:
       specifier: ^8.18.0
       version: 8.20.0
@@ -1080,8 +1083,8 @@ importers:
   plugins/silero:
     dependencies:
       onnxruntime-node:
-        specifier: 1.21.0
-        version: 1.21.0
+        specifier: 1.24.3
+        version: 1.24.3
       ws:
         specifier: 'catalog:'
         version: 8.20.0
@@ -1099,8 +1102,8 @@ importers:
         specifier: 'catalog:'
         version: 8.18.1
       onnxruntime-common:
-        specifier: 1.21.0
-        version: 1.21.0
+        specifier: 1.24.3
+        version: 1.24.3
       tsup:
         specifier: ^8.3.5
         version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@25.6.0))(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)
@@ -2811,6 +2814,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -4330,8 +4337,15 @@ packages:
   onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
     resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
 
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+
   onnxruntime-node@1.21.0:
     resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
     os: [win32, darwin, linux]
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
@@ -6761,6 +6775,7 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+    optional: true
 
   '@types/pidusage@2.0.5': {}
 
@@ -7010,6 +7025,8 @@ snapshots:
   acorn-walk@8.3.2: {}
 
   acorn@8.15.0: {}
+
+  adm-zip@0.5.17: {}
 
   agent-base@7.1.4: {}
 
@@ -8713,11 +8730,19 @@ snapshots:
 
   onnxruntime-common@1.22.0-dev.20250409-89f8206ba4: {}
 
+  onnxruntime-common@1.24.3: {}
+
   onnxruntime-node@1.21.0:
     dependencies:
       global-agent: 3.0.0
       onnxruntime-common: 1.21.0
       tar: 7.4.3
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.17
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     dependencies:
@@ -8980,7 +9005,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.1
       long: 5.2.3
 
   protobufjs@7.5.6:
@@ -8995,7 +9020,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.6.0
+      '@types/node': 22.19.1
       long: 5.3.2
 
   pump@3.0.0:
@@ -9628,7 +9653,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.19.2:
+    optional: true
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
## Summary

Closes #1375.

`@livekit/agents-plugin-silero` pins `onnxruntime-node` to `1.21.0` exactly. That version (and 1.21.x..1.23.x) has a static-destructor race that aborts the Node process on shutdown when LiveKit's tokio runtime threads are still alive at exit — a 100%-reproducible crash on macOS arm64 with a libc++abi mutex error.

The bug was fixed upstream in `onnxruntime-node@1.24.1`. This PR bumps the pin (and the matching `onnxruntime-common` devDep) to `1.24.3`.

## Bisect

Same minimal repro, only changing the `onnxruntime-node` version:

| onnxruntime-node | Result |
| --- | --- |
| 1.20.1 | clean exit |
| **1.21.0** | **crash** (silero's pinned version) |
| 1.21.1 / 1.22.0 / 1.23.0 / 1.23.2 | crash |
| **1.24.1** | **clean exit** — fix landed here |
| 1.24.2 / 1.24.3 / 1.25.1 | clean exit |

## Native stack trace at the abort

```
frame #8:  libonnxruntime.1.21.0.dylib`__clang_call_terminate + 12
frame #9:  libonnxruntime.1.21.0.dylib`std::__1::unique_ptr<OrtEnv,
              std::__1::default_delete<OrtEnv>>::~unique_ptr() + 84
frame #10: libsystem_c.dylib`__cxa_finalize_ranges + 416
frame #11: libsystem_c.dylib`exit + 44
frame #12: node`node::Exit(node::ExitCode) + 12
frame #15: node`Builtins_CallApiCallbackGeneric + 184  ← process.exit(0) from JS
```

10 `tokio-rt-worker` threads from `rtc-node.darwin-arm64.node` are still alive at the moment of abort (parked in `__psynch_cvwait`/`kevent`). Full lldb trace and bisection in #1375.

## Test plan

- [x] `pnpm install` resolves cleanly (lockfile regenerated, only the silero workspace is affected)
- [x] `pnpm --filter @livekit/agents build` succeeds
- [x] `pnpm --filter @livekit/agents-plugin-silero build` succeeds
- [x] Minimal repro from #1375 (`silero.VAD.load() + process.exit(0)`) exits cleanly with status 0 against the new version
- [x] `pnpm -w format:write` and `pnpm -w lint:fix` produce no new warnings (existing 120 warnings in `agents/src/voice/generation_tools.test.ts` are unrelated)

`onnxruntime-node` 1.21 → 1.24 is a minor bump within the same major. The exposed API surface used by `silero/src/onnx_model.ts` (`InferenceSession.create`, `Tensor`, run-options) is unchanged across this range, and the silero plugin's own build + types pass.
