### PR TITLE
fix(voice): prevent scheduling deadlock on crashed pipeline

### DIFF
--- a/.changeset/gentle-pipelines-wait.md
+++ b/.changeset/gentle-pipelines-wait.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Prevent voice pipeline scheduling from hanging when a pipeline task crashes after a speech handle is already marked done.

--- a/agents/src/voice/speech_handle.test.ts
+++ b/agents/src/voice/speech_handle.test.ts
@@ -168,3 +168,19 @@ describe('SpeechHandle - simulated tool-call deadlock scenario', () => {
     expect(outcome).toBe('resolved');
   });
 });
+
+describe('SpeechHandle._markDone - generation completion', () => {
+  it('resolves an active generation even when the handle is already done', async () => {
+    const handle = SpeechHandle.create();
+    const internalHandle = handle as unknown as { doneFut: { resolve(value: void): void } };
+
+    internalHandle.doneFut.resolve(undefined);
+    handle._authorizeGeneration();
+
+    const generationWait = handle._waitForGeneration();
+    handle._markDone();
+
+    const outcome = await raceTimeout(generationWait, 1000);
+    expect(outcome).toBe('resolved');
+  });
+});

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -328,9 +328,12 @@ export class SpeechHandle {
   _markDone(): void {
     if (!this.doneFut.done) {
       this.doneFut.resolve();
-      if (this.generations.length > 0) {
-        this._markGenerationDone(); // preemptive generation could be cancelled before being scheduled
-      }
+    }
+
+    // Keep this outside the doneFut guard: if the handle is already done but a
+    // generation future is still active, _waitForGeneration() must be released.
+    if (this.generations.length > 0) {
+      this._markGenerationDone();
     }
   }
 


### PR DESCRIPTION
## Summary
- Port livekit/agents#5678 to JS by always resolving active speech generation futures when marking a handle done.
- Add a regression test for already-done handles with pending generation waits.
- Add a patch changeset for @livekit/agents.

## Testing
- pnpm test -- agents/src/voice/speech_handle.test.ts