### PR TITLE
chore(amd): add uncertain branch in example

### DIFF
--- a/examples/src/telephony_amd.ts
+++ b/examples/src/telephony_amd.ts
@@ -139,13 +139,14 @@ export default defineAgent({
 
       if (
         result.category === voice.AMDCategory.HUMAN ||
-        result.category === voice.AMDCategory.UNCERTAIN ||
-        result.category === voice.AMDCategory.MACHINE_IVR
+        result.category === voice.AMDCategory.UNCERTAIN
       ) {
         logger.info(
           { amd: result },
-          'human or ivr menu detected, proceeding with normal conversation',
+          'human answered the call or amd is uncertain, proceeding with normal conversation',
         );
+      } else if (result.category === voice.AMDCategory.MACHINE_IVR) {
+        logger.info({ amd: result }, 'ivr menu detected, starting navigation');
       } else if (result.category === voice.AMDCategory.MACHINE_VM) {
         logger.info({ amd: result }, 'voicemail detected, leaving a message');
         const speechHandle = session.generateReply({


### PR DESCRIPTION
## Summary
- Ports livekit/agents#5658 to the JS AMD telephony example.
- Treats uncertain AMD results with the human-answer path while keeping IVR logging separate.

## Testing
- pnpm prettier --check examples/src/telephony_amd.ts
- pnpm --filter livekit-agents-examples build (fails: workspace package dist/types are not built, so @livekit/agents and plugin modules cannot be resolved)