### PR TITLE
fix(inference): prefer inference credentials for interruption detector

### DIFF
--- a/agents/src/inference/interruption/defaults.ts
+++ b/agents/src/inference/interruption/defaults.ts
@@ -45,7 +45,7 @@ export const interruptionOptionDefaults: Omit<InterruptionOptions, 'baseUrl' | '
   audioPrefixDurationInS: AUDIO_PREFIX_DURATION_IN_S,
   detectionIntervalInS: DETECTION_INTERVAL_IN_S,
   inferenceTimeout: REMOTE_INFERENCE_TIMEOUT_IN_S * 1_000,
-  apiKey: process.env.LIVEKIT_API_KEY || '',
-  apiSecret: process.env.LIVEKIT_API_SECRET || '',
+  apiKey:  process.env.LIVEKIT_INFERENCE_API_KEY || process.env.LIVEKIT_API_KEY || "",
+  apiSecret: process.env.LIVEKIT_INFERENCE_API_SECRET || process.env.LIVEKIT_API_SECRET || "",
   minInterruptionDurationInS: MIN_INTERRUPTION_DURATION_IN_S,
 } as const;

--- a/agents/src/inference/interruption/defaults.ts
+++ b/agents/src/inference/interruption/defaults.ts
@@ -45,7 +45,7 @@ export const interruptionOptionDefaults: Omit<InterruptionOptions, 'baseUrl' | '
   audioPrefixDurationInS: AUDIO_PREFIX_DURATION_IN_S,
   detectionIntervalInS: DETECTION_INTERVAL_IN_S,
   inferenceTimeout: REMOTE_INFERENCE_TIMEOUT_IN_S * 1_000,
-  apiKey:  process.env.LIVEKIT_INFERENCE_API_KEY || process.env.LIVEKIT_API_KEY || "",
-  apiSecret: process.env.LIVEKIT_INFERENCE_API_SECRET || process.env.LIVEKIT_API_SECRET || "",
+  apiKey: process.env.LIVEKIT_INFERENCE_API_KEY || process.env.LIVEKIT_API_KEY || '',
+  apiSecret: process.env.LIVEKIT_INFERENCE_API_SECRET || process.env.LIVEKIT_API_SECRET || '',
   minInterruptionDurationInS: MIN_INTERRUPTION_DURATION_IN_S,
 } as const;


### PR DESCRIPTION
## Description
Fixes adaptive interruption detector credential precedence when using a self-hosted LiveKit SFU with LiveKit Cloud Inference. Issue #1353 

Previously, adaptive interruption could pick up `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` before `LIVEKIT_INFERENCE_API_KEY` / `LIVEKIT_INFERENCE_API_SECRET` as described in the issue, causing Cloud inference websocket auth to fail with 401 when the SFU credentials were local/self-hosted credentials.

## Changes Made
- Prefer inference-specific env vars for adaptive interruption auth.
- Preserve fallback to regular LiveKit credentials when inference-specific credentials are not set.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
- [x] All tests pass

## Additional Notes
Before change (local SFU):

<img width="888" height="46" alt="Screenshot 2026-05-12 at 8 12 41 PM" src="https://github.com/user-attachments/assets/eba7567d-a2b0-4a0e-9b9a-8d6f06f927cc" />
<br/>
<br/>


After change (local SFU):

<img width="638" height="49" alt="Screenshot 2026-05-12 at 8 23 41 PM" src="https://github.com/user-attachments/assets/01b000d8-9da0-4bc2-a549-3dac06ab9d79" />