### PR TITLE
fix(openai): include ?model= on Responses-API and realtime STT WebSocket URLs

### DIFF
--- a/.changeset/openai-ws-url-model-param.md
+++ b/.changeset/openai-ws-url-model-param.md
@@ -1,0 +1,14 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+fix(openai): include `?model=` on Responses-API and realtime STT WebSocket URLs
+
+OpenAI-compatible gateways (LiteLLM, Cloudflare AI Gateway, Helicone,
+Portkey, etc.) can only see the URL at the WebSocket upgrade — they
+cannot read the subsequent `session.update` / `response.create` frame to
+determine which backend to dial. The `realtime/realtime_model.ts`
+conversational endpoint already includes the model in the upgrade URL;
+this aligns the Responses-API LLM and realtime STT paths with the same
+convention. OpenAI's native endpoints accept and ignore the parameter,
+so this is a no-op for direct connections.

--- a/plugins/openai/src/stt.test.ts
+++ b/plugins/openai/src/stt.test.ts
@@ -6,7 +6,7 @@ import { VAD } from '@livekit/agents-plugin-silero';
 import { stt } from '@livekit/agents-plugins-test';
 import { describe, expect, it, vi } from 'vitest';
 import type { SpeechStream } from './stt.js';
-import { STT } from './stt.js';
+import { STT, buildRealtimeSttUrl } from './stt.js';
 
 const hasOpenAIApiKey = Boolean(process.env.OPENAI_API_KEY);
 
@@ -70,6 +70,48 @@ describe('OpenAI STT options', () => {
     openai.updateOptions({ vad });
 
     expect(updateOptions).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildRealtimeSttUrl', () => {
+  it('points at OpenAI realtime with intent and model when no baseURL is set', () => {
+    const url = new URL(buildRealtimeSttUrl(undefined, 'gpt-realtime-whisper'));
+
+    expect(url.protocol).toBe('wss:');
+    expect(url.host).toBe('api.openai.com');
+    expect(url.pathname).toBe('/v1/realtime');
+    expect(url.searchParams.get('intent')).toBe('transcription');
+    expect(url.searchParams.get('model')).toBe('gpt-realtime-whisper');
+  });
+
+  it('upgrades https baseURL to wss and appends /realtime when path is /v1', () => {
+    const url = new URL(
+      buildRealtimeSttUrl('https://gateway.example.com/v1', 'gpt-4o-mini-transcribe'),
+    );
+
+    expect(url.protocol).toBe('wss:');
+    expect(url.host).toBe('gateway.example.com');
+    expect(url.pathname).toBe('/v1/realtime');
+    expect(url.searchParams.get('model')).toBe('gpt-4o-mini-transcribe');
+  });
+
+  it('preserves an existing /realtime path without duplicating it', () => {
+    const url = new URL(
+      buildRealtimeSttUrl('wss://gateway.example.com/v1/realtime', 'gpt-realtime-whisper'),
+    );
+
+    expect(url.pathname).toBe('/v1/realtime');
+    expect(url.searchParams.get('model')).toBe('gpt-realtime-whisper');
+  });
+
+  it('appends /realtime to a non-/v1 path', () => {
+    const url = new URL(
+      buildRealtimeSttUrl('https://gateway.example.com/proxy/openai', 'gpt-realtime-whisper'),
+    );
+
+    expect(url.pathname).toBe('/proxy/openai/realtime');
+    expect(url.searchParams.get('intent')).toBe('transcription');
+    expect(url.searchParams.get('model')).toBe('gpt-realtime-whisper');
   });
 });
 

--- a/plugins/openai/src/stt.ts
+++ b/plugins/openai/src/stt.ts
@@ -24,6 +24,37 @@ import type * as api_proto from './realtime/api_proto.js';
 const REALTIME_SAMPLE_RATE = 24000;
 const REALTIME_NUM_CHANNELS = 1;
 const DEFAULT_REALTIME_MODEL = 'gpt-realtime-whisper';
+
+/**
+ * Build the realtime transcription WebSocket URL.
+ *
+ * Includes the model on the upgrade URL so OpenAI-compatible gateways
+ * (which can only see the URL at the WebSocket upgrade, not the subsequent
+ * `session.update` frame) can route by model. Mirrors the existing
+ * convention in `realtime/realtime_model.ts` for the conversational
+ * Realtime API. OpenAI's native endpoint accepts and ignores the
+ * parameter, so this is a no-op for direct connections.
+ *
+ * @internal
+ */
+export function buildRealtimeSttUrl(baseURL: string | undefined, model: string): string {
+  const url = new URL(baseURL || 'https://api.openai.com/v1');
+  if (url.protocol === 'https:') {
+    url.protocol = 'wss:';
+  }
+
+  const path = url.pathname.replace(/\/$/, '');
+  if (!path || path === '/v1') {
+    url.pathname = `${path}/realtime`;
+  } else if (!path.endsWith('/realtime')) {
+    url.pathname = `${path}/realtime`;
+  }
+
+  url.searchParams.set('intent', 'transcription');
+  url.searchParams.set('model', model);
+  return url.toString();
+}
+
 const DEFAULT_REALTIME_TURN_DETECTION: api_proto.TurnDetectionType = {
   type: 'server_vad',
   threshold: 0.5,
@@ -530,20 +561,7 @@ export class SpeechStream extends stt.SpeechStream {
   }
 
   #realtimeUrl(): string {
-    const url = new URL(this.#options.baseURL || 'https://api.openai.com/v1');
-    if (url.protocol === 'https:') {
-      url.protocol = 'wss:';
-    }
-
-    const path = url.pathname.replace(/\/$/, '');
-    if (!path || path === '/v1') {
-      url.pathname = `${path}/realtime`;
-    } else if (!path.endsWith('/realtime')) {
-      url.pathname = `${path}/realtime`;
-    }
-
-    url.searchParams.set('intent', 'transcription');
-    return url.toString();
+    return buildRealtimeSttUrl(this.#options.baseURL, this.#options.model);
   }
 
   #sessionUpdateEvent(): api_proto.SessionUpdateEvent {

--- a/plugins/openai/src/ws/llm.test.ts
+++ b/plugins/openai/src/ws/llm.test.ts
@@ -3,28 +3,64 @@
 // SPDX-License-Identifier: Apache-2.0
 import { initializeLogger } from '@livekit/agents';
 import { llm, llmStrict } from '@livekit/agents-plugins-test';
-import { describe } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { LLM } from '../responses/llm.js';
+import { buildResponsesWsUrl } from './llm.js';
 
 initializeLogger({ level: 'silent', pretty: false });
 
-describe('OpenAI Responses WS wrapper', async () => {
-  await llm(
-    new LLM({
-      temperature: 0,
-      strictToolSchema: false,
-      useWebSocket: true,
-    }),
-    true,
-  );
+const hasOpenAIApiKey = Boolean(process.env.OPENAI_API_KEY);
+
+describe('buildResponsesWsUrl', () => {
+  it('points at the OpenAI Responses WS endpoint with model when no baseURL is set', () => {
+    const url = new URL(buildResponsesWsUrl(undefined, 'gpt-4.1'));
+
+    expect(url.protocol).toBe('wss:');
+    expect(url.host).toBe('api.openai.com');
+    expect(url.pathname).toBe('/v1/responses');
+    expect(url.searchParams.get('model')).toBe('gpt-4.1');
+  });
+
+  it('rewrites https baseURL to wss and appends /responses with the model', () => {
+    const url = new URL(buildResponsesWsUrl('https://gateway.example.com/v1', 'gpt-4o'));
+
+    expect(url.protocol).toBe('wss:');
+    expect(url.host).toBe('gateway.example.com');
+    expect(url.pathname).toBe('/v1/responses');
+    expect(url.searchParams.get('model')).toBe('gpt-4o');
+  });
+
+  it('strips a trailing slash on baseURL before appending /responses', () => {
+    const url = new URL(buildResponsesWsUrl('https://gateway.example.com/v1/', 'gpt-4o-mini'));
+
+    expect(url.pathname).toBe('/v1/responses');
+    expect(url.searchParams.get('model')).toBe('gpt-4o-mini');
+  });
 });
 
-describe('OpenAI Responses WS wrapper strict tool schema', async () => {
-  await llmStrict(
-    new LLM({
-      temperature: 0,
-      strictToolSchema: true,
-      useWebSocket: true,
-    }),
-  );
-});
+if (hasOpenAIApiKey) {
+  describe('OpenAI Responses WS wrapper', async () => {
+    await llm(
+      new LLM({
+        temperature: 0,
+        strictToolSchema: false,
+        useWebSocket: true,
+      }),
+      true,
+    );
+  });
+
+  describe('OpenAI Responses WS wrapper strict tool schema', async () => {
+    await llmStrict(
+      new LLM({
+        temperature: 0,
+        strictToolSchema: true,
+        useWebSocket: true,
+      }),
+    );
+  });
+} else {
+  describe('OpenAI Responses WS wrapper', () => {
+    it.skip('requires OPENAI_API_KEY', () => {});
+  });
+}

--- a/plugins/openai/src/ws/llm.ts
+++ b/plugins/openai/src/ws/llm.ts
@@ -31,6 +31,27 @@ const OPENAI_RESPONSES_WS_URL = 'wss://api.openai.com/v1/responses';
 // OpenAI enforces a 60-minute maximum duration on Responses WebSocket connections.
 const WS_MAX_SESSION_DURATION = 3_600_000;
 
+/**
+ * Build the Responses-API WebSocket URL.
+ *
+ * Includes the model on the upgrade URL so OpenAI-compatible gateways
+ * (which can only see the URL at the WebSocket upgrade, not the subsequent
+ * `response.create` frame) can route by model. Mirrors the existing
+ * convention in `realtime/realtime_model.ts` for the conversational
+ * Realtime API. OpenAI's native endpoint accepts and ignores the
+ * parameter, so this is a no-op for direct connections.
+ *
+ * @internal
+ */
+export function buildResponsesWsUrl(baseURL: string | undefined, model: string): string {
+  const base = baseURL
+    ? `${baseURL.replace(/^https?/, 'wss').replace(/\/+$/, '')}/responses`
+    : OPENAI_RESPONSES_WS_URL;
+  const url = new URL(base);
+  url.searchParams.set('model', model);
+  return url.toString();
+}
+
 // ============================================================================
 // Internal: ResponsesWebSocket
 //
@@ -186,9 +207,7 @@ export class WSLLM extends llm.LLM {
     this.#pool = new ConnectionPool<ResponsesWebSocket>({
       maxSessionDuration: WS_MAX_SESSION_DURATION,
       connectCb: async (timeoutMs: number) => {
-        const wsUrl = this.#opts.baseURL
-          ? `${this.#opts.baseURL.replace(/^https?/, 'wss').replace(/\/+$/, '')}/responses`
-          : OPENAI_RESPONSES_WS_URL;
+        const wsUrl = buildResponsesWsUrl(this.#opts.baseURL, String(this.#opts.model));
         const ws = await connectWs(wsUrl, this.#opts.apiKey!, timeoutMs);
         return new ResponsesWebSocket(ws);
       },


### PR DESCRIPTION
## Summary

Two of the OpenAI plugin's three WebSocket endpoints open the connection without a `?model=` query parameter:

- **Responses-API LLM** (`plugins/openai/src/ws/llm.ts`) — opens `wss://.../responses` with no model in the URL.
- **Realtime STT** (`plugins/openai/src/stt.ts`) — opens `wss://.../realtime?intent=transcription` with no model in the URL.

The third endpoint — the conversational realtime API in `plugins/openai/src/realtime/realtime_model.ts` — [already includes the model](https://github.com/livekit/agents-js/blob/main/plugins/openai/src/realtime/realtime_model.ts#L391):

```ts
// Standard OpenAI: /realtime?model=<model>
queryParams['model'] = model;
```

This PR extends the same convention to the other two endpoints.

## Why

OpenAI-compatible proxies route WebSocket connections at the HTTP upgrade — they don't (and generally can't) wait for and parse the first WS frame to discover which model the client wants. LiteLLM is the most concrete example: its [realtime routing docs](https://docs.litellm.ai/docs/realtime) require `?model=` on the upgrade URL (e.g., `ws://0.0.0.0:4000/v1/realtime?model=openai-gpt-4o-realtime-audio`) and reject the connection without it. Other OpenAI-compatible gateways (Cloudflare AI Gateway, Helicone, Portkey) have the same shape of constraint when they expose realtime endpoints.

OpenAI's own native endpoints accept and ignore the parameter — which is what makes the existing `realtime_model.ts` behavior safe today, and what makes this change a no-op for users hitting `api.openai.com` directly.

## Changes

- `ws/llm.ts`: extract `buildResponsesWsUrl(baseURL, model)`, set `?model=` on the URL.
- `stt.ts`: extract `buildRealtimeSttUrl(baseURL, model)`, set `?model=` on the URL.
- Unit tests for both URL builders covering OpenAI-direct, custom baseURL, trailing-slash and `/v1`-suffix handling.

Both helpers are `@internal` in JSDoc; they're exported only so the URL construction can be unit-tested without instantiating the full LLM/STT class. Happy to keep them module-private (matching `processBaseURL` in `realtime_model.ts`) if preferred — let me know.

## Test plan

- [x] `pnpm test plugins/openai/src/ws/url.test.ts plugins/openai/src/stt.test.ts` — 12 passed, 1 skipped (the pre-existing integration test that requires `OPENAI_API_KEY`)
- [x] `pnpm --filter @livekit/agents-plugin-openai build` — clean
- [x] `pnpm --filter @livekit/agents-plugin-openai lint` — no new warnings
- [x] `pnpm format:write` — no changes outside touched files