### PR TITLE
fix(livekit): skip system/developer messages in EOU input

### DIFF
--- a/.changeset/livekit-eou-skip-system-messages.md
+++ b/.changeset/livekit-eou-skip-system-messages.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-livekit': patch
+---
+
+fix(livekit): skip system and developer messages when building EOU input; the previous `in` check never matched and let those messages reach the end-of-utterance model as user turns

--- a/plugins/livekit/src/turn_detector/base.ts
+++ b/plugins/livekit/src/turn_detector/base.ts
@@ -237,7 +237,7 @@ export abstract class EOUModel {
 
     for (const message of chatCtx.items) {
       // skip system and developer messages or tool call messages
-      if (message.type !== 'message' || message.role in ['system', 'developer']) {
+      if (message.type !== 'message' || message.role === 'system' || message.role === 'developer') {
         continue;
       }
 


### PR DESCRIPTION
## Description
`message.role in ['system', 'developer']` in `EOUModel.predictEndOfTurn` used the JS `in` operator on an array literal, which checks property keys (`0`, `1`, `length`), not values — so the guard was always false and system/developer messages were rewritten to `'user'` and fed to the EOU model.

## Changes Made
- Replace the `in` check with explicit `=== 'system' || === 'developer'`, matching the pattern used in `chat_context.ts`, `provider_format/mistralai.ts`, and `phonic/realtime_model.ts`.

## Testing
- Lint + prettier (pre-commit hooks) pass.