### PR TITLE
fix(openai): correct withOllama defaults

### DIFF
--- a/.changeset/openai-with-ollama-defaults.md
+++ b/.changeset/openai-with-ollama-defaults.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+fix(openai): `LLM.withOllama` was using the OctoAI base URL and model; default to `http://localhost:11434/v1` and `llama3.1`

--- a/plugins/openai/src/llm.ts
+++ b/plugins/openai/src/llm.ts
@@ -316,8 +316,8 @@ export class LLM extends llm.LLM {
     }> = {},
   ): LLM {
     return new LLM({
-      model: 'llama-2-13b-chat',
-      baseURL: 'https://text.octoai.run/v1',
+      model: 'llama3.1',
+      baseURL: 'http://localhost:11434/v1',
       apiKey: 'ollama',
       ...opts,
     });


### PR DESCRIPTION
## Description
`LLM.withOllama` was copy-pasted from `withOcto` and pointed at the OctoAI endpoint with an OctoAI model, so it never actually talked to Ollama.

## Changes Made
- Default `baseURL` to `http://localhost:11434/v1` (Ollama's OpenAI-compatible endpoint).
- Default `model` to `llama3.1`.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable)

## Testing
- [ ] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
None.