### PR TITLE
fix(transcription): rstrip punctuation from interim segments

### DIFF
--- a/.changeset/lucky-ladybugs-sell.md
+++ b/.changeset/lucky-ladybugs-sell.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(transcription): rstrip punctuation from interim segments

--- a/agents/src/transcription.ts
+++ b/agents/src/transcription.ts
@@ -236,7 +236,7 @@ export class TextAudioSynchronizer extends (EventEmitter as new () => TypedEmitt
       processedWords.push(word);
 
       const elapsed = Date.now() - segStartTime;
-      const text = sentence.slice(0, end); // TODO: rstrip punctuations
+      const text = sentence.slice(0, end).replace(/[.,!?;:\-—]+$/, '');
 
       let speed = this.#speed;
       let delay: number;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->
Resolves a TODO in [TextAudioSynchronizer](cci:2://file:///home/krishna/Contribution/agents-js/agents/src/transcription.ts:57:0-314:1) by right-stripping trailing punctuation (`.,!?;:\-—`) from interim transcription updates (`final: false`). This prevents visual artifacts in UI subtitles where punctuations awkwardly appear before the sentence is finished. The original punctuation remains perfectly intact when the full sentence is emitted (`final: true`).


## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.