### PR TITLE
Fail download-files when plugin downloads fail

### DIFF
--- a/.changeset/chilly-trains-sin.md
+++ b/.changeset/chilly-trains-sin.md
@@ -1,0 +1,6 @@
+---
+"@livekit/agents": patch
+"@livekit/agents-plugin-openai": patch
+---
+
+Fail download-files when plugin downloads fail

--- a/agents/src/cli.test.ts
+++ b/agents/src/cli.test.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { formatDownloadFailureMessage, runApp } from './cli.js';
+import { Plugin } from './plugin.js';
+import { ServerOptions } from './worker.js';
+
+class FailingDownloadPlugin extends Plugin {
+  constructor() {
+    super({ title: 'failing-test-plugin', version: '0.0.0', package: 'test-plugin' });
+  }
+
+  async downloadFiles(): Promise<void> {
+    throw new Error('download failed');
+  }
+}
+
+describe('download-files CLI', () => {
+  const originalArgv = process.argv;
+  const originalPlugins = Plugin.registeredPlugins;
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    Plugin.registeredPlugins = originalPlugins;
+    vi.restoreAllMocks();
+  });
+
+  it('exits non-zero when a plugin fails to download files', async () => {
+    process.argv = ['node', 'test-agent.js', 'download-files'];
+    Plugin.registeredPlugins = [new FailingDownloadPlugin()];
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    runApp(new ServerOptions({ agent: 'test-agent.js' }));
+
+    await vi.waitFor(() => {
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('includes plugin details in download failure messages', () => {
+    const message = formatDownloadFailureMessage([
+      { plugin: new FailingDownloadPlugin(), error: new Error('download failed') },
+    ]);
+
+    expect(message).toContain('Failed to download files for 1 plugin');
+    expect(message).toContain('failing-test-plugin');
+    expect(message).toContain('test-plugin@0.0.0');
+    expect(message).toContain('download failed');
+  });
+});

--- a/agents/src/cli.ts
+++ b/agents/src/cli.ts
@@ -228,7 +228,9 @@ export const runApp = (opts: ServerOptions) => {
             logger.info(`Finished downloading files for ${plugin.title}`);
           } catch (error) {
             failures.push({ plugin, error });
-            logger.error(`Failed to download files for ${plugin.title}: ${formatErrorMessage(error)}`);
+            logger.error(
+              `Failed to download files for ${plugin.title}: ${formatErrorMessage(error)}`,
+            );
           }
         }
 

--- a/agents/src/cli.ts
+++ b/agents/src/cli.ts
@@ -17,6 +17,27 @@ type CliArgs = {
   participantIdentity?: string;
 };
 
+type PluginDownloadFailure = {
+  plugin: Plugin;
+  error: unknown;
+};
+
+const formatErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+/** @internal */
+export const formatDownloadFailureMessage = (failures: PluginDownloadFailure[]): string => {
+  const pluginLabel = failures.length === 1 ? 'plugin' : 'plugins';
+  const details = failures
+    .map(
+      ({ plugin, error }) =>
+        `- ${plugin.title} (${plugin.package}@${plugin.version}): ${formatErrorMessage(error)}`,
+    )
+    .join('\n');
+
+  return `Failed to download files for ${failures.length} ${pluginLabel}:\n${details}`;
+};
+
 const runServer = async (args: CliArgs) => {
   initializeLogger({ pretty: !args.production, level: args.opts.logLevel });
   const logger = log();
@@ -198,24 +219,31 @@ export const runApp = (opts: ServerOptions) => {
       const logger = log();
 
       const downloadFiles = async () => {
+        const failures: PluginDownloadFailure[] = [];
+
         for (const plugin of Plugin.registeredPlugins) {
           logger.info(`Downloading files for ${plugin.title}`);
           try {
             await plugin.downloadFiles();
             logger.info(`Finished downloading files for ${plugin.title}`);
           } catch (error) {
-            logger.error(`Failed to download files for ${plugin.title}: ${error}`);
+            failures.push({ plugin, error });
+            logger.error(`Failed to download files for ${plugin.title}: ${formatErrorMessage(error)}`);
           }
+        }
+
+        if (failures.length > 0) {
+          throw new Error(formatDownloadFailureMessage(failures));
         }
       };
 
       downloadFiles()
+        .then(() => {
+          process.exit(0);
+        })
         .catch((error) => {
           logger.fatal(`Error during file downloads: ${error}`);
           process.exit(1);
-        })
-        .finally(() => {
-          process.exit(0);
         });
     });
 

--- a/plugins/openai/src/stt.test.ts
+++ b/plugins/openai/src/stt.test.ts
@@ -5,7 +5,8 @@ import { VAD as BaseVAD, type VADStream } from '@livekit/agents';
 import { VAD } from '@livekit/agents-plugin-silero';
 import { stt } from '@livekit/agents-plugins-test';
 import { describe, expect, it, vi } from 'vitest';
-import { STT, SpeechStream } from './stt.js';
+import type { SpeechStream } from './stt.js';
+import { STT } from './stt.js';
 
 const hasOpenAIApiKey = Boolean(process.env.OPENAI_API_KEY);
 


### PR DESCRIPTION
## Summary

Fixes `download-files` so Docker builds fail when any plugin dependency file fails to download.

Previously, plugin download errors were logged but swallowed, and the CLI always exited `0` from `finally()`. That allowed builds to continue even when required files like turn detector `.onnx` models were missing, causing runtime failures later.

This now tracks failed plugin downloads, reports which plugin/package/version failed with the original error message, and exits non-zero after attempting all plugin downloads.

## Test plan

- `pnpm test -- agents/src/cli.test.ts`
- Verified the regression test fails before the fix because `download-files` exits `0`.
- Verified the test passes after the fix and the fatal error includes plugin details.