### PR TITLE
Add non-blocking tool calls

### DIFF
--- a/.changeset/async-toolset-node.md
+++ b/.changeset/async-toolset-node.md
@@ -1,5 +1,5 @@
 ---
-"@livekit/agents": minor
+'@livekit/agents': patch
 ---
 
 Add async toolsets for non-blocking background tool calls.

--- a/.changeset/async-toolset-node.md
+++ b/.changeset/async-toolset-node.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": minor
+---
+
+Add async toolsets for non-blocking background tool calls.

--- a/.changeset/async-toolset-node.md
+++ b/.changeset/async-toolset-node.md
@@ -1,5 +1,5 @@
 ---
-'@livekit/agents': patch
+"@livekit/agents": patch
 ---
 
 Add async toolsets for non-blocking background tool calls.

--- a/agents/src/llm/async_toolset.test.ts
+++ b/agents/src/llm/async_toolset.test.ts
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { ReadableStream as NodeReadableStream } from 'node:stream/web';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { delay } from '../utils.js';
+import type { AgentSession } from '../voice/agent_session.js';
+import { performToolExecutions } from '../voice/generation.js';
+import { RunContext } from '../voice/run_context.js';
+import { SpeechHandle } from '../voice/speech_handle.js';
+import { AsyncRunContext, AsyncToolset } from './async_toolset.js';
+import { ChatContext, FunctionCall } from './chat_context.js';
+import { tool } from './tool_context.js';
+
+function createFunctionCallStream(functionCall: FunctionCall): ReadableStream<FunctionCall> {
+  return new NodeReadableStream<FunctionCall>({
+    start(controller) {
+      controller.enqueue(functionCall);
+      controller.close();
+    },
+  });
+}
+
+function createFakeSession() {
+  let chatCtx = ChatContext.empty();
+  const waitForInactive = vi.fn(async () => {});
+  const generateReply = vi.fn();
+  const agent = {
+    get chatCtx() {
+      return chatCtx;
+    },
+    updateChatCtx: vi.fn(async (nextChatCtx: ChatContext) => {
+      chatCtx = nextChatCtx;
+    }),
+  };
+  const session = {
+    get currentAgent() {
+      return agent;
+    },
+    get userData() {
+      return {};
+    },
+    waitForInactive,
+    generateReply,
+  };
+
+  return { agent, generateReply, session: session as unknown as AgentSession, waitForInactive };
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 1000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (check()) return;
+    await delay(10);
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+describe('AsyncToolset source parity', () => {
+  const mockTool1 = tool({
+    description: 'first mock tool',
+    parameters: z.object({ arg1: z.string() }),
+    execute: async ({ arg1 }) => `arg1: ${arg1}`,
+  });
+
+  const mockTool2 = tool({
+    description: 'second mock tool',
+    parameters: z.object({ arg1: z.string() }),
+    execute: async ({ arg1 }) => `arg1: ${arg1}`,
+  });
+
+  it('two async toolsets share singleton management tools without conflict', () => {
+    const ts1 = new AsyncToolset({ id: 'booking', tools: { mockTool1 } });
+    const ts2 = new AsyncToolset({ id: 'search', tools: { mockTool2 } });
+
+    const ctx = { ...ts1.toolCtx, ...ts2.toolCtx };
+    const names = Object.keys(ctx);
+
+    expect(names.filter((name) => name === 'getRunningTasks')).toHaveLength(1);
+    expect(names.filter((name) => name === 'cancelTask')).toHaveLength(1);
+  });
+
+  it('two async toolsets with the same id do not conflict', () => {
+    const ts1 = new AsyncToolset({ id: 'same_id', tools: { mockTool1 } });
+    const ts2 = new AsyncToolset({ id: 'same_id', tools: { mockTool2 } });
+
+    const ctx = { ...ts1.toolCtx, ...ts2.toolCtx };
+    const names = Object.keys(ctx);
+
+    expect(names.filter((name) => name === 'getRunningTasks')).toHaveLength(1);
+    expect(names.filter((name) => name === 'cancelTask')).toHaveLength(1);
+  });
+});
+
+describe('AsyncToolset runtime integration', () => {
+  it('returns from tool execution after the first update while the tool continues running', async () => {
+    const { agent, generateReply, session, waitForInactive } = createFakeSession();
+    let finish!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    let finalReturnReached = false;
+
+    const bookFlight = tool({
+      description: 'book a flight',
+      parameters: z.object({}),
+      execute: async (_, { ctx }) => {
+        await (ctx as AsyncRunContext).update('Looking up flights.');
+        await finished;
+        finalReturnReached = true;
+        return 'Flight booked.';
+      },
+    });
+
+    const toolset = new AsyncToolset({ id: 'travel', tools: { bookFlight } });
+    const speechHandle = SpeechHandle.create();
+    const functionCall = FunctionCall.create({
+      callId: 'call_1',
+      name: 'bookFlight',
+      args: '{}',
+    });
+
+    const [execTask, toolOutput] = performToolExecutions({
+      session,
+      speechHandle,
+      toolCtx: toolset.toolCtx,
+      toolCallStream: createFunctionCallStream(functionCall),
+      controller: new AbortController(),
+    });
+
+    await execTask.result;
+
+    expect(finalReturnReached).toBe(false);
+    expect(toolOutput.output).toHaveLength(1);
+    expect(toolOutput.output[0]?.toolCallOutput?.output).toContain('Looking up flights.');
+
+    finish();
+    await waitFor(() => generateReply.mock.calls.length === 1);
+
+    expect(agent.chatCtx.items.some((item) => item.type === 'function_call')).toBe(true);
+    expect(
+      agent.chatCtx.items.some(
+        (item) => item.type === 'function_call_output' && item.callId === 'call_1/finished',
+      ),
+    ).toBe(true);
+    expect(waitForInactive).toHaveBeenCalledTimes(1);
+    expect(generateReply).toHaveBeenCalledWith({
+      instructions: expect.stringContaining('call_1/finished'),
+      toolChoice: 'none',
+    });
+
+    await toolset.aclose();
+  });
+
+  it('lists and cancels a running background tool', async () => {
+    const { session } = createFakeSession();
+    let aborted = false;
+
+    const slowTool = tool({
+      description: 'slow background tool',
+      parameters: z.object({}),
+      execute: async (_, { ctx, abortSignal }) => {
+        await (ctx as AsyncRunContext).update('Started slow work.');
+        await new Promise<void>((resolve) => {
+          abortSignal?.addEventListener('abort', () => {
+            aborted = true;
+            resolve();
+          });
+        });
+      },
+    });
+
+    const toolset = new AsyncToolset({ id: 'slow', tools: { slowTool } });
+    const speechHandle = SpeechHandle.create();
+    const functionCall = FunctionCall.create({
+      callId: 'call_cancel',
+      name: 'slowTool',
+      args: '{}',
+    });
+
+    const [execTask] = performToolExecutions({
+      session,
+      speechHandle,
+      toolCtx: toolset.toolCtx,
+      toolCallStream: createFunctionCallStream(functionCall),
+      controller: new AbortController(),
+    });
+    await execTask.result;
+
+    const managementCtx = new RunContext(
+      session,
+      speechHandle,
+      FunctionCall.create({ callId: 'management', name: 'getRunningTasks', args: '{}' }),
+    );
+    const running = await toolset.toolCtx.getRunningTasks.execute(
+      {},
+      { ctx: managementCtx, toolCallId: 'management' },
+    );
+
+    expect(Array.isArray(running)).toBe(true);
+    expect(JSON.stringify(running)).toContain('call_cancel');
+
+    const cancelResult = await toolset.toolCtx.cancelTask.execute(
+      { callId: 'call_cancel' },
+      { ctx: managementCtx, toolCallId: 'management' },
+    );
+
+    expect(cancelResult).toContain('cancelled successfully');
+    await waitFor(() => aborted);
+
+    const remaining = await toolset.toolCtx.getRunningTasks.execute(
+      {},
+      { ctx: managementCtx, toolCallId: 'management' },
+    );
+    expect(remaining).toEqual([]);
+
+    await toolset.aclose();
+  });
+});

--- a/agents/src/llm/async_toolset.test.ts
+++ b/agents/src/llm/async_toolset.test.ts
@@ -153,6 +153,139 @@ describe('AsyncToolset runtime integration', () => {
     await toolset.aclose();
   });
 
+  it('parses wrapped tool arguments through the original Zod schema', async () => {
+    const { session } = createFakeSession();
+    const normalized = tool({
+      description: 'uses zod defaults and transforms',
+      parameters: z.object({
+        count: z.number().default(5),
+        name: z.string().transform((value) => value.toUpperCase()),
+      }),
+      execute: async ({ count, name }) => `${count}:${name}`,
+    });
+
+    const toolset = new AsyncToolset({ id: 'zod', tools: { normalized } });
+    const [execTask, toolOutput] = performToolExecutions({
+      session,
+      speechHandle: SpeechHandle.create(),
+      toolCtx: toolset.toolCtx,
+      toolCallStream: createFunctionCallStream(
+        FunctionCall.create({
+          callId: 'call_zod',
+          name: 'normalized',
+          args: JSON.stringify({ name: 'alice' }),
+        }),
+      ),
+      controller: new AbortController(),
+    });
+
+    await execTask.result;
+
+    expect(toolOutput.output).toHaveLength(1);
+    expect(toolOutput.output[0]?.toolCallOutput?.isError).toBe(false);
+    expect(toolOutput.output[0]?.toolCallOutput?.output).toBe('"5:ALICE"');
+
+    await toolset.aclose();
+  });
+
+  it('checks original Zod refinements for wrapped tool arguments', async () => {
+    const { session } = createFakeSession();
+    const refined = tool({
+      description: 'uses zod refinements',
+      parameters: z.object({
+        count: z.number().refine((value) => value > 0, 'count must be positive'),
+      }),
+      execute: async () => 'should not run',
+    });
+
+    const toolset = new AsyncToolset({ id: 'refined', tools: { refined } });
+    const [execTask, toolOutput] = performToolExecutions({
+      session,
+      speechHandle: SpeechHandle.create(),
+      toolCtx: toolset.toolCtx,
+      toolCallStream: createFunctionCallStream(
+        FunctionCall.create({
+          callId: 'call_refined',
+          name: 'refined',
+          args: JSON.stringify({ count: -1 }),
+        }),
+      ),
+      controller: new AbortController(),
+    });
+
+    await execTask.result;
+
+    expect(toolOutput.output).toHaveLength(1);
+    expect(toolOutput.output[0]?.toolCallOutput?.isError).toBe(true);
+    expect(toolOutput.output[0]?.toolCallOutput?.output).not.toContain('should not run');
+
+    await toolset.aclose();
+  });
+
+  it('cancels a pending reply delivery without waiting for inactivity forever', async () => {
+    let finish!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    let waitForInactiveSignal: AbortSignal | undefined;
+    const generateReply = vi.fn();
+    const agent = {
+      chatCtx: ChatContext.empty(),
+      updateChatCtx: vi.fn(async (chatCtx: ChatContext) => {
+        agent.chatCtx = chatCtx;
+      }),
+    };
+    const session = {
+      get currentAgent() {
+        return agent;
+      },
+      get userData() {
+        return {};
+      },
+      waitForInactive: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal } = {}) => {
+        waitForInactiveSignal = abortSignal;
+        await new Promise<void>((resolve) => {
+          abortSignal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      }),
+      generateReply,
+    } as unknown as AgentSession;
+
+    const background = tool({
+      description: 'background work',
+      parameters: z.object({}),
+      execute: async (_, { ctx }) => {
+        await (ctx as AsyncRunContext).update('Started background work.');
+        await finished;
+        return 'Finished background work.';
+      },
+    });
+
+    const toolset = new AsyncToolset({ id: 'blocking-delivery', tools: { background } });
+    const [execTask] = performToolExecutions({
+      session,
+      speechHandle: SpeechHandle.create(),
+      toolCtx: toolset.toolCtx,
+      toolCallStream: createFunctionCallStream(
+        FunctionCall.create({ callId: 'call_delivery', name: 'background', args: '{}' }),
+      ),
+      controller: new AbortController(),
+    });
+
+    await execTask.result;
+    finish();
+    await waitFor(() => waitForInactiveSignal !== undefined);
+
+    const outcome = await Promise.race([
+      toolset.aclose().then(() => 'closed' as const),
+      delay(500).then(() => 'timeout' as const),
+    ]);
+
+    expect(outcome).toBe('closed');
+    expect(waitForInactiveSignal?.aborted).toBe(true);
+    expect(generateReply).not.toHaveBeenCalled();
+  });
+
   it('lists and cancels a running background tool', async () => {
     const { session } = createFakeSession();
     let aborted = false;

--- a/agents/src/llm/async_toolset.ts
+++ b/agents/src/llm/async_toolset.ts
@@ -1,0 +1,583 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+import { z } from 'zod';
+import { type JobContext, getJobContext } from '../job.js';
+import { log } from '../log.js';
+import { Future, Task, asError } from '../utils.js';
+import type { AgentSession } from '../voice/agent_session.js';
+import { RunContext, type UnknownUserData } from '../voice/run_context.js';
+import { type ChatItem, FunctionCall, FunctionCallOutput } from './chat_context.js';
+import {
+  type FunctionTool,
+  type JSONObject,
+  type ToolContext,
+  ToolError,
+  isAgentHandoff,
+  isToolError,
+  tool,
+} from './tool_context.js';
+import { toJsonSchema } from './utils.js';
+
+const UPDATE_TEMPLATE = `The tool \`{function_name}\` has updated, message: {message}
+The task is still running, so DON'T make up or give information not included in the message above.`;
+
+const DUPLICATE_REJECT = `Same tool \`{function_name}\` is already running:
+{running_fnc_calls}
+If you want to cancel the existing one, call \`cancelTask\` with callId.`;
+
+const DUPLICATE_CONFIRM = `Same tool \`{function_name}\` is already running:
+{running_fnc_calls}
+Re-call with confirm duplicate true to run a duplicate if needed,
+or if you want to cancel the existing one, call \`cancelTask\` with callId.`;
+
+const REPLY_INSTRUCTIONS = `New results arrived from background tool calls (call_ids: {pending_call_ids}).
+Summarize these results to the user naturally. Do NOT repeat information you have already told the user.`;
+
+const CONFIRM_DUPLICATE_PARAM = '_lk_agents_confirm_duplicate';
+const TOOL_PENDING_KEY = '__livekit_agents_tool_pending';
+
+type DuplicateMode = 'allow' | 'replace' | 'reject' | 'confirm';
+
+type AsyncToolExecutionOutput = {
+  toolCall: FunctionCall;
+  toolCallOutput?: FunctionCallOutput;
+  rawOutput: unknown;
+  rawException?: Error;
+  replyRequired: boolean;
+};
+
+type RunningTask<UserData = UnknownUserData> = {
+  ctx: AsyncRunContext<UserData>;
+  execTask: Task<void>;
+};
+
+type RunningTaskView = {
+  ctx: {
+    functionCall: FunctionCall;
+    _toolset: Pick<AsyncToolset, 'cancel'>;
+  };
+  execTask: Task<void>;
+};
+
+type PendingUpdate<UserData = UnknownUserData> = {
+  ctx: AsyncRunContext<UserData>;
+  items: ChatItem[];
+};
+
+const runningTasks = new Map<JobContext | undefined, Map<string, RunningTaskView>>();
+
+function tasksForJob(jobCtx: JobContext | undefined): Map<string, RunningTaskView> {
+  let tasks = runningTasks.get(jobCtx);
+  if (!tasks) {
+    tasks = new Map<string, RunningTaskView>();
+    runningTasks.set(jobCtx, tasks);
+  }
+  return tasks;
+}
+
+function removeTaskForJob(jobCtx: JobContext | undefined, callId: string): void {
+  const tasks = runningTasks.get(jobCtx);
+  if (!tasks) return;
+
+  tasks.delete(callId);
+  if (tasks.size === 0) {
+    runningTasks.delete(jobCtx);
+  }
+}
+
+function formatTemplate(template: string, values: Record<string, string>): string {
+  return Object.entries(values).reduce(
+    (acc, [key, value]) => acc.replaceAll(`{${key}}`, value),
+    template,
+  );
+}
+
+function cloneFunctionCall(toolCall: FunctionCall, callId?: string | null): FunctionCall {
+  const params = {
+    callId: callId ?? toolCall.callId,
+    name: toolCall.name,
+    args: toolCall.args,
+    createdAt: Date.now(),
+    extra: toolCall.extra,
+    groupId: toolCall.groupId,
+    thoughtSignature: toolCall.thoughtSignature,
+  };
+
+  return FunctionCall.create(
+    callId !== undefined && callId !== null ? params : { ...params, id: toolCall.id },
+  );
+}
+
+function isValidToolOutput(toolOutput: unknown): boolean {
+  const validTypes = ['string', 'number', 'boolean'];
+
+  if (validTypes.includes(typeof toolOutput)) {
+    return true;
+  }
+
+  if (toolOutput === undefined || toolOutput === null) {
+    return true;
+  }
+
+  if (Array.isArray(toolOutput)) {
+    return toolOutput.every(isValidToolOutput);
+  }
+
+  if (toolOutput instanceof Set) {
+    return Array.from(toolOutput).every(isValidToolOutput);
+  }
+
+  if (toolOutput instanceof Map) {
+    return Array.from(toolOutput.values()).every(isValidToolOutput);
+  }
+
+  if (toolOutput instanceof Object) {
+    return Object.entries(toolOutput).every(
+      ([key, value]) => validTypes.includes(typeof key) && isValidToolOutput(value),
+    );
+  }
+
+  return false;
+}
+
+function makeToolOutput({
+  toolCall,
+  output,
+  exception,
+  callId,
+}: {
+  toolCall: FunctionCall;
+  output: unknown;
+  exception?: Error;
+  callId?: string | null;
+}): AsyncToolExecutionOutput {
+  const logger = log();
+  let finalOutput = output;
+  let finalException = exception;
+
+  if (output instanceof Error) {
+    finalException = output;
+    finalOutput = undefined;
+  }
+
+  const clonedCall = cloneFunctionCall(toolCall, callId);
+
+  if (isToolError(finalException)) {
+    return {
+      toolCall: clonedCall,
+      toolCallOutput: FunctionCallOutput.create({
+        name: clonedCall.name,
+        callId: clonedCall.callId,
+        output: finalException.message,
+        isError: true,
+      }),
+      rawOutput: finalOutput,
+      rawException: finalException,
+      replyRequired: true,
+    };
+  }
+
+  if (finalException !== undefined) {
+    return {
+      toolCall: clonedCall,
+      toolCallOutput: FunctionCallOutput.create({
+        name: clonedCall.name,
+        callId: clonedCall.callId,
+        output: 'An internal error occurred',
+        isError: true,
+      }),
+      rawOutput: finalOutput,
+      rawException: finalException,
+      replyRequired: true,
+    };
+  }
+
+  let toolOutput = finalOutput;
+  if (isAgentHandoff(finalOutput)) {
+    toolOutput = finalOutput.returns;
+  }
+
+  if (!isValidToolOutput(toolOutput)) {
+    logger.error(
+      {
+        callId: clonedCall.callId,
+        output: finalOutput,
+      },
+      `AI function ${clonedCall.name} returned an invalid output`,
+    );
+    return {
+      toolCall: clonedCall,
+      rawOutput: finalOutput,
+      rawException: finalException,
+      replyRequired: true,
+    };
+  }
+
+  return {
+    toolCall: clonedCall,
+    toolCallOutput: FunctionCallOutput.create({
+      name: clonedCall.name,
+      callId: clonedCall.callId,
+      output: toolOutput !== undefined ? JSON.stringify(toolOutput) : '',
+      isError: false,
+    }),
+    rawOutput: finalOutput,
+    rawException: finalException,
+    replyRequired: toolOutput !== undefined,
+  };
+}
+
+function cloneSchema(schema: JSONSchema7): JSONSchema7 {
+  return JSON.parse(JSON.stringify(schema)) as JSONSchema7;
+}
+
+function buildRawSchema<UserData>(
+  toolName: string,
+  fnTool: FunctionTool<JSONObject, UserData, unknown>,
+): JSONSchema7 {
+  const schema = cloneSchema(toJsonSchema(fnTool.parameters));
+  schema.type ??= 'object';
+  schema.properties ??= {};
+  schema.title ??= toolName;
+  schema.description ??= fnTool.description;
+  return schema;
+}
+
+export const getRunningTasks = tool({
+  description: 'Get the list of running async tool calls across all async toolsets.',
+  execute: async () => {
+    const jobCtx = getJobContext(false);
+    const tasks = runningTasks.get(jobCtx);
+    return tasks ? Array.from(tasks.values()).map((task) => task.ctx.functionCall.toJSON()) : [];
+  },
+});
+
+export const cancelTask = tool({
+  description: 'Cancel a running async tool call by callId.',
+  parameters: z.object({ callId: z.string() }),
+  execute: async ({ callId }) => {
+    const jobCtx = getJobContext(false);
+    const task = runningTasks.get(jobCtx)?.get(callId);
+    if (task && (await task.ctx._toolset.cancel(callId))) {
+      return `Task ${callId} cancelled successfully.`;
+    }
+    return `Task ${callId} not found or already completed.`;
+  },
+});
+
+export class AsyncRunContext<UserData = UnknownUserData> extends RunContext<UserData> {
+  /** @internal */
+  readonly _toolset: AsyncToolset<UserData>;
+  /** @internal */
+  readonly _pendingFut = new Future<unknown>();
+  /** @internal */
+  _stepIdx = 0;
+
+  constructor({
+    runCtx,
+    toolset,
+  }: {
+    runCtx: RunContext<UserData>;
+    toolset: AsyncToolset<UserData>;
+  }) {
+    super(runCtx.session, runCtx.speechHandle, runCtx.functionCall);
+    this._toolset = toolset;
+  }
+
+  async update(message: string | unknown, _template: string = UPDATE_TEMPLATE): Promise<void> {
+    const output =
+      typeof message === 'string'
+        ? formatTemplate(_template, {
+            function_name: this.functionCall.name,
+            call_id: this.functionCall.callId,
+            message,
+          })
+        : message;
+
+    if (!this._pendingFut.done) {
+      this._pendingFut.resolve(output);
+      this.functionCall.extra[TOOL_PENDING_KEY] = true;
+      return;
+    }
+
+    this._stepIdx += 1;
+    const toolOutput = this._makeToolOutput(
+      output,
+      `${this.functionCall.callId}/update_${this._stepIdx}`,
+    );
+    if (!toolOutput.toolCallOutput) return;
+
+    await this._toolset._enqueueReply(this, [toolOutput.toolCall, toolOutput.toolCallOutput]);
+  }
+
+  /** @internal */
+  _makeToolOutput(output: unknown | Error, callId: string | null): AsyncToolExecutionOutput {
+    const exception = output instanceof Error ? output : undefined;
+    return makeToolOutput({
+      toolCall: this.functionCall,
+      output: exception ? undefined : output,
+      exception,
+      callId,
+    });
+  }
+}
+
+export class AsyncToolset<UserData = UnknownUserData> {
+  readonly id: string;
+  private readonly _onDuplicateCall: DuplicateMode;
+  private readonly _tools: ToolContext<UserData>;
+  private readonly _runningTasks = new Map<string, RunningTask<UserData>>();
+  private readonly _pendingUpdates: PendingUpdate<UserData>[] = [];
+  private _replyTask?: Task<void>;
+
+  constructor({
+    id,
+    tools = {},
+    onDuplicateCall = 'confirm',
+  }: {
+    id: string;
+    tools?: ToolContext<UserData>;
+    onDuplicateCall?: DuplicateMode;
+  }) {
+    this.id = id;
+    this._onDuplicateCall = onDuplicateCall;
+    this._tools = {};
+
+    for (const [name, fnTool] of Object.entries(tools)) {
+      this._tools[name] = this._wrapTool(name, fnTool);
+    }
+
+    this._tools.getRunningTasks = getRunningTasks as FunctionTool<
+      Record<string, never>,
+      UserData,
+      unknown
+    >;
+    this._tools.cancelTask = cancelTask as FunctionTool<{ callId: string }, UserData, unknown>;
+  }
+
+  get tools(): ToolContext<UserData> {
+    return { ...this._tools };
+  }
+
+  get toolCtx(): ToolContext<UserData> {
+    return this.tools;
+  }
+
+  async cancel(callId: string): Promise<boolean> {
+    const task = this._runningTasks.get(callId);
+    if (!task) return false;
+
+    if (!task.ctx.speechHandle.allowInterruptions) {
+      throw new ToolError(
+        `Tool call ${callId} is not cancellable because interruptions are disallowed`,
+      );
+    }
+
+    await task.execTask.cancelAndWait();
+    return true;
+  }
+
+  async aclose(): Promise<void> {
+    const tasks = Array.from(this._runningTasks.values()).map((task) => task.execTask);
+    if (this._replyTask) {
+      tasks.push(this._replyTask);
+    }
+    await Promise.allSettled(tasks.map((task) => task.cancelAndWait()));
+    this._runningTasks.clear();
+  }
+
+  private _wrapTool(
+    name: string,
+    fnTool: FunctionTool<JSONObject, UserData, unknown>,
+  ): FunctionTool<JSONObject, UserData, unknown> {
+    const rawSchema = buildRawSchema(name, fnTool);
+
+    if (this._onDuplicateCall === 'confirm') {
+      const props = rawSchema.properties as Record<string, JSONSchema7Definition>;
+      props[CONFIRM_DUPLICATE_PARAM] = {
+        type: 'boolean',
+        description:
+          'Set this to true to confirm you want to run a duplicate. Only do this when user confirms the duplication is needed.',
+        default: false,
+      };
+    }
+
+    return tool({
+      description: fnTool.description,
+      parameters: rawSchema,
+      flags: fnTool.flags,
+      execute: async (rawArguments, options) => {
+        const callId = options.ctx.functionCall.callId;
+        const fncName = options.ctx.functionCall.name;
+        const args = { ...rawArguments };
+        const confirmDuplicate = args[CONFIRM_DUPLICATE_PARAM] === true;
+        delete args[CONFIRM_DUPLICATE_PARAM];
+
+        const duplicateResult = await this._checkDuplicate(fncName, confirmDuplicate);
+        if (duplicateResult !== null) {
+          log().debug({ callId, function: fncName }, 'duplicate tool call rejected');
+          return duplicateResult;
+        }
+
+        if (this._runningTasks.has(callId)) {
+          throw new Error(`Task already running for callId: ${callId}`);
+        }
+
+        const asyncCtx = new AsyncRunContext({ runCtx: options.ctx, toolset: this });
+
+        const execTask = Task.from(
+          async (controller) => {
+            let output: unknown;
+            try {
+              output = await fnTool.execute(args, {
+                ...options,
+                ctx: asyncCtx,
+                abortSignal: controller.signal,
+              });
+            } catch (rawError) {
+              if (controller.signal.aborted) {
+                log().debug({ callId, function: fncName }, 'async tool cancelled');
+                if (!asyncCtx._pendingFut.done) {
+                  asyncCtx._pendingFut.resolve(undefined);
+                }
+                return;
+              }
+
+              output = asError(rawError);
+              log().error({ callId, function: fncName, error: output }, 'error in async tool');
+            }
+
+            if (!asyncCtx._pendingFut.done) {
+              if (output instanceof Error) {
+                asyncCtx._pendingFut.reject(output);
+              } else {
+                asyncCtx._pendingFut.resolve(output);
+              }
+              return;
+            }
+
+            if (output === undefined || output === null) {
+              return;
+            }
+
+            const toolOutput = asyncCtx._makeToolOutput(output, `${callId}/finished`);
+            if (!toolOutput.toolCallOutput) return;
+
+            await this._enqueueReply(asyncCtx, [toolOutput.toolCall, toolOutput.toolCallOutput]);
+          },
+          undefined,
+          `asyncTool:${fncName}`,
+        );
+
+        const runningTask = { ctx: asyncCtx, execTask };
+        this._runningTasks.set(callId, runningTask);
+
+        const jobCtx = getJobContext(false);
+        tasksForJob(jobCtx).set(callId, runningTask);
+
+        execTask.addDoneCallback(() => {
+          this._runningTasks.delete(callId);
+          removeTaskForJob(jobCtx, callId);
+        });
+
+        return await asyncCtx._pendingFut.await;
+      },
+    });
+  }
+
+  /** @internal */
+  async _enqueueReply(ctx: AsyncRunContext<UserData>, items: ChatItem[]): Promise<void> {
+    const agent = ctx.session.currentAgent;
+    const chatCtx = agent.chatCtx.copy();
+    chatCtx.insert(items);
+    await agent.updateChatCtx(chatCtx);
+
+    this._pendingUpdates.push({ ctx, items });
+
+    if (!this._replyTask || this._replyTask.done) {
+      this._replyTask = Task.from(
+        async () => this._deliverReply(ctx.session),
+        undefined,
+        'AsyncToolset.deliverReply',
+      );
+    }
+  }
+
+  private async _deliverReply(session: AgentSession<UserData>): Promise<void> {
+    await session.waitForInactive();
+
+    const updates = this._pendingUpdates.splice(0, this._pendingUpdates.length);
+    const pendingItems = updates.flatMap((update) => update.items);
+    if (pendingItems.length === 0) return;
+
+    const agentChatItems = session.currentAgent.chatCtx.items;
+    const lastAgentItem = agentChatItems.at(-1);
+    const lastPendingItem = pendingItems.at(-1);
+    if (lastAgentItem && lastPendingItem && lastAgentItem.createdAt > lastPendingItem.createdAt) {
+      log().debug('skipping async toolset reply - agent already spoke after updates');
+      return;
+    }
+
+    const pendingCallIds = pendingItems
+      .filter((item): item is FunctionCallOutput => item.type === 'function_call_output')
+      .map((item) => item.callId);
+
+    session.generateReply({
+      instructions: formatTemplate(REPLY_INSTRUCTIONS, {
+        pending_call_ids: pendingCallIds.join(', '),
+      }),
+      toolChoice: 'none',
+    });
+  }
+
+  private async _checkDuplicate(
+    fncName: string,
+    confirmDuplicate: boolean,
+  ): Promise<string | null> {
+    if (this._onDuplicateCall === 'allow') {
+      return null;
+    }
+
+    const runningFunctionCalls = Array.from(this._runningTasks.values())
+      .map((task) => task.ctx.functionCall)
+      .filter((functionCall) => functionCall.name === fncName);
+
+    if (runningFunctionCalls.length === 0) {
+      return null;
+    }
+
+    if (this._onDuplicateCall === 'replace') {
+      const results = await Promise.allSettled(
+        runningFunctionCalls.map((functionCall) => this.cancel(functionCall.callId)),
+      );
+      const errors = results.filter((result) => result.status === 'rejected');
+      if (errors.length > 0) {
+        const errorMessages = errors.map((result) => String(result.reason)).join('\n');
+        throw new ToolError(`Failed to cancel duplicate tool calls: ${errorMessages}`);
+      }
+      return null;
+    }
+
+    const runningCalls = runningFunctionCalls
+      .map((functionCall) => JSON.stringify(functionCall.toJSON()))
+      .join('\n');
+
+    if (this._onDuplicateCall === 'reject') {
+      return formatTemplate(DUPLICATE_REJECT, {
+        function_name: fncName,
+        running_fnc_calls: runningCalls,
+      });
+    }
+
+    if (this._onDuplicateCall === 'confirm' && !confirmDuplicate) {
+      return formatTemplate(DUPLICATE_CONFIRM, {
+        function_name: fncName,
+        running_fnc_calls: runningCalls,
+      });
+    }
+
+    return null;
+  }
+}

--- a/agents/src/llm/async_toolset.ts
+++ b/agents/src/llm/async_toolset.ts
@@ -19,6 +19,7 @@ import {
   tool,
 } from './tool_context.js';
 import { toJsonSchema } from './utils.js';
+import { isZodSchema, parseZodSchema } from './zod-utils.js';
 
 const UPDATE_TEMPLATE = `The tool \`{function_name}\` has updated, message: {message}
 The task is still running, so DON'T make up or give information not included in the message above.`;
@@ -431,7 +432,18 @@ export class AsyncToolset<UserData = UnknownUserData> {
           async (controller) => {
             let output: unknown;
             try {
-              output = await fnTool.execute(args, {
+              let parsedArgs = args;
+              if (isZodSchema(fnTool.parameters)) {
+                const result = await parseZodSchema<JSONObject>(fnTool.parameters, args);
+                if (!result.success) {
+                  throw result.error instanceof Error
+                    ? result.error
+                    : new Error(String(result.error));
+                }
+                parsedArgs = result.data;
+              }
+
+              output = await fnTool.execute(parsedArgs, {
                 ...options,
                 ctx: asyncCtx,
                 abortSignal: controller.signal,
@@ -498,15 +510,19 @@ export class AsyncToolset<UserData = UnknownUserData> {
 
     if (!this._replyTask || this._replyTask.done) {
       this._replyTask = Task.from(
-        async () => this._deliverReply(ctx.session),
+        async (controller) => this._deliverReply(ctx.session, controller.signal),
         undefined,
         'AsyncToolset.deliverReply',
       );
     }
   }
 
-  private async _deliverReply(session: AgentSession<UserData>): Promise<void> {
-    await session.waitForInactive();
+  private async _deliverReply(
+    session: AgentSession<UserData>,
+    abortSignal: AbortSignal,
+  ): Promise<void> {
+    await session.waitForInactive({ abortSignal });
+    if (abortSignal.aborted) return;
 
     const updates = this._pendingUpdates.splice(0, this._pendingUpdates.length);
     const pendingItems = updates.flatMap((update) => update.items);

--- a/agents/src/llm/index.ts
+++ b/agents/src/llm/index.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+export { AsyncRunContext, AsyncToolset, cancelTask, getRunningTasks } from './async_toolset.js';
+
 export {
   handoff,
   isFunctionTool,

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1551,6 +1551,16 @@ export class AgentActivity implements RecognitionHooks {
     return toWait;
   }
 
+  /** @internal */
+  async _waitForInactive(): Promise<void> {
+    while (this._currentSpeech || this.speechQueue.size() > 0) {
+      if (this._currentSpeech?._hasGenerations) {
+        await this._currentSpeech._waitForGeneration();
+      }
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+
   private wakeupMainTask(): void {
     this.q_updated.resolve();
   }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -47,7 +47,15 @@ import { STT, type STTError, type SpeechEvent } from '../stt/stt.js';
 import { recordRealtimeMetrics, traceTypes, tracer } from '../telemetry/index.js';
 import { splitWords } from '../tokenize/basic/word.js';
 import { TTS, type TTSError } from '../tts/tts.js';
-import { Future, Task, cancelAndWait, isDevMode, isHosted, waitFor } from '../utils.js';
+import {
+  Future,
+  Task,
+  cancelAndWait,
+  isDevMode,
+  isHosted,
+  waitFor,
+  waitForAbort,
+} from '../utils.js';
 import { VAD, type VADEvent } from '../vad.js';
 import type { Agent, ModelSettings } from './agent.js';
 import {
@@ -1552,12 +1560,24 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   /** @internal */
-  async _waitForInactive(): Promise<void> {
-    while (this._currentSpeech || this.speechQueue.size() > 0) {
-      if (this._currentSpeech?._hasGenerations) {
-        await this._currentSpeech._waitForGeneration();
+  async _waitForInactive(abortSignal?: AbortSignal): Promise<void> {
+    const waitIfNotAborted = async (promise: Promise<unknown>): Promise<void> => {
+      if (!abortSignal) {
+        await promise;
+        return;
       }
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await Promise.race([promise, waitForAbort(abortSignal)]);
+    };
+
+    while (this._currentSpeech || this.speechQueue.size() > 0) {
+      if (abortSignal?.aborted) return;
+
+      if (this._currentSpeech?._hasGenerations) {
+        await waitIfNotAborted(this._currentSpeech._waitForGeneration());
+      }
+
+      if (abortSignal?.aborted) return;
+      await waitIfNotAborted(new Promise<void>((resolve) => setImmediate(resolve)));
     }
   }
 

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -938,6 +938,12 @@ export class AgentSession<
     return this.agent;
   }
 
+  async waitForInactive(): Promise<void> {
+    if (this.activity) {
+      await this.activity._waitForInactive();
+    }
+  }
+
   async close(): Promise<void> {
     await this.closeImpl(CloseReason.USER_INITIATED);
   }

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -938,9 +938,9 @@ export class AgentSession<
     return this.agent;
   }
 
-  async waitForInactive(): Promise<void> {
+  async waitForInactive(options: { abortSignal?: AbortSignal } = {}): Promise<void> {
     if (this.activity) {
-      await this.activity._waitForInactive();
+      await this.activity._waitForInactive(options.abortSignal);
     }
   }
 

--- a/agents/src/voice/speech_handle.test.ts
+++ b/agents/src/voice/speech_handle.test.ts
@@ -41,6 +41,18 @@ describe('SpeechHandle.waitForPlayout - tool-context owner check', () => {
     });
   });
 
+  it('allows the owning handle once the tool is marked pending', async () => {
+    const owningHandle = SpeechHandle.create();
+    const functionCall = makeFunctionCall();
+    functionCall.extra.__livekit_agents_tool_pending = true;
+    setTimeout(() => owningHandle._markDone(), 10);
+
+    await functionCallStorage.run({ functionCall, speechHandle: owningHandle }, async () => {
+      const outcome = await raceTimeout(owningHandle.waitForPlayout(), 1000);
+      expect(outcome).toBe('resolved');
+    });
+  });
+
   it('does NOT throw when awaiting a different handle from inside a tool', async () => {
     const owningHandle = SpeechHandle.create();
     const otherHandle = SpeechHandle.create();

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -194,7 +194,11 @@ export class SpeechHandle {
    */
   async waitForPlayout(): Promise<void> {
     const store = functionCallStorage.getStore();
-    if (store?.functionCall && store.speechHandle === this) {
+    if (
+      store?.functionCall &&
+      store.speechHandle === this &&
+      store.functionCall.extra.__livekit_agents_tool_pending !== true
+    ) {
       throw new SpeechHandleCircularWaitError(store.functionCall.name);
     }
     await this.doneFut.await;


### PR DESCRIPTION
## Summary
- Add `llm.AsyncToolset` and `llm.AsyncRunContext` for background tool execution with progress updates, final-result replies, duplicate handling, and management tools.
- Add `AgentSession.waitForInactive()` and the speech-handle pending escape hatch needed for async tools to avoid circular playout waits.
- Port the Python AsyncToolset dedupe tests and add Node runtime coverage for non-blocking execution, final reply scheduling, cancellation, and pending playout waits.

## Verification
- `bun run test agents/src/llm/async_toolset.test.ts`
- `bun run test agents/src/voice/speech_handle.test.ts agents/src/voice/generation_tools.test.ts`
- `bun run test agents/src/llm/tool_context.test.ts agents/src/llm/tool_context.type.test.ts`
- `bun run test agents/src/voice/agent_activity.test.ts agents/src/voice/agent_activity_handoff.test.ts agents/src/voice/agent_session_handoff.test.ts`
- `bun run build:types` from `agents/`
- `bun x tsup` from `agents/`
- `bun x prettier --check <touched files>`
- `git diff --check`