### PR TITLE
fix(examples): pin HOME so plugin caches resolve under appuser

### DIFF
--- a/examples/src/Dockerfile-example
+++ b/examples/src/Dockerfile-example
@@ -15,6 +15,9 @@ FROM node:${NODE_VERSION}-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
+# Pin HOME so plugin asset caches land under /app/.cache for appuser
+ENV HOME="/app"
+
 # Install required system packages and pnpm, then clean up the apt cache for a smaller image
 # ca-certificates: enables TLS/SSL for securely fetching dependencies and calling HTTPS services
 # --no-install-recommends keeps the image minimal


### PR DESCRIPTION
## Summary
- Docker's `USER` directive switches UID/GID but doesn't set `$HOME` from `/etc/passwd`, so plugin asset caches under `$HOME/.cache` (Silero VAD, the LiveKit turn detector, HuggingFace, etc.) land in `/root` instead of `/app` and the worker can't find them at startup.
- Pinning `ENV HOME="/app"` makes the cache path deterministic for `appuser`.
- This is the upstream version of a fix carried in the `agent-starter-node` template ([livekit-examples/agent-starter-node#46](https://github.com/livekit-examples/agent-starter-node/pull/46)).

## Test plan
- [ ] Build the example image and confirm `download-files` writes under `/app/.cache/...`.
- [ ] Deploy to LiveKit Cloud and confirm the worker boots without re-downloading plugin assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)