### PR TITLE
Add beta EndCallTool

### DIFF
--- a/.changeset/beta-end-call-tool.md
+++ b/.changeset/beta-end-call-tool.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': minor
+---
+
+Add beta `EndCallTool` and `JobContext.deleteRoom()` for gracefully ending voice calls.

--- a/agents/src/beta/tools/end_call.test.ts
+++ b/agents/src/beta/tools/end_call.test.ts
@@ -1,0 +1,239 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { type JobContext, runWithJobContext } from '../../job.js';
+import { FunctionCall } from '../../llm/chat_context.js';
+import { type FunctionTool, RealtimeModel, type RealtimeSession } from '../../llm/index.js';
+import { AgentSessionEventTypes, type CloseEvent } from '../../voice/events.js';
+import { RunContext } from '../../voice/run_context.js';
+import { SpeechHandle } from '../../voice/speech_handle.js';
+import { EndCallTool } from './end_call.js';
+
+function makeFunctionCall(): FunctionCall {
+  return FunctionCall.create({
+    callId: 'call_test',
+    name: 'end_call',
+    args: '{}',
+  });
+}
+
+function makeRunContext() {
+  const speechHandle = SpeechHandle.create();
+  const session = Object.assign(new EventEmitter(), {
+    currentAgent: {
+      getActivityOrThrow: () => ({ llm: undefined }),
+    },
+    shutdown: vi.fn(),
+  });
+
+  return {
+    ctx: new RunContext(session as never, speechHandle, makeFunctionCall()),
+    session,
+    speechHandle,
+  };
+}
+
+function makeCloseEvent(reason = 'end_call'): CloseEvent {
+  return {
+    type: 'close',
+    error: null,
+    reason,
+    createdAt: Date.now(),
+  };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+class FakeRealtimeModel extends RealtimeModel {
+  constructor(autoToolReplyGeneration: boolean) {
+    super({
+      messageTruncation: false,
+      turnDetection: false,
+      userTranscription: false,
+      autoToolReplyGeneration,
+      audioOutput: true,
+      manualFunctionCalls: true,
+    });
+  }
+
+  get model(): string {
+    return 'fake-realtime';
+  }
+
+  session(): RealtimeSession {
+    throw new Error('not implemented');
+  }
+
+  async close(): Promise<void> {}
+}
+
+describe('EndCallTool', () => {
+  it('exposes an end_call function tool', () => {
+    const endCallTool = new EndCallTool({ deleteRoom: false });
+
+    expect(endCallTool.tools.end_call).toBeDefined();
+    expect(endCallTool.tools.end_call.type).toBe('function');
+  });
+
+  it('returns end instructions and waits for speech playout before shutdown', async () => {
+    const onToolCalled = vi.fn();
+    const onToolCompleted = vi.fn();
+    const endCallTool = new EndCallTool({
+      deleteRoom: false,
+      endInstructions: 'thank the user and say goodbye',
+      onToolCalled,
+      onToolCompleted,
+    });
+    const { ctx, session, speechHandle } = makeRunContext();
+    const endCall = endCallTool.tools.end_call as FunctionTool;
+
+    const result = await endCall.execute({}, { ctx, toolCallId: 'tool_call_test' });
+
+    expect(result).toBe('thank the user and say goodbye');
+    expect(onToolCalled).toHaveBeenCalledWith({ ctx, arguments: {} });
+    expect(onToolCompleted).toHaveBeenCalledWith({
+      ctx,
+      output: 'thank the user and say goodbye',
+    });
+    expect(session.shutdown).not.toHaveBeenCalled();
+
+    speechHandle._markDone();
+    await flushMicrotasks();
+
+    expect(session.shutdown).toHaveBeenCalledWith({ drain: true, reason: 'end_call' });
+  });
+
+  it('returns undefined when end instructions are null', async () => {
+    const endCallTool = new EndCallTool({
+      deleteRoom: false,
+      endInstructions: null,
+    });
+    const { ctx, session, speechHandle } = makeRunContext();
+    const endCall = endCallTool.tools.end_call as FunctionTool;
+
+    const result = await endCall.execute({}, { ctx, toolCallId: 'tool_call_test' });
+
+    expect(result).toBeUndefined();
+    expect(session.shutdown).not.toHaveBeenCalled();
+
+    speechHandle._markDone();
+    await flushMicrotasks();
+
+    expect(session.shutdown).toHaveBeenCalledWith({ drain: true, reason: 'end_call' });
+  });
+
+  it('shuts down the job after the session closes', async () => {
+    const endCallTool = new EndCallTool({ deleteRoom: false });
+    const { ctx, session, speechHandle } = makeRunContext();
+    const endCall = endCallTool.tools.end_call as FunctionTool;
+    const jobCtx = {
+      addShutdownCallback: vi.fn(),
+      shutdown: vi.fn(),
+    };
+
+    await runWithJobContext(jobCtx as unknown as JobContext, () =>
+      endCall.execute({}, { ctx, toolCallId: 'tool_call_test' }),
+    );
+
+    speechHandle._markDone();
+    await flushMicrotasks();
+
+    expect(jobCtx.shutdown).not.toHaveBeenCalled();
+
+    session.emit(AgentSessionEventTypes.Close, makeCloseEvent());
+
+    expect(jobCtx.addShutdownCallback).not.toHaveBeenCalled();
+    expect(jobCtx.shutdown).toHaveBeenCalledWith('end_call');
+  });
+
+  it('registers room deletion before job shutdown when configured', async () => {
+    const endCallTool = new EndCallTool({ deleteRoom: true });
+    const { ctx, session, speechHandle } = makeRunContext();
+    const endCall = endCallTool.tools.end_call as FunctionTool;
+    const jobCtx = {
+      addShutdownCallback: vi.fn(),
+      shutdown: vi.fn(),
+    };
+
+    await runWithJobContext(jobCtx as unknown as JobContext, () =>
+      endCall.execute({}, { ctx, toolCallId: 'tool_call_test' }),
+    );
+
+    speechHandle._markDone();
+    await flushMicrotasks();
+    session.emit(AgentSessionEventTypes.Close, makeCloseEvent());
+
+    expect(jobCtx.addShutdownCallback).toHaveBeenCalledTimes(1);
+    expect(jobCtx.shutdown).toHaveBeenCalledWith('end_call');
+  });
+
+  it('waits for auto-generated realtime tool reply speech before shutdown', async () => {
+    const endCallTool = new EndCallTool({ deleteRoom: false });
+    const speechHandle = SpeechHandle.create();
+    const replySpeechHandle = SpeechHandle.create();
+    const session = Object.assign(new EventEmitter(), {
+      currentAgent: {
+        getActivityOrThrow: () => ({ llm: new FakeRealtimeModel(true) }),
+      },
+      shutdown: vi.fn(),
+    });
+    const ctx = new RunContext(session as never, speechHandle, makeFunctionCall());
+    const endCall = endCallTool.tools.end_call as FunctionTool;
+
+    await endCall.execute({}, { ctx, toolCallId: 'tool_call_test' });
+
+    session.emit(AgentSessionEventTypes.SpeechCreated, {
+      type: 'speech_created',
+      userInitiated: false,
+      source: 'generate_reply',
+      speechHandle: replySpeechHandle,
+      createdAt: Date.now(),
+    });
+    replySpeechHandle._markDone();
+
+    expect(session.shutdown).not.toHaveBeenCalled();
+
+    speechHandle._markDone();
+    await flushMicrotasks();
+
+    expect(session.shutdown).toHaveBeenCalledWith({ drain: true, reason: 'end_call' });
+  });
+
+  it('does not register duplicate shutdown callbacks after repeated calls', async () => {
+    const endCallTool = new EndCallTool({ deleteRoom: false });
+    const { ctx, session, speechHandle } = makeRunContext();
+    const endCall = endCallTool.tools.end_call as FunctionTool;
+
+    await endCall.execute({}, { ctx, toolCallId: 'first_call' });
+    await endCall.execute({}, { ctx, toolCallId: 'second_call' });
+
+    speechHandle._markDone();
+    await flushMicrotasks();
+
+    expect(session.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the same tool instance to end a later call', async () => {
+    const endCallTool = new EndCallTool({ deleteRoom: false });
+    const first = makeRunContext();
+    const second = makeRunContext();
+    const endCall = endCallTool.tools.end_call as FunctionTool;
+
+    await endCall.execute({}, { ctx: first.ctx, toolCallId: 'first_call' });
+    first.speechHandle._markDone();
+    await flushMicrotasks();
+
+    await endCall.execute({}, { ctx: second.ctx, toolCallId: 'second_call' });
+    second.speechHandle._markDone();
+    await flushMicrotasks();
+
+    expect(first.session.shutdown).toHaveBeenCalledWith({ drain: true, reason: 'end_call' });
+    expect(second.session.shutdown).toHaveBeenCalledWith({ drain: true, reason: 'end_call' });
+  });
+});

--- a/agents/src/beta/tools/end_call.ts
+++ b/agents/src/beta/tools/end_call.ts
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { type JobContext, getJobContext } from '../../job.js';
+import { RealtimeModel, type ToolContext, type ToolOptions, tool } from '../../llm/index.js';
+import {
+  AgentSessionEventTypes,
+  type CloseEvent,
+  type SpeechCreatedEvent,
+} from '../../voice/events.js';
+import type { RunContext, UnknownUserData } from '../../voice/run_context.js';
+import type { SpeechHandle } from '../../voice/speech_handle.js';
+
+export const END_CALL_DESCRIPTION = `
+Ends the current call and disconnects immediately.
+
+Call when:
+- The user clearly indicates they are done (e.g., "that's all, bye").
+- The agent determines the conversation is complete and should end.
+
+Do not call when:
+- The user asks to pause, hold, or transfer.
+- Intent is unclear.
+
+This is the final action the agent can take.
+Once called, no further interaction is possible with the user.
+Don't generate any other text or response when the tool is called.
+`;
+
+export type EndCallToolCalledEvent<UserData = UnknownUserData> = {
+  ctx: RunContext<UserData>;
+  arguments: Record<string, never>;
+};
+
+export type EndCallToolCompletedEvent<UserData = UnknownUserData> = {
+  ctx: RunContext<UserData>;
+  output: string | undefined;
+};
+
+export interface EndCallToolOptions<UserData = UnknownUserData> {
+  /**
+   * Additional description to append to the end call tool.
+   */
+  extraDescription?: string;
+
+  /**
+   * Whether to delete the room when the call ends.
+   *
+   * Deleting the room disconnects all remote users, including SIP callers.
+   */
+  deleteRoom?: boolean;
+
+  /**
+   * Tool output to the LLM for generating the final response.
+   *
+   * Set to `null` to skip generating a final tool response.
+   */
+  endInstructions?: string | null;
+
+  /**
+   * Called when the tool starts.
+   */
+  onToolCalled?: (event: EndCallToolCalledEvent<UserData>) => Promise<void>;
+
+  /**
+   * Called after the tool has produced its output.
+   */
+  onToolCompleted?: (event: EndCallToolCompletedEvent<UserData>) => Promise<void>;
+}
+
+type ToolResponseSpeechWaiter = {
+  promise: Promise<SpeechHandle>;
+  startTimeout: () => void;
+};
+
+/**
+ * Tool that lets an agent gracefully end the current call.
+ *
+ * The tool returns `endInstructions` so the LLM can produce a final response,
+ * then shuts down the session and job after the final speech has played out.
+ */
+export class EndCallTool<UserData = UnknownUserData> {
+  readonly tools: ToolContext<UserData>;
+  private readonly deleteRoom: boolean;
+  private readonly endInstructions: string | undefined;
+  private readonly onToolCalled?: (event: EndCallToolCalledEvent<UserData>) => Promise<void>;
+  private readonly onToolCompleted?: (event: EndCallToolCompletedEvent<UserData>) => Promise<void>;
+  private readonly handledSpeechHandles = new WeakSet<SpeechHandle>();
+
+  constructor(options: EndCallToolOptions<UserData> = {}) {
+    const {
+      extraDescription = '',
+      deleteRoom = true,
+      endInstructions = 'say goodbye to the user',
+      onToolCalled,
+      onToolCompleted,
+    } = options;
+
+    this.deleteRoom = deleteRoom;
+    this.endInstructions = endInstructions === null ? undefined : endInstructions;
+    this.onToolCalled = onToolCalled;
+    this.onToolCompleted = onToolCompleted;
+    this.tools = {
+      end_call: tool<UserData, string | undefined>({
+        description: extraDescription
+          ? `${END_CALL_DESCRIPTION}\n${extraDescription}`
+          : END_CALL_DESCRIPTION,
+        execute: async (_, opts) => this.endCall(opts),
+      }),
+    };
+  }
+
+  private async endCall({ ctx }: ToolOptions<UserData>): Promise<string | undefined> {
+    if (this.handledSpeechHandles.has(ctx.speechHandle)) {
+      return this.endInstructions;
+    }
+    this.handledSpeechHandles.add(ctx.speechHandle);
+
+    const llm = ctx.session.currentAgent.getActivityOrThrow().llm;
+    const shouldWaitForToolResponse =
+      this.endInstructions !== undefined &&
+      llm instanceof RealtimeModel &&
+      llm.capabilities.autoToolReplyGeneration;
+    const toolResponseSpeech = shouldWaitForToolResponse
+      ? this.watchForToolResponseSpeech(ctx)
+      : undefined;
+    const jobCtx = getJobContext(false);
+
+    ctx.session.once(AgentSessionEventTypes.Close, (event) => {
+      this.onSessionClose(event, jobCtx);
+    });
+
+    ctx.speechHandle.addDoneCallback(() => {
+      if (toolResponseSpeech) {
+        void this.shutdownAfterToolResponse(ctx, toolResponseSpeech);
+      } else {
+        this.shutdownSession(ctx);
+      }
+    });
+
+    await this.onToolCalled?.({ ctx, arguments: {} });
+
+    const completedEvent = {
+      ctx,
+      output: this.endInstructions,
+    };
+    await this.onToolCompleted?.(completedEvent);
+
+    return completedEvent.output;
+  }
+
+  private async shutdownAfterToolResponse(
+    ctx: RunContext<UserData>,
+    toolResponseSpeech: ToolResponseSpeechWaiter,
+  ) {
+    try {
+      toolResponseSpeech.startTimeout();
+      const speechHandle = await toolResponseSpeech.promise;
+      await speechHandle.waitForPlayout();
+    } catch {
+      // If no separate tool response is created, fall through and shut down.
+    } finally {
+      this.shutdownSession(ctx);
+    }
+  }
+
+  private watchForToolResponseSpeech(ctx: RunContext<UserData>): ToolResponseSpeechWaiter {
+    let timeout: NodeJS.Timeout | undefined;
+    let settled = false;
+    let rejectPromise: (reason: Error) => void = () => {};
+    let cleanup = () => {};
+
+    const promise = new Promise<SpeechHandle>((resolve, reject) => {
+      rejectPromise = reject;
+
+      const onSpeechCreated = (event: SpeechCreatedEvent) => {
+        if (event.userInitiated) return;
+
+        cleanup();
+        settled = true;
+        resolve(event.speechHandle);
+      };
+
+      cleanup = () => {
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = undefined;
+        }
+        ctx.session.off(AgentSessionEventTypes.SpeechCreated, onSpeechCreated);
+      };
+
+      ctx.session.on(AgentSessionEventTypes.SpeechCreated, onSpeechCreated);
+    });
+
+    return {
+      promise,
+      startTimeout: () => {
+        if (settled || timeout) return;
+        timeout = setTimeout(() => {
+          settled = true;
+          cleanup();
+          rejectPromise(new Error('tool response timed out'));
+        }, 5000);
+      },
+    };
+  }
+
+  private shutdownSession(ctx: RunContext<UserData>) {
+    ctx.session.shutdown({ drain: true, reason: 'end_call' });
+  }
+
+  private onSessionClose(event: CloseEvent, jobCtx: JobContext | undefined) {
+    if (!jobCtx) {
+      return;
+    }
+
+    if (this.deleteRoom) {
+      jobCtx.addShutdownCallback(() => jobCtx.deleteRoom());
+    }
+
+    jobCtx.shutdown(event.reason);
+  }
+}

--- a/agents/src/beta/tools/index.ts
+++ b/agents/src/beta/tools/index.ts
@@ -2,15 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 export {
-  TaskGroup,
-  type TaskCompletedEvent,
-  type TaskGroupOptions,
-  type TaskGroupResult,
-} from './workflows/index.js';
-export {
   END_CALL_DESCRIPTION,
   EndCallTool,
   type EndCallToolCalledEvent,
   type EndCallToolCompletedEvent,
   type EndCallToolOptions,
-} from './tools/index.js';
+} from './end_call.js';

--- a/agents/src/job.ts
+++ b/agents/src/job.ts
@@ -11,6 +11,7 @@ import type {
 } from '@livekit/rtc-node';
 import { ParticipantKind, RoomEvent, TrackKind } from '@livekit/rtc-node';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
+import { RoomServiceClient } from 'livekit-server-sdk';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -84,6 +85,8 @@ export type RunningJobInfo = {
   url: string;
   token: string;
   workerId: string;
+  apiKey?: string;
+  apiSecret?: string;
 };
 
 /** Attempted to add a function callback, but the function already exists. */
@@ -188,6 +191,27 @@ export class JobContext<ProcessUserData = Record<string, unknown>> {
   /** Adds a promise to be awaited when {@link JobContext.shutdown | shutdown} is called. */
   addShutdownCallback(callback: () => Promise<void>) {
     this.shutdownCallbacks.push(callback);
+  }
+
+  /**
+   * Deletes the current room.
+   *
+   * Deleting the room disconnects all remote users, including SIP callers.
+   */
+  async deleteRoom() {
+    const roomName = this.#room.name;
+    if (!roomName) {
+      return;
+    }
+
+    const apiKey = this.#info.apiKey || process.env.LIVEKIT_API_KEY;
+    const apiSecret = this.#info.apiSecret || process.env.LIVEKIT_API_SECRET;
+    if (!apiKey || !apiSecret) {
+      throw new Error('LIVEKIT_API_KEY and LIVEKIT_API_SECRET are required to delete the room');
+    }
+
+    const roomService = new RoomServiceClient(this.#info.url, apiKey, apiSecret);
+    await roomService.deleteRoom(roomName);
   }
 
   async waitForParticipant(identity?: string): Promise<RemoteParticipant> {

--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -772,6 +772,8 @@ export class AgentServer {
             url: asgn.url || this.#opts.wsURL,
             token: asgn.token,
             workerId: this.id,
+            apiKey: this.#opts.apiKey,
+            apiSecret: this.#opts.apiSecret,
           });
         } catch (e) {
           this.#logger.child({ requestId: req.id }).error(e, 'error launching job');


### PR DESCRIPTION
## Summary
- add beta EndCallTool under @livekit/agents/beta, modeled after Python behavior
- add JobContext.deleteRoom() and pass worker credentials into RunningJobInfo so deleteRoom works with env or ServerOptions credentials
- cover end-call lifecycle, duplicate same-turn calls, reusable tool instances, realtime auto tool replies, and null endInstructions behavior

## Testing
- pnpm test agents/src/beta/tools/end_call.test.ts
- pnpm --filter @livekit/agents build
- pnpm --filter @livekit/agents lint (passes with existing warnings)
- pnpm exec prettier --check agents/src/beta/index.ts agents/src/beta/tools/end_call.ts agents/src/beta/tools/end_call.test.ts agents/src/beta/tools/index.ts agents/src/job.ts agents/src/worker.ts .changeset/beta-end-call-tool.md
- git diff --check

## Notes
- pnpm --filter @livekit/agents api:check currently fails before this change on generated dist/index.d.ts export * as syntax already present on upstream/main.