### PR TITLE
Add bootstrapper for implicit agent entry paths

### DIFF
--- a/.changeset/gentle-rats-flow.md
+++ b/.changeset/gentle-rats-flow.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Add bootstrapper for implicit agent entry paths

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,17 @@ be approved:
 - There's no need to mess around with `CHANGELOG.md` or package manifests — we have a bot handle
   that for us. A maintainer will add the necessary notes before merging.
 
+## Running examples while developing
+
+Use the repo-local helper to run examples against the workspace packages:
+
+```bash
+pnpm build
+pnpm run:agent ./examples/src/basic_agent.ts dev --log-level=debug
+```
+
+`pnpm run:agent` executes from the repository root, so pass paths relative to the root.
+
 ## Assist others in the community
 
 If you can't contribute code, you can still help us greatly by helping out community members who

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ Checkout the [quickstart guide](https://docs.livekit.io/agents/start/voice-ai/)
 import {
   type JobContext,
   type JobProcess,
-  WorkerOptions,
   cli,
   defineAgent,
   llm,
@@ -121,7 +120,6 @@ import {
   inference,
 } from '@livekit/agents';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 const lookupWeather = llm.tool({
@@ -173,7 +171,7 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new WorkerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();
 ```
 
 No third-party API keys are required for this example. It runs out of the box via the [LiveKit Inference Gateway](https://docs.livekit.io/agents/models/#inference).
@@ -277,7 +275,7 @@ environment variables set:
 The following command will start the worker and wait for users to connect to your LiveKit server:
 
 ```bash
-pnpm run build && node ./examples/src/restaurant_agent.ts dev
+pnpm run:agent ./examples/src/restaurant_agent.ts dev
 ```
 
 ### Using playground for your agent UI
@@ -293,7 +291,7 @@ serve as a starting point for a completely custom agent application.
 ### Running for production
 
 ```shell
-pnpm run build && node ./examples/src/restaurant_agent.ts start
+pnpm run:agent ./examples/src/restaurant_agent.ts start
 ```
 
 Runs the agent with production-ready optimizations.
@@ -339,19 +337,7 @@ To contribute to this project:
 
 ### Testing changes and plugins
 
-To test any changes or plugins:
-
-1. Build the project:
-   ```bash
-   pnpm build
-   ```
-
-2. Edit `./examples/src/basic_agent.ts` as necessary for any plugin changes
-
-3. Run the basic agent with debug logging:
-   ```bash
-   node ./examples/src/basic_agent.ts dev --log-level=debug
-   ```
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for contributor setup and local development commands.
 
 ### Testing agent connectivity
 

--- a/agents/package.json
+++ b/agents/package.json
@@ -5,6 +5,9 @@
   "main": "dist/index.js",
   "require": "dist/index.cjs",
   "types": "dist/index.d.ts",
+  "bin": {
+    "lk-agent": "./dist/cli/bin.js"
+  },
   "exports": {
     "import": {
       "types": "./dist/index.d.ts",

--- a/agents/src/cli/bin.test.ts
+++ b/agents/src/cli/bin.test.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { prepareBootstrap, validateAgentEntryFile } from './bin.js';
+
+describe('lk-agent bootstrapper', () => {
+  it('resolves the entry path and rewrites argv for cli.runApp', () => {
+    const prepared = prepareBootstrap(
+      ['/usr/local/bin/node', '/repo/node_modules/.bin/lk-agent', 'dist/main.js', 'dev'],
+      '/repo',
+    );
+
+    expect(prepared.agentPath).toBe(resolve('/repo', 'dist/main.js'));
+    expect(prepared.argv).toEqual(['/usr/local/bin/node', resolve('/repo', 'dist/main.js'), 'dev']);
+  });
+
+  it('preserves command arguments after the LiveKit command', () => {
+    const prepared = prepareBootstrap(
+      [
+        '/usr/local/bin/node',
+        '/repo/node_modules/.bin/lk-agent',
+        './main.js',
+        'connect',
+        '--room',
+        'demo',
+      ],
+      '/repo',
+    );
+
+    expect(prepared.argv).toEqual([
+      '/usr/local/bin/node',
+      resolve('/repo', './main.js'),
+      'connect',
+      '--room',
+      'demo',
+    ]);
+  });
+
+  it('rejects invocations without an entry file', () => {
+    expect(() =>
+      prepareBootstrap(['/usr/local/bin/node', '/repo/node_modules/.bin/lk-agent'], '/repo'),
+    ).toThrow('Usage: lk-agent <entry> <command> [...args]');
+  });
+
+  it('rejects invocations without a LiveKit command', () => {
+    expect(() =>
+      prepareBootstrap(
+        ['/usr/local/bin/node', '/repo/node_modules/.bin/lk-agent', 'dist/main.js'],
+        '/repo',
+      ),
+    ).toThrow('Usage: lk-agent <entry> <command> [...args]');
+  });
+
+  it('rejects a missing agent entry file before import', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'lk-agent-'));
+    const missing = join(dir, 'missing.js');
+
+    await expect(validateAgentEntryFile(missing)).rejects.toThrow(
+      `Agent entry file does not exist: ${missing}`,
+    );
+  });
+
+  it('rejects an agent entry path that is not a file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'lk-agent-'));
+    const entryDir = join(dir, 'entry');
+    await mkdir(entryDir);
+
+    await expect(validateAgentEntryFile(entryDir)).rejects.toThrow(
+      `Agent entry path is not a file: ${entryDir}`,
+    );
+  });
+
+  it('accepts an existing agent entry file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'lk-agent-'));
+    const entry = join(dir, 'main.js');
+    await writeFile(entry, 'export default {};');
+
+    await expect(validateAgentEntryFile(entry)).resolves.toBeUndefined();
+  });
+});

--- a/agents/src/cli/bin.ts
+++ b/agents/src/cli/bin.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { stat } from 'node:fs/promises';
+import { basename, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { setDefaultAgentPath } from './context.js';
+
+const USAGE = 'Usage: lk-agent <entry> <command> [...args]';
+
+export type PreparedBootstrap = {
+  agentPath: string;
+  argv: string[];
+};
+
+export function prepareBootstrap(argv: string[], cwd = process.cwd()): PreparedBootstrap {
+  const [nodePath = process.execPath, , entry, ...commandArgs] = argv;
+  if (!entry || commandArgs.length === 0) {
+    throw new Error(USAGE);
+  }
+
+  const agentPath = resolve(cwd, entry);
+  return {
+    agentPath,
+    argv: [nodePath, agentPath, ...commandArgs],
+  };
+}
+
+export async function validateAgentEntryFile(agentPath: string) {
+  let entryStat;
+  try {
+    entryStat = await stat(agentPath);
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(`Agent entry file does not exist: ${agentPath}`);
+    }
+    throw error;
+  }
+
+  if (!entryStat.isFile()) {
+    throw new Error(`Agent entry path is not a file: ${agentPath}`);
+  }
+}
+
+export async function bootstrap(argv = process.argv, cwd = process.cwd()) {
+  const prepared = prepareBootstrap(argv, cwd);
+  await validateAgentEntryFile(prepared.agentPath);
+  setDefaultAgentPath(prepared.agentPath);
+  process.argv = prepared.argv;
+  const importUrl = pathToFileURL(prepared.agentPath).href;
+  await import(importUrl);
+}
+
+function isCliInvocation() {
+  const invoked = process.argv[1];
+  if (!invoked) {
+    return false;
+  }
+
+  const invokedName = basename(invoked);
+  return invokedName === 'lk-agent' || invokedName === 'bin.js';
+}
+
+if (isCliInvocation()) {
+  bootstrap().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/agents/src/cli/context.test.ts
+++ b/agents/src/cli/context.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { ServerOptions } from '../worker.js';
 import { clearDefaultAgentPath, getDefaultAgentPath, setDefaultAgentPath } from './context.js';
+import { normalizeRunAppOptions } from './index.js';
 
 describe('cli context', () => {
   afterEach(() => {
@@ -38,5 +39,21 @@ describe('cli context', () => {
 
     expect(opts.agent).toBe('');
     expect(opts.agentName).toBe('support-agent');
+  });
+
+  it('normalizes plain runApp options using the bootstrapped agent path', () => {
+    setDefaultAgentPath('/app/dist/main.js');
+
+    const opts = normalizeRunAppOptions({ agentName: 'support-agent' });
+
+    expect(opts).toBeInstanceOf(ServerOptions);
+    expect(opts.agent).toBe('/app/dist/main.js');
+    expect(opts.agentName).toBe('support-agent');
+  });
+
+  it('preserves existing ServerOptions passed to runApp', () => {
+    const opts = new ServerOptions({ agent: '/custom/agent.js', agentName: 'support-agent' });
+
+    expect(normalizeRunAppOptions(opts)).toBe(opts);
   });
 });

--- a/agents/src/cli/context.test.ts
+++ b/agents/src/cli/context.test.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, describe, expect, it } from 'vitest';
+import { ServerOptions } from '../worker.js';
+import { clearDefaultAgentPath, getDefaultAgentPath, setDefaultAgentPath } from './context.js';
+
+describe('cli context', () => {
+  afterEach(() => {
+    clearDefaultAgentPath();
+  });
+
+  it('stores a default agent path for the current process', () => {
+    setDefaultAgentPath('/app/dist/main.js');
+
+    expect(getDefaultAgentPath()).toBe('/app/dist/main.js');
+  });
+
+  it('lets ServerOptions use the bootstrapped agent path when agent is omitted', () => {
+    setDefaultAgentPath('/app/dist/main.js');
+
+    const opts = new ServerOptions({ agentName: 'support-agent' });
+
+    expect(opts.agent).toBe('/app/dist/main.js');
+    expect(opts.agentName).toBe('support-agent');
+  });
+
+  it('prefers an explicit ServerOptions agent over the bootstrapped path', () => {
+    setDefaultAgentPath('/app/dist/main.js');
+
+    const opts = new ServerOptions({ agent: '/custom/agent.js' });
+
+    expect(opts.agent).toBe('/custom/agent.js');
+  });
+
+  it('allows ServerOptions without an agent before the CLI command starts', () => {
+    const opts = new ServerOptions({ agentName: 'support-agent' });
+
+    expect(opts.agent).toBe('');
+    expect(opts.agentName).toBe('support-agent');
+  });
+});

--- a/agents/src/cli/context.ts
+++ b/agents/src/cli/context.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+let defaultAgentPath: string | undefined;
+
+/** @internal */
+export function setDefaultAgentPath(agentPath: string) {
+  defaultAgentPath = agentPath;
+}
+
+/** @internal */
+export function getDefaultAgentPath(): string | undefined {
+  return defaultAgentPath;
+}
+
+/** @internal */
+export function clearDefaultAgentPath() {
+  defaultAgentPath = undefined;
+}

--- a/agents/src/cli/context.ts
+++ b/agents/src/cli/context.ts
@@ -2,19 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-let defaultAgentPath: string | undefined;
+const defaultAgentPathKey = Symbol.for('@livekit/agents.cli.defaultAgentPath');
+const globalAgentContext = globalThis as typeof globalThis & {
+  [key: symbol]: string | undefined;
+};
 
 /** @internal */
 export function setDefaultAgentPath(agentPath: string) {
-  defaultAgentPath = agentPath;
+  globalAgentContext[defaultAgentPathKey] = agentPath;
 }
 
 /** @internal */
 export function getDefaultAgentPath(): string | undefined {
-  return defaultAgentPath;
+  return globalAgentContext[defaultAgentPathKey];
 }
 
 /** @internal */
 export function clearDefaultAgentPath() {
-  defaultAgentPath = undefined;
+  delete globalAgentContext[defaultAgentPathKey];
 }

--- a/agents/src/cli/index.ts
+++ b/agents/src/cli/index.ts
@@ -6,7 +6,7 @@ import type { EventEmitter } from 'node:events';
 import { initializeLogger, log } from '../log.js';
 import { Plugin } from '../plugin.js';
 import { version } from '../version.js';
-import { AgentServer, ServerOptions } from '../worker.js';
+import { AgentServer, ServerOptions, type ServerOptionsInput } from '../worker.js';
 
 type CliArgs = {
   opts: ServerOptions;
@@ -73,16 +73,23 @@ const runServer = async (args: CliArgs) => {
   }
 };
 
+/** @internal */
+export function normalizeRunAppOptions(opts?: ServerOptions | ServerOptionsInput): ServerOptions {
+  return opts instanceof ServerOptions ? opts : new ServerOptions(opts ?? {});
+}
+
 /**
  * Exposes a CLI for creating a new worker, in development or production mode.
  *
  * @param opts - Options to launch the worker with
  * @example
  * ```
- * cli.runApp();
+ * cli.runApp({
+ *   agentName: 'my-agent',
+ * });
  * ```
  */
-export const runApp = (opts?: ServerOptions) => {
+export const runApp = (opts?: ServerOptions | ServerOptionsInput) => {
   const logLevelOption = (defaultLevel: string) =>
     new Option('--log-level <level>', 'Set the logging level')
       .choices(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
@@ -128,16 +135,16 @@ export const runApp = (opts?: ServerOptions) => {
     .description('Start the worker in production mode')
     .addOption(logLevelOption('info'))
     .action((...[, command]) => {
-      opts = opts ?? new ServerOptions({});
+      const serverOptions = normalizeRunAppOptions(opts);
       const globalOptions = program.optsWithGlobals();
       const commandOptions = command.opts();
-      opts.wsURL = globalOptions.url || opts.wsURL;
-      opts.apiKey = globalOptions.apiKey || opts.apiKey;
-      opts.apiSecret = globalOptions.apiSecret || opts.apiSecret;
-      opts.logLevel = commandOptions.logLevel;
-      opts.workerToken = globalOptions.workerToken || opts.workerToken;
+      serverOptions.wsURL = globalOptions.url || serverOptions.wsURL;
+      serverOptions.apiKey = globalOptions.apiKey || serverOptions.apiKey;
+      serverOptions.apiSecret = globalOptions.apiSecret || serverOptions.apiSecret;
+      serverOptions.logLevel = commandOptions.logLevel;
+      serverOptions.workerToken = globalOptions.workerToken || serverOptions.workerToken;
       runServer({
-        opts,
+        opts: serverOptions,
         production: true,
         watch: false,
       });
@@ -148,17 +155,17 @@ export const runApp = (opts?: ServerOptions) => {
     .description('Start the worker in development mode')
     .addOption(logLevelOption('debug'))
     .action((...[, command]) => {
-      opts = opts ?? new ServerOptions({});
+      const serverOptions = normalizeRunAppOptions(opts);
       const globalOptions = program.optsWithGlobals();
       const commandOptions = command.opts();
-      opts.wsURL = globalOptions.url || opts.wsURL;
-      opts.apiKey = globalOptions.apiKey || opts.apiKey;
-      opts.apiSecret = globalOptions.apiSecret || opts.apiSecret;
-      opts.logLevel = commandOptions.logLevel;
-      opts.workerToken = globalOptions.workerToken || opts.workerToken;
+      serverOptions.wsURL = globalOptions.url || serverOptions.wsURL;
+      serverOptions.apiKey = globalOptions.apiKey || serverOptions.apiKey;
+      serverOptions.apiSecret = globalOptions.apiSecret || serverOptions.apiSecret;
+      serverOptions.logLevel = commandOptions.logLevel;
+      serverOptions.workerToken = globalOptions.workerToken || serverOptions.workerToken;
       process.env.LIVEKIT_DEV_MODE = '1';
       runServer({
-        opts,
+        opts: serverOptions,
         production: false,
         watch: false,
       });
@@ -171,17 +178,17 @@ export const runApp = (opts?: ServerOptions) => {
     .option('--participant-identity <string>', 'Identity of user to listen to')
     .addOption(logLevelOption('info'))
     .action((...[, command]) => {
-      opts = opts ?? new ServerOptions({});
+      const serverOptions = normalizeRunAppOptions(opts);
       const globalOptions = program.optsWithGlobals();
       const commandOptions = command.opts();
-      opts.wsURL = globalOptions.url || opts.wsURL;
-      opts.apiKey = globalOptions.apiKey || opts.apiKey;
-      opts.apiSecret = globalOptions.apiSecret || opts.apiSecret;
-      opts.logLevel = commandOptions.logLevel;
-      opts.workerToken = globalOptions.workerToken || opts.workerToken;
+      serverOptions.wsURL = globalOptions.url || serverOptions.wsURL;
+      serverOptions.apiKey = globalOptions.apiKey || serverOptions.apiKey;
+      serverOptions.apiSecret = globalOptions.apiSecret || serverOptions.apiSecret;
+      serverOptions.logLevel = commandOptions.logLevel;
+      serverOptions.workerToken = globalOptions.workerToken || serverOptions.workerToken;
       process.env.LIVEKIT_DEV_MODE = '1';
       runServer({
-        opts,
+        opts: serverOptions,
         production: false,
         watch: false,
         room: commandOptions.room,

--- a/agents/src/cli/index.ts
+++ b/agents/src/cli/index.ts
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Command, Option } from 'commander';
 import type { EventEmitter } from 'node:events';
-import { initializeLogger, log } from './log.js';
-import { Plugin } from './plugin.js';
-import { version } from './version.js';
-import { AgentServer, ServerOptions } from './worker.js';
+import { initializeLogger, log } from '../log.js';
+import { Plugin } from '../plugin.js';
+import { version } from '../version.js';
+import { AgentServer, ServerOptions } from '../worker.js';
 
 type CliArgs = {
   opts: ServerOptions;
@@ -79,12 +79,10 @@ const runServer = async (args: CliArgs) => {
  * @param opts - Options to launch the worker with
  * @example
  * ```
- * if (process.argv[1] === fileURLToPath(import.meta.url)) {
- *   cli.runApp(new ServerOptions({ agent: import.meta.filename }));
- * }
+ * cli.runApp();
  * ```
  */
-export const runApp = (opts: ServerOptions) => {
+export const runApp = (opts?: ServerOptions) => {
   const logLevelOption = (defaultLevel: string) =>
     new Option('--log-level <level>', 'Set the logging level')
       .choices(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
@@ -118,7 +116,7 @@ export const runApp = (opts: ServerOptions) => {
     .action(() => {
       if (
         // do not run CLI if origin file is agents/ipc/job_main.js
-        process.argv[1] !== new URL('ipc/job_main.js', import.meta.url).pathname &&
+        process.argv[1] !== new URL('../ipc/job_main.js', import.meta.url).pathname &&
         process.argv.length < 3
       ) {
         program.help();
@@ -130,6 +128,7 @@ export const runApp = (opts: ServerOptions) => {
     .description('Start the worker in production mode')
     .addOption(logLevelOption('info'))
     .action((...[, command]) => {
+      opts = opts ?? new ServerOptions({});
       const globalOptions = program.optsWithGlobals();
       const commandOptions = command.opts();
       opts.wsURL = globalOptions.url || opts.wsURL;
@@ -149,6 +148,7 @@ export const runApp = (opts: ServerOptions) => {
     .description('Start the worker in development mode')
     .addOption(logLevelOption('debug'))
     .action((...[, command]) => {
+      opts = opts ?? new ServerOptions({});
       const globalOptions = program.optsWithGlobals();
       const commandOptions = command.opts();
       opts.wsURL = globalOptions.url || opts.wsURL;
@@ -171,6 +171,7 @@ export const runApp = (opts: ServerOptions) => {
     .option('--participant-identity <string>', 'Identity of user to listen to')
     .addOption(logLevelOption('info'))
     .action((...[, command]) => {
+      opts = opts ?? new ServerOptions({});
       const globalOptions = program.optsWithGlobals();
       const commandOptions = command.opts();
       opts.wsURL = globalOptions.url || opts.wsURL;

--- a/agents/src/index.ts
+++ b/agents/src/index.ts
@@ -12,7 +12,7 @@
 export * from './_exceptions.js';
 export * from './audio.js';
 export * as beta from './beta/index.js';
-export * as cli from './cli.js';
+export * as cli from './cli/index.js';
 export * from './connection_pool.js';
 export * from './generator.js';
 export * as inference from './inference/index.js';

--- a/agents/src/worker.test.ts
+++ b/agents/src/worker.test.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { AgentServer, ServerOptions } from './worker.js';
+
+describe('AgentServer options validation', () => {
+  it('throws a clear error when no agent path is available at server start', () => {
+    const opts = new ServerOptions({
+      wsURL: 'ws://localhost:7880',
+      apiKey: 'key',
+      apiSecret: 'secret',
+    });
+
+    expect(() => new AgentServer(opts)).toThrow(
+      'No Agent file was passed to the worker. Pass `agent` in ServerOptions or run via `lk-agent <entry> <command>`.',
+    );
+  });
+});

--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -15,6 +15,7 @@ import type { ParticipantInfo } from 'livekit-server-sdk';
 import { AccessToken, RoomServiceClient } from 'livekit-server-sdk';
 import { EventEmitter } from 'node:events';
 import { WebSocket } from 'ws';
+import { getDefaultAgentPath } from './cli/context.js';
 import { getCpuMonitor } from './cpu.js';
 import { HTTPServer } from './http_server.js';
 import { InferenceRunner } from './inference_runner.js';
@@ -148,7 +149,7 @@ export class ServerOptions {
 
   /** @param options - Worker options */
   constructor({
-    agent,
+    agent = getDefaultAgentPath(),
     requestFunc = defaultRequestFunc,
     loadFunc = defaultCpuLoad,
     loadThreshold = undefined,
@@ -175,7 +176,7 @@ export class ServerOptions {
      * Path to a file that has {@link Agent} as a default export, dynamically imported later for
      * entrypoint and prewarm functions
      */
-    agent: string;
+    agent?: string;
     requestFunc?: (job: JobRequest) => Promise<void>;
     /** Called to determine the current load of the worker. Should return a value between 0 and 1. */
     loadFunc?: (worker: AgentServer) => Promise<number>;
@@ -212,10 +213,7 @@ export class ServerOptions {
     jobMemoryWarnMB?: number;
     jobMemoryLimitMB?: number;
   }) {
-    this.agent = agent;
-    if (!this.agent) {
-      throw new Error('No Agent file was passed to the worker');
-    }
+    this.agent = agent ?? '';
     this.requestFunc = requestFunc;
     this.loadFunc = loadFunc;
     this.loadThreshold = loadThreshold || Default.loadThreshold(production);
@@ -288,6 +286,12 @@ export class AgentServer {
 
   /* @throws {@link MissingCredentialsError} if URL, API key or API secret are missing */
   constructor(opts: ServerOptions) {
+    if (!opts.agent) {
+      throw new Error(
+        'No Agent file was passed to the worker. Pass `agent` in ServerOptions or run via `lk-agent <entry> <command>`.',
+      );
+    }
+
     opts.wsURL = opts.wsURL || process.env.LIVEKIT_URL || '';
     opts.apiKey = opts.apiKey || process.env.LIVEKIT_API_KEY || '';
     opts.apiSecret = opts.apiSecret || process.env.LIVEKIT_API_SECRET || '';

--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -114,6 +114,49 @@ export class WorkerPermissions {
   }
 }
 
+export type ServerOptionsInput = {
+  /**
+   * Path to a file that has {@link Agent} as a default export, dynamically imported later for
+   * entrypoint and prewarm functions
+   */
+  agent?: string;
+  requestFunc?: (job: JobRequest) => Promise<void>;
+  /** Called to determine the current load of the worker. Should return a value between 0 and 1. */
+  loadFunc?: (worker: AgentServer) => Promise<number>;
+  /** When the load exceeds this threshold, the worker will be marked as unavailable. */
+  loadThreshold?: number;
+  numIdleProcesses?: number;
+  shutdownProcessTimeout?: number;
+  initializeProcessTimeout?: number;
+  permissions?: WorkerPermissions;
+  /**
+   * Set agentName to enable explicit dispatch. When explicit dispatch is enabled, jobs will not
+   * be dispatched to rooms automatically. Instead, you can either specify the agent(s) to be
+   * dispatched in the end-user's token, or use the AgentDispatch.createDispatch API.
+   *
+   * By default it uses `LIVEKIT_AGENT_NAME` from environment.
+   */
+  agentName?: string;
+  /**
+   * Internal flag indicating that `agentName` was resolved from `LIVEKIT_AGENT_NAME`. Forwarded
+   * through ServerOptions re-construction (e.g. cli.ts spread) so the env-source signal isn't
+   * lost.
+   */
+  agentNameIsEnv?: boolean;
+  serverType?: JobType;
+  maxRetry?: number;
+  wsURL?: string;
+  apiKey?: string;
+  apiSecret?: string;
+  workerToken?: string;
+  host?: string;
+  port?: number;
+  logLevel?: string;
+  production?: boolean;
+  jobMemoryWarnMB?: number;
+  jobMemoryLimitMB?: number;
+};
+
 /**
  * Data class describing worker behaviour.
  *
@@ -171,48 +214,7 @@ export class ServerOptions {
     production = false,
     jobMemoryWarnMB = 500,
     jobMemoryLimitMB = 0,
-  }: {
-    /**
-     * Path to a file that has {@link Agent} as a default export, dynamically imported later for
-     * entrypoint and prewarm functions
-     */
-    agent?: string;
-    requestFunc?: (job: JobRequest) => Promise<void>;
-    /** Called to determine the current load of the worker. Should return a value between 0 and 1. */
-    loadFunc?: (worker: AgentServer) => Promise<number>;
-    /** When the load exceeds this threshold, the worker will be marked as unavailable. */
-    loadThreshold?: number;
-    numIdleProcesses?: number;
-    shutdownProcessTimeout?: number;
-    initializeProcessTimeout?: number;
-    permissions?: WorkerPermissions;
-    /**
-     * Set agentName to enable explicit dispatch. When explicit dispatch is enabled, jobs will not
-     * be dispatched to rooms automatically. Instead, you can either specify the agent(s) to be
-     * dispatched in the end-user's token, or use the AgentDispatch.createDispatch API.
-     *
-     * By default it uses `LIVEKIT_AGENT_NAME` from environment.
-     */
-    agentName?: string;
-    /**
-     * Internal flag indicating that `agentName` was resolved from `LIVEKIT_AGENT_NAME`. Forwarded
-     * through ServerOptions re-construction (e.g. cli.ts spread) so the env-source signal isn't
-     * lost.
-     */
-    agentNameIsEnv?: boolean;
-    serverType?: JobType;
-    maxRetry?: number;
-    wsURL?: string;
-    apiKey?: string;
-    apiSecret?: string;
-    workerToken?: string;
-    host?: string;
-    port?: number;
-    logLevel?: string;
-    production?: boolean;
-    jobMemoryWarnMB?: number;
-    jobMemoryLimitMB?: number;
-  }) {
+  }: ServerOptionsInput) {
     this.agent = agent ?? '';
     this.requestFunc = requestFunc;
     this.loadFunc = loadFunc;

--- a/examples/src/anam_realtime_agent.ts
+++ b/examples/src/anam_realtime_agent.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -15,7 +14,6 @@ import * as anam from '@livekit/agents-plugin-anam';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 
 // Uses OpenAI Advanced Voice (Realtime), so no separate STT/TTS/VAD.
 
@@ -81,4 +79,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/background_audio.ts
+++ b/examples/src/background_audio.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
   type JobContext,
-  ServerOptions,
   cli,
   defineAgent,
   initializeLogger,
@@ -11,7 +10,6 @@ import {
   log,
   voice,
 } from '@livekit/agents';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 /**
@@ -76,4 +74,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/basic_agent.ts
+++ b/examples/src/basic_agent.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -16,7 +15,6 @@ import {
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
 import { BackgroundVoiceCancellation } from '@livekit/noise-cancellation-node';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 export default defineAgent({
@@ -125,4 +123,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/basic_agent_task.ts
+++ b/examples/src/basic_agent_task.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -13,7 +12,6 @@ import {
 } from '@livekit/agents';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 class InfoTask extends voice.AgentTask<string> {
@@ -131,4 +129,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/basic_eou.ts
+++ b/examples/src/basic_eou.ts
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { type JobContext, ServerOptions, cli, defineAgent, llm, log } from '@livekit/agents';
+import { type JobContext, cli, defineAgent, llm, log } from '@livekit/agents';
 import { turnDetector } from '@livekit/agents-plugin-livekit';
-import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
   entry: async (ctx: JobContext) => {
@@ -44,4 +43,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/basic_task_group.ts
+++ b/examples/src/basic_task_group.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   beta,
   cli,
   defineAgent,
@@ -14,7 +13,6 @@ import {
 } from '@livekit/agents';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 const taskTts = 'elevenlabs/eleven_turbo_v2_5';
@@ -143,4 +141,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/basic_tool_call_agent.ts
+++ b/examples/src/basic_tool_call_agent.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -14,7 +13,6 @@ import {
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
 import { BackgroundVoiceCancellation } from '@livekit/noise-cancellation-node';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 const roomNameSchema = z.enum(['bedroom', 'living room', 'kitchen', 'bathroom', 'office']);
@@ -160,4 +158,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/bey_avatar.ts
+++ b/examples/src/bey_avatar.ts
@@ -1,18 +1,9 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import {
-  type JobContext,
-  ServerOptions,
-  cli,
-  defineAgent,
-  log,
-  metrics,
-  voice,
-} from '@livekit/agents';
+import { type JobContext, cli, defineAgent, log, metrics, voice } from '@livekit/agents';
 import * as bey from '@livekit/agents-plugin-bey';
 import * as openai from '@livekit/agents-plugin-openai';
-import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
   entry: async (ctx: JobContext) => {
@@ -62,4 +53,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/cartesia_tts.ts
+++ b/examples/src/cartesia_tts.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   log,
@@ -17,7 +16,6 @@ import * as livekit from '@livekit/agents-plugin-livekit';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
 import { BackgroundVoiceCancellation } from '@livekit/noise-cancellation-node';
-import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
   prewarm: async (proc: JobProcess) => {
@@ -69,4 +67,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/comprehensive_test.ts
+++ b/examples/src/comprehensive_test.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   dedent,
   defineAgent,
@@ -23,7 +22,6 @@ import * as openai from '@livekit/agents-plugin-openai';
 import * as resemble from '@livekit/agents-plugin-resemble';
 import * as silero from '@livekit/agents-plugin-silero';
 import { BackgroundVoiceCancellation } from '@livekit/noise-cancellation-node';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 const sttOptions = {
@@ -280,4 +278,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/custom_text_handler.ts
+++ b/examples/src/custom_text_handler.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -13,7 +12,6 @@ import {
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
 import { BackgroundVoiceCancellation } from '@livekit/noise-cancellation-node';
-import { fileURLToPath } from 'node:url';
 
 const customTextInputHandler = (session: voice.AgentSession, event: voice.TextInputEvent): void => {
   const message = event.text;
@@ -74,4 +72,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/drive-thru/drivethru_agent.ts
+++ b/examples/src/drive-thru/drivethru_agent.ts
@@ -1,21 +1,12 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import {
-  type JobContext,
-  type JobProcess,
-  ServerOptions,
-  cli,
-  defineAgent,
-  llm,
-  voice,
-} from '@livekit/agents';
+import { type JobContext, type JobProcess, cli, defineAgent, llm, voice } from '@livekit/agents';
 import * as deepgram from '@livekit/agents-plugin-deepgram';
 import * as elevenlabs from '@livekit/agents-plugin-elevenlabs';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import {
   COMMON_INSTRUCTIONS,
@@ -406,5 +397,5 @@ export default defineAgent({
 // eslint-disable-next-line turbo/no-undeclared-env-vars
 if (process.env.VITEST === undefined) {
   // eslint-disable-next-line turbo/no-undeclared-env-vars
-  cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+  cli.runApp();
 }

--- a/examples/src/elevenlabs_scribe_v2.ts
+++ b/examples/src/elevenlabs_scribe_v2.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -12,7 +11,6 @@ import {
 } from '@livekit/agents';
 import * as elevenlabs from '@livekit/agents-plugin-elevenlabs';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
   prewarm: async (proc: JobProcess) => {
@@ -47,4 +45,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/frontdesk/frontdesk_agent.ts
+++ b/examples/src/frontdesk/frontdesk_agent.ts
@@ -1,22 +1,13 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import {
-  type JobContext,
-  type JobProcess,
-  ServerOptions,
-  cli,
-  defineAgent,
-  llm,
-  voice,
-} from '@livekit/agents';
+import { type JobContext, type JobProcess, cli, defineAgent, llm, voice } from '@livekit/agents';
 import * as deepgram from '@livekit/agents-plugin-deepgram';
 import * as elevenlabs from '@livekit/agents-plugin-elevenlabs';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
 import { BackgroundVoiceCancellation } from '@livekit/noise-cancellation-node';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import {
   type AvailableSlot,
@@ -251,5 +242,5 @@ export default defineAgent({
 // eslint-disable-next-line turbo/no-undeclared-env-vars
 if (process.env.VITEST === undefined) {
   // eslint-disable-next-line turbo/no-undeclared-env-vars
-  cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+  cli.runApp();
 }

--- a/examples/src/gemini_realtime_agent.ts
+++ b/examples/src/gemini_realtime_agent.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   dedent,
   defineAgent,
@@ -13,7 +12,6 @@ import {
 } from '@livekit/agents';
 import * as google from '@livekit/agents-plugin-google';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
@@ -148,4 +146,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/hume_tts.ts
+++ b/examples/src/hume_tts.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   log,
@@ -15,7 +14,6 @@ import * as hume from '@livekit/agents-plugin-hume';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
 import { BackgroundVoiceCancellation } from '@livekit/noise-cancellation-node';
-import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
   prewarm: async (proc: JobProcess) => {
@@ -71,4 +69,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/idle_user_timeout_example.ts
+++ b/examples/src/idle_user_timeout_example.ts
@@ -9,7 +9,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   Task,
   cli,
   defineAgent,
@@ -20,7 +19,6 @@ import {
   voice,
 } from '@livekit/agents';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 
 initializeLogger({ pretty: true });
 
@@ -91,4 +89,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/inworld_tts.ts
+++ b/examples/src/inworld_tts.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   log,
@@ -15,7 +14,6 @@ import * as inworld from '@livekit/agents-plugin-inworld';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
 import { BackgroundVoiceCancellation } from '@livekit/noise-cancellation-node';
-import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
   prewarm: async (proc: JobProcess) => {
@@ -125,4 +123,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/lemonslice_realtime_avatar.ts
+++ b/examples/src/lemonslice_realtime_avatar.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -14,7 +13,6 @@ import {
 import * as lemonslice from '@livekit/agents-plugin-lemonslice';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 
 initializeLogger({ pretty: true });
 
@@ -84,4 +82,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/liveavatar_avatar.ts
+++ b/examples/src/liveavatar_avatar.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -15,7 +14,6 @@ import {
 import * as liveavatar from '@livekit/agents-plugin-liveavatar';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
   prewarm: async (proc: JobProcess) => {
@@ -99,4 +97,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/llm_fallback_adapter.ts
+++ b/examples/src/llm_fallback_adapter.ts
@@ -16,20 +16,11 @@
  * - Configurable timeouts and retry behavior
  * - Event emission when provider availability changes
  */
-import {
-  type JobContext,
-  type JobProcess,
-  ServerOptions,
-  cli,
-  defineAgent,
-  llm,
-  voice,
-} from '@livekit/agents';
+import { type JobContext, type JobProcess, cli, defineAgent, llm, voice } from '@livekit/agents';
 import * as deepgram from '@livekit/agents-plugin-deepgram';
 import * as elevenlabs from '@livekit/agents-plugin-elevenlabs';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 export default defineAgent({
@@ -103,4 +94,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/manual_shutdown.ts
+++ b/examples/src/manual_shutdown.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -14,7 +13,6 @@ import {
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
 import { BackgroundVoiceCancellation } from '@livekit/noise-cancellation-node';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 export default defineAgent({
@@ -90,4 +88,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/multi_agent.ts
+++ b/examples/src/multi_agent.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   dedent,
   defineAgent,
@@ -14,7 +13,6 @@ import {
 } from '@livekit/agents';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 // Shared data that's used by the storyteller agent.
@@ -102,4 +100,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/phonic_realtime_agent.ts
+++ b/examples/src/phonic_realtime_agent.ts
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { type JobContext, ServerOptions, cli, defineAgent, llm, voice } from '@livekit/agents';
+import { type JobContext, cli, defineAgent, llm, voice } from '@livekit/agents';
 import * as phonic from '@livekit/agents-plugin-phonic';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 const toggleLight = llm.tool({
@@ -62,4 +61,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/play_local_audio_file.ts
+++ b/examples/src/play_local_audio_file.ts
@@ -1,14 +1,7 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import {
-  type JobContext,
-  ServerOptions,
-  cli,
-  defineAgent,
-  log,
-  loopAudioFramesFromFile,
-} from '@livekit/agents';
+import { type JobContext, cli, defineAgent, log, loopAudioFramesFromFile } from '@livekit/agents';
 import { AudioSource, LocalAudioTrack, TrackPublishOptions, TrackSource } from '@livekit/rtc-node';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -64,4 +57,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/push_to_talk.ts
+++ b/examples/src/push_to_talk.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -13,7 +12,6 @@ import {
 } from '@livekit/agents';
 import * as silero from '@livekit/agents-plugin-silero';
 import type { ChatContext, ChatMessage } from 'agents/dist/llm/chat_context.js';
-import { fileURLToPath } from 'node:url';
 
 class MyAgent extends voice.Agent {
   async onUserTurnCompleted(chatCtx: ChatContext, newMessage: ChatMessage) {
@@ -70,4 +68,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/raw_function_description.ts
+++ b/examples/src/raw_function_description.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -13,7 +12,6 @@ import {
 } from '@livekit/agents';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 
 function createRawFunctionAgent() {
   return new voice.Agent({
@@ -78,4 +76,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/realtime_agent.ts
+++ b/examples/src/realtime_agent.ts
@@ -1,19 +1,10 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import {
-  type JobContext,
-  type JobProcess,
-  ServerOptions,
-  cli,
-  defineAgent,
-  llm,
-  voice,
-} from '@livekit/agents';
+import { type JobContext, type JobProcess, cli, defineAgent, llm, voice } from '@livekit/agents';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 const roomNameSchema = z.enum(['bedroom', 'living room', 'kitchen', 'bathroom', 'office']);
@@ -95,4 +86,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/realtime_turn_detector.ts
+++ b/examples/src/realtime_turn_detector.ts
@@ -1,20 +1,12 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import {
-  type JobContext,
-  type JobProcess,
-  ServerOptions,
-  cli,
-  defineAgent,
-  voice,
-} from '@livekit/agents';
+import { type JobContext, type JobProcess, cli, defineAgent, voice } from '@livekit/agents';
 import * as deepgram from '@livekit/agents-plugin-deepgram';
 import * as elevenlabs from '@livekit/agents-plugin-elevenlabs';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
   prewarm: async (proc: JobProcess) => {
@@ -48,4 +40,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/realtime_with_tts.ts
+++ b/examples/src/realtime_with_tts.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   llm,
@@ -15,7 +14,6 @@ import * as cartesia from '@livekit/agents-plugin-cartesia';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
 import { BackgroundVoiceCancellation } from '@livekit/noise-cancellation-node';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 export default defineAgent({
@@ -76,4 +74,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/restaurant_agent.ts
+++ b/examples/src/restaurant_agent.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   dedent,
   defineAgent,
@@ -13,7 +12,6 @@ import {
   voice,
 } from '@livekit/agents';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 const voices = {
@@ -397,4 +395,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/runway_avatar.ts
+++ b/examples/src/runway_avatar.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   log,
@@ -14,7 +13,6 @@ import {
 import * as google from '@livekit/agents-plugin-google';
 import * as runway from '@livekit/agents-plugin-runway';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
   prewarm: async (proc: JobProcess) => {
@@ -57,4 +55,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/survey_agent.ts
+++ b/examples/src/survey_agent.ts
@@ -1,18 +1,9 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import {
-  type JobContext,
-  ServerOptions,
-  beta,
-  cli,
-  defineAgent,
-  llm,
-  voice,
-} from '@livekit/agents';
+import { type JobContext, beta, cli, defineAgent, llm, voice } from '@livekit/agents';
 // import * as phonic from '@livekit/agents-plugin-phonic';
 import { access, appendFile } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 type SurveyUserData = {
@@ -372,4 +363,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/telephony_amd.ts
+++ b/examples/src/telephony_amd.ts
@@ -4,7 +4,6 @@
 import {
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   inference,
@@ -15,7 +14,6 @@ import * as livekit from '@livekit/agents-plugin-livekit';
 import * as silero from '@livekit/agents-plugin-silero';
 import { TrackKind } from '@livekit/rtc-node';
 import { RoomServiceClient, SipClient } from 'livekit-server-sdk';
-import { fileURLToPath } from 'node:url';
 
 class MyAgent extends voice.Agent {
   constructor() {
@@ -190,4 +188,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/tool_call_disfluency.ts
+++ b/examples/src/tool_call_disfluency.ts
@@ -5,7 +5,6 @@ import {
   AutoSubscribe,
   type JobContext,
   type JobProcess,
-  ServerOptions,
   cli,
   defineAgent,
   llm,
@@ -15,7 +14,6 @@ import * as elevenlabs from '@livekit/agents-plugin-elevenlabs';
 import * as livekit from '@livekit/agents-plugin-livekit';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as silero from '@livekit/agents-plugin-silero';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 class VoiceAgent extends voice.Agent {
@@ -74,4 +72,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/trugen_avatar.ts
+++ b/examples/src/trugen_avatar.ts
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { type JobContext, ServerOptions, cli, defineAgent, metrics, voice } from '@livekit/agents';
+import { type JobContext, cli, defineAgent, metrics, voice } from '@livekit/agents';
 import * as openai from '@livekit/agents-plugin-openai';
 import * as trugen from '@livekit/agents-plugin-trugen';
-import { fileURLToPath } from 'node:url';
 
 export default defineAgent({
   entry: async (ctx: JobContext) => {
@@ -44,4 +43,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/examples/src/xai-realtime.ts
+++ b/examples/src/xai-realtime.ts
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { type JobContext, ServerOptions, cli, defineAgent, llm, voice } from '@livekit/agents';
+import { type JobContext, cli, defineAgent, llm, voice } from '@livekit/agents';
 import * as xai from '@livekit/agents-plugin-xai';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
 export default defineAgent({
@@ -34,4 +33,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp();

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:examples": "vitest run examples",
+    "run:agent": "node agents/dist/cli/bin.js",
     "throws:check": "turbo throws:check",
     "doc": "typedoc && mkdir -p docs/assets/github && cp .github/*.png docs/assets/github/ && find docs -name '*.html' -type f -exec sed -i.bak 's|=\"/.github/|=\"assets/github/|g' {} + && find docs -name '*.bak' -delete"
   },


### PR DESCRIPTION
## Summary
- Allow `cli.runApp()` to accept either a `ServerOptions` instance or a plain options object.
- Keep `new ServerOptions(...)` backward compatible while simplifying starter usage to `cli.runApp({ agentName: 'my-agent' })`.
- Add regression tests for plain-object normalization and preserving existing `ServerOptions` instances.


```ts
// Before
import { ServerOptions, cli, defineAgent } from '@livekit/agents';
import { fileURLToPath } from 'node:url';

export default defineAgent({
  // ...
});

cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
```
```ts
// After
import { cli, defineAgent } from '@livekit/agents';

export default defineAgent({
  // ...
});

cli.runApp();
```


## Test 
- `pnpm test -- agents/src/cli/bin.test.ts agents/src/cli/context.test.ts agents/src/worker.test.ts`
- `pnpm --filter @livekit/agents lint`
- `pnpm --filter @livekit/agents build`
- `pnpm run:agent ./examples/src/basic_agent.ts dev --help`