### PR TITLE
feat(telemetry): emit AgentConfigUpdate in OTLP session logs

### DIFF
--- a/.changeset/agent-config-update-otlp.md
+++ b/.changeset/agent-config-update-otlp.md
@@ -1,0 +1,15 @@
+---
+'@livekit/agents': patch
+---
+
+feat(telemetry): emit `AgentConfigUpdate` chat items in OTLP session logs
+
+Adds an `AgentConfigUpdate` chat item that records changes to the agent's
+instructions and tools (additions/removals). The initial agent configuration
+and subsequent `updateTools` calls now insert an `AgentConfigUpdate` into both
+the agent's and the session's chat context, and the OTLP `chat_history`
+exporter serializes these items so config changes are visible alongside the
+surrounding conversation. Insertions are skipped when there is no visible
+diff (no instructions and no tool diff).
+
+Ports https://github.com/livekit/agents/pull/5601 from the Python repo.

--- a/agents/src/llm/chat_context.ts
+++ b/agents/src/llm/chat_context.ts
@@ -451,8 +451,89 @@ export class AgentHandoffItem {
   }
 }
 
-// TODO(parity): Add AgentConfigUpdate type to ChatItem union
-export type ChatItem = ChatMessage | FunctionCall | FunctionCallOutput | AgentHandoffItem;
+/**
+ * Records a change to the agent's configuration (instructions and/or tools)
+ * within the chat context. Emitted as an `agent_config_update` chat item so
+ * downstream consumers (e.g. OTLP session logs) can correlate config changes
+ * with the surrounding conversation.
+ */
+export class AgentConfigUpdate {
+  readonly id: string;
+
+  readonly type = 'agent_config_update' as const;
+
+  instructions?: string;
+
+  toolsAdded?: string[];
+
+  toolsRemoved?: string[];
+
+  createdAt: number;
+
+  /** Full tool definitions (in-memory only, not serialized). */
+  _tools: ToolContext;
+
+  constructor(params: {
+    instructions?: string;
+    toolsAdded?: string[];
+    toolsRemoved?: string[];
+    id?: string;
+    createdAt?: number;
+  }) {
+    const {
+      instructions,
+      toolsAdded,
+      toolsRemoved,
+      id = shortuuid('item_'),
+      createdAt = Date.now(),
+    } = params;
+    this.id = id;
+    this.instructions = instructions;
+    this.toolsAdded = toolsAdded;
+    this.toolsRemoved = toolsRemoved;
+    this.createdAt = createdAt;
+    this._tools = {};
+  }
+
+  static create(params: {
+    instructions?: string;
+    toolsAdded?: string[];
+    toolsRemoved?: string[];
+    id?: string;
+    createdAt?: number;
+  }) {
+    return new AgentConfigUpdate(params);
+  }
+
+  toJSON(excludeTimestamp: boolean = false): JSONValue {
+    const result: JSONValue = {
+      id: this.id,
+      type: this.type,
+    };
+
+    if (this.instructions !== undefined) {
+      result.instructions = this.instructions;
+    }
+    if (this.toolsAdded !== undefined) {
+      result.toolsAdded = this.toolsAdded;
+    }
+    if (this.toolsRemoved !== undefined) {
+      result.toolsRemoved = this.toolsRemoved;
+    }
+    if (!excludeTimestamp) {
+      result.createdAt = this.createdAt;
+    }
+
+    return result;
+  }
+}
+
+export type ChatItem =
+  | ChatMessage
+  | FunctionCall
+  | FunctionCallOutput
+  | AgentHandoffItem
+  | AgentConfigUpdate;
 
 export class ChatContext {
   protected _items: ChatItem[];
@@ -517,13 +598,13 @@ export class ChatContext {
     return idx !== -1 ? idx : undefined;
   }
 
-  // TODO(parity): Add excludeConfigUpdate option when AgentConfigUpdate is ported
   copy(
     options: {
       excludeFunctionCall?: boolean;
       excludeInstructions?: boolean;
       excludeEmptyMessage?: boolean;
       excludeHandoff?: boolean;
+      excludeConfigUpdate?: boolean;
       toolCtx?: ToolContext<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
     } = {},
   ): ChatContext {
@@ -532,6 +613,7 @@ export class ChatContext {
       excludeInstructions = false,
       excludeEmptyMessage = false,
       excludeHandoff = false,
+      excludeConfigUpdate = false,
       toolCtx,
     } = options;
     const items: ChatItem[] = [];
@@ -561,6 +643,10 @@ export class ChatContext {
         continue;
       }
 
+      if (excludeConfigUpdate && item.type === 'agent_config_update') {
+        continue;
+      }
+
       if (toolCtx !== undefined && isToolCallOrOutput(item) && toolCtx[item.name] === undefined) {
         continue;
       }
@@ -571,15 +657,19 @@ export class ChatContext {
     return new ChatContext(items);
   }
 
-  // TODO(parity): Add excludeConfigUpdate option when AgentConfigUpdate is ported
   merge(
     other: ChatContext,
     options: {
       excludeFunctionCall?: boolean;
       excludeInstructions?: boolean;
+      excludeConfigUpdate?: boolean;
     } = {},
   ): ChatContext {
-    const { excludeFunctionCall = false, excludeInstructions = false } = options;
+    const {
+      excludeFunctionCall = false,
+      excludeInstructions = false,
+      excludeConfigUpdate = false,
+    } = options;
     const existingIds = new Set(this._items.map((item) => item.id));
 
     for (const item of other.items) {
@@ -592,6 +682,10 @@ export class ChatContext {
         item.type === 'message' &&
         (item.role === 'system' || item.role === 'developer')
       ) {
+        continue;
+      }
+
+      if (excludeConfigUpdate && item.type === 'agent_config_update') {
         continue;
       }
 

--- a/agents/src/llm/index.ts
+++ b/agents/src/llm/index.ts
@@ -18,6 +18,7 @@ export {
 } from './tool_context.js';
 
 export {
+  AgentConfigUpdate,
   AgentHandoffItem,
   ChatContext,
   ChatMessage,

--- a/agents/src/llm/provider_format/utils.ts
+++ b/agents/src/llm/provider_format/utils.ts
@@ -53,6 +53,8 @@ class ChatItemGroup {
       this.toolOutputs.push(item);
     } else if (item.type === 'agent_handoff') {
       // provider formatters don't serialize handoff records into model input.
+    } else if (item.type === 'agent_config_update') {
+      // provider formatters don't serialize config updates into model input.
     }
     return this;
   }

--- a/agents/src/llm/utils.ts
+++ b/agents/src/llm/utils.ts
@@ -458,8 +458,10 @@ function formatChatHistoryItem(
     if (item.isError) {
       headerParts.push('error=true');
     }
-  } else {
+  } else if (item.type === 'agent_handoff') {
     headerParts.push('agent_handoff');
+  } else {
+    headerParts.push('agent_config_update');
   }
 
   if (options.includeIds) {
@@ -492,7 +494,21 @@ function formatChatHistoryItemBody(item: ChatItem): string {
     return prettyJsonText(item.output);
   }
 
-  return `${item.oldAgentId ?? '(none)'} -> ${item.newAgentId}`;
+  if (item.type === 'agent_handoff') {
+    return `${item.oldAgentId ?? '(none)'} -> ${item.newAgentId}`;
+  }
+
+  const parts: string[] = [];
+  if (item.instructions !== undefined) {
+    parts.push(`instructions=${JSON.stringify(item.instructions)}`);
+  }
+  if (item.toolsAdded && item.toolsAdded.length > 0) {
+    parts.push(`tools_added=${item.toolsAdded.join(',')}`);
+  }
+  if (item.toolsRemoved && item.toolsRemoved.length > 0) {
+    parts.push(`tools_removed=${item.toolsRemoved.join(',')}`);
+  }
+  return parts.length > 0 ? parts.join(' ') : '(empty)';
 }
 
 function formatMessageContentPart(part: ChatContent): string {

--- a/agents/src/telemetry/traces.ts
+++ b/agents/src/telemetry/traces.ts
@@ -346,11 +346,20 @@ interface ProtoAgentHandoff {
   oldAgentId?: string;
 }
 
+interface ProtoAgentConfigUpdate {
+  id: string;
+  createdAt: string;
+  instructions?: string;
+  toolsAdded?: string[];
+  toolsRemoved?: string[];
+}
+
 interface ProtoChatItem {
   message?: ProtoMessage;
   functionCall?: ProtoFunctionCall;
   functionCallOutput?: ProtoFunctionCallOutput;
   agentHandoff?: ProtoAgentHandoff;
+  agentConfigUpdate?: ProtoAgentConfigUpdate;
 }
 
 /**
@@ -441,6 +450,21 @@ function chatItemToProto(item: ChatItem): ProtoChatItem {
       handoff.oldAgentId = item.oldAgentId;
     }
     itemDict.agentHandoff = handoff;
+  } else if (item.type === 'agent_config_update') {
+    const acu: ProtoAgentConfigUpdate = {
+      id: item.id,
+      createdAt: toRFC3339(item.createdAt),
+    };
+    if (item.instructions !== undefined) {
+      acu.instructions = item.instructions;
+    }
+    if (item.toolsAdded !== undefined) {
+      acu.toolsAdded = item.toolsAdded;
+    }
+    if (item.toolsRemoved !== undefined) {
+      acu.toolsRemoved = item.toolsRemoved;
+    }
+    itemDict.agentConfigUpdate = acu;
   }
 
   try {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -13,7 +13,12 @@ import type { Logger } from 'pino';
 import type { InterruptionDetectionError } from '../inference/interruption/errors.js';
 import { AdaptiveInterruptionDetector } from '../inference/interruption/interruption_detector.js';
 import type { OverlappingSpeechEvent } from '../inference/interruption/types.js';
-import { type ChatContext, ChatMessage, type MetricsReport } from '../llm/chat_context.js';
+import {
+  AgentConfigUpdate,
+  type ChatContext,
+  ChatMessage,
+  type MetricsReport,
+} from '../llm/chat_context.js';
 import {
   type ChatItem,
   type FunctionCall,
@@ -459,7 +464,17 @@ export class AgentActivity implements RecognitionHooks {
       }
     }
 
-    // TODO(parity): Record initial AgentConfigUpdate in chat context
+    // Record initial agent configuration (skip if empty)
+    const initialToolNames = Object.keys(this.tools);
+    if (this.agent.instructions || initialToolNames.length > 0) {
+      const initialConfig = new AgentConfigUpdate({
+        instructions: this.agent.instructions || undefined,
+        toolsAdded: initialToolNames.length > 0 ? initialToolNames : undefined,
+      });
+      initialConfig._tools = { ...this.tools };
+      this.agent._chatCtx.insert(initialConfig);
+      this.agentSession._chatCtx.insert(initialConfig);
+    }
 
     // metrics and error handling
     if (this.llm instanceof LLM) {
@@ -723,9 +738,24 @@ export class AgentActivity implements RecognitionHooks {
     }
   }
 
-  // TODO: Add when AgentConfigUpdate is ported to ChatContext.
   async updateTools(tools: ToolContext): Promise<void> {
+    const previousToolNames = new Set(Object.keys(this.agent._tools ?? {}));
+    const newToolNames = new Set(Object.keys(tools));
+    const toolsAdded = [...newToolNames].filter((n) => !previousToolNames.has(n));
+    const toolsRemoved = [...previousToolNames].filter((n) => !newToolNames.has(n));
+
     this.agent._tools = { ...tools };
+
+    // Record the configuration change (skip if no visible diff)
+    if (toolsAdded.length > 0 || toolsRemoved.length > 0) {
+      const configUpdate = new AgentConfigUpdate({
+        toolsAdded: toolsAdded.length > 0 ? toolsAdded : undefined,
+        toolsRemoved: toolsRemoved.length > 0 ? toolsRemoved : undefined,
+      });
+      configUpdate._tools = { ...tools };
+      this.agent._chatCtx.insert(configUpdate);
+      this.agentSession._chatCtx.insert(configUpdate);
+    }
 
     if (this.realtimeSession) {
       await this.realtimeSession.updateTools(tools);

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -220,7 +220,8 @@ export class AgentSession<
   private started = false;
   private sessionHost?: SessionHost;
 
-  private _chatCtx: ChatContext;
+  /** @internal */
+  _chatCtx: ChatContext;
   private _userData: UserData | undefined;
   private _userState: UserState = 'listening';
   private _agentState: AgentState = 'initializing';

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -361,6 +361,11 @@ function chatItemToProto(item: ChatItem): pb.ChatContext_ChatItem {
         },
       });
     }
+    case 'agent_config_update': {
+      // The remote session protocol does not yet support agent_config_update items;
+      // emit an empty wrapper so the wire format stays valid for older peers.
+      return new pb.ChatContext_ChatItem({});
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Ports https://github.com/livekit/agents/pull/5601 from `livekit/agents` (Python) into agents-js.

The Python PR makes `AgentConfigUpdate` items reach the OTLP `chat_history` exporter so config changes (instructions / tool list) appear alongside the surrounding conversation in session logs, while skipping no-op updates.

In agents-js, `AgentConfigUpdate` was not yet ported (existing `TODO(parity)` markers in `chat_context.ts`, `agent_activity.ts:462`, and `agent_activity.ts:726`), so this PR also lays the prerequisite foundation, then layers PR #5601's behavior on top.

cc @toubatbrian @livekit/agent-devs

## What changed

**Foundation (prerequisite, not in #5601 itself but required to make it meaningful in JS):**

- `agents/src/llm/chat_context.ts`
  - New `AgentConfigUpdate` class (id, optional `instructions`, optional `toolsAdded`/`toolsRemoved`, `createdAt`, in-memory `_tools` ToolContext that is intentionally not serialized).
  - `ChatItem` union now includes `AgentConfigUpdate`.
  - `ChatContext.copy()` and `ChatContext.merge()` gain an `excludeConfigUpdate` option (mirroring Python's `exclude_config_update`).
- `agents/src/llm/index.ts` — re-exports `AgentConfigUpdate`.
- `agents/src/llm/provider_format/utils.ts` — provider formatters skip `agent_config_update` items (same behavior as `agent_handoff`); they aren't serialized into the model input.
- `agents/src/llm/utils.ts` — chat-history pretty printer formats `agent_config_update` items.
- `agents/src/voice/remote_session.ts` — `chatItemToProto` returns an empty `ChatContext_ChatItem` wrapper for `agent_config_update` since the remote-session protobuf does not yet have a corresponding case (keeps wire compat with peers that don't know the type).

**Equivalent of PR #5601:**

- `agents/src/telemetry/traces.ts`
  - New `ProtoAgentConfigUpdate` shape and `agentConfigUpdate` field on `ProtoChatItem`.
  - `chatItemToProto` emits the new field for `agent_config_update` items so they appear in the OTLP `chat_history` log records.
- `agents/src/voice/agent_activity.ts`
  - Initial setup (replaces the `TODO(parity)` at line 462): records an initial `AgentConfigUpdate` (instructions + tool names) into both `agent._chatCtx` and `agentSession._chatCtx` — skipped when there are no instructions and no tools.
  - `updateTools` (replaces the `TODO` at line 726): computes `toolsAdded`/`toolsRemoved` against the previous tool set, inserts an `AgentConfigUpdate` into both contexts, and skips when the diff is empty.
- `agents/src/voice/agent_session.ts` — `_chatCtx` switched from `private` to `/** @internal */` so `AgentActivity` can insert into it (matches the existing pattern on `Agent._chatCtx`).

## Implementation nuances (where 1:1 parity wasn't possible)

- **`agent_id` field**: the Python construction sites pass `agent_id=self._agent.id`, but the Python `AgentConfigUpdate` Pydantic model does not declare an `agent_id` field — it is silently dropped. The JS port omits `agentId` accordingly.
- **`update_instructions` insertion**: the Python PR also wires `self._session._chat_ctx.insert(config_update)` inside `update_instructions`. agents-js does not currently have an equivalent `updateInstructions` method on `AgentActivity` (instructions are read off `agent.instructions` and re-applied via `updateInstructions(...)` from `generation.ts` — not a config-mutating user-facing API). Therefore only the initial-config and `updateTools` insertion sites were ported. If/when an `updateInstructions` method is added to `AgentActivity`, the same dual-insertion should be wired there.
- **Remote session protobuf**: the Python PR doesn't touch this path; in JS we needed an explicit `agent_config_update` case in `chatItemToProto` for exhaustiveness. Returning an empty wrapper is the least-invasive option until `pb.AgentConfigUpdate` lands in `@livekit/protocol`.
- **`get_fnc_tool_names` equivalent**: Python computes `get_fnc_tool_names(self.tools) or None` (returns names of function-tools, excluding toolsets). agents-js's `ToolContext` is `{ [name: string]: FunctionTool }`, so `Object.keys(this.tools)` is the direct equivalent.

## Test plan

- [x] `pnpm build:agents` — clean build, no type errors.
- [x] `pnpm lint` — no new errors (only pre-existing warnings unrelated to this change).
- [x] `pnpm test -- agents/src/llm/ agents/src/voice/agent_activity` — all 284 tests pass.
- [ ] Manual: run a session that calls `updateTools` and verify `agent_config_update` items appear in the uploaded session report / OTLP chat history with `toolsAdded` / `toolsRemoved` populated and that no-op calls are skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZmAxeea6jRC51LbWJ1oHz)_