### PR TITLE
feat(inworld): add inworld-tts-2 model

### DIFF
--- a/.changeset/inworld-tts-2-model.md
+++ b/.changeset/inworld-tts-2-model.md
@@ -1,0 +1,17 @@
+---
+"@livekit/agents-plugin-inworld": patch
+"@livekit/agents": patch
+---
+
+Add support for the new `inworld-tts-2` Inworld TTS model.
+
+- Adds `inworld/inworld-tts-2` to the `InworldModels` union exported from
+  `@livekit/agents/inference` so the model is selectable when using the
+  LiveKit Inference Gateway TTS client.
+- Exports a new `TTSModels` type from `@livekit/agents-plugin-inworld`
+  (`'inworld-tts-2' | 'inworld-tts-1.5-max'`) and updates `TTSOptions.model`
+  to `TTSModels | string`, mirroring the Python plugin so callers get
+  autocomplete for the curated model names while still being able to pass
+  any custom model id.
+
+Ports https://github.com/livekit/agents/pull/5646 from `livekit/agents`.

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -49,6 +49,7 @@ export type ElevenlabsModels =
   | 'elevenlabs/eleven_multilingual_v2';
 
 export type InworldModels =
+  | 'inworld/inworld-tts-2'
   | 'inworld/inworld-tts-1.5-max'
   | 'inworld/inworld-tts-1.5-mini'
   | 'inworld/inworld-tts-1-max'

--- a/plugins/inworld/src/tts.ts
+++ b/plugins/inworld/src/tts.ts
@@ -32,6 +32,7 @@ const DEFAULT_BUFFER_CHAR_THRESHOLD = 100;
 const DEFAULT_MAX_BUFFER_DELAY_MS = 3000;
 const NUM_CHANNELS = 1;
 
+export type TTSModels = 'inworld-tts-2' | 'inworld-tts-1.5-max';
 export type Encoding = 'PCM' | 'LINEAR16';
 export type TimestampType = 'TIMESTAMP_TYPE_UNSPECIFIED' | 'WORD' | 'CHARACTER';
 export type TextNormalization = 'APPLY_TEXT_NORMALIZATION_UNSPECIFIED' | 'ON' | 'OFF';
@@ -43,7 +44,7 @@ export type TimestampTransportStrategy =
 export interface TTSOptions {
   apiKey?: string;
   voice: string;
-  model: string;
+  model: TTSModels | string;
   encoding: Encoding;
   bitRate: number;
   sampleRate: number;


### PR DESCRIPTION
## Summary

Ports livekit/agents#5646 (`(inworld tts): add new model`) from the Python `livekit-agents` repo into `agents-js`, exposing Inworld's new `inworld-tts-2` model.

This is an automated Claude Code Routine port created by @toubatbrian.

cc @toubatbrian @livekit/agent-devs for review.

## Ported features

1. **New `inworld-tts-2` model on the Inference Gateway TTS client.** Adds `'inworld/inworld-tts-2'` to the `InworldModels` literal union in `agents/src/inference/tts.ts` so callers using `inference.TTS({ model: 'inworld/inworld-tts-2', ... })` get type-checked autocomplete and the value is accepted by the gateway-bound type.

2. **`TTSModels` literal exported from `@livekit/agents-plugin-inworld`.** Mirrors the new Python `TTSModels = Literal["inworld-tts-2", "inworld-tts-1.5-max"]` alias by exporting:

   ```ts
   export type TTSModels = 'inworld-tts-2' | 'inworld-tts-1.5-max';
   ```

   `TTSOptions.model` is now typed `TTSModels | string` (matching `model: TTSModels | str` in Python), preserving the freeform-string fallback so users can still pass any model id the Inworld API accepts while getting IDE autocomplete on the curated names.

## Implementation notes / nuances vs. Python

- The Python plugin re-exports `TTSModels` from `livekit/plugins/inworld/__init__.py`. In the JS plugin, `src/index.ts` already does `export * from './tts.js'`, so adding the new `export type TTSModels` in `tts.ts` is automatically re-exported from the package root — no additional change to `index.ts` needed.
- The Python PR also widens both `__init__` and `update_options` signatures to `TTSModels | str`. In the JS plugin those argument types come transitively from `TTSOptions['model']` (`Partial<TTSOptions>` in `constructor` / `updateOptions`), so widening the field type on the interface widens the constructor and `updateOptions` simultaneously — a single edit covers both call sites that the Python diff touches in two places.
- TS-level caveat: `TTSModels | string` widens to `string` in TypeScript, so the union is effectively documentation/IDE help, not a runtime constraint. We chose this form (over `TTSModels | (string & {})`) to stay consistent with how `cartesia`, `minimax`, `google` and `neuphonic` plugins already type their `model` field in this repo.
- No changes are needed to existing tests: `plugins/inworld/src/tts.test.ts` doesn't pin a model and the inference TTS tests don't reference the new literal. All 51 tests in `agents/src/inference/tts.test.ts` continue to pass.

## Out-of-scope vs. Python diff

The Python PR also modifies `livekit-plugins/livekit-plugins-inworld/livekit/plugins/inworld/__init__.py` to export `TTSModels` alongside the other public symbols. The TS equivalent is automatic via `export * from './tts.js'` (see note above), so there is no analogous file edit on the JS side.

## Changeset

`patch` bump for `@livekit/agents-plugin-inworld` and `@livekit/agents` (the latter because the public `InworldModels` union exported from `agents/inference` also gained a member).

## Test plan

- [x] `pnpm --filter @livekit/agents build` — passes
- [x] `pnpm --filter @livekit/agents-plugin-inworld build` — passes
- [x] `pnpm --filter @livekit/agents-plugin-inworld lint` — passes (clean)
- [x] `pnpm --filter @livekit/agents lint` — passes (no new warnings)
- [x] `pnpm vitest run agents/src/inference/tts.test.ts` — 51/51 pass
- [ ] Manual smoke test against the Inworld API with `model: 'inworld-tts-2'` (would require live `INWORLD_API_KEY`; deferred to human reviewer)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERT4wdZaQ7LnQuHhTJVChY)_