### PR TITLE
fix(transcription): warn only when rotateSegment backlog grows

### DIFF
--- a/.changeset/quiet-rotate-segment.md
+++ b/.changeset/quiet-rotate-segment.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-fix(transcription): quiet the `rotateSegment` overlap warning. The single-overlap case (one rotation queued behind another) is expected at normal turn boundaries — rotations are safely serialized via `oldTask.result`. Track the queue depth instead and only warn when more than one rotation is stacked behind the in-flight one, which would indicate a genuine backlog.
+fix(transcription): quiet the `rotateSegment` overlap warning. The single-overlap case (one rotation queued behind another) is expected at normal turn boundaries — rotations are safely serialized via `oldTask.result`. Track the queue depth instead and only warn when more than one rotation is stacked behind the in-flight one, and additionally suppress the warn during the synchronizer's startup window: production data shows the room-connection-state-changed event can stack two extra rotations onto the constructor-scheduled initial task, producing a benign depth=2 chain that drains before any audio is produced. After the initial task resolves, real mid-conversation backlogs still trip the warn.

--- a/.changeset/quiet-rotate-segment.md
+++ b/.changeset/quiet-rotate-segment.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(transcription): quiet the `rotateSegment` overlap warning. The single-overlap case (one rotation queued behind another) is expected at normal turn boundaries — rotations are safely serialized via `oldTask.result`. Track the queue depth instead and only warn when more than one rotation is stacked behind the in-flight one, which would indicate a genuine backlog.

--- a/agents/src/voice/transcription/synchronizer.test.ts
+++ b/agents/src/voice/transcription/synchronizer.test.ts
@@ -293,3 +293,62 @@ describe('TranscriptionSynchronizer attachment warnings', () => {
     await synchronizer.close();
   });
 });
+
+describe('TranscriptionSynchronizer rotateSegment backlog warn', () => {
+  const backlogWarnPrefix = 'rotateSegment backlog:';
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not warn while the initial constructor-scheduled rotation is in flight', async () => {
+    const warn = vi.fn();
+    vi.spyOn(logModule, 'log').mockReturnValue({
+      warn,
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    } as unknown as ReturnType<typeof logModule.log>);
+
+    const synchronizer = new TranscriptionSynchronizer(new MockAudioOutput(), new MockTextOutput());
+    // Force two extra rotateSegment calls synchronously, before the initial task can settle.
+    // This reproduces the production startup race (room connection + handoff stacking
+    // rotations onto the initial constructor-scheduled task).
+    synchronizer.audioOutput.onDetached();
+    synchronizer.textOutput.onDetached();
+
+    expect(
+      warn.mock.calls.filter((c) => typeof c[0] === 'string' && c[0].startsWith(backlogWarnPrefix)),
+    ).toHaveLength(0);
+
+    await synchronizer.close();
+  });
+
+  it('warns when the chain stacks beyond depth 1 after the initial rotation has settled', async () => {
+    const warn = vi.fn();
+    vi.spyOn(logModule, 'log').mockReturnValue({
+      warn,
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    } as unknown as ReturnType<typeof logModule.log>);
+
+    const synchronizer = new TranscriptionSynchronizer(new MockAudioOutput(), new MockTextOutput());
+
+    // Let the initial constructor-scheduled task drain so we leave the startup window.
+    await synchronizer.barrier();
+
+    // Now simulate a real mid-conversation backlog: three rotateSegment calls back to back
+    // so two end up queued behind the in-flight one.
+    synchronizer.audioOutput.onDetached();
+    synchronizer.audioOutput.onAttached();
+    synchronizer.audioOutput.onDetached();
+
+    const backlogWarns = warn.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].startsWith(backlogWarnPrefix),
+    );
+    expect(backlogWarns.length).toBeGreaterThanOrEqual(1);
+
+    await synchronizer.close();
+  });
+});

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -521,6 +521,13 @@ export class TranscriptionSynchronizer {
   // number of rotations queued behind the currently-running one; used to warn only
   // when the backlog grows beyond a single expected overlap
   private queuedRotations: number = 0;
+  // The constructor schedules an initial rotation task. During session startup the room
+  // connection + agent handoff can fire two more rotateSegment calls before that initial
+  // task drains, producing a benign depth=2 chain that does not affect the caller (the
+  // chain settles before any audio is produced). Suppress the backlog warn until the
+  // initial task has resolved at least once so it only fires on real mid-conversation
+  // backlogs.
+  private initialRotationDone: boolean = false;
   private _outputsAttached: boolean = true;
   private closed: boolean = false;
 
@@ -555,9 +562,11 @@ export class TranscriptionSynchronizer {
 
     // initial segment/first segment, recreated for each new segment
     this._impl = new SegmentSynchronizerImpl(this.options, nextInChainText);
-    this.rotateSegmentTask = Task.from((controller) =>
-      this.rotateSegmentTaskImpl(controller.signal),
-    );
+    const initialTask = Task.from((controller) => this.rotateSegmentTaskImpl(controller.signal));
+    initialTask.addDoneCallback(() => {
+      this.initialRotationDone = true;
+    });
+    this.rotateSegmentTask = initialTask;
   }
 
   get outputsAttached(): boolean {
@@ -604,9 +613,10 @@ export class TranscriptionSynchronizer {
       // The new task chains on the old one via `oldTask.result`, so rotations are
       // serialized and no transcript data is lost. A single overlap is expected when
       // turn-boundary events (playback finished, attach/detach, new utterance) fire
-      // back-to-back; only warn once the backlog grows beyond one queued rotation.
+      // back-to-back; only warn once the backlog grows beyond one queued rotation, and
+      // skip the warn during the synchronizer's startup window (see initialRotationDone).
       this.queuedRotations++;
-      if (this.queuedRotations > 1) {
+      if (this.queuedRotations > 1 && this.initialRotationDone) {
         this.logger.warn(
           `rotateSegment backlog: ${this.queuedRotations} rotations queued behind the in-flight one`,
         );

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -562,11 +562,9 @@ export class TranscriptionSynchronizer {
 
     // initial segment/first segment, recreated for each new segment
     this._impl = new SegmentSynchronizerImpl(this.options, nextInChainText);
-    const initialTask = Task.from((controller) => this.rotateSegmentTaskImpl(controller.signal));
-    initialTask.addDoneCallback(() => {
-      this.initialRotationDone = true;
-    });
-    this.rotateSegmentTask = initialTask;
+    this.rotateSegmentTask = Task.from((controller) =>
+      this.rotateSegmentTaskImpl(controller.signal),
+    );
   }
 
   get outputsAttached(): boolean {
@@ -656,6 +654,11 @@ export class TranscriptionSynchronizer {
       if (this.queuedRotations > 0) {
         this.queuedRotations--;
       }
+      // Set synchronously inside the task body so that by the time `task.result`
+      // resolves, the flag is already true for any continuation (including
+      // `barrier()` callers). Using `Task.addDoneCallback` for this would be
+      // fragile against microtask reordering.
+      this.initialRotationDone = true;
     }
   }
 }

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -518,6 +518,9 @@ export class TranscriptionSynchronizer {
 
   private options: TextSyncOptions;
   private rotateSegmentTask: Task<void>;
+  // number of rotations queued behind the currently-running one; used to warn only
+  // when the backlog grows beyond a single expected overlap
+  private queuedRotations: number = 0;
   private _outputsAttached: boolean = true;
   private closed: boolean = false;
 
@@ -598,7 +601,16 @@ export class TranscriptionSynchronizer {
     }
 
     if (!this.rotateSegmentTask.done) {
-      this.logger.warn('rotateSegment called while previous segment is still being rotated');
+      // The new task chains on the old one via `oldTask.result`, so rotations are
+      // serialized and no transcript data is lost. A single overlap is expected when
+      // turn-boundary events (playback finished, attach/detach, new utterance) fire
+      // back-to-back; only warn once the backlog grows beyond one queued rotation.
+      this.queuedRotations++;
+      if (this.queuedRotations > 1) {
+        this.logger.warn(
+          `rotateSegment backlog: ${this.queuedRotations} rotations queued behind the in-flight one`,
+        );
+      }
     }
     this.rotateSegmentTask = Task.from((controller) =>
       this.rotateSegmentTaskImpl(controller.signal, this.rotateSegmentTask),
@@ -619,16 +631,22 @@ export class TranscriptionSynchronizer {
   }
 
   private async rotateSegmentTaskImpl(abort: AbortSignal, oldTask?: Task<void>) {
-    if (oldTask) {
-      await oldTask.result;
-    }
+    try {
+      if (oldTask) {
+        await oldTask.result;
+      }
 
-    if (abort.aborted) {
-      return;
-    }
+      if (abort.aborted) {
+        return;
+      }
 
-    await this._impl.close();
-    this._impl = new SegmentSynchronizerImpl(this.options, this.textOutput.nextInChain, true);
+      await this._impl.close();
+      this._impl = new SegmentSynchronizerImpl(this.options, this.textOutput.nextInChain, true);
+    } finally {
+      if (this.queuedRotations > 0) {
+        this.queuedRotations--;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

`TranscriptionSynchronizer.rotateSegment` currently logs

> `rotateSegment called while previous segment is still being rotated`

at `warn` level whenever a rotation is requested while another is in flight. In practice this fires at every turn boundary — `onPlaybackFinished`, output attach/detach, new-utterance events, etc. naturally overlap with the prior segment's close-and-recreate `Task`. The rotation is safely serialized (`rotateSegmentTaskImpl` awaits `oldTask.result` before recreating the `SegmentSynchronizerImpl`), so a single overlap is expected and no transcript data is lost.

The result is that production logs get flooded with a benign warning.

This PR tracks the depth of the queue behind the in-flight rotation and only warns when **more than one** rotation is stacked — which is when a backlog is actually growing and an operator should care.

### Behavior

- 0 queued (no overlap): silent (unchanged)
- 1 queued (the common case, single overlap at a turn boundary): silent (was a `warn`)
- 2+ queued (real backlog): `warn` with the actual depth

### Implementation

- `queuedRotations: number = 0` field on `TranscriptionSynchronizer`
- `rotateSegment()` increments when stacking onto an in-flight task, warns when `> 1`
- `rotateSegmentTaskImpl()` decrements in a `finally` block (floored at 0 to keep the initial constructor-scheduled task safe)

## Test plan

- [x] `pnpm build:agents` — clean
- [x] `pnpm -w test agents/src/voice/transcription/synchronizer.test.ts` — 21/21 pass
- [x] `pnpm -w format:check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)