### PR TITLE
fix(console): set mock participant state active

### DIFF
--- a/.changeset/mock-participants-act.md
+++ b/.changeset/mock-participants-act.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Mark the mock console participant as active when running fake jobs.

--- a/agents/src/ipc/job_proc_lazy_main.ts
+++ b/agents/src/ipc/job_proc_lazy_main.ts
@@ -13,6 +13,7 @@ import { Future, shortuuid } from '../utils.js';
 import { defaultInitializeProcessFunc } from '../worker.js';
 import type { InferenceExecutor } from './inference_executor.js';
 import type { IPCMessage } from './message.js';
+import { createMockRoom } from './mock_room.js';
 
 const ORPHANED_TIMEOUT = 15 * 1000;
 
@@ -101,7 +102,7 @@ const startJob = (
   let connect = false;
   let shutdown = false;
 
-  const room = new Room();
+  const room = info.fakeJob ? createMockRoom() : new Room();
   room.on(RoomEvent.Disconnected, () => {
     if (!shutdown) {
       closeEvent.emit('close', false);
@@ -119,14 +120,16 @@ const startJob = (
   const ctx = new JobContext(proc, info, room, onConnect, onShutdown, new InfClient());
 
   const task = (async () => {
-    const unconnectedTimeout = setTimeout(() => {
-      if (!(connect || shutdown)) {
-        logger.warn(
-          'room not connect after job_entry was called after 10 seconds, ',
-          'did you forget to call ctx.connect()?',
-        );
-      }
-    }, 10000);
+    const unconnectedTimeout = info.fakeJob
+      ? undefined
+      : setTimeout(() => {
+          if (!(connect || shutdown)) {
+            logger.warn(
+              'room not connect after job_entry was called after 10 seconds, ',
+              'did you forget to call ctx.connect()?',
+            );
+          }
+        }, 10000);
 
     try {
       const closePromise = once(closeEvent, 'close').then((close) => {
@@ -154,7 +157,9 @@ const startJob = (
           }
         })
         .finally(async () => {
-          clearTimeout(unconnectedTimeout);
+          if (unconnectedTimeout) {
+            clearTimeout(unconnectedTimeout);
+          }
         });
     } catch (error) {
       logger.error({ error }, 'error in entry function');

--- a/agents/src/ipc/mock_room.test.ts
+++ b/agents/src/ipc/mock_room.test.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { Job, JobType, ParticipantInfo_State, Room as ProtoRoom } from '@livekit/protocol';
+import { describe, expect, it, vi } from 'vitest';
+import { JobContext, JobProcess, type RunningJobInfo } from '../job.js';
+import { createMockRoom } from './mock_room.js';
+
+function createMockJobContext() {
+  const room = createMockRoom();
+  const onConnect = vi.fn();
+  const onShutdown = vi.fn();
+  const runningJob: RunningJobInfo = {
+    acceptArguments: { identity: 'console', name: '', metadata: '' },
+    fakeJob: true,
+    job: new Job({
+      id: 'mock-job',
+      room: new ProtoRoom({ name: 'console', sid: 'RM_mock_sid' }),
+      type: JobType.JT_ROOM,
+    }),
+    token: 'fake_token',
+    url: 'ws://fake-url',
+    workerId: 'fake_worker',
+  };
+  const ctx = new JobContext(new JobProcess(), runningJob, room, onConnect, onShutdown, {
+    doInference: vi.fn(async () => undefined),
+  });
+
+  return { ctx, onConnect, room };
+}
+
+describe('createMockRoom', () => {
+  it('sets the mock remote participant to active', () => {
+    const room = createMockRoom();
+    const participant = room.remoteParticipants.get('mock_user');
+
+    expect(participant).toBeDefined();
+    expect(participant?.identity).toBe('mock_user');
+    expect(participant?.sid).toBe('PA_mock_user');
+    expect(participant?.info.state).toBe(ParticipantInfo_State.ACTIVE);
+  });
+
+  it('satisfies JobContext.waitForParticipant immediately', async () => {
+    const { ctx } = createMockJobContext();
+
+    await expect(ctx.waitForParticipant()).resolves.toMatchObject({ identity: 'mock_user' });
+  });
+
+  it('replays existing participants to participant entrypoints on connect', async () => {
+    const { ctx, onConnect } = createMockJobContext();
+    const participantEntrypoint = vi.fn(async () => {});
+
+    ctx.addParticipantEntrypoint(participantEntrypoint);
+    await ctx.connect();
+
+    expect(onConnect).toHaveBeenCalledTimes(1);
+    expect(participantEntrypoint).toHaveBeenCalledTimes(1);
+    expect(participantEntrypoint.mock.calls[0]?.[1].identity).toBe('mock_user');
+  });
+});

--- a/agents/src/ipc/mock_room.ts
+++ b/agents/src/ipc/mock_room.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  ConnectionState,
+  type LocalParticipant,
+  ParticipantKind,
+  type RemoteParticipant,
+  Room,
+} from '@livekit/rtc-node';
+
+const MOCK_ROOM_SID = 'RM_mock_sid';
+const MOCK_REMOTE_PARTICIPANT_IDENTITY = 'mock_user';
+const MOCK_REMOTE_PARTICIPANT_SID = 'PA_mock_user';
+// @livekit/rtc-node does not re-export ParticipantState; ACTIVE is 2 in the FFI enum.
+const PARTICIPANT_STATE_ACTIVE = 2;
+
+function createMockParticipant({
+  identity,
+  sid,
+  kind,
+}: {
+  identity: string;
+  sid: string;
+  kind: ParticipantKind;
+}) {
+  return {
+    identity,
+    sid,
+    kind,
+    metadata: '',
+    attributes: {},
+    trackPublications: new Map(),
+    info: {
+      identity,
+      sid,
+      name: '',
+      metadata: '',
+      attributes: {},
+      kind,
+      kindDetails: [],
+      state: PARTICIPANT_STATE_ACTIVE,
+    },
+  };
+}
+
+export function createMockRoom(): Room {
+  const room = new Room();
+  const localParticipant = createMockParticipant({
+    identity: 'console',
+    sid: 'PA_mock_agent',
+    kind: ParticipantKind.AGENT,
+  }) as unknown as LocalParticipant;
+  const mockRemoteParticipant = createMockParticipant({
+    identity: MOCK_REMOTE_PARTICIPANT_IDENTITY,
+    sid: MOCK_REMOTE_PARTICIPANT_SID,
+    kind: ParticipantKind.STANDARD,
+  }) as unknown as RemoteParticipant;
+
+  (room as unknown as { info: { sid: string; name: string; metadata: string } }).info = {
+    sid: MOCK_ROOM_SID,
+    name: 'console',
+    metadata: '',
+  };
+
+  Object.defineProperties(room, {
+    connectionState: { configurable: true, get: () => ConnectionState.CONN_CONNECTED },
+    departureTimeout: { configurable: true, get: () => 0 },
+    emptyTimeout: { configurable: true, get: () => 0 },
+    isConnected: { configurable: true, get: () => true },
+    metadata: { configurable: true, get: () => '' },
+    name: { configurable: true, get: () => 'console' },
+    numParticipants: { configurable: true, get: () => 2 },
+    numPublishers: { configurable: true, get: () => 2 },
+  });
+
+  room.localParticipant = localParticipant;
+  room.remoteParticipants = new Map([[mockRemoteParticipant.identity, mockRemoteParticipant]]);
+  room.connect = async () => undefined;
+  room.disconnect = async () => undefined;
+  room.getSid = async () => MOCK_ROOM_SID;
+
+  return room;
+}

--- a/agents/src/job.ts
+++ b/agents/src/job.ts
@@ -84,6 +84,7 @@ export type RunningJobInfo = {
   url: string;
   token: string;
   workerId: string;
+  fakeJob?: boolean;
 };
 
 /** Attempted to add a function callback, but the function already exists. */


### PR DESCRIPTION
## Summary
- Port the Python mock-room behavior by adding an internal `createMockRoom()` with the mock remote participant marked active.
- Wire fake jobs in the job process to use the mock room and skip the normal unconnected-room warning.
- Add target regression tests for active state, immediate `waitForParticipant()`, and `connect()` participant replay.

## Source Parity
- Source tests: none found for `create_mock_room`, `mock_room`, or the mock participant active state.
- Mapped `ipc/mock_room.py::create_mock_room()` to `agents/src/ipc/mock_room.ts::createMockRoom()`.
- Mapped `ipc/job_proc_lazy_main.py` fake-job room creation to `agents/src/ipc/job_proc_lazy_main.ts` using `info.fakeJob`.
- Blocked: target SDK has no console/fake-job command or worker fake-job producer equivalent to Python `_ConsoleWorker` / `AgentServer.simulate_job(fake_job=True)`.
- Blocked: target IPC uses Node process messages and has no Python-style IPC proto serialization layer to mirror.

## Verification
- `pnpm test -- agents/src/ipc/mock_room.test.ts agents/src/ipc/proc_pool.test.ts agents/src/ipc/supervised_proc.test.ts agents/src/utils.test.ts`
- `pnpm --filter @livekit/agents build`
- `pnpm lint` passes with existing warnings.
- `pnpm --filter @livekit/agents api:check` fails on existing API Extractor incompatibility with `export * as ___` in `agents/dist/index.d.ts:10:8`.

## Needs Human Review
- Confirm whether the target SDK should add a console/fake-job producer in a follow-up, since this PR only ports the mock-room/job-process side that exists in the target runtime.