### PR TITLE
fix(inference): use non-empty placeholder apiKey for internal OpenAI client

### DIFF
--- a/.changeset/inference-llm-empty-apikey.md
+++ b/.changeset/inference-llm-empty-apikey.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-fix(inference): use non-empty placeholder for the internal OpenAI client's apiKey, which openai >= 6.36.0 rejects at construction (the value is replaced with a fresh access token before each request)
+fix(inference): make `inference.LLM` compatible with openai >= 6.36.0

--- a/.changeset/inference-llm-empty-apikey.md
+++ b/.changeset/inference-llm-empty-apikey.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(inference): use non-empty placeholder for the internal OpenAI client's apiKey, which openai >= 6.36.0 rejects at construction (the value is replaced with a fresh access token before each request)

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -225,7 +225,9 @@ export class LLM extends llm.LLM {
 
     this.client = new OpenAI({
       baseURL: this.opts.baseURL,
-      apiKey: '', // leave a temporary empty string to avoid OpenAI complain about missing key
+      // Non-empty placeholder; replaced with a fresh access token before each
+      // request (see LLMStream.run). openai >= 6.36.0 rejects an empty apiKey.
+      apiKey: 'placeholder',
     });
   }
 


### PR DESCRIPTION
## Summary
- `inference.LLM` constructs an `OpenAI` client with `apiKey: ''` as a placeholder, then overwrites `client.apiKey` with a fresh access token before each request (see `LLMStream.run`).
- `openai@6.36.0` tightened its credential check to reject empty-string `apiKey` at construction, so the constructor now throws before the per-request token is ever assigned.
- Use a non-empty `'placeholder'` string instead — the value is replaced before any actual HTTP call, so behavior is unchanged on every supported `openai` version.

Verified by linking `@livekit/agents` from `livekit-examples/agent-starter-node` against `openai@6.36.0` and removing the workaround `pnpm.overrides.openai: <6.36.0`; the test suite passes.