### PR TITLE
fix(voice): prevent RecorderIO shutdown write-loop noise

### DIFF
--- a/.changeset/tender-peaches-tan.md
+++ b/.changeset/tender-peaches-tan.md
@@ -1,0 +1,7 @@
+---
+"@livekit/agents": patch
+---
+
+Harden RecorderIO teardown by fencing writes before channel closure and stopping
+the forward task first, preventing repeated closed WritableStream write errors on disconnect.
+Also centralize writable-stream closed error detection in utils and add regression tests.

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -759,6 +759,24 @@ export function isStreamClosedError(error: unknown): boolean {
   );
 }
 
+/**
+ * Check if an error indicates writes to a closed WritableStream.
+ *
+ * @param error - The error to check.
+ * @returns True if the error is a writable stream closed error.
+ */
+export function isWritableStreamClosedError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if ('code' in error && (error as { code?: string }).code === 'ERR_INVALID_STATE') {
+    return true;
+  }
+
+  return error.message.includes('WritableStream is closed');
+}
+
 /** FFmpeg error messages expected during normal teardown/shutdown. */
 const FFMPEG_TEARDOWN_ERRORS = ['Output stream closed', 'received signal 2', 'SIGKILL', 'SIGINT'];
 

--- a/agents/src/voice/recorder_io/recorder_io.test.ts
+++ b/agents/src/voice/recorder_io/recorder_io.test.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { isWritableStreamClosedError } from '../../utils.js';
+
+describe('RecorderIO writable stream error detection', () => {
+  it('detects ERR_INVALID_STATE stream closure errors', () => {
+    const err = new TypeError('Invalid state: WritableStream is closed');
+    Object.assign(err, { code: 'ERR_INVALID_STATE' });
+
+    expect(isWritableStreamClosedError(err)).toBe(true);
+  });
+
+  it('detects writable stream closed errors by message', () => {
+    const err = new TypeError('Invalid state: WritableStream is closed');
+
+    expect(isWritableStreamClosedError(err)).toBe(true);
+  });
+
+  it('does not treat unrelated errors as stream closure', () => {
+    const err = new Error('network timeout');
+
+    expect(isWritableStreamClosedError(err)).toBe(false);
+  });
+});

--- a/agents/src/voice/recorder_io/recorder_io.ts
+++ b/agents/src/voice/recorder_io/recorder_io.ts
@@ -13,7 +13,14 @@ import { TransformStream } from 'node:stream/web';
 import { log } from '../../log.js';
 import { isStreamReaderReleaseError } from '../../stream/deferred_stream.js';
 import { type StreamChannel, createStreamChannel } from '../../stream/stream_channel.js';
-import { Future, Task, cancelAndWait, delay, isFfmpegTeardownError } from '../../utils.js';
+import {
+  Future,
+  Task,
+  cancelAndWait,
+  delay,
+  isFfmpegTeardownError,
+  isWritableStreamClosedError,
+} from '../../utils.js';
 import type { AgentSession } from '../agent_session.js';
 import { AudioInput, AudioOutput, type PlaybackFinishedEvent } from '../io.js';
 
@@ -50,6 +57,7 @@ export class RecorderIO {
   private closeFuture: Future<void> = new Future();
   private lock: Mutex = new Mutex();
   private started: boolean = false;
+  private closing: boolean = false;
 
   // FFmpeg streaming state
   private pcmStream?: PassThrough;
@@ -80,6 +88,7 @@ export class RecorderIO {
 
       this._outputPath = outputPath;
       this.started = true;
+      this.closing = false;
       this.closeFuture = new Future();
 
       // Ensure output directory exists
@@ -101,13 +110,24 @@ export class RecorderIO {
     try {
       if (!this.started) return;
 
+      // Establish shutdown fence before any async operations, so no writer can proceed.
+      this.closing = true;
+      this.started = false;
+
+      if (this.forwardTask) {
+        await cancelAndWait([this.forwardTask]);
+      }
+
       await this.inChan.close();
       await this.outChan.close();
       await this.closeFuture.await;
-      await cancelAndWait([this.forwardTask!, this.encodeTask!]);
-      await this.inRecord?.close();
 
-      this.started = false;
+      if (this.encodeTask) {
+        await cancelAndWait([this.encodeTask]);
+      }
+
+      await this.inRecord?.close();
+      this.closing = false;
     } finally {
       unlock();
     }
@@ -124,9 +144,21 @@ export class RecorderIO {
   }
 
   private writeCb(buf: AudioFrame[]): void {
+    if (!this.started || this.closing || this.inChan.closed || this.outChan.closed) {
+      return;
+    }
+
     const inputBuf = this.inRecord!.takeBuf(this.outRecord?._lastSpeechEndTime);
-    this.inChan.write(inputBuf);
-    this.outChan.write(buf);
+    this.inChan.write(inputBuf).catch((err) => {
+      if (!isWritableStreamClosedError(err)) {
+        this.logger.error({ err }, 'Error writing RecorderIO input buffer');
+      }
+    });
+    this.outChan.write(buf).catch((err) => {
+      if (!isWritableStreamClosedError(err)) {
+        this.logger.error({ err }, 'Error writing RecorderIO output buffer');
+      }
+    });
   }
 
   get recording(): boolean {
@@ -156,7 +188,7 @@ export class RecorderIO {
    * Forward task: periodically flush input buffer to encoder
    */
   private async forward(signal: AbortSignal): Promise<void> {
-    while (!signal.aborted) {
+    while (!signal.aborted && this.started && !this.closing) {
       try {
         await delay(WRITE_INTERVAL_MS, { signal });
       } catch {
@@ -171,12 +203,17 @@ export class RecorderIO {
 
       // Flush input buffer
       const inputBuf = this.inRecord!.takeBuf(this.outRecord!._lastSpeechEndTime);
-      this.inChan
-        .write(inputBuf)
-        .catch((err) => this.logger.error({ err }, 'Error writing RecorderIO input buffer'));
-      this.outChan
-        .write([])
-        .catch((err) => this.logger.error({ err }, 'Error writing RecorderIO output buffer'));
+      try {
+        await this.inChan.write(inputBuf);
+        await this.outChan.write([]);
+      } catch (err) {
+        if (this.inChan.closed || this.outChan.closed || isWritableStreamClosedError(err)) {
+          // Channel closure is expected during teardown; stop forwarding to avoid noisy logs.
+          break;
+        }
+
+        this.logger.error({ err }, 'Error writing RecorderIO output buffer');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Hardened `RecorderIO` shutdown to prevent repeated writes during teardown:
  - Set a shutdown fence (`closing`) and stop writes immediately when close starts
  - Cancel `forwardTask` before closing channels
  - Exit forward loop on closed-stream/channel conditions
- Centralized `isWritableStreamClosedError()` into `agents/src/utils.ts` for reuse
- Added focused regression tests for writable-stream closed error detection in:
  - `agents/src/voice/recorder_io/recorder_io.test.ts`

## Why
On disconnect, recorder background writes could race with stream closure and emit repeated
`Invalid state: WritableStream is closed` errors. This change makes post-close writes structurally
impossible and treats teardown-expected closure as terminal, removing log spam.

## Test Plan
- `pnpm test agents/src/voice/recorder_io/recorder_io.test.ts`
- Manual verification with multiple back-to-back session disconnects:
  - Confirm no repeated `Error writing RecorderIO output buffer` logs after disconnect