### PR TITLE
fix(voice): prevent scheduling deadlock when SpeechHandle._markDone re-enters

### DIFF
--- a/.changeset/fix-speech-handle-mark-done-deadlock.md
+++ b/.changeset/fix-speech-handle-mark-done-deadlock.md
@@ -1,0 +1,13 @@
+---
+'@livekit/agents': patch
+---
+
+fix(voice): prevent scheduling deadlock when pipeline task crashes
+
+Move the `_markGenerationDone()` call in `SpeechHandle._markDone()` outside the
+`if (!doneFut.done)` guard so a pending generation future is always resolved,
+even when `doneFut` was already settled by a prior interrupt / shutdown path.
+Previously, the second `_markDone()` short-circuited and left the generation
+unresolved, which caused `mainTask` to hang on `_waitForGeneration()` and
+starve subsequent speech handles. Ports
+[livekit/agents#5678](https://github.com/livekit/agents/pull/5678).

--- a/agents/src/voice/speech_handle.test.ts
+++ b/agents/src/voice/speech_handle.test.ts
@@ -168,3 +168,28 @@ describe('SpeechHandle - simulated tool-call deadlock scenario', () => {
     expect(outcome).toBe('resolved');
   });
 });
+
+describe('SpeechHandle._markDone - generation resolution after early done', () => {
+  // Regression for the scheduling-deadlock fix ported from livekit/agents#5678.
+  // If _markDone runs after doneFut has already been resolved (force-interrupt
+  // shutdown path), a generation that gets authorized in the interim — or any
+  // re-entry from the pipeline reply task — must still resolve. Otherwise
+  // _waitForGeneration hangs in mainTask and starves subsequent speech handles.
+  it('resolves a pending generation when called after doneFut is already done', async () => {
+    const handle = SpeechHandle.create();
+
+    // First _markDone resolves doneFut (no generations yet).
+    handle._markDone();
+    expect(handle.done()).toBe(true);
+
+    // A generation is authorized after the handle was marked done. With the
+    // pre-fix guard, the next _markDone short-circuits inside `if
+    // (!doneFut.done)` and never resolves this generation.
+    handle._authorizeGeneration();
+
+    handle._markDone();
+
+    const outcome = await raceTimeout(handle._waitForGeneration(), 500);
+    expect(outcome).toBe('resolved');
+  });
+});

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -328,9 +328,15 @@ export class SpeechHandle {
   _markDone(): void {
     if (!this.doneFut.done) {
       this.doneFut.resolve();
-      if (this.generations.length > 0) {
-        this._markGenerationDone(); // preemptive generation could be cancelled before being scheduled
-      }
+    }
+
+    // Ref: python livekit-agents/livekit/agents/voice/speech_handle.py - _mark_done
+    // Must be outside the doneFut.done guard: if doneFut is already resolved
+    // (e.g. interrupted before _markDone is called), the guarded block is
+    // skipped and the generation future would be left unresolved, leaving
+    // _waitForGeneration stuck and starving subsequent speech handles.
+    if (this.generations.length > 0) {
+      this._markGenerationDone();
     }
   }
 


### PR DESCRIPTION
## Summary

Automated port of [livekit/agents#5678](https://github.com/livekit/agents/pull/5678) (`fix(voice): prevent scheduling deadlock when pipeline task crashes`) into `agents-js`.

> [!NOTE]
> This is an automated Claude Code Routine created by @toubatbrian. Right now it is in experimentation stage.

cc @toubatbrian @livekit/agent-devs for review.

## What was broken

`SpeechHandle._markDone()` short-circuits when `doneFut` is already resolved, but the call to `_markGenerationDone()` was nested inside the same `if (!doneFut.done)` guard:

```ts
// Pre-fix (agents/src/voice/speech_handle.ts)
_markDone(): void {
  if (!this.doneFut.done) {
    this.doneFut.resolve();
    if (this.generations.length > 0) {
      this._markGenerationDone(); // preemptive generation could be cancelled before being scheduled
    }
  }
}
```

This meant that if `_markDone()` ran a second time after `doneFut` was already settled — e.g. the force-interrupt shutdown path in `AgentActivity.interrupt()` runs first, and the pipeline reply task later tries to clean up — and a generation had been authorized in the interim, that generation future was never resolved. `mainTask` then hangs forever on `_waitForGeneration()`, starving every subsequent speech handle (a real production failure mode that already had a workaround comment at `agent_activity.ts:1709-1712`: "the generation future created by `_authorizeGeneration` would never resolve since `_markDone` is a no-op once `doneFut` is already settled").

This is the JS twin of the Python bug: in Python the equivalent issue surfaced through `contextlib.suppress(asyncio.InvalidStateError)` swallowing `_done_fut.set_result(None)` and aborting the whole block; here it's the explicit `if (!doneFut.done)` guard. Same root cause, different idiom.

## Fix

Move `_markGenerationDone()` out of the `if (!doneFut.done)` guard so it always runs when a generation is pending:

```ts
_markDone(): void {
  if (!this.doneFut.done) {
    this.doneFut.resolve();
  }

  // Ref: python livekit-agents/livekit/agents/voice/speech_handle.py - _mark_done
  // Must be outside the doneFut.done guard: if doneFut is already resolved
  // (e.g. interrupted before _markDone is called), the guarded block is
  // skipped and the generation future would be left unresolved, leaving
  // _waitForGeneration stuck and starving subsequent speech handles.
  if (this.generations.length > 0) {
    this._markGenerationDone();
  }
}
```

`_markGenerationDone()` is already idempotent (it only resolves the last generation if `!lastGeneration.done`), so calling it on a re-entry where the generation was already resolved is a no-op.

## Implementation nuances vs. Python

The Python diff (6 / -3 in `speech_handle.py`) also re-orders the `_interrupt_timeout_handle.cancel()` call relative to the suppressed block. The JS `SpeechHandle` doesn't carry an `_interruptTimeoutHandle` field at all (no equivalent timeout-driven cancellation logic exists yet in agents-js), so that part of the Python change has no JS counterpart and is intentionally not ported. The behavioral fix — always run `_markGenerationDone()` when there's a pending generation — is identical in both languages.

The Python PR did not include a regression test. Because the JS bug pattern (re-entering `_markDone` after `doneFut` is settled, *then* authorizing/finishing a generation) is easy to reproduce deterministically with the existing public-internal API, this PR adds a single regression test in `agents/src/voice/speech_handle.test.ts`:

```ts
it('resolves a pending generation when called after doneFut is already done', async () => {
  const handle = SpeechHandle.create();
  handle._markDone();                // resolves doneFut (no generations yet)
  handle._authorizeGeneration();     // generation authorized after handle is "done"
  handle._markDone();                // pre-fix: short-circuit, generation never resolves

  const outcome = await raceTimeout(handle._waitForGeneration(), 500);
  expect(outcome).toBe('resolved');
});
```

Verified: this test times out on the pre-fix code (`Expected: "resolved", Received: "timeout"`) and passes on the fix.

## Files changed

- `agents/src/voice/speech_handle.ts` — move `_markGenerationDone()` out of the `if (!doneFut.done)` guard.
- `agents/src/voice/speech_handle.test.ts` — add `SpeechHandle._markDone - generation resolution after early done` regression suite.
- `.changeset/fix-speech-handle-mark-done-deadlock.md` — `patch` for `@livekit/agents`.

## Test plan

- [x] `pnpm --filter @livekit/agents build` — passes.
- [x] `pnpm exec prettier --check` on changed files — passes.
- [x] `pnpm --filter @livekit/agents lint` — no new errors / warnings on touched files.
- [x] `pnpm exec vitest run agents/src/voice/speech_handle.test.ts` — 10/10 pass (9 existing + 1 new).
- [x] `pnpm exec vitest run agents/src/voice/` — 169/169 pass (full voice suite green).
- [x] Confirmed regression: reverting the `speech_handle.ts` change makes the new test fail with a 500 ms timeout, then re-applying restores it to green.
- [ ] Manual smoke against a force-interrupt shutdown (left to reviewer with a real session).

## Changeset

`patch` for `@livekit/agents` (per the routine's standing instructions).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQyfoU5f21EryyRbE98AE5)_