### PR TITLE
fix(worker): use available CPU cores for numIdleProcesses in production

### DIFF
--- a/.changeset/lazy-carrots-change.md
+++ b/.changeset/lazy-carrots-change.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(worker): use available CPU cores for numIdleProcesses in production

--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -14,6 +14,7 @@ import { type Throws, ThrowsPromise } from '@livekit/throws-transformer/throws';
 import type { ParticipantInfo } from 'livekit-server-sdk';
 import { AccessToken, RoomServiceClient } from 'livekit-server-sdk';
 import { EventEmitter } from 'node:events';
+import { availableParallelism } from 'node:os';
 import { WebSocket } from 'ws';
 import { getCpuMonitor } from './cpu.js';
 import { HTTPServer } from './http_server.js';
@@ -42,8 +43,7 @@ class Default {
 
   static numIdleProcesses(production: boolean): number {
     if (production) {
-      // TODO: use number of cores
-      return 3;
+      return Math.min(availableParallelism(), 4);
     } else {
       return 0;
     }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->
Resolves a TODO in `Default.numIdleProcesses()` by replacing the hardcoded value of `3` with `Math.min(availableParallelism(), 4)`.
This dynamically uses the available CPU core count (via `os.availableParallelism()`, which respects Docker/K8s cgroup limits), capped at 4 to prevent excessive memory usage from pre-warmed child processes on large machines.
Matches the Python SDK's `ServerOptions.num_idle_processes` default: `min(math.ceil(cpu_count), 4)`.
## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.