### PR TITLE
fix(neuphonic): pass API key via header in TTS WebSocket

### DIFF
--- a/.changeset/neuphonic-tts-header-auth.md
+++ b/.changeset/neuphonic-tts-header-auth.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-neuphonic': patch
+---
+
+fix(neuphonic): pass API key via `X-API-KEY` header instead of URL query string in TTS WebSocket

--- a/plugins/neuphonic/src/tts.ts
+++ b/plugins/neuphonic/src/tts.ts
@@ -286,8 +286,10 @@ export class SynthesizeStream extends tts.SynthesizeStream {
       }
     };
 
-    const url = `wss://${API_BASE_URL}/speak/${getBaseLanguage(this.#opts.langCode)}?${getQueryParamString(this.#opts)}&api_key=${this.#opts.apiKey}`;
-    const ws = new WebSocket(url);
+    const url = `wss://${API_BASE_URL}/speak/${getBaseLanguage(this.#opts.langCode)}?${getQueryParamString(this.#opts)}`;
+    const ws = new WebSocket(url, {
+      headers: { [AUTHORIZATION_HEADER]: this.#opts.apiKey! },
+    });
 
     try {
       await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->
The Neuphonic TTS `SynthesizeStream` was concatenating the API key into the WS URL unencoded. Pass it as the `X-API-KEY` header on the handshake instead — matches `ChunkedStream` in the same file and Neuphonic's recommended auth method.

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- Drop `&api_key=...` from the WS URL in `SynthesizeStream`.
- Set `X-API-KEY` via the `WebSocket` constructor's `headers` option.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
<!-- Describe how you tested these changes -->
- [x] All tests pass

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.