### PR TITLE
fix(agents): use underscores in synthetic tool call ids

### DIFF
--- a/.changeset/async-toolset-call-id.md
+++ b/.changeset/async-toolset-call-id.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Use underscore-separated synthetic tool call IDs so generated function call IDs remain provider-safe.

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -498,7 +498,7 @@ export function performLLMInference(
               if (tool.type !== 'function_call') continue;
 
               const toolCall = FunctionCall.create({
-                callId: `${data.id}/fnc_${data.generatedToolCalls.length}`,
+                callId: `${data.id}_fnc_${data.generatedToolCalls.length}`,
                 name: tool.name,
                 args: tool.args,
                 // Preserve thought signature for Gemini 3+ thinking mode

--- a/agents/src/voice/generation_tools.test.ts
+++ b/agents/src/voice/generation_tools.test.ts
@@ -4,11 +4,16 @@
 import { ReadableStream as NodeReadableStream } from 'stream/web';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { FunctionCall, tool } from '../llm/index.js';
+import { type ChatChunk, ChatContext, FunctionCall, tool } from '../llm/index.js';
 import { initializeLogger } from '../log.js';
 import type { Task } from '../utils.js';
 import { cancelAndWait, delay } from '../utils.js';
-import { type _TextOut, performTextForwarding, performToolExecutions } from './generation.js';
+import {
+  type _TextOut,
+  performLLMInference,
+  performTextForwarding,
+  performToolExecutions,
+} from './generation.js';
 
 function createStringStream(chunks: string[], delayMs: number = 0): NodeReadableStream<string> {
   return new NodeReadableStream<string>({
@@ -46,6 +51,52 @@ function createFunctionCallStreamFromArray(fcs: FunctionCall[]): NodeReadableStr
 
 describe('Generation + Tool Execution', () => {
   initializeLogger({ pretty: false, level: 'silent' });
+
+  it('should use underscores in synthetic LLM tool call ids', async () => {
+    const llmChunk: ChatChunk = {
+      id: 'response_1',
+      delta: {
+        role: 'assistant',
+        toolCalls: [
+          FunctionCall.create({
+            callId: 'provider_call_1',
+            name: 'echo',
+            args: '{}',
+          }),
+        ],
+      },
+    };
+
+    const llmNode = async () =>
+      new NodeReadableStream<string | ChatChunk>({
+        start(controller) {
+          controller.enqueue(llmChunk);
+          controller.close();
+        },
+      });
+
+    const [llmTask, llmData] = performLLMInference(
+      llmNode,
+      ChatContext.empty(),
+      {},
+      {},
+      new AbortController(),
+    );
+
+    await llmTask.result;
+    const reader = llmData.toolCallStream.getReader();
+    try {
+      const first = await reader.read();
+      const second = await reader.read();
+
+      expect(first.done).toBe(false);
+      expect(first.value?.callId).toContain('_fnc_0');
+      expect(first.value?.callId).not.toContain('/');
+      expect(second.done).toBe(true);
+    } finally {
+      reader.releaseLock();
+    }
+  });
 
   it('should not abort tool when preamble forwarders are cleaned up', async () => {
     const replyAbortController = new AbortController();


### PR DESCRIPTION
## Summary
- Replace slash-separated synthetic tool call IDs in pipeline LLM generation with underscore separators.
- Add regression coverage for `performLLMInference` to ensure generated tool call IDs are slash-free.
- Add a changeset for `@livekit/agents`.

## Source Parity Notes
- Source commit `56d90d3` touched Python `AsyncToolset` synthetic `call_id` values.
- Direct source `AsyncToolset` tests/call sites are blocked in this target because the Node SDK does not expose a Python-style `AsyncToolset`/`Toolset` API.
- Target equivalent runtime path covered here: synthetic `FunctionCall.callId` creation in `agents/src/voice/generation.ts`.

## Tests
- `pnpm test agents/src/voice/generation_tools.test.ts`
- `pnpm test agents/src/voice/generation_tts_timeout.test.ts`
- `pnpm --filter @livekit/agents lint` (passes with existing warnings)
- `pnpm --filter @livekit/agents build:types`