### PR TITLE
feat(deepgram): add `redact` STT option

### DIFF
--- a/.changeset/deepgram-stt-redact.md
+++ b/.changeset/deepgram-stt-redact.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-deepgram': patch
+---
+
+feat(deepgram): add `redact` STT option to redact sensitive information from transcripts

--- a/plugins/deepgram/src/stt.ts
+++ b/plugins/deepgram/src/stt.ts
@@ -36,6 +36,7 @@ export interface STTOptions {
   keywords: [string, number][];
   keyterm: string[];
   profanityFilter: boolean;
+  redact: string | string[];
   dictation: boolean;
   diarize: boolean;
   numerals: boolean;
@@ -59,6 +60,7 @@ const defaultSTTOptions: STTOptions = {
   keywords: [],
   keyterm: [],
   profanityFilter: false,
+  redact: [],
   dictation: false,
   diarize: false,
   numerals: false,
@@ -194,6 +196,10 @@ export class SpeechStream extends stt.SpeechStream {
         profanity_filter: this.#opts.profanityFilter,
         language: this.#opts.language,
         mip_opt_out: this.#opts.mipOptOut,
+        ...(this.#opts.redact &&
+        (Array.isArray(this.#opts.redact) ? this.#opts.redact.length : true)
+          ? { redact: this.#opts.redact }
+          : {}),
       };
       Object.entries(params).forEach(([k, v]) => {
         if (v !== undefined) {


### PR DESCRIPTION
## Summary

Ports the new `redact` parameter for the Deepgram STT plugin from the Python `livekit/agents` repo into `agents-js`.

Upstream PR: livekit/agents#5692 (closes upstream issue livekit/agents#5683).

This is an automated Claude Code Routine port created by @toubatbrian. Right now it is in experimentation stage.

cc @toubatbrian @livekit/agent-devs — please review.

## Ported feature

Adds an optional `redact` field to `STTOptions` (Deepgram V1 streaming STT) that lets callers redact sensitive information from transcripts.

- **Type:** `string | string[]`
- **Supported values** (per Deepgram): `"pci"`, `"numbers"`, `"ssn"`, `"true"` (redact all). See https://developers.deepgram.com/docs/redaction for details.
- **Default:** `[]` (no redaction).
- When set to a non-empty value, the parameter is forwarded to Deepgram as `redact=<value>` on the `/v1/listen` WebSocket query string. Multiple values are sent as repeated query params (matching how `keyterm`/`keywords` are encoded).
- When empty (default), the parameter is omitted from the request entirely, preserving existing behavior.

### Usage

```ts
import { STT } from '@livekit/agents-plugin-deepgram';

const stt = new STT({
  redact: ['pci', 'numbers'], // or 'true' to redact everything
});
```

## Implementation notes / parity differences

The Python upstream patch updates `STTOptions`, the `STT.__init__` signature, `update_options`, and both `_recognize_impl` (REST) and `_connect_ws` (WebSocket) call sites. The JS plugin is structured differently, so the port collapses naturally:

1. **Single code path.** The JS Deepgram plugin only exposes a streaming WebSocket implementation (`SpeechStream`); there is no `_recognize_impl` REST batch path (`STT._recognize` throws `'Recognize is not supported on Deepgram STT'`). So only the WebSocket query-string construction needed updating, vs. the two sites in Python.
2. **`update_options` signature.** Python adds `redact` as a separate kwarg in two `update_options` overloads. JS already has a generic `updateOptions(opts: Partial<STTOptions>)` that spreads the new options, so no new parameter wiring was needed — adding the field to `STTOptions` is sufficient.
3. **Conditional emission.** Python uses `if config.redact:` to omit the field when falsy. The JS port mirrors that with a conditional spread when constructing the params object: only included when `redact` is a non-empty string or non-empty array. This matches the Python truthiness check (empty list/empty string are both omitted).
4. **STT V2 (Flux) not modified.** The Python PR only touched `stt.py` (V1 endpoint), not `stt_v2.py`. The JS port likewise leaves `stt_v2.ts` untouched. If/when upstream adds `redact` to V2, that should be a follow-up port.
5. **No JSDoc on the new field.** The existing `STTOptions` interface in JS does not document individual fields with JSDoc (unlike `STTv2Options`). The port preserves that style; the option is documented in this PR description and via the upstream Deepgram link.

## Out of scope

- No tests added — the existing `stt.test.ts` does not exercise URL parameter construction, and the upstream PR did not add tests either.

## Test plan

- [ ] `pnpm build` succeeds
- [ ] `pnpm lint` produces no new errors in `plugins/deepgram/src/stt.ts`
- [ ] Manual: instantiate `STT({ redact: 'pci' })` and verify the `redact` query parameter appears on the Deepgram `/v1/listen` WebSocket URL
- [ ] Manual: instantiate `STT()` (default) and verify no `redact` parameter is sent
- [ ] Manual: instantiate `STT({ redact: ['pci', 'numbers'] })` and verify two repeated `redact` query params

## Changeset

A patch-level changeset is included for `@livekit/agents-plugin-deepgram`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H7yysArHsE2UvHHXVSjUUo)_