### PR TITLE
fix(stt): reflect active child in FallbackAdapter model/provider

### DIFF
--- a/.changeset/fallback-adapter-active-child-attribution.md
+++ b/.changeset/fallback-adapter-active-child-attribution.md
@@ -1,0 +1,13 @@
+---
+'@livekit/agents': patch
+---
+
+fix(stt): reflect active child in `FallbackAdapter` `model`/`provider`
+
+`audio_recognition.refreshUserTurnSttAttributes` reads these on every
+STT event to stamp `gen_ai.request.model` / `gen_ai.provider.name`
+on the `user_turn` span. With static wrapper labels, every span
+reported `FallbackAdapter` / `livekit` regardless of which provider
+actually transcribed — so a mid-turn fallover was invisible in
+traces. Track the elected child from both the streaming and
+recognize paths and surface its identifiers.

--- a/agents/src/stt/fallback_adapter.test.ts
+++ b/agents/src/stt/fallback_adapter.test.ts
@@ -333,3 +333,94 @@ describe('FallbackSpeechStream (streaming path)', () => {
     expect(adapter.status[1]?.available).toBe(true);
   });
 });
+
+describe('FallbackAdapter dynamic model/provider getters', () => {
+  // The OTel `gen_ai.request.model` / `gen_ai.provider.name` attributes on
+  // the `user_turn` span are refreshed on every STT event by
+  // `audio_recognition.refreshUserTurnSttAttributes`. Without dynamic
+  // getters that reflect the active child, those attributes are frozen at
+  // the static wrapper labels (`FallbackAdapter` / `livekit`) regardless
+  // of which provider actually transcribed, so a mid-turn fallover is
+  // invisible in traces.
+
+  class IdentifiedFakeSTT extends FakeSTT {
+    private readonly _model: string;
+    private readonly _provider: string;
+    constructor(opts: { label: string; model: string; provider: string; fakeTranscript?: string }) {
+      super({ label: opts.label, fakeTranscript: opts.fakeTranscript });
+      this._model = opts.model;
+      this._provider = opts.provider;
+    }
+    override get model(): string {
+      return this._model;
+    }
+    override get provider(): string {
+      return this._provider;
+    }
+  }
+
+  it('returns wrapper defaults before any STT is active', () => {
+    const a = new IdentifiedFakeSTT({ label: 'a', model: 'a-model', provider: 'a-provider' });
+    const adapter = new FallbackAdapter({ sttInstances: [a] });
+    expect(adapter.model).toBe('FallbackAdapter');
+    expect(adapter.provider).toBe('livekit');
+  });
+
+  it('reflects the active child after a successful recognize()', async () => {
+    const primary = new IdentifiedFakeSTT({
+      label: 'primary',
+      model: 'primary-model',
+      provider: 'primary-provider',
+      fakeTranscript: 'hello',
+    });
+    const adapter = new FallbackAdapter({ sttInstances: [primary] });
+
+    await adapter.recognize(emptyAudioFrame());
+
+    expect(adapter.model).toBe('primary-model');
+    expect(adapter.provider).toBe('primary-provider');
+  });
+
+  it('reflects the fallback child after recognize() falls through', async () => {
+    const primary = new IdentifiedFakeSTT({
+      label: 'primary',
+      model: 'primary-model',
+      provider: 'primary-provider',
+    });
+    // Force primary to throw without touching the IdentifiedFakeSTT constructor
+    // surface — updateOptions is the documented runtime knob on FakeSTT.
+    primary.updateOptions({ fakeException: new APIConnectionError({ message: 'down' }) });
+    const fallback = new IdentifiedFakeSTT({
+      label: 'fallback',
+      model: 'fallback-model',
+      provider: 'fallback-provider',
+      fakeTranscript: 'hello',
+    });
+    const adapter = new FallbackAdapter({ sttInstances: [primary, fallback] });
+
+    await adapter.recognize(emptyAudioFrame());
+
+    expect(adapter.model).toBe('fallback-model');
+    expect(adapter.provider).toBe('fallback-provider');
+  });
+
+  it('reflects the active child once streaming events flow', async () => {
+    const primary = new IdentifiedFakeSTT({
+      label: 'primary',
+      model: 'primary-model',
+      provider: 'primary-provider',
+      fakeTranscript: 'hello world',
+    });
+    const adapter = new FallbackAdapter({ sttInstances: [primary] });
+
+    const stream = adapter.stream();
+    stream.endInput();
+
+    const events: SpeechEvent[] = [];
+    for await (const ev of stream) events.push(ev);
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(adapter.model).toBe('primary-model');
+    expect(adapter.provider).toBe('primary-provider');
+  });
+});

--- a/agents/src/stt/fallback_adapter.ts
+++ b/agents/src/stt/fallback_adapter.ts
@@ -97,6 +97,14 @@ export class FallbackAdapter extends STT {
   private _status: STTStatus[] = [];
   private _logger = log();
   private _metricsForwarders = new Map<STT, (m: STTMetrics) => void>();
+  // Last child that produced output or returned a recognize result. Surfaced
+  // via the dynamic label/model/provider getters so OTel attributes like
+  // `gen_ai.request.model` on `user_turn` (refreshed on every STT event by
+  // {@link audio_recognition.refreshUserTurnSttAttributes}) reflect the
+  // actual provider used, not the wrapper. Not safe to share an adapter
+  // across concurrent sessions/streams — concurrent writers would corrupt
+  // attribution.
+  private _activeStt: STT | undefined;
 
   label = 'stt.FallbackAdapter';
 
@@ -147,12 +155,27 @@ export class FallbackAdapter extends STT {
     this.setupEventForwarding();
   }
 
+  // Reflect the active child's model/provider so OTel `gen_ai.request.model`
+  // and `gen_ai.provider.name` on `user_turn` spans identify the provider
+  // that actually transcribed, not the static wrapper. `audio_recognition.
+  // refreshUserTurnSttAttributes` re-reads these on every STT event, so a
+  // mid-turn fallover surfaces the new child immediately.
   override get model(): string {
-    return 'FallbackAdapter';
+    return this._activeStt?.model ?? 'FallbackAdapter';
   }
 
   override get provider(): string {
-    return 'livekit';
+    return this._activeStt?.provider ?? 'livekit';
+  }
+
+  /**
+   * Record the child that most recently produced output. Called by
+   * `_recognize()` on a successful return and by the streaming path on
+   * every event yielded by the elected child.
+   * @internal
+   */
+  _setActiveStt(stt: STT): void {
+    this._activeStt = stt;
   }
 
   /**
@@ -232,7 +255,9 @@ export class FallbackAdapter extends STT {
       const status = this._status[i]!;
       if (status.available || allFailed) {
         try {
-          return await stt.recognize(frame, abortSignal);
+          const result = await stt.recognize(frame, abortSignal);
+          this._setActiveStt(stt);
+          return result;
         } catch (e) {
           if (e instanceof APIError) {
             this._logger.warn(
@@ -466,6 +491,7 @@ class FallbackSpeechStream extends SpeechStream {
 
         try {
           for await (const ev of child) {
+            this.fallbackAdapter._setActiveStt(sttInstance);
             this.queue.put(ev);
           }
         } finally {


### PR DESCRIPTION
## Description

The STT `FallbackAdapter` exposes static `model` (`'FallbackAdapter'`) and `provider` (`'livekit'`) getters. But `audio_recognition.refreshUserTurnSttAttributes` reads `this.sttInstance.model` / `this.sttInstance.provider` on every STT event to stamp the OTel `gen_ai.request.model` and `gen_ai.provider.name` attributes on the `user_turn` span. Its own docstring describes the intended behaviour:

> Set/refresh the STT model and provider attributes on `user_turn`. Called from `ensureUserTurnSpan` and again on each STT event so providers that switch mid-turn (e.g. `FallbackAdapter`) update the span instead of being frozen at construction-time labels.

Because the getters are static, every `user_turn` span reports `"FallbackAdapter"` / `"livekit"` regardless of which child actually transcribed. A mid-turn fallover is invisible in traces, and the per-provider performance/error comparison that motivates running a `FallbackAdapter` in the first place is lost.

This PR makes the getters reflect the elected child.

## Changes Made

- Add a private `_activeStt: STT | undefined` field on `FallbackAdapter`.
- Override `model` and `provider` to return `this._activeStt?.{model,provider} ?? 'FallbackAdapter'|'livekit'`.
- Expose `_setActiveStt(stt: STT)` (`@internal`) so the co-located `FallbackSpeechStream` can record the elected child without the field becoming public.
- Set `_activeStt` from both paths:
  - `_recognize()`: immediately after a successful `stt.recognize()` returns.
  - Streaming: inside the inner `for await (const ev of child)` loop in `FallbackSpeechStream.run()`, matching the cadence at which `refreshUserTurnSttAttributes` is called.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title

## Testing

- [x] Automated tests added/updated: 4 new cases in a new `FallbackAdapter dynamic model/provider getters` describe block in `agents/src/stt/fallback_adapter.test.ts` covering (1) wrapper defaults before any STT is active, (2) post-`recognize()` reflection, (3) fallback child reflection after recognize fall-through, and (4) the streaming path. They use a small test-local `IdentifiedFakeSTT` subclass of the existing `FakeSTT` harness that overrides `model` / `provider` (the harness doesn't yet expose these as constructor opts).
- [x] All tests pass: `pnpm --filter '@livekit/agents' exec vitest run` → 822 passed, 0 failed in the agents package (full repo-level `pnpm test` has unrelated failures in `examples/` that require real `OPENAI_API_KEY` etc.)
- [x] `pnpm format:check` and `pnpm --filter '@livekit/agents' lint` both clean on the changed files
- [x] `pnpm --filter '@livekit/agents' exec tsc --noEmit` clean

## Additional Notes

Includes a changeset entry (`@livekit/agents`: patch).

The `_activeStt` field is documented as not safe to share an adapter across concurrent sessions/streams — the same caveat already implicitly applies to the existing `_status` array, and the typical pattern is one adapter per session.

This PR is independent of the upstream STT `FallbackAdapter` shutdown-race fix that I understand is also planned for upstream (the `forwardOrShutdown` / `isShuttingDown` work). Both can land in either order.