### PR TITLE
fix(google): abort realtime sender on reconnect

### DIFF
--- a/.changeset/google-realtime-abortable-queue.md
+++ b/.changeset/google-realtime-abortable-queue.md
@@ -1,0 +1,6 @@
+---
+'@livekit/agents': patch
+'@livekit/agents-plugin-google': patch
+---
+
+fix(google): abort pending realtime sends during reconnect

--- a/agents/src/utils.test.ts
+++ b/agents/src/utils.test.ts
@@ -5,11 +5,32 @@ import { AudioFrame } from '@livekit/rtc-node';
 import { ReadableStream } from 'node:stream/web';
 import { describe, expect, it } from 'vitest';
 import { initializeLogger } from '../src/log.js';
-import { Event, Task, TaskResult, dedent, delay, isPending, resampleStream } from '../src/utils.js';
+import {
+  Event,
+  Queue,
+  Task,
+  TaskResult,
+  dedent,
+  delay,
+  isPending,
+  resampleStream,
+} from '../src/utils.js';
 
 describe('utils', () => {
   // initialize logger
   initializeLogger({ pretty: true, level: 'debug' });
+
+  describe('Queue', () => {
+    it('aborts a pending get', async () => {
+      const queue = new Queue<string>();
+      const controller = new AbortController();
+      const pending = queue.get({ signal: controller.signal });
+
+      controller.abort();
+
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    });
+  });
 
   describe('Task', () => {
     it('should execute task successfully and return result', async () => {

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -98,20 +98,18 @@ export class Queue<T> {
     this.#limit = limit;
   }
 
-  async get(): Promise<T> {
-    const _get = async (): Promise<T> => {
-      if (this.items.length === 0) {
-        await once(this.#events, 'put');
-      }
-      let item = this.items.shift();
-      if (typeof item === 'undefined') {
-        item = await _get();
-      }
-      return item;
-    };
+  async get(options: { signal?: AbortSignal } = {}): Promise<T> {
+    while (this.items.length === 0) {
+      await once(this.#events, 'put', { signal: options.signal });
+    }
 
-    const item = _get();
+    const item = this.items.shift();
     this.#events.emit('get');
+
+    if (typeof item === 'undefined') {
+      return this.get(options);
+    }
+
     return item;
   }
 

--- a/plugins/google/src/beta/realtime/realtime_api.ts
+++ b/plugins/google/src/beta/realtime/realtime_api.ts
@@ -1003,7 +1003,7 @@ export class RealtimeSession extends llm.RealtimeSession {
   private async sendTask(session: types.Session, controller: AbortController): Promise<void> {
     try {
       while (!this.#closed && !this.sessionShouldClose.isSet && !controller.signal.aborted) {
-        const msg = await this.messageChannel.get();
+        const msg = await this.messageChannel.get({ signal: controller.signal });
         if (controller.signal.aborted) break;
 
         const unlock = await this.sessionLock.lock();


### PR DESCRIPTION
## Summary
- Add abortable `Queue.get()` support so blocked consumers can be cancelled without waiting for another item.
- Use abortable queue reads in Google realtime sender cleanup to avoid retaining stale send tasks across reconnects when no audio/input is flowing.
- Add a regression test for aborting a pending queue read.

## Testing
- `pnpm test -- agents/src/utils.test.ts`
- `pnpm --filter @livekit/agents build`
- `pnpm --filter @livekit/agents-plugin-silero build && pnpm --filter @livekit/agents-plugin-openai build && pnpm --filter @livekit/agents-plugin-google build`