### PR TITLE
feat(elevenlabs): add applyLanguageTextNormalization TTS option

### DIFF
--- a/.changeset/elevenlabs-language-text-normalization.md
+++ b/.changeset/elevenlabs-language-text-normalization.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-elevenlabs': patch
+---
+
+feat(elevenlabs): add `applyLanguageTextNormalization` option to TTS

--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -73,6 +73,7 @@ export interface TTSOptions {
   inactivityTimeout?: number;
   syncAlignment?: boolean;
   applyTextNormalization?: 'auto' | 'on' | 'off';
+  applyLanguageTextNormalization?: boolean;
   preferredAlignment?: 'normalized' | 'original';
   autoMode?: boolean;
   pronunciationDictionaryLocators?: PronunciationDictionaryLocator[];
@@ -96,6 +97,7 @@ interface ResolvedTTSOptions {
   inactivityTimeout: number;
   syncAlignment: boolean;
   applyTextNormalization: 'auto' | 'on' | 'off';
+  applyLanguageTextNormalization?: boolean;
   preferredAlignment: 'normalized' | 'original';
   autoMode: boolean;
   pronunciationDictionaryLocators?: PronunciationDictionaryLocator[];
@@ -155,6 +157,9 @@ function multiStreamUrl(opts: ResolvedTTSOptions): string {
   params.push(`enable_logging=${opts.enableLogging}`);
   params.push(`inactivity_timeout=${opts.inactivityTimeout}`);
   params.push(`apply_text_normalization=${opts.applyTextNormalization}`);
+  if (opts.applyLanguageTextNormalization !== undefined) {
+    params.push(`apply_language_text_normalization=${opts.applyLanguageTextNormalization}`);
+  }
   if (opts.syncAlignment) {
     params.push('sync_alignment=true');
   }
@@ -703,6 +708,7 @@ export class TTS extends tts.TTS {
       inactivityTimeout: opts.inactivityTimeout ?? WS_INACTIVITY_TIMEOUT,
       syncAlignment: opts.syncAlignment ?? true,
       applyTextNormalization: opts.applyTextNormalization ?? 'auto',
+      applyLanguageTextNormalization: opts.applyLanguageTextNormalization,
       preferredAlignment: opts.preferredAlignment ?? 'normalized',
       autoMode,
       pronunciationDictionaryLocators: opts.pronunciationDictionaryLocators,


### PR DESCRIPTION
## Summary

Ports [livekit/agents#5679](https://github.com/livekit/agents/pull/5679) (`(elevenlabs tts): add apply_language_text_normalization param`) from the Python `livekit-agents` repo into `agents-js`.

This PR adds support for ElevenLabs' `apply_language_text_normalization` query parameter on the multi-stream WebSocket URL. When set to `true`, ElevenLabs applies language-aware text normalization, which helps with proper pronunciation of text in some supported languages.

cc @toubatbrian @livekit/agent-devs for review.

## Ported features

### `applyLanguageTextNormalization` option on `TTS` (`plugins/elevenlabs/src/tts.ts`)

New optional `applyLanguageTextNormalization?: boolean` field on `TTSOptions`. When provided, it is appended to the `multi-stream-input` WebSocket URL as `apply_language_text_normalization=<true|false>`. When omitted, the parameter is not sent at all (preserving ElevenLabs' server-side default).

```ts
// Ref: python livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/tts.py - 112 line
applyLanguageTextNormalization?: boolean;
```

The option flows through the same path as the existing `applyTextNormalization` option:

1. Surfaced on the public `TTSOptions` interface.
2. Stored on the internal `ResolvedTTSOptions` (kept optional so the URL builder can detect "not given").
3. Conditionally appended in `multiStreamUrl(...)` only when defined, matching Python's `is_given(...)` guard.

## Implementation nuances vs Python

- **`NotGivenOr[bool]` mapping**: Python represents "not given" with the sentinel `NOT_GIVEN` and gates URL inclusion on `is_given(...)`. JS uses `boolean | undefined` and gates on `!== undefined`. Behavior is equivalent: when the user does not pass the option, the query parameter is omitted from the WebSocket URL and ElevenLabs falls back to its server-side default.
- **Boolean serialization**: Python uses `str(value).lower()` to produce `"true"` / `"false"`. JS template-literal interpolation of a `boolean` already yields `"true"` / `"false"` lowercase, so no explicit conversion is needed.
- **Option naming**: snake_case `apply_language_text_normalization` (Python field & wire param) maps to camelCase `applyLanguageTextNormalization` in JS. The wire query parameter remains `apply_language_text_normalization`.
- **`ChunkedStream` (REST `/text-to-speech/.../stream`) not modified**: The Python diff only touches the multi-stream WebSocket URL builder (`_multi_stream_url`); the REST `synthesize_url` is unchanged. Mirroring that exactly here — only `multiStreamUrl` learns the new param.
- **No `updateOptions` change**: The Python PR does not add this field to runtime `update_options` either, so it is a constructor-only knob in JS for parity.

## Files changed

| File | Change |
|------|--------|
| `plugins/elevenlabs/src/tts.ts` | Add `applyLanguageTextNormalization?: boolean` to `TTSOptions` and `ResolvedTTSOptions`, propagate from constructor, conditionally append `apply_language_text_normalization=...` to the multi-stream URL. |
| `.changeset/elevenlabs-language-text-normalization.md` | `patch` changeset for `@livekit/agents-plugin-elevenlabs`. |

## Test plan

- [x] `pnpm --filter '@livekit/agents-plugin-elevenlabs...' build` succeeds
- [x] `pnpm format:check` passes
- [x] `pnpm --filter '@livekit/agents-plugin-elevenlabs' lint` passes
- [ ] Manual: instantiate `new TTS({ applyLanguageTextNormalization: true })`, run a streaming synthesis on a non-English voice, and confirm the WebSocket URL includes `apply_language_text_normalization=true` and pronunciation is improved
- [ ] Manual: instantiate `new TTS()` without the option and confirm the URL omits the parameter (current behavior unchanged)

---

This PR was created by an automated Claude Code Routine maintained by @toubatbrian. The routine is currently in experimentation stage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RwBFn2KAkuyCps7361o9dt)_