### PR TITLE
Stream Rime TTS response chunks

### DIFF
--- a/.changeset/rime-streaming-response.md
+++ b/.changeset/rime-streaming-response.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-rime': patch
+---
+
+Stream Rime TTS response chunks as they arrive instead of waiting for the full response body.

--- a/plugins/rime/src/tts.test.ts
+++ b/plugins/rime/src/tts.test.ts
@@ -1,12 +1,87 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { initializeLogger } from '@livekit/agents';
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts } from '@livekit/agents-plugins-test';
-import { describe, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TTS } from './tts.js';
 
+initializeLogger({ pretty: false, level: 'silent' });
+
 const hasRimeConfig = Boolean(process.env.RIME_API_KEY && process.env.OPENAI_API_KEY);
+
+function pcmChunk(byteLength: number): Uint8Array {
+  const chunk = new Uint8Array(byteLength);
+  for (let i = 0; i < chunk.length; i += 2) {
+    chunk[i] = 1;
+  }
+  return chunk;
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | 'timeout'> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), ms);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+describe('Rime TTS streaming', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('emits audio before the Rime response body closes', async () => {
+    let bodyController!: ReadableStreamDefaultController<Uint8Array>;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: { 'Content-Type': 'audio/pcm' },
+      }),
+    );
+
+    const rimeTTS = new TTS({
+      apiKey: 'test-rime-key',
+      baseURL: 'https://rime.test/v1/rime-tts',
+      modelId: 'arcana',
+      speaker: 'luna',
+      samplingRate: 16000,
+    });
+
+    const stream = rimeTTS.synthesize('This should stream before the response ends.');
+    const firstAudio = stream.next();
+
+    bodyController.enqueue(pcmChunk(3200));
+    bodyController.enqueue(pcmChunk(3200));
+
+    const firstResult = await withTimeout(firstAudio, 1000);
+    expect(firstResult).not.toBe('timeout');
+    if (firstResult === 'timeout') return;
+
+    expect(firstResult.done).toBe(false);
+    expect(firstResult.value.final).toBe(false);
+    expect(firstResult.value.frame.samplesPerChannel).toBe(1600);
+
+    bodyController.close();
+
+    const finalResult = await stream.next();
+    expect(finalResult.done).toBe(false);
+    expect(finalResult.value.final).toBe(true);
+
+    const doneResult = await stream.next();
+    expect(doneResult.done).toBe(true);
+  });
+});
 
 if (hasRimeConfig) {
   describe('Rime TTS', async () => {

--- a/plugins/rime/src/tts.ts
+++ b/plugins/rime/src/tts.ts
@@ -162,10 +162,12 @@ export class ChunkedStream extends tts.ChunkedStream {
       throw new Error(`Rime AI TTS request failed: ${response.status} ${response.statusText}`);
     }
 
-    const buffer = await response.arrayBuffer();
+    if (!response.body) {
+      throw new Error('Rime AI TTS response has no body');
+    }
+
     const sampleRate = getSampleRate(this.opts);
     const audioByteStream = new AudioByteStream(sampleRate, RIME_TTS_CHANNELS);
-    const frames = audioByteStream.write(buffer);
     let lastFrame: AudioFrame | undefined;
     const sendLastFrame = (segmentId: string, final: boolean) => {
       if (lastFrame) {
@@ -174,12 +176,28 @@ export class ChunkedStream extends tts.ChunkedStream {
       }
     };
 
-    for (const frame of frames) {
-      sendLastFrame(requestId, false);
-      lastFrame = frame;
-    }
-    sendLastFrame(requestId, true);
+    const reader = response.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
 
-    this.queue.close();
+        for (const frame of audioByteStream.write(value)) {
+          sendLastFrame(requestId, false);
+          lastFrame = frame;
+        }
+      }
+
+      for (const frame of audioByteStream.flush()) {
+        if (frame.samplesPerChannel === 0) continue;
+        sendLastFrame(requestId, false);
+        lastFrame = frame;
+      }
+
+      sendLastFrame(requestId, true);
+    } finally {
+      reader.releaseLock();
+      this.queue.close();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- stream Rime PCM response chunks from `response.body` instead of waiting for the full `response.arrayBuffer()`
- keep the existing one-frame deferral behavior so only the last emitted frame is marked `final: true`
- flush a non-empty trailing PCM remainder after the HTTP stream ends
- add a regression test that proves the Rime plugin emits audio before the mocked HTTP body closes

## Context
The Rime JS TTS plugin was buffering the whole HTTP response before writing any audio into the LiveKit audio queue. Rime can flush PCM as synthesis progresses, but `await response.arrayBuffer()` means the agent sees no audio until the provider response has completely finished. For longer utterances, app-observed TTS TTFB therefore grows with total synthesis duration instead of reflecting the provider's first available audio chunk.

This brings the JS plugin behavior in line with the intended streaming path: consume the response body reader incrementally, pass each received PCM chunk through `AudioByteStream`, and enqueue complete 100ms `AudioFrame`s as soon as they are available.

## Implementation notes
- `response.body` is checked before reading so a missing body fails explicitly.
- `ReadableStream.getReader()` is released in `finally`, and the queue is closed in the same cleanup path.
- `AudioByteStream.write()` already accepts `ArrayBufferView` and honors `byteOffset` / `byteLength`, so the streamed `Uint8Array` chunks can be passed directly without copying into a sliced `ArrayBuffer`.
- `AudioByteStream.flush()` is still called after EOF to drain a valid partial-frame remainder; empty flush frames are skipped.

## Validation
- `pnpm test -- plugins/rime/src/tts.test.ts`
- `pnpm --filter @livekit/agents-plugin-rime lint`
- `pnpm format:check`
- `pnpm turbo run build --filter=@livekit/agents-plugin-rime`
- `git diff --check`