### PR TITLE
refactor(elevenlabs): abort recv channel on ws close/error

### DIFF
--- a/.changeset/elevenlabs-recv-error-var.md
+++ b/.changeset/elevenlabs-recv-error-var.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-elevenlabs': patch
+---
+
+refactor(elevenlabs): abort the TTS recv channel on websocket close/error instead of holding the error in a Future

--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -8,7 +8,6 @@ import {
   APIStatusError,
   APITimeoutError,
   AudioByteStream,
-  Future,
   type TimedString,
   asError,
   createTimedString,
@@ -431,7 +430,6 @@ class Connection {
   async #recvLoop(): Promise<void> {
     try {
       const messageChannel = stream.createStreamChannel<Record<string, unknown>>();
-      const errorFuture = new Future<Error>();
 
       const onMessage = (rawData: Buffer) => {
         try {
@@ -444,19 +442,19 @@ class Connection {
 
       const onClose = (code: number) => {
         if (!this.#closed && this.#contextData.size > 0) {
-          errorFuture.reject(
+          messageChannel.abort(
             new APIStatusError({
               message: 'ElevenLabs websocket connection closed unexpectedly',
               options: { statusCode: code },
             }),
           );
+        } else {
+          messageChannel.close();
         }
-        messageChannel.close();
       };
 
       const onError = (error: Error) => {
-        errorFuture.reject(error);
-        messageChannel.close();
+        messageChannel.abort(error);
       };
 
       // Set up persistent listeners
@@ -595,11 +593,6 @@ class Connection {
               break;
             }
           }
-        }
-
-        // Throw any error that occurred
-        if (errorFuture.done) {
-          await errorFuture.await;
         }
       } finally {
         reader.releaseLock();

--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -428,175 +428,165 @@ class Connection {
   }
 
   async #recvLoop(): Promise<void> {
-    try {
-      const messageChannel = stream.createStreamChannel<Record<string, unknown>>();
+    if (!this.#ws) return;
 
-      const onMessage = (rawData: Buffer) => {
-        try {
-          const parsed = JSON.parse(rawData.toString());
-          messageChannel.write(parsed);
-        } catch (e) {
-          this.#logger.warn({ error: e }, 'failed to parse WebSocket message');
-        }
-      };
+    const messageChannel = stream.createStreamChannel<Record<string, unknown>>();
 
-      const onClose = (code: number) => {
-        if (!this.#closed && this.#contextData.size > 0) {
-          messageChannel.abort(
-            new APIStatusError({
-              message: 'ElevenLabs websocket connection closed unexpectedly',
-              options: { statusCode: code },
-            }),
-          );
-        } else {
-          messageChannel.close();
-        }
-      };
-
-      const onError = (error: Error) => {
-        messageChannel.abort(error);
-      };
-
-      // Set up persistent listeners
-      if (!this.#ws) return;
-      this.#ws.on('message', onMessage);
-      this.#ws.on('close', onClose);
-      this.#ws.on('error', onError);
-
-      const cleanup = () => {
-        this.#ws?.off('message', onMessage);
-        this.#ws?.off('close', onClose);
-        this.#ws?.off('error', onError);
-      };
-
-      const reader = messageChannel.stream().getReader();
+    const onMessage = (rawData: Buffer) => {
       try {
-        while (!this.#closed) {
-          const result = await reader.read();
-          if (result.done || this.#closed) break;
+        const parsed = JSON.parse(rawData.toString());
+        messageChannel.write(parsed);
+      } catch (e) {
+        this.#logger.warn({ error: e }, 'failed to parse WebSocket message');
+      }
+    };
 
-          const data = result.value;
-          const contextId = data.contextId as string | undefined;
-          const ctx = contextId ? this.#contextData.get(contextId) : undefined;
+    const onClose = (code: number) => {
+      if (!this.#closed && this.#contextData.size > 0) {
+        messageChannel.abort(
+          new APIStatusError({
+            message: 'ElevenLabs websocket connection closed unexpectedly',
+            options: { statusCode: code },
+          }),
+        );
+      } else {
+        messageChannel.close();
+      }
+    };
 
-          if (data.error) {
-            this.#logger.error(
-              { context_id: contextId, error: data.error, data },
-              'elevenlabs tts returned error',
+    const onError = (error: Error) => {
+      messageChannel.abort(error);
+    };
+
+    this.#ws.on('message', onMessage);
+    this.#ws.on('close', onClose);
+    this.#ws.on('error', onError);
+
+    const reader = messageChannel.stream().getReader();
+
+    try {
+      while (!this.#closed) {
+        const result = await reader.read();
+        if (result.done || this.#closed) break;
+
+        const data = result.value;
+        const contextId = data.contextId as string | undefined;
+        const ctx = contextId ? this.#contextData.get(contextId) : undefined;
+
+        if (data.error) {
+          this.#logger.error(
+            { context_id: contextId, error: data.error, data },
+            'elevenlabs tts returned error',
+          );
+          if (contextId) {
+            if (ctx) {
+              ctx.waiter.reject(new APIError(data.error as string));
+            }
+            this.#cleanupContext(contextId);
+          }
+          continue;
+        }
+
+        if (!ctx) {
+          this.#logger.warn({ data }, 'unexpected message received from elevenlabs tts');
+          continue;
+        }
+
+        const stream = ctx.stream;
+
+        // Process alignment data
+        const alignment =
+          this.#opts.preferredAlignment === 'normalized'
+            ? (data.normalizedAlignment as Record<string, unknown>)
+            : (data.alignment as Record<string, unknown>);
+
+        if (alignment && stream) {
+          const chars = alignment.chars as string[] | undefined;
+          const starts = (alignment.charStartTimesMs || alignment.charsStartTimesMs) as
+            | number[]
+            | undefined;
+          const durs = (alignment.charDurationsMs || alignment.charsDurationsMs) as
+            | number[]
+            | undefined;
+
+          if (
+            chars &&
+            starts &&
+            durs &&
+            chars.length === durs.length &&
+            starts.length === durs.length
+          ) {
+            ctx.textBuffer += chars.join('');
+
+            // Handle chars with multiple characters
+            for (let i = 0; i < chars.length; i++) {
+              const char = chars[i]!;
+              const start = starts[i]!;
+              const dur = durs[i]!;
+
+              // Capture the first word's start time for normalization
+              // This removes leading silence from timestamps
+              if (ctx.firstWordOffsetMs === null && start > 0) {
+                ctx.firstWordOffsetMs = start;
+              }
+
+              if (char.length > 1) {
+                for (let j = 0; j < char.length - 1; j++) {
+                  ctx.startTimesMs.push(start);
+                  ctx.durationsMs.push(0);
+                }
+              }
+              ctx.startTimesMs.push(start);
+              ctx.durationsMs.push(dur);
+            }
+
+            const [timedWords, remainingText] = toTimedWords(
+              ctx.textBuffer,
+              ctx.startTimesMs,
+              ctx.durationsMs,
+              false,
+              ctx.firstWordOffsetMs ?? 0,
             );
-            if (contextId) {
-              if (ctx) {
-                ctx.waiter.reject(new APIError(data.error as string));
-              }
-              this.#cleanupContext(contextId);
-            }
-            continue;
-          }
 
-          if (!ctx) {
-            this.#logger.warn({ data }, 'unexpected message received from elevenlabs tts');
-            continue;
-          }
-
-          const stream = ctx.stream;
-
-          // Process alignment data
-          const alignment =
-            this.#opts.preferredAlignment === 'normalized'
-              ? (data.normalizedAlignment as Record<string, unknown>)
-              : (data.alignment as Record<string, unknown>);
-
-          if (alignment && stream) {
-            const chars = alignment.chars as string[] | undefined;
-            const starts = (alignment.charStartTimesMs || alignment.charsStartTimesMs) as
-              | number[]
-              | undefined;
-            const durs = (alignment.charDurationsMs || alignment.charsDurationsMs) as
-              | number[]
-              | undefined;
-
-            if (
-              chars &&
-              starts &&
-              durs &&
-              chars.length === durs.length &&
-              starts.length === durs.length
-            ) {
-              ctx.textBuffer += chars.join('');
-
-              // Handle chars with multiple characters
-              for (let i = 0; i < chars.length; i++) {
-                const char = chars[i]!;
-                const start = starts[i]!;
-                const dur = durs[i]!;
-
-                // Capture the first word's start time for normalization
-                // This removes leading silence from timestamps
-                if (ctx.firstWordOffsetMs === null && start > 0) {
-                  ctx.firstWordOffsetMs = start;
-                }
-
-                if (char.length > 1) {
-                  for (let j = 0; j < char.length - 1; j++) {
-                    ctx.startTimesMs.push(start);
-                    ctx.durationsMs.push(0);
-                  }
-                }
-                ctx.startTimesMs.push(start);
-                ctx.durationsMs.push(dur);
-              }
-
-              const [timedWords, remainingText] = toTimedWords(
-                ctx.textBuffer,
-                ctx.startTimesMs,
-                ctx.durationsMs,
-                false,
-                ctx.firstWordOffsetMs ?? 0,
-              );
-
-              if (timedWords.length > 0) {
-                stream.pushTimedTranscript(timedWords);
-              }
-
-              ctx.textBuffer = remainingText;
-              ctx.startTimesMs = ctx.startTimesMs.slice(-remainingText.length);
-              ctx.durationsMs = ctx.durationsMs.slice(-remainingText.length);
-            }
-          }
-
-          if (data.audio) {
-            const audioData = Buffer.from(data.audio as string, 'base64');
-            stream.pushAudio(audioData);
-          }
-
-          if (data.isFinal) {
-            // Flush remaining alignment data
-            if (ctx.textBuffer) {
-              const [timedWords] = toTimedWords(
-                ctx.textBuffer,
-                ctx.startTimesMs,
-                ctx.durationsMs,
-                true,
-                ctx.firstWordOffsetMs ?? 0,
-              );
-              if (timedWords.length > 0) {
-                stream.pushTimedTranscript(timedWords);
-              }
+            if (timedWords.length > 0) {
+              stream.pushTimedTranscript(timedWords);
             }
 
-            stream.markDone();
-            ctx.waiter.resolve();
-            this.#cleanupContext(contextId!);
-
-            if (!this.#isCurrent && this.#activeContexts.size === 0) {
-              this.#logger.debug('no active contexts, shutting down connection');
-              break;
-            }
+            ctx.textBuffer = remainingText;
+            ctx.startTimesMs = ctx.startTimesMs.slice(-remainingText.length);
+            ctx.durationsMs = ctx.durationsMs.slice(-remainingText.length);
           }
         }
-      } finally {
-        reader.releaseLock();
-        cleanup();
+
+        if (data.audio) {
+          const audioData = Buffer.from(data.audio as string, 'base64');
+          stream.pushAudio(audioData);
+        }
+
+        if (data.isFinal) {
+          // Flush remaining alignment data
+          if (ctx.textBuffer) {
+            const [timedWords] = toTimedWords(
+              ctx.textBuffer,
+              ctx.startTimesMs,
+              ctx.durationsMs,
+              true,
+              ctx.firstWordOffsetMs ?? 0,
+            );
+            if (timedWords.length > 0) {
+              stream.pushTimedTranscript(timedWords);
+            }
+          }
+
+          stream.markDone();
+          ctx.waiter.resolve();
+          this.#cleanupContext(contextId!);
+
+          if (!this.#isCurrent && this.#activeContexts.size === 0) {
+            this.#logger.debug('no active contexts, shutting down connection');
+            break;
+          }
+        }
       }
     } catch (e) {
       this.#logger.warn({ error: e }, 'recv loop error');
@@ -605,6 +595,10 @@ class Connection {
       }
       this.#contextData.clear();
     } finally {
+      reader.releaseLock();
+      this.#ws?.off('message', onMessage);
+      this.#ws?.off('close', onClose);
+      this.#ws?.off('error', onError);
       if (!this.#closed) {
         await this.close();
       }


### PR DESCRIPTION
## Description
Replace the side-channel `Future<Error>` in the TTS recv loop with a `messageChannel.abort(err)` call from the ws event handlers, so the pending `reader.read()` rejects inline. Mirrors Python's `_recv_loop`, which raises directly from `await ws.receive()`.

## Changes Made
- `onClose`/`onError` now call `messageChannel.abort(err)` instead of resolving a separate `Future`
- Drop the post-loop `if (errorFuture.done) throw` check — the outer `try/catch` handles it
- Drop the now-unused `Future` import

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
- [x] All elevenlabs tests pass (one pre-existing unrelated failure in shared TTS scaffold around `openai/STT` VAD)