### PR TITLE
fix(agents): improve missing argument error wording

### DIFF
--- a/.changeset/missing-required-argument-wording.md
+++ b/.changeset/missing-required-argument-wording.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(agents): improve wording for missing required tool argument errors

--- a/agents/src/llm/zod-utils.test.ts
+++ b/agents/src/llm/zod-utils.test.ts
@@ -393,6 +393,32 @@ describe('Zod Utils', () => {
         }
       });
 
+      it('should report null required v4 fields as missing values', async () => {
+        const schema = z4.object({
+          name: z4.string(),
+        });
+
+        const result = await parseZodSchema(schema, { name: null });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(String(result.error)).toContain("Received no value for required parameter 'name'");
+        }
+      });
+
+      it('should not report null optional v4 fields as required', async () => {
+        const schema = z4.object({
+          name: z4.string().optional(),
+        });
+
+        const result = await parseZodSchema(schema, { name: null });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(String(result.error)).not.toContain('Received no value for required parameter');
+        }
+      });
+
       it('should handle v4 optional fields', async () => {
         const schema = z4.object({
           name: z4.string(),
@@ -447,6 +473,32 @@ describe('Zod Utils', () => {
         expect(result.success).toBe(false);
         if (!result.success) {
           expect(result.error).toBeDefined();
+        }
+      });
+
+      it('should report null required v3 fields as missing values', async () => {
+        const schema = z3.object({
+          name: z3.string(),
+        });
+
+        const result = await parseZodSchema(schema, { name: null });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(String(result.error)).toContain("Received no value for required parameter 'name'");
+        }
+      });
+
+      it('should not report null optional v3 fields as required', async () => {
+        const schema = z3.object({
+          name: z3.string().optional(),
+        });
+
+        const result = await parseZodSchema(schema, { name: null });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(String(result.error)).not.toContain('Received no value for required parameter');
         }
       });
 

--- a/agents/src/llm/zod-utils.ts
+++ b/agents/src/llm/zod-utils.ts
@@ -145,9 +145,95 @@ export async function parseZodSchema<T = unknown>(
 ): Promise<ZodParseResult<T>> {
   if (isZod4Schema(schema)) {
     const result = await z4.safeParseAsync(schema, value);
-    return result as ZodParseResult<T>;
+    return normalizeZodParseResult(schema, result as ZodParseResult<T>);
   } else {
     const result = await schema.safeParseAsync(value);
-    return result as ZodParseResult<T>;
+    return normalizeZodParseResult(schema, result as ZodParseResult<T>);
   }
+}
+
+function normalizeZodParseResult<T>(
+  schema: ZodSchema,
+  result: ZodParseResult<T>,
+): ZodParseResult<T> {
+  if (result.success) {
+    return result;
+  }
+
+  const paramName = missingRequiredParameterName(schema, result.error);
+  if (!paramName) {
+    return result;
+  }
+
+  return {
+    success: false,
+    error: new Error(
+      `Received no value for required parameter '${paramName}': this argument cannot be null.`,
+    ),
+  };
+}
+
+function missingRequiredParameterName(schema: ZodSchema, error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('issues' in error)) {
+    return undefined;
+  }
+
+  const issues = (error as { issues?: unknown }).issues;
+  if (!Array.isArray(issues)) {
+    return undefined;
+  }
+
+  for (const issue of issues) {
+    if (typeof issue !== 'object' || issue === null) {
+      continue;
+    }
+
+    const { code, message, path, received } = issue as {
+      code?: unknown;
+      message?: unknown;
+      path?: unknown;
+      received?: unknown;
+    };
+    if (code !== 'invalid_type' || !Array.isArray(path) || path.length !== 1) {
+      continue;
+    }
+
+    const receivedNull = received === 'null' || String(message).includes('received null');
+    if (!receivedNull) {
+      continue;
+    }
+
+    const paramName = String(path[0]);
+    if (isRequiredParameter(schema, paramName)) {
+      return paramName;
+    }
+  }
+
+  return undefined;
+}
+
+function isRequiredParameter(schema: ZodSchema, paramName: string): boolean {
+  if (typeof schema !== 'object' || schema === null || !('shape' in schema)) {
+    return false;
+  }
+
+  const shape = (schema as { shape?: unknown }).shape;
+  if (typeof shape !== 'object' || shape === null) {
+    return false;
+  }
+
+  const field = (shape as Record<string, unknown>)[paramName];
+  if (typeof field !== 'object' || field === null) {
+    return false;
+  }
+
+  const isOptional = (field as { isOptional?: unknown }).isOptional;
+  const isNullable = (field as { isNullable?: unknown }).isNullable;
+
+  return (
+    typeof isOptional === 'function' &&
+    typeof isNullable === 'function' &&
+    !isOptional.call(field) &&
+    !isNullable.call(field)
+  );
 }


### PR DESCRIPTION
## Summary
- Port Python #5659 wording update for null required tool arguments to the JS Zod parsing path.
- Preserve standard Zod errors for optional fields receiving null.
- Add a patch changeset for @livekit/agents.

## Testing
- pnpm test -- agents/src/llm/zod-utils.test.ts
- pnpm --filter @livekit/agents build
- pnpm --filter @livekit/agents lint (passes with existing warnings)