### PR TITLE
feat(agents): make TTS pipeline idle timeouts configurable

### DIFF
--- a/.changeset/configurable-tts-stall-timeout.md
+++ b/.changeset/configurable-tts-stall-timeout.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Expose `AgentSessionOptions.ttsReadIdleTimeout` and `AgentSessionOptions.forwardAudioIdleTimeout` to configure the two pipeline stall guards in `performTTSInference` and `performAudioForwarding`. Useful for custom LLM/TTS backends whose first-token latency can legitimately exceed the previous 10s default. Defaults remain 10 seconds, preserving existing behavior.

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2006,6 +2006,7 @@ export class AgentActivity implements RecognitionHooks {
           replyAbortController,
           this.tts?.model,
           this.tts?.provider,
+          this.agentSession.sessionOptions.ttsReadIdleTimeout,
         );
         tasks.push(ttsTask);
         replyTtsGenData = ttsGenData;
@@ -2014,6 +2015,7 @@ export class AgentActivity implements RecognitionHooks {
           ttsGenData.audioStream,
           audioOutput,
           replyAbortController,
+          this.agentSession.sessionOptions.forwardAudioIdleTimeout,
         );
         tasks.push(forwardTask);
         audioOut = _audioOut;
@@ -2023,6 +2025,7 @@ export class AgentActivity implements RecognitionHooks {
           audio,
           audioOutput,
           replyAbortController,
+          this.agentSession.sessionOptions.forwardAudioIdleTimeout,
         );
         tasks.push(forwardTask);
         audioOut = _audioOut;
@@ -2189,6 +2192,7 @@ export class AgentActivity implements RecognitionHooks {
         replyAbortController,
         this.tts?.model,
         this.tts?.provider,
+        this.agentSession.sessionOptions.ttsReadIdleTimeout,
       );
     };
 
@@ -2280,6 +2284,7 @@ export class AgentActivity implements RecognitionHooks {
           ttsGenData.audioStream,
           audioOutput,
           replyAbortController,
+          this.agentSession.sessionOptions.forwardAudioIdleTimeout,
         );
         audioOut = _audioOut;
         tasks.push(forwardTask);
@@ -2752,6 +2757,7 @@ export class AgentActivity implements RecognitionHooks {
                 abortController,
                 this.tts?.model,
                 this.tts?.provider,
+                this.agentSession.sessionOptions.ttsReadIdleTimeout,
               );
               tasks.push(ttsTask);
               realtimeAudioResult = ttsGenData.audioStream;
@@ -2777,6 +2783,7 @@ export class AgentActivity implements RecognitionHooks {
                 realtimeAudioResult,
                 audioOutput,
                 abortController,
+                this.agentSession.sessionOptions.forwardAudioIdleTimeout,
               );
               forwardTasks.push(forwardTask);
               audioOut = _audioOut;

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -101,12 +101,16 @@ export interface InternalSessionOptions<UserData> extends AgentSessionOptions<Us
   useTtsAlignedTranscript: boolean;
   maxToolSteps: number;
   userAwayTimeout: number | null;
+  ttsReadIdleTimeout: number;
+  forwardAudioIdleTimeout: number;
 }
 
 export const defaultAgentSessionOptions = {
   maxToolSteps: 3,
   userAwayTimeout: 15.0,
   aecWarmupDuration: 3000,
+  ttsReadIdleTimeout: 10_000,
+  forwardAudioIdleTimeout: 10_000,
   turnHandling: {},
   useTtsAlignedTranscript: true,
 } as const satisfies AgentSessionOptions;
@@ -181,6 +185,23 @@ export type AgentSessionOptions<UserData = UnknownUserData> = {
    * @defaultValue 3000
    */
   aecWarmupDuration?: number | null;
+
+  /**
+   * Maximum time in milliseconds to wait for the next frame on the TTS audio stream
+   * inside `performTTSInference`. Applies to every read, including the first.
+   * If exceeded, the TTS stream is forcibly closed and a stall warning is logged.
+   * @defaultValue 10000
+   */
+  ttsReadIdleTimeout?: number;
+
+  /**
+   * Maximum time in milliseconds to wait for the next frame while forwarding TTS
+   * audio to the audio output inside `performAudioForwarding`. Applies to every read,
+   * including the first. If exceeded, forwarding is forcibly closed and a stall
+   * warning is logged.
+   * @defaultValue 10000
+   */
+  forwardAudioIdleTimeout?: number;
 
   /**
    * Configuration for turn handling.

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -55,7 +55,8 @@ import {
 import { RunContext } from './run_context.js';
 import type { SpeechHandle } from './speech_handle.js';
 
-const TTS_READ_IDLE_TIMEOUT_MS = 10_000;
+export const DEFAULT_TTS_READ_IDLE_TIMEOUT_MS = 10_000;
+export const DEFAULT_FORWARD_AUDIO_IDLE_TIMEOUT_MS = 10_000;
 
 /** @internal */
 export class _LLMGenerationData {
@@ -565,6 +566,7 @@ export function performTTSInference(
   controller: AbortController,
   model?: string,
   provider?: string,
+  readIdleTimeout: number = DEFAULT_TTS_READ_IDLE_TIMEOUT_MS,
 ): [Task<void>, _TTSGenerationData] {
   const logger = log();
   const audioStream = new IdentityTransform<AudioFrame>();
@@ -648,7 +650,7 @@ export function performTTSInference(
 
         const { done, value: frame } = await waitUntilTimeout(
           ttsStreamReader.read(),
-          TTS_READ_IDLE_TIMEOUT_MS,
+          readIdleTimeout,
         );
         if (done) {
           break;
@@ -800,13 +802,12 @@ async function forwardAudio(
   ttsStream: ReadableStream<AudioFrame>,
   audioOutput: AudioOutput,
   out: _AudioOut,
+  idleTimeout: number,
   signal?: AbortSignal,
 ): Promise<void> {
   const logger = log();
   const reader = ttsStream.getReader();
   let resampler: AudioResampler | null = null;
-
-  const FORWARD_AUDIO_IDLE_TIMEOUT_MS = 10_000;
 
   const onPlaybackStarted = (ev: { createdAt: number }) => {
     if (!out.firstFrameFut.done) {
@@ -823,10 +824,7 @@ async function forwardAudio(
         break;
       }
 
-      const { done, value: frame } = await waitUntilTimeout(
-        reader.read(),
-        FORWARD_AUDIO_IDLE_TIMEOUT_MS,
-      );
+      const { done, value: frame } = await waitUntilTimeout(reader.read(), idleTimeout);
       if (done) break;
 
       out.audio.push(frame);
@@ -880,6 +878,7 @@ export function performAudioForwarding(
   ttsStream: ReadableStream<AudioFrame>,
   audioOutput: AudioOutput,
   controller: AbortController,
+  idleTimeout: number = DEFAULT_FORWARD_AUDIO_IDLE_TIMEOUT_MS,
 ): [Task<void>, _AudioOut] {
   const out: _AudioOut = {
     audio: [],
@@ -888,7 +887,7 @@ export function performAudioForwarding(
 
   return [
     Task.from(
-      (controller) => forwardAudio(ttsStream, audioOutput, out, controller.signal),
+      (controller) => forwardAudio(ttsStream, audioOutput, out, idleTimeout, controller.signal),
       controller,
       'performAudioForwarding',
     ),

--- a/agents/src/voice/generation_tts_timeout.test.ts
+++ b/agents/src/voice/generation_tts_timeout.test.ts
@@ -60,6 +60,30 @@ describe('TTS stream idle timeout', () => {
     expect(audioOut.firstFrameFut.done).toBe(true);
   }, 10_000);
 
+  it('forwardAudio honours a custom idle timeout', async () => {
+    const stalledStream = new ReadableStream<AudioFrame>({
+      start(controller) {
+        controller.enqueue(createSilentFrame());
+      },
+    });
+
+    const audioOutput = new MockAudioOutput();
+    const controller = new AbortController();
+
+    const [task, audioOut] = performAudioForwarding(stalledStream, audioOutput, controller, 500);
+
+    vi.useFakeTimers();
+
+    const taskPromise = task.result;
+    await vi.advanceTimersByTimeAsync(600);
+    await taskPromise;
+
+    vi.useRealTimers();
+
+    expect(audioOutput.capturedFrames.length).toBe(1);
+    expect(audioOut.firstFrameFut.done).toBe(true);
+  });
+
   it('forwardAudio completes normally when TTS stream closes properly', async () => {
     const normalStream = new ReadableStream<AudioFrame>({
       start(controller) {
@@ -103,6 +127,43 @@ describe('TTS stream idle timeout', () => {
 
     const taskPromise = task.result;
     await vi.advanceTimersByTimeAsync(11_000);
+    await taskPromise;
+
+    vi.useRealTimers();
+
+    expect(genData.ttfb).toBeDefined();
+  }, 10_000);
+
+  it('performTTSInference honours a custom read idle timeout', async () => {
+    const stalledTtsStream = new ReadableStream<AudioFrame>({
+      start(controller) {
+        controller.enqueue(createSilentFrame());
+      },
+    });
+
+    const ttsNode = async () => stalledTtsStream;
+    const textInput = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue('Hello world');
+        controller.close();
+      },
+    });
+
+    const controller = new AbortController();
+    const [task, genData] = performTTSInference(
+      ttsNode,
+      textInput,
+      {},
+      controller,
+      undefined,
+      undefined,
+      500,
+    );
+
+    vi.useFakeTimers();
+
+    const taskPromise = task.result;
+    await vi.advanceTimersByTimeAsync(600);
     await taskPromise;
 
     vi.useRealTimers();

--- a/agents/src/voice/turn_config/utils.ts
+++ b/agents/src/voice/turn_config/utils.ts
@@ -17,6 +17,8 @@ const defaultSessionOptions = {
   maxToolSteps: 3,
   userAwayTimeout: 15.0,
   aecWarmupDuration: 3000,
+  ttsReadIdleTimeout: 10_000,
+  forwardAudioIdleTimeout: 10_000,
   turnHandling: {},
   useTtsAlignedTranscript: true,
 } as const satisfies AgentSessionOptions;


### PR DESCRIPTION
## Description
Expose `ttsReadIdleTimeout` and `forwardAudioIdleTimeout` on `AgentSessionOptions` so adapters whose first-token latency exceeds the 10s default can raise the limit without patching SDK internals. Defaults stay at 10s.
Closes [#1448](https://github.com/livekit/agents-js/issues/1448).

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- Expose `ttsReadIdleTimeout` and `forwardAudioIdleTimeout` on `AgentSessionOptions`
- Both values will be set with default 10s if no value is provided. 

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [x] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.