### PR TITLE
fix(voice): clean up turn variables when committing a user turn manually

### DIFF
--- a/.changeset/clear-user-turn-cleanup.md
+++ b/.changeset/clear-user-turn-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(voice): clean up turn variables and end user_turn span when committing a user turn manually

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -1404,7 +1404,17 @@ export class AudioRecognition {
     this.audioInterimTranscript = '';
     this.audioPreflightTranscript = '';
     this.finalTranscriptConfidence = [];
+    this.lastFinalTranscriptTime = 0;
+    this.speechStartTime = undefined;
+    this.lastSpeakingTime = undefined;
     this.userTurnCommitted = false;
+
+    // end any in-progress user_turn span so the next speech starts a fresh one
+    if (this.userTurnSpan && this.userTurnSpan.isRecording()) {
+      this.userTurnSpan.end();
+    }
+    this.userTurnSpan = undefined;
+    this.sttRequestIds = [];
 
     const restartStt = async () => {
       const unlock = await this.sttLifecycleLock.lock();


### PR DESCRIPTION
## Summary

Automated port of [livekit/agents#5671](https://github.com/livekit/agents/pull/5671) into agents-js.

When `clearUserTurn()` is invoked (the path used by manual turn detection to abandon an in-progress turn), it previously left several turn-scoped fields stale:

- `lastFinalTranscriptTime`, `lastSpeakingTime`, `speechStartTime` would carry over into the next turn, corrupting the EOU `transcriptionDelay` / `endOfUtteranceDelay` metrics and the preemptive-generation `startedSpeakingAt` for the next turn.
- The current `user_turn` span was kept open and would be reused for the next user turn instead of starting a fresh one. Any provider STT request ids collected so far would also be flushed onto the wrong span.

This fix resets those turn variables and ends the in-progress `user_turn` span so the next speech starts a fresh span and metrics window.

cc @toubatbrian @livekit/agent-devs

## Ported features

- **`agents/src/voice/audio_recognition.ts`** — extends `clearUserTurn()` to:
  - reset `lastFinalTranscriptTime` to `0`, `speechStartTime` and `lastSpeakingTime` to `undefined` (mirrors `_last_final_transcript_time = None`, `_speech_start_time = None`, `_last_speaking_time = None` in Python)
  - end the in-progress `userTurnSpan` (if recording) and clear the cached span + accumulated `sttRequestIds`, so the next speech starts a fresh span and the next ended span doesn't inherit stale provider request ids

## Implementation nuances vs. Python

- **`_vad_speech_started` field has no JS equivalent.** In Python, `_vad_speech_started` is a separate boolean used to gate `_speech_start_time` assignment in the VAD `START_OF_SPEECH` handler. The Python diff resets both fields together (`self._speech_start_time = None`, `self._vad_speech_started = False`).

  In agents-js, that gate is implemented directly as `if (this.speechStartTime === undefined)` in the VAD `INFERENCE_DONE` handler — there is no separate `vadSpeechStarted` field. Resetting `speechStartTime = undefined` therefore re-arms the same gate, so the Python `_vad_speech_started = False` line maps to a no-op in JS. No new field was introduced.

- **`lastFinalTranscriptTime` sentinel value.** Python uses `float | None`; agents-js types this as `number` and uses `0` as the "not set" sentinel (already established in `bounceEOUTask`'s `lastFinalTranscriptTime !== 0` check and in the existing `endUserTurn` reset path that assigns `this.lastFinalTranscriptTime = 0`). The port resets to `0` for consistency rather than introducing `undefined`.

- **`update_stt(None) / update_stt(stt)` reset.** The existing `restartStt()` IIFE already mirrors the Python `update_stt` reset (it stops the STT tasks, closes the pipeline, then re-starts the pipeline), so no change was needed there. It's preserved as-is and runs after the new resets.

## Test plan

- [x] `pnpm build:agents` succeeds.
- [x] `pnpm exec eslint agents/src/voice/audio_recognition.ts` clean.
- [x] `pnpm exec prettier --check` clean for the touched file and changeset.
- [x] `pnpm exec vitest run agents/src/voice/audio_recognition_span.test.ts` (4 passed).
- [ ] Manual verification with manual turn detection: trigger `clearUserTurn` mid-turn, confirm the next turn produces a fresh `user_turn` span and correct EOU metrics.

https://claude.ai/code/session_01P6kkyq5V2krvxdChbADKzg

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6kkyq5V2krvxdChbADKzg)_