### PR TITLE
refactor(agents): replace uuid with crypto.randomUUID

### DIFF
--- a/.changeset/popular-coats-march.md
+++ b/.changeset/popular-coats-march.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+refactor(agents): replace uuid with crypto.randomUUID

--- a/agents/package.json
+++ b/agents/package.json
@@ -78,7 +78,6 @@
     "pino": "^8.19.0",
     "pino-pretty": "^11.0.0",
     "sharp": "0.34.5",
-    "uuid": "^14.0.0",
     "ws": "catalog:",
     "zod-to-json-schema": "^3.24.6"
   },

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -10,8 +10,8 @@ import type {
 } from '@livekit/rtc-node';
 import { AudioFrame, AudioResampler, RoomEvent } from '@livekit/rtc-node';
 import { type Throws, ThrowsPromise } from '@livekit/throws-transformer/throws';
-import { randomUUID } from 'node:crypto';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
 import { EventEmitter, once } from 'node:events';
 import type { ReadableStream } from 'node:stream/web';
 import { TransformStream, type TransformStreamDefaultController } from 'node:stream/web';

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -10,11 +10,11 @@ import type {
 } from '@livekit/rtc-node';
 import { AudioFrame, AudioResampler, RoomEvent } from '@livekit/rtc-node';
 import { type Throws, ThrowsPromise } from '@livekit/throws-transformer/throws';
+import { randomUUID } from 'node:crypto';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { EventEmitter, once } from 'node:events';
 import type { ReadableStream } from 'node:stream/web';
 import { TransformStream, type TransformStreamDefaultController } from 'node:stream/web';
-import { v4 as uuidv4 } from 'uuid';
 import { log } from './log.js';
 
 /**
@@ -620,7 +620,7 @@ export function withResolvers<T = unknown>() {
  * @returns A short UUID with the prefix.
  */
 export function shortuuid(prefix: string = ''): string {
-  return `${prefix}${uuidv4().slice(0, 12)}`;
+  return `${prefix}${randomUUID().slice(0, 12)}`;
 }
 
 const READONLY_SYMBOL = Symbol('Readonly');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,9 +199,6 @@ importers:
       sharp:
         specifier: 0.34.5
         version: 0.34.5
-      uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
       ws:
         specifier: 'catalog:'
         version: 8.20.0
@@ -849,10 +846,10 @@ importers:
         version: 0.13.27
       '@microsoft/api-extractor':
         specifier: ^7.35.0
-        version: 7.43.7(@types/node@22.19.1)
+        version: 7.43.7(@types/node@25.6.0)
       tsup:
         specifier: ^8.3.5
-        version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@22.19.1))(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@25.6.0))(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -5162,10 +5159,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
 
   validator@13.12.0:
     resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
@@ -9691,8 +9684,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  uuid@14.0.0: {}
 
   validator@13.12.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,6 @@ minimumReleaseAgeExclude:
   - '@livekit/*'
   # Renovate security update: vite@7.3.2
   - vite@7.3.2
-  # Renovate security update: uuid@14.0.0
-  - uuid@14.0.0
 
 catalog:
   '@livekit/rtc-node': ^0.13.27


### PR DESCRIPTION
## Summary

- Remove the `uuid` npm dependency from `@livekit/agents`.
- Implement `shortuuid` using `randomUUID()` from `node:crypto` (same RFC 4122 string shape as before and available since node 14.17, so `.slice(0, 12)` behavior is unchanged).
- Refresh `pnpm-lock.yaml` and drop the Renovate minimum-release-age exclude entry for `uuid`.

## Verification

- `pnpm --filter @livekit/agents build`
- `pnpm test -- agents/src/utils.test.ts`

Made with [Cursor](https://cursor.com)