### PR TITLE
fix(agents): support constructing AgentSession with no arguments

### DIFF
--- a/.changeset/agent-session-default-options.md
+++ b/.changeset/agent-session-default-options.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(agents): support constructing `AgentSession` with no arguments

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -282,7 +282,7 @@ export class AgentSession<
 
   private logger = log();
 
-  constructor(options: AgentSessionOptions<UserData>) {
+  constructor(options: AgentSessionOptions<UserData> = {}) {
     super();
 
     const { agentSessionOptions: opts, legacyVoiceOptions } =


### PR DESCRIPTION
## Summary
- `new AgentSession()` previously threw `TypeError: Cannot destructure property 'voiceOptions' of 'legacyOptions' as it is undefined` because the constructor required an options arg, even though every field on `AgentSessionOptions` is optional.
- Default the constructor parameter to `{}` so callers can omit it.