### PR TITLE
fix: remove double URL-encoding in Deepgram STT plugin

### DIFF
--- a/.changeset/shaggy-buckets-cheer.md
+++ b/.changeset/shaggy-buckets-cheer.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-deepgram": patch
+---
+
+fix: remove double URL-encoding in Deepgram STT plugin

--- a/plugins/deepgram/src/stt.ts
+++ b/plugins/deepgram/src/stt.ts
@@ -198,9 +198,9 @@ export class SpeechStream extends stt.SpeechStream {
       Object.entries(params).forEach(([k, v]) => {
         if (v !== undefined) {
           if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
-            streamURL.searchParams.append(k, encodeURIComponent(v));
+            streamURL.searchParams.append(k, String(v));
           } else {
-            v.forEach((x) => streamURL.searchParams.append(k, encodeURIComponent(x)));
+            v.forEach((x) => streamURL.searchParams.append(k, String(x)));
           }
         }
       });


### PR DESCRIPTION
Fixes #1379

- Remove encodeURIComponent() wrapper around URLSearchParams.append() calls
- URLSearchParams.append() already handles URL encoding
- Fixes issue where parameters with special chars (spaces, quotes, etc.) were corrupted
- Example: keyterm=["Joe's Plumbing"] was being double-encoded to keyterm=Joe%2527s%2520Plumbing