### PR TITLE
feat(amd): port AMDResult → AMDPredictionEvent + event emission from python

### DIFF
--- a/.changeset/amd-prediction-event.md
+++ b/.changeset/amd-prediction-event.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Port AMD result → `AMDPredictionEvent` rename and event emission from Python (livekit/agents#5621). The `AMD` detector now extends an `EventEmitter` and emits `amd_prediction` with an `AMDPredictionEvent` payload (`type: 'amd_prediction'`, plus the existing `category` / `reason` / `transcript` / `rawResponse` / `isMachine` fields and a new optional `speechDurationMs`). `AMDResult` is kept as a deprecated type alias for `AMDPredictionEvent` for backward compatibility. The remote-session wire serialization for AMD predictions is intentionally deferred until `@livekit/protocol` ships the corresponding `AgentSessionEvent.AmdPrediction` / `AmdCategory` message types; a TODO marker has been left in `voice/remote_session.ts` where it will be wired up.

--- a/agents/src/voice/amd.test.ts
+++ b/agents/src/voice/amd.test.ts
@@ -9,7 +9,7 @@ import { LLM, type LLMStream } from '../llm/llm.js';
 import type { ToolChoice, ToolContext } from '../llm/tool_context.js';
 import type { APIConnectOptions } from '../types.js';
 import type { AgentSession } from './agent_session.js';
-import { AMD, AMDCategory } from './amd.js';
+import { AMD, AMDCategory, type AMDPredictionEvent } from './amd.js';
 import { AgentSessionEventTypes } from './events.js';
 
 class StaticLLM extends LLM {
@@ -70,6 +70,9 @@ describe('AMD', () => {
     llm.on('error', () => {});
     const amd = new AMD(asAgentSession(session), { llm, detectionTimeoutMs: 50 });
 
+    const events: AMDPredictionEvent[] = [];
+    amd.on('amd_prediction', (ev) => events.push(ev));
+
     const promise = amd.execute();
     session.emit(AgentSessionEventTypes.UserInputTranscribed, {
       type: 'user_input_transcribed',
@@ -81,12 +84,18 @@ describe('AMD', () => {
     });
 
     await expect(promise).resolves.toMatchObject({
+      type: 'amd_prediction',
       category: AMDCategory.MACHINE_VM,
       isMachine: true,
     });
     expect(session.pauseReplyAuthorization).toHaveBeenCalledTimes(1);
     expect(session.resumeReplyAuthorization).toHaveBeenCalled();
     expect(session.interrupt).toHaveBeenCalledWith({ force: true });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'amd_prediction',
+      category: AMDCategory.MACHINE_VM,
+    });
   });
 
   it('should classify unavailable mailbox as machine', async () => {

--- a/agents/src/voice/amd.ts
+++ b/agents/src/voice/amd.ts
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import type { TypedEventEmitter } from '@livekit/typed-emitter';
 import type { Span } from '@opentelemetry/api';
+import EventEmitter from 'node:events';
 import { ChatContext } from '../llm/chat_context.js';
 import { LLM } from '../llm/llm.js';
 import { traceTypes, tracer } from '../telemetry/index.js';
@@ -21,13 +23,25 @@ export enum AMDCategory {
   UNCERTAIN = 'uncertain',
 }
 
-export interface AMDResult {
+export interface AMDPredictionEvent {
+  type: 'amd_prediction';
   category: AMDCategory;
   transcript: string;
   reason: string;
   rawResponse: string;
   isMachine: boolean;
+  /** Duration of detected user speech in milliseconds, when known. */
+  speechDurationMs?: number;
 }
+
+/**
+ * @deprecated Use {@link AMDPredictionEvent}.
+ */
+export type AMDResult = AMDPredictionEvent;
+
+export type AMDCallbacks = {
+  amd_prediction: (ev: AMDPredictionEvent) => void;
+};
 
 export interface AMDOptions {
   llm?: LLM;
@@ -80,8 +94,11 @@ Do not include markdown fences or extra text.`;
  * Mirrors Python's `_AMDClassifier` two-gate architecture:
  * a result is only emitted when both a **verdict** (from LLM or heuristic) and
  * a **silence gate** (from VAD or timeout) are satisfied.
+ *
+ * Emits `amd_prediction` with an {@link AMDPredictionEvent} payload when a
+ * prediction settles. Callers can subscribe via `amd.on('amd_prediction', ...)`.
  */
-export class AMD {
+export class AMD extends (EventEmitter as new () => TypedEventEmitter<AMDCallbacks>) {
   private readonly llm: LLM;
   private readonly interruptOnMachine: boolean;
   private readonly noSpeechTimeoutMs: number;
@@ -92,16 +109,17 @@ export class AMD {
   private active = false;
   private settled = false;
   private transcriptParts: string[] = [];
-  private verdictResult: AMDResult | undefined;
+  private verdictResult: AMDPredictionEvent | undefined;
   private machineSilenceReached = false;
   private speechStartedAt: number | undefined;
+  private speechEndedAt: number | undefined;
   private detectGeneration = 0;
 
   private noSpeechTimer: ReturnType<typeof setTimeout> | undefined;
   private detectionTimer: ReturnType<typeof setTimeout> | undefined;
   private silenceTimer: ReturnType<typeof setTimeout> | undefined;
 
-  private resolveRun: ((value: AMDResult) => void) | undefined;
+  private resolveRun: ((value: AMDPredictionEvent) => void) | undefined;
   private rejectRun: ((reason?: unknown) => void) | undefined;
   private span: Span | undefined;
 
@@ -109,6 +127,7 @@ export class AMD {
     private readonly session: AgentSession,
     options: AMDOptions = {},
   ) {
+    super();
     const llm = options.llm ?? this.resolveSessionLLM();
     if (!llm) {
       throw new Error(
@@ -125,7 +144,7 @@ export class AMD {
 
   // ─── public API ──────────────────────────────────────────────────────────────
 
-  async execute(): Promise<AMDResult> {
+  async execute(): Promise<AMDPredictionEvent> {
     return tracer.startActiveSpan(
       async (span) => {
         if (this.active) {
@@ -146,7 +165,7 @@ export class AMD {
         }
 
         try {
-          const result = await new Promise<AMDResult>((resolve, reject) => {
+          const result = await new Promise<AMDPredictionEvent>((resolve, reject) => {
             this.resolveRun = resolve;
             this.rejectRun = reject;
             this.subscribe();
@@ -181,6 +200,7 @@ export class AMD {
     this.verdictResult = undefined;
     this.machineSilenceReached = false;
     this.speechStartedAt = undefined;
+    this.speechEndedAt = undefined;
     this.detectGeneration = 0;
     this.resolveRun = undefined;
     this.rejectRun = undefined;
@@ -220,7 +240,7 @@ export class AMD {
    * Ref: python classifier.py `_set_verdict` — stores the LLM/heuristic verdict.
    * Emission is deferred until the silence gate also opens.
    */
-  private setVerdict(result: AMDResult): void {
+  private setVerdict(result: AMDPredictionEvent): void {
     this.verdictResult = result;
     this.tryEmitResult();
   }
@@ -237,7 +257,7 @@ export class AMD {
     this.finish(this.verdictResult);
   }
 
-  private finish(result: AMDResult): void {
+  private finish(result: AMDPredictionEvent): void {
     if (this.settled) {
       return;
     }
@@ -247,6 +267,7 @@ export class AMD {
     if (result.isMachine && this.interruptOnMachine) {
       this.session.interrupt({ force: true }).await.catch(() => {});
     }
+    this.emit('amd_prediction', result);
     this.resolveRun?.(result);
   }
 
@@ -260,11 +281,13 @@ export class AMD {
   private onSilenceTimerFired(category?: AMDCategory, reason?: string): void {
     if (category && reason && !this.verdictResult) {
       this.setVerdict({
+        type: 'amd_prediction',
         category,
         reason,
         transcript: this.joinTranscript(),
         rawResponse: '',
         isMachine: isMachineCategory(category),
+        speechDurationMs: this.computeSpeechDurationMs(),
       });
     }
     this.machineSilenceReached = true;
@@ -304,6 +327,7 @@ export class AMD {
       return;
     }
 
+    this.speechEndedAt = ev.createdAt;
     const speechDurationMs = ev.createdAt - (this.speechStartedAt ?? ev.createdAt);
 
     this.clearTimer('silence');
@@ -390,14 +414,22 @@ export class AMD {
     return this.transcriptParts.join('\n');
   }
 
-  private setSpanAttributes(result: AMDResult): void {
+  private computeSpeechDurationMs(): number | undefined {
+    if (this.speechStartedAt === undefined) {
+      return undefined;
+    }
+    const end = this.speechEndedAt ?? Date.now();
+    return Math.max(0, end - this.speechStartedAt);
+  }
+
+  private setSpanAttributes(result: AMDPredictionEvent): void {
     this.span?.setAttribute(traceTypes.ATTR_AMD_CATEGORY, result.category);
     this.span?.setAttribute(traceTypes.ATTR_AMD_REASON, result.reason);
     this.span?.setAttribute(traceTypes.ATTR_AMD_IS_MACHINE, result.isMachine);
     this.span?.setAttribute(traceTypes.ATTR_USER_TRANSCRIPT, result.transcript);
   }
 
-  private async detect(transcript: string): Promise<AMDResult> {
+  private async detect(transcript: string): Promise<AMDPredictionEvent> {
     const chatCtx = new ChatContext();
     chatCtx.addMessage({ role: 'system', content: AMD_PROMPT });
     chatCtx.addMessage({
@@ -417,14 +449,16 @@ export class AMD {
 
     const parsed = this.parseDetection(rawResponse);
     return {
+      type: 'amd_prediction',
       ...parsed,
       transcript,
       rawResponse,
       isMachine: isMachineCategory(parsed.category),
+      speechDurationMs: this.computeSpeechDurationMs(),
     };
   }
 
-  private parseDetection(rawResponse: string): Pick<AMDResult, 'category' | 'reason'> {
+  private parseDetection(rawResponse: string): Pick<AMDPredictionEvent, 'category' | 'reason'> {
     const normalized = rawResponse.trim();
     const jsonStart = normalized.indexOf('{');
     const jsonEnd = normalized.lastIndexOf('}');

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -655,6 +655,12 @@ export class SessionHost {
     this.emitEvent({ case: 'overlappingSpeech', value });
   };
 
+  // TODO(amd_prediction): mirror Python `_on_amd_prediction` once
+  // `@livekit/protocol` ships `AgentSessionEvent.AmdPrediction` / `AmdCategory`.
+  // The AMD detector now emits an `amd_prediction` event (see voice/amd.ts);
+  // wire this handler up via `amd.on('amd_prediction', ...)` and forward the
+  // payload through `emitEvent({ case: 'amdPrediction', value: ... })`.
+
   private onMetricsCollected = (event: MetricsCollectedEvent): void => {
     if (!this.session) return;
     this.emitEvent(


### PR DESCRIPTION
## Summary

Automated port of [livekit/agents#5621](https://github.com/livekit/agents/pull/5621) (`feat(amd): add remote session event for amd AGT-2828`) — a core-runtime change to the Answering Machine Detection module.

This is an automated Claude Code routine created by @toubatbrian. Right now it is in experimentation stage.

## What's ported

### `agents/src/voice/amd.ts`

- **Renamed `AMDResult` → `AMDPredictionEvent`** to match Python's new event-shaped name. `AMDResult` is preserved as a `@deprecated` type alias re-exporting `AMDPredictionEvent` so existing JS consumers don't immediately break (Python performed a hard rename; we soften this for the JS port — see _Implementation nuances_ below).
- **`AMD` now extends `EventEmitter`** (typed via `@livekit/typed-emitter` with an `AMDCallbacks` map). It emits `'amd_prediction'` once a prediction settles, mirroring Python's `_AMDClassifier` → `AMD` event chain. Subscribers register with `amd.on('amd_prediction', listener)`.
- **Added a `type: 'amd_prediction'` discriminator** on the payload. This makes `AMDPredictionEvent` consistent with the rest of the JS event types in `voice/events.ts` (e.g. `UserInputTranscribedEvent`, `MetricsCollectedEvent`) which all use a `type` literal.
- **Added optional `speechDurationMs`** on the payload. Computed from existing `speechStartedAt` / new `speechEndedAt` tracking inside the detector, populated for both heuristic and LLM-driven verdicts. (See _Implementation nuances_ for why this is in ms and optional.)
- The `finish()` method now `emit`s `amd_prediction` immediately before resolving the `execute()` promise, so listeners and `await amd.execute()` callers see the same payload.

### `agents/src/voice/amd.test.ts`

- Updated to assert the new `type: 'amd_prediction'` discriminator on the resolved value.
- Added an explicit `amd.on('amd_prediction', ...)` subscriber that verifies the event fires exactly once and carries the right category, alongside the existing `execute()` resolution assertion.

### `agents/src/voice/remote_session.ts`

- Added a `TODO(amd_prediction)` marker on `SessionHost` next to the other `on*` handlers, pointing at the spot where Python's `_on_amd_prediction` belongs. It is intentionally not wired up yet — see _What's deferred_.

## Implementation nuances (where exact parity wasn't possible)

1. **Wire-format remote-session serialization is deferred.** Python's PR adds a new `AgentSessionEvent.AmdPrediction` message and an `AmdCategory` enum to `livekit/protocol` and bumps the Python protocol dependency to `>=1.1.8`. The JS protocol package (`@livekit/protocol@1.45.6`) currently shipped in `agents-js` does **not** yet contain those types. Rather than vendoring the protobuf or adding a hand-rolled serializer, this PR leaves a TODO at the wire-up site in `remote_session.ts`. Once `@livekit/protocol` ships the AMD prediction types, a follow-up PR can:
   - subscribe `SessionHost` to `amd.on('amd_prediction', this.onAmdPrediction)` (or, more likely, expose the AMD instance through the session)
   - mirror the Python `_AMD_CATEGORY_MAP` in TS
   - convert `speechDurationMs` → seconds-typed `Duration` and forward via `emitEvent({ case: 'amdPrediction', value: ... })`
2. **`AMDResult` kept as a deprecated alias.** Python performed a hard rename (no backward-compat alias), but Python is mid-major (1.x) and ships AMD as part of the same release window. agents-js publishes against an installed user base, so we soften the rename with `export type AMDResult = AMDPredictionEvent;` marked `@deprecated`. Same shape, no runtime impact, gives consumers one release to migrate.
3. **`speechDurationMs` is `number | undefined` (ms), not `float` (seconds).** Python ships `speech_duration: float` (seconds) on the event. Per `CLAUDE.md` JS time-unit conventions, the JS port uses milliseconds with no `InS` suffix. It is also marked optional because there are paths (no-speech timeout before any VAD `speaking` transition) where the detector legitimately has no measured speech duration; in Python those paths fall back to `self.speech_duration` which the classifier always tracks, but the JS `AMD` class doesn't track a continuous speech duration outside an active `execute()` run.
4. **No `delay` field yet.** Python's `AmdPrediction` proto includes a `delay` (LLM detection delay). The JS detector doesn't currently instrument LLM-call timing for AMD, so adding a `delay` field would require additional bookkeeping. Left out for this patch; will come naturally with the wire-format follow-up.
5. **Skipped Python-only changes.** Per the porting policy, the following from #5621 were intentionally **not** ported: `livekit-protocol` version bump in `pyproject.toml`, `uv.lock` regeneration, `# type: ignore[assignment]` annotation in `llm/_provider_format/openai.py`, fal-plugin `await` correctness fix, spitch-plugin `# type: ignore` cleanup. None of these have JS equivalents.
6. **Example update skipped.** Python touched `examples/telephony/amd.py` to make SIP optional. The agents-js examples don't ship a corresponding AMD telephony example, so there is nothing to mirror.

## Test plan

- [x] `pnpm vitest run src/voice/amd.test.ts` — 4/4 pass
- [x] `pnpm vitest run src/voice/amd.test.ts src/voice/agent.test.ts` — 22/22 pass
- [x] `pnpm build:agents` — clean build
- [x] `pnpm format:write` — formatting clean
- [x] `pnpm lint` on touched files (`amd.ts`, `amd.test.ts`, `remote_session.ts`) — no new errors (pre-existing repo-wide warnings unrelated)
- [ ] (Manual) verify in agents playground / a real call — _the AMD path requires a live SIP setup and isn't covered by the JS unit tests_

## Notes

- Changeset added: `.changeset/amd-prediction-event.md` (`@livekit/agents`: **patch**).
- Wire-format follow-up tracked via the inline `TODO(amd_prediction)` in `voice/remote_session.ts`.

cc @toubatbrian @livekit/agent-devs

https://claude.ai/code/session_01EKYkaTHopcXtBQXb8d4yrV

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKYkaTHopcXtBQXb8d4yrV)_