### PR TITLE
feat(google): add `serviceTier` option to LLM

### DIFF
--- a/.changeset/google-llm-service-tier.md
+++ b/.changeset/google-llm-service-tier.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-google': patch
+---
+
+feat(google): add `serviceTier` option to LLM (e.g. `ServiceTier.PRIORITY`)

--- a/plugins/google/src/llm.ts
+++ b/plugins/google/src/llm.ts
@@ -37,6 +37,7 @@ export interface LLMOptions {
   geminiTools?: LLMTools;
   httpOptions?: types.HttpOptions;
   seed?: number;
+  serviceTier?: types.ServiceTier;
 }
 
 export class LLM extends llm.LLM {
@@ -85,6 +86,7 @@ export class LLM extends llm.LLM {
    * @param geminiTools - The Gemini-specific tools to use for the session.
    * @param httpOptions - The HTTP options to use for the session.
    * @param seed - Random seed for reproducible results. Defaults to undefined.
+   * @param serviceTier - The service tier for the request (e.g. ServiceTier.PRIORITY). Defaults to undefined.
    */
   constructor(
     {
@@ -105,6 +107,7 @@ export class LLM extends llm.LLM {
       geminiTools,
       httpOptions,
       seed,
+      serviceTier,
     }: LLMOptions = {
       model: 'gemini-2.0-flash-001',
     },
@@ -175,6 +178,7 @@ export class LLM extends llm.LLM {
       geminiTools,
       httpOptions,
       seed,
+      serviceTier,
       apiKey,
     };
   }
@@ -264,6 +268,10 @@ export class LLM extends llm.LLM {
 
     if (this.#opts.automaticFunctionCallingConfig !== undefined) {
       extras.automaticFunctionCalling = this.#opts.automaticFunctionCallingConfig;
+    }
+
+    if (this.#opts.serviceTier !== undefined) {
+      extras.serviceTier = this.#opts.serviceTier;
     }
 
     geminiTools = geminiTools !== undefined ? geminiTools : this.#opts.geminiTools;


### PR DESCRIPTION
## Summary

Ports livekit/agents#5680 from the Python `livekit-agents` repo into `agents-js`.

This adds a new `serviceTier` option to the Google Gemini `LLM`, allowing users to opt into the Gemini API's service tiers (e.g. `ServiceTier.PRIORITY` for priority inference).

## What changed

- New `serviceTier?: types.ServiceTier` field on `LLMOptions` (`plugins/google/src/llm.ts`).
- Wired through the constructor (destructured + persisted on `#opts`).
- When set, it is forwarded into the `GenerateContentConfig` passed to `client.models.generateContentStream({ config })` via `extras.serviceTier`.
- JSDoc updated for the new constructor parameter.

## Implementation notes / parity with Python

Closely mirrors the Python implementation in [`livekit-plugins-google/llm.py`](https://github.com/livekit/agents/pull/5680/files):

| Python (livekit/agents#5680) | TypeScript (this PR) |
| --- | --- |
| `service_tier: NotGivenOr[types.ServiceTier]` on `_LLMOptions` | `serviceTier?: types.ServiceTier` on `LLMOptions` |
| `if is_given(self._opts.service_tier): extra["service_tier"] = self._opts.service_tier` | `if (this.#opts.serviceTier !== undefined) { extras.serviceTier = this.#opts.serviceTier; }` |

Naming differences vs. Python (camelCase vs. snake_case) follow the existing JS plugin conventions:

- The option name is `serviceTier` to match other agents-js plugins (`openai`, `baseten`, `openai/ws`, `openai/responses`) which already expose `serviceTier?: string`.
- The wire field on `GenerateContentConfig` is `serviceTier` (camelCase) in `@google/genai` ≥ 1.50, while the Python `google-genai` SDK accepts `service_tier`. The locked version in `pnpm-lock.yaml` (`@google/genai@1.50.1`) introduces this field, and the package range (`^1.44.0`) resolves to a compatible version.
- The TS port is strongly typed using `types.ServiceTier` from `@google/genai` (rather than the loose `string` typing used by other plugins) since the enum is exported by the SDK, matching how the Python upstream uses `types.ServiceTier`.

No behavioural changes when `serviceTier` is not provided.

## Changeset

Added `.changeset/google-llm-service-tier.md` as a `patch` change to `@livekit/agents-plugin-google`.

## Test plan

- [x] `pnpm build:agents` and `pnpm --filter @livekit/agents-plugin-google build` succeed (the plugin's own source compiles cleanly; remaining errors in the build output are in unrelated `beta/realtime/realtime_api.ts` and unbuilt test-only deps, not introduced by this PR).
- [x] `pnpm prettier --check` passes for the changed files.
- [x] `pnpm --filter @livekit/agents-plugin-google lint` produces no new warnings (3 pre-existing warnings in `beta/realtime/realtime_api.ts` only).
- [ ] Manual verification of priority inference end-to-end against the Gemini API (requires API key; not run here).

---

This PR was generated by an automated Claude Code Routine created by @toubatbrian, currently in experimentation. cc @toubatbrian @livekit/agent-devs for review.

Closes parity gap with livekit/agents#5680.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8Za42QgwU7fyKVMfYVtuf)_