### PR TITLE
add comments to agent side and inference side fallback adapters

### DIFF
--- a/.changeset/metal-jars-relate.md
+++ b/.changeset/metal-jars-relate.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Add comments to agent side and inference side fallback adapters

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -146,7 +146,7 @@ export type STTOptions<TModel extends STTModels> = TModel extends DeepgramModels
         ? XaiOptions
         : Record<string, unknown>;
 
-/** A fallback model with optional extra configuration. Extra fields are passed through to the provider. */
+/** Inference Fallback Adapter: configuration for a fallback STT model that runs server-side in LiveKit Inference, providing automatic fallback between providers. Extra fields are passed through to the provider. */
 export interface STTFallbackModel {
   /** Model name (e.g. "deepgram/nova-3", "assemblyai/universal-streaming", "cartesia/ink-whisper"). */
   model: string;

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -187,7 +187,7 @@ export function hasAlignedTranscript(
   return false;
 }
 
-/** A fallback model with optional extra configuration. Extra fields are passed through to the provider. */
+/** Inference Fallback Adapter: configuration for a fallback TTS model that runs server-side in LiveKit Inference, providing automatic fallback between providers. */
 export interface TTSFallbackModel {
   /** Model name (e.g. "cartesia/sonic", "elevenlabs/eleven_flash_v2", "rime/arcana"). */
   model: string;

--- a/agents/src/llm/fallback_adapter.ts
+++ b/agents/src/llm/fallback_adapter.ts
@@ -53,7 +53,7 @@ export interface FallbackAdapterOptions {
 }
 
 /**
- * FallbackAdapter is an LLM that can fallback to a different LLM if the current LLM fails.
+ * Agent Fallback Adapter for LLM. Manages multiple LLM instances with automatic fallback when the current LLM fails.
  *
  * @example
  * ```typescript

--- a/agents/src/stt/fallback_adapter.ts
+++ b/agents/src/stt/fallback_adapter.ts
@@ -63,8 +63,8 @@ const DEFAULT_FALLBACK_API_CONNECT_OPTIONS: APIConnectOptions = {
 };
 
 /**
- * `FallbackAdapter` is an STT wrapper that provides automatic failover between
- * multiple STT providers.
+ * Agent Fallback Adapter for STT. Manages multiple STT instances with automatic
+ * fallback when the primary provider fails.
  *
  * When the primary STT fails, the adapter switches to the next available
  * provider in the list for the active session. Failed providers are monitored

--- a/agents/src/tts/fallback_adapter.ts
+++ b/agents/src/tts/fallback_adapter.ts
@@ -51,7 +51,7 @@ const DEFAULT_FALLBACK_API_CONNECT_OPTIONS: APIConnectOptions = {
 const FORWARD_POLL_MS = 10;
 
 /**
- * FallbackAdapter is a TTS wrapper that provides automatic failover between multiple TTS providers.
+ * Agent Fallback Adapter for TTS. Manages multiple TTS instances, providing automatic fallback between providers.
  *
  * When the primary TTS fails, it automatically switches to the next available provider in the list.
  * Failed providers are monitored in the background and restored when they recover.


### PR DESCRIPTION
We're updating the docs to describe how users can write model fallbacks on the LiveKit Agent side and on the LiveKit Inference side. We would like the comments to make it easy to find the code for the agent side fallback and the inference side fallback. 