### PR TITLE
fix(agents): bypass AudioResampler when input and output sample rates…

### DIFF
--- a/.changeset/loose-pans-search.md
+++ b/.changeset/loose-pans-search.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix audio resampler memory leak.

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -25,19 +25,19 @@ import { log } from './log.js';
 export type Expand<T> = T extends Function
   ? T
   : T extends object
-    ? T extends Array<infer U>
-      ? Array<Expand<U>>
-      : T extends Map<infer K, infer V>
-        ? Map<Expand<K>, Expand<V>>
-        : T extends Set<infer M>
-          ? Set<Expand<M>>
-          : { [K in keyof T]: Expand<T[K]> }
-    : T;
+  ? T extends Array<infer U>
+  ? Array<Expand<U>>
+  : T extends Map<infer K, infer V>
+  ? Map<Expand<K>, Expand<V>>
+  : T extends Set<infer M>
+  ? Set<Expand<M>>
+  : { [K in keyof T]: Expand<T[K]> }
+  : T;
 
 /** Union of a single and a list of {@link AudioFrame}s */
 export type AudioBuffer = AudioFrame[] | AudioFrame;
 
-export const noop = () => {};
+export const noop = () => { };
 
 export const isPending = async (promise: Promise<unknown>): Promise<Throws<boolean, Error>> => {
   const sentinel = Symbol('sentinel');
@@ -708,14 +708,17 @@ export function resampleStream({
   outputRate: number;
 }): ReadableStream<AudioFrame> {
   let resampler: AudioResampler | null = null;
+  let currentInputRate = 0;
   const transformStream = new TransformStream<AudioFrame, AudioFrame>({
     transform(chunk: AudioFrame, controller: TransformStreamDefaultController<AudioFrame>) {
-      if (chunk.samplesPerChannel === 0) {
+      if (chunk.samplesPerChannel === 0 || chunk.sampleRate === outputRate) {
         controller.enqueue(chunk);
         return;
       }
-      if (!resampler) {
+      if (!resampler || currentInputRate !== chunk.sampleRate) {
+        resampler?.close();
         resampler = new AudioResampler(chunk.sampleRate, outputRate);
+        currentInputRate = chunk.sampleRate;
       }
       for (const frame of resampler.push(chunk)) {
         controller.enqueue(frame);

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -711,15 +711,34 @@ export function resampleStream({
   let currentInputRate = 0;
   const transformStream = new TransformStream<AudioFrame, AudioFrame>({
     transform(chunk: AudioFrame, controller: TransformStreamDefaultController<AudioFrame>) {
-      if (chunk.samplesPerChannel === 0 || chunk.sampleRate === outputRate) {
+      if (chunk.samplesPerChannel === 0) {
         controller.enqueue(chunk);
         return;
       }
+
+      if (chunk.sampleRate === outputRate) {
+        if (resampler) {
+          for (const frame of resampler.flush()) {
+            controller.enqueue(frame);
+          }
+          resampler.close();
+          resampler = null;
+        }
+        controller.enqueue(chunk);
+        return;
+      }
+
       if (!resampler || currentInputRate !== chunk.sampleRate) {
-        resampler?.close();
+        if (resampler) {
+          for (const frame of resampler.flush()) {
+            controller.enqueue(frame);
+          }
+          resampler.close();
+        }
         resampler = new AudioResampler(chunk.sampleRate, outputRate);
         currentInputRate = chunk.sampleRate;
       }
+
       for (const frame of resampler.push(chunk)) {
         controller.enqueue(frame);
       }
@@ -730,6 +749,7 @@ export function resampleStream({
           controller.enqueue(frame);
         }
         resampler.close();
+        resampler = null;
       }
     },
   });

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -25,19 +25,19 @@ import { log } from './log.js';
 export type Expand<T> = T extends Function
   ? T
   : T extends object
-  ? T extends Array<infer U>
-  ? Array<Expand<U>>
-  : T extends Map<infer K, infer V>
-  ? Map<Expand<K>, Expand<V>>
-  : T extends Set<infer M>
-  ? Set<Expand<M>>
-  : { [K in keyof T]: Expand<T[K]> }
-  : T;
+    ? T extends Array<infer U>
+      ? Array<Expand<U>>
+      : T extends Map<infer K, infer V>
+        ? Map<Expand<K>, Expand<V>>
+        : T extends Set<infer M>
+          ? Set<Expand<M>>
+          : { [K in keyof T]: Expand<T[K]> }
+    : T;
 
 /** Union of a single and a list of {@link AudioFrame}s */
 export type AudioBuffer = AudioFrame[] | AudioFrame;
 
-export const noop = () => { };
+export const noop = () => {};
 
 export const isPending = async (promise: Promise<unknown>): Promise<Throws<boolean, Error>> => {
   const sentinel = Symbol('sentinel');


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->
Fixes #1431 

Short-circuits the `AudioResampler` logic natively in [utils.ts](cci:7://file:///home/krishna/Contribution/agents-js/agents/src/utils.ts:0:0-0:0) when the incoming chunk `sampleRate` perfectly matches the requested `outputRate`. 

This efficiently prevents exhaustive runtime FFI overhead instantiations and stops the runaway RSS memory padding up to several gigabytes over long streaming sessions.


## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.