### PR TITLE
chore: stop gitignoring plugin CHANGELOG.md files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,7 @@ examples/src/test_*.ts
 !README.md
 !.changeset/*.md
 !**/README.md
+!**/CHANGELOG.md
 !CONTRIBUTING.md
 !CLAUDE.md
 !.CODE_OF_CONDUCT.md


### PR DESCRIPTION
## Summary

The blanket `*.md` rule in `.gitignore` (added in #811 on 2025-11-14) has no negation for `CHANGELOG.md`. Plugins that already existed when the rule landed had their `CHANGELOG.md` tracked at the time, so git keeps updating those files. **Every plugin added after 2025-11-14** has its generated `CHANGELOG.md` silently dropped by `git add` during the release commit.

This cascades into two release-side bugs:

1. **No GitHub release gets created.** [`changesets/action`'s `createRelease`](https://github.com/changesets/action/blob/main/src/run.ts) reads `CHANGELOG.md` from disk to build the GitHub release body. For untracked plugins it hits `ENOENT` and silently returns — npm publish still goes out, but no GitHub release ever appears.
2. **Release notes for `@livekit/agents` lose attribution.** When a PR's changeset is scoped only to a plugin (e.g. #1219 → `@livekit/agents-plugin-assemblyai`), the descriptive entry only lives in that plugin's CHANGELOG. With the file gitignored, the description never reaches `main`, and `agents/CHANGELOG.md` only gets the bare "Updated dependencies" line from the fixed-group bump — so the PR shows up nowhere in the published release notes. That's why #1219 is missing from the [`@livekit/agents@1.2.7` release notes](https://github.com/livekit/agents-js/releases/tag/%40livekit%2Fagents%401.2.7) even though it's listed in the version-packages PR (#1233).

**Affected plugins** (added after the rule landed): `assemblyai`, `baseten`, `cerebras`, `fishaudio`, `hedra`, `hume`, `inworld`, `lemonslice`, `liveavatar`, `minimax`, `mistral`, `mistralai`, `phonic`, `runway`, `sarvam`, `trugen`, `xai`.

## Fix

Add `!**/CHANGELOG.md` to `.gitignore`. From the next \`Version Packages\` PR onward, the regenerated CHANGELOG files for these plugins will actually be committed, giving them GitHub releases and proper release-note attribution.

## Note on backfill

Historical 1.2.x–1.4.x GitHub releases for the affected plugins won't be created retroactively by this fix — the original `.changeset/*.md` source files for those versions were already consumed. If the docs scraper needs them, we'd have to reconstruct entries from PR titles + commit history and create the releases via the GitHub API in a separate pass.

## Test plan

- [ ] On the next release, verify the `Version Packages` commit on \`main\` includes new \`plugins/<affected>/CHANGELOG.md\` files.
- [ ] On the next release, verify GitHub releases get created for all affected plugin packages.

Made with [Cursor](https://cursor.com)