### PR TITLE
fix(openai,baseten): cancel in-flight TTS syntheses on close()

### DIFF
--- a/.changeset/openai-baseten-tts-close-cancels-synthesis.md
+++ b/.changeset/openai-baseten-tts-close-cancels-synthesis.md
@@ -1,0 +1,6 @@
+---
+'@livekit/agents-plugin-openai': patch
+'@livekit/agents-plugin-baseten': patch
+---
+
+fix(openai,baseten): wire TTS `close()` to cancel in-flight synthesis requests

--- a/plugins/baseten/src/tts.ts
+++ b/plugins/baseten/src/tts.ts
@@ -73,7 +73,10 @@ export class TTS extends tts.TTS {
     connOptions?: APIConnectOptions,
     abortSignal?: AbortSignal,
   ): ChunkedStream {
-    return new ChunkedStream(this, text, this.opts, connOptions, abortSignal);
+    const signal = abortSignal
+      ? AbortSignal.any([abortSignal, this.abortController.signal])
+      : this.abortController.signal;
+    return new ChunkedStream(this, text, this.opts, connOptions, signal);
   }
 
   stream(): tts.SynthesizeStream {

--- a/plugins/openai/src/tts.ts
+++ b/plugins/openai/src/tts.ts
@@ -77,6 +77,9 @@ export class TTS extends tts.TTS {
     connOptions?: APIConnectOptions,
     abortSignal?: AbortSignal,
   ): ChunkedStream {
+    const signal = abortSignal
+      ? AbortSignal.any([abortSignal, this.abortController.signal])
+      : this.abortController.signal;
     return new ChunkedStream(
       this,
       text,
@@ -89,10 +92,10 @@ export class TTS extends tts.TTS {
           response_format: 'pcm',
           speed: this.#opts.speed,
         },
-        { signal: abortSignal },
+        { signal },
       ),
       connOptions,
-      abortSignal,
+      signal,
     );
   }
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->
`TTS.close()` in the OpenAI and Baseten plugins was a no-op for in-flight syntheses — the class-level `abortController` was never wired into the SDK call or fetch, so calling `close()` did not cancel active requests.

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- `plugins/openai/src/tts.ts`: combine caller's `abortSignal` with `this.abortController.signal` via `AbortSignal.any()` and pass through to the OpenAI SDK call and `ChunkedStream`.
- `plugins/baseten/src/tts.ts`: same combined-signal pattern, propagated into `ChunkedStream`'s `fetch`.
- Changeset: patch bump for both plugins.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
<!-- Describe how you tested these changes -->
- [x] All tests pass