### PR TITLE
docs(fallback): add searchable Agent/Inference Fallback Adapter prefixes

### DIFF
--- a/.changeset/agent-fallback-adapter-comments.md
+++ b/.changeset/agent-fallback-adapter-comments.md
@@ -1,0 +1,10 @@
+---
+"@livekit/agents": patch
+---
+
+Update fallback adapter docstrings to use searchable "Agent Fallback Adapter" / "Inference Fallback Adapter" prefixes so the relevant code is easy to locate from the docs.
+
+- `agents/src/llm/fallback_adapter.ts`, `agents/src/stt/fallback_adapter.ts`, `agents/src/tts/fallback_adapter.ts`: prefix the class docstring with "Agent Fallback Adapter for LLM/STT/TTS".
+- `agents/src/inference/stt.ts` (`STTFallbackModel`) and `agents/src/inference/tts.ts` (`TTSFallbackModel`): prefix the typedef docstring with "Inference Fallback Adapter".
+
+Ports https://github.com/livekit/agents/pull/5654 from `livekit/agents`.

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -146,7 +146,12 @@ export type STTOptions<TModel extends STTModels> = TModel extends DeepgramModels
         ? XaiOptions
         : Record<string, unknown>;
 
-/** A fallback model with optional extra configuration. Extra fields are passed through to the provider. */
+/**
+ * Inference Fallback Adapter: configuration for a fallback STT model that runs server-side
+ * in LiveKit Inference, providing automatic fallback between providers.
+ *
+ * Extra fields are passed through to the provider.
+ */
 export interface STTFallbackModel {
   /** Model name (e.g. "deepgram/nova-3", "assemblyai/universal-streaming", "cartesia/ink-whisper"). */
   model: string;

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -187,7 +187,12 @@ export function hasAlignedTranscript(
   return false;
 }
 
-/** A fallback model with optional extra configuration. Extra fields are passed through to the provider. */
+/**
+ * Inference Fallback Adapter: configuration for a fallback TTS model that runs server-side
+ * in LiveKit Inference, providing automatic fallback between providers.
+ *
+ * Extra fields are passed through to the provider.
+ */
 export interface TTSFallbackModel {
   /** Model name (e.g. "cartesia/sonic", "elevenlabs/eleven_flash_v2", "rime/arcana"). */
   model: string;

--- a/agents/src/llm/fallback_adapter.ts
+++ b/agents/src/llm/fallback_adapter.ts
@@ -53,7 +53,8 @@ export interface FallbackAdapterOptions {
 }
 
 /**
- * FallbackAdapter is an LLM that can fallback to a different LLM if the current LLM fails.
+ * Agent Fallback Adapter for LLM. Manages multiple LLM instances with automatic fallback
+ * when the primary provider fails.
  *
  * @example
  * ```typescript

--- a/agents/src/stt/fallback_adapter.ts
+++ b/agents/src/stt/fallback_adapter.ts
@@ -63,8 +63,8 @@ const DEFAULT_FALLBACK_API_CONNECT_OPTIONS: APIConnectOptions = {
 };
 
 /**
- * `FallbackAdapter` is an STT wrapper that provides automatic failover between
- * multiple STT providers.
+ * Agent Fallback Adapter for STT. Manages multiple STT instances with automatic
+ * fallback when the primary provider fails.
  *
  * When the primary STT fails, the adapter switches to the next available
  * provider in the list for the active session. Failed providers are monitored

--- a/agents/src/tts/fallback_adapter.ts
+++ b/agents/src/tts/fallback_adapter.ts
@@ -51,7 +51,8 @@ const DEFAULT_FALLBACK_API_CONNECT_OPTIONS: APIConnectOptions = {
 const FORWARD_POLL_MS = 10;
 
 /**
- * FallbackAdapter is a TTS wrapper that provides automatic failover between multiple TTS providers.
+ * Agent Fallback Adapter for TTS. Manages multiple TTS instances with automatic fallback
+ * when the primary provider fails.
  *
  * When the primary TTS fails, it automatically switches to the next available provider in the list.
  * Failed providers are monitored in the background and restored when they recover.


### PR DESCRIPTION
## Summary

Ports the docstring update from livekit/agents#5654 ("add comments to agent side and inference side fallback adapters") into agents-js. The Python PR adds searchable "Agent Fallback Adapter for X" and "Inference Fallback Adapter" prefixes to the relevant docstrings so the LiveKit docs team can deep-link to the correct piece of code (agent-side fallback vs. inference-side fallback) from user-facing documentation.

## Files updated

Agent-side fallback adapters — added the "Agent Fallback Adapter for LLM/STT/TTS. Manages multiple X instances with automatic fallback when the primary provider fails." prefix:

- `agents/src/llm/fallback_adapter.ts` — `FallbackAdapter` class docstring
- `agents/src/stt/fallback_adapter.ts` — `FallbackAdapter` class docstring (preserved the existing detailed body about probe streams and `StreamAdapter` wrapping)
- `agents/src/tts/fallback_adapter.ts` — `FallbackAdapter` class docstring (preserved the existing Features list and example)

Inference-side fallback model configs — replaced the generic "A fallback model with optional extra configuration" comment with the searchable "Inference Fallback Adapter: configuration for a fallback STT/TTS model that runs server-side in LiveKit Inference, providing automatic fallback between providers." prefix:

- `agents/src/inference/stt.ts` — `STTFallbackModel` interface
- `agents/src/inference/tts.ts` — `TTSFallbackModel` interface

## Implementation notes / parity caveats

- **Interface vs. TypedDict.** Python's `FallbackModel` is a `TypedDict`; the JS equivalent is a TS `interface` named `STTFallbackModel` / `TTSFallbackModel` (the TS files prefix the type with the modality to distinguish the STT and TTS variants). The doc text is the same; only the symbol it sits on differs.
- **Typo fixed during port.** The Python diff says "Manages multiple STT instances" on both the LLM and TTS adapters (it's a copy-paste from the STT adapter wording in the original PR). The JS port substitutes the correct modality on each adapter ("Manages multiple LLM instances" / "Manages multiple TTS instances") since it's clearly unintentional rather than a language difference.
- **Existing JS docs are richer than Python's pre-PR text.** The JS docstrings already documented behavior in detail (probe streams for STT recovery, Features list and `@example` block for TTS, etc.). Rather than overwriting that content with the shorter Python prefix, this PR prepends the searchable prefix to the first line and preserves the existing body so the published TSDoc keeps the additional context. This matches the spirit of the Python PR (make the code findable) without losing JS-specific documentation.

## Changeset

`@livekit/agents`: patch.

## Test plan

- [ ] `pnpm api:check` passes (no exported types changed; only doc comments)
- [ ] `pnpm build` passes
- [ ] Visual diff confirms the new prefixes are present and the existing detailed docs are preserved

cc @toubatbrian @livekit/agent-devs

Ports https://github.com/livekit/agents/pull/5654 from `livekit/agents`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019iKdtjYchC2cd8dgngzHHz)_