### PR TITLE
fix(generation): preserve LLM-supplied call_id instead of overwriting with item id

### DIFF
--- a/.changeset/cuddly-parrots-hug.md
+++ b/.changeset/cuddly-parrots-hug.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(generation): preserve LLM-supplied call_id instead of overwriting with item id

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -539,7 +539,8 @@ export function performLLMInference(
               if (tool.type !== 'function_call') continue;
 
               const toolCall = FunctionCall.create({
-                callId: `${data.id}/fnc_${data.generatedToolCalls.length}`,
+                id: `${data.id}/fnc_${data.generatedToolCalls.length}`,
+                callId: tool.callId,
                 name: tool.name,
                 args: tool.args,
                 // Preserve thought signature for Gemini 3+ thinking mode

--- a/examples/src/testing/basic_task_group.test.ts
+++ b/examples/src/testing/basic_task_group.test.ts
@@ -436,7 +436,28 @@ describe('basic_task_group', { timeout: 120_000 }, () => {
           toolCalls: [{ name: 'save_email', args: { email: 'charlie@test.com' } }],
         },
         {
-          input: 'Conversation to summarize:\n\nuser: My name is Charlie.\nuser: charlie@test.com',
+          input: [
+            'Conversation to summarize:',
+            '',
+            '<user>',
+            'My name is Charlie.',
+            '</user>',
+            '<function_call name="save_name" call_id="fake_call_0">',
+            '{"name":"Charlie"}',
+            '</function_call>',
+            '<function_call_output name="save_name" call_id="fake_call_0">',
+            '"Saved name: Charlie"',
+            '</function_call_output>',
+            '<user>',
+            'charlie@test.com',
+            '</user>',
+            '<function_call name="save_email" call_id="fake_call_0">',
+            '{"email":"charlie@test.com"}',
+            '</function_call>',
+            '<function_call_output name="save_email" call_id="fake_call_0">',
+            '"Saved email: charlie@test.com"',
+            '</function_call_output>',
+          ].join('\n'),
           content: 'Summary: name=Charlie, email=charlie@test.com.',
         },
       ]);
@@ -461,7 +482,7 @@ describe('basic_task_group', { timeout: 120_000 }, () => {
       );
       expect(summaryMsg).toBeDefined();
       if (summaryMsg && summaryMsg.type === 'message') {
-        expect(summaryMsg.textContent).toContain('[history summary]');
+        expect(summaryMsg.textContent).toContain('<chat_history_summary>');
       }
     });
   });


### PR DESCRIPTION
## Summary

`voice/generation.ts` was overwriting the LLM-supplied `callId` with the generation's per-item UUID. Python keeps these two identifiers distinct (`id` = framework item id, `call_id` = the LLM's identifier that pairs `function_call` ↔ `function_call_output`). This change restores that separation, matching `livekit-agents/.../generation.py:170-176`.

```ts
// before
const toolCall = FunctionCall.create({
  callId: `${data.id}/fnc_${data.generatedToolCalls.length}`,
  name: tool.name,
  args: tool.args,
  ...
});

// after
const toolCall = FunctionCall.create({
  id: `${data.id}/fnc_${data.generatedToolCalls.length}`,
  callId: tool.callId,
  name: tool.name,
  args: tool.args,
  ...
});
```

Also fixes `examples/src/testing/basic_task_group.test.ts > summarizeChatCtx`, which was failing because its `FakeLLM` mock used the old pre-XML prompt format and `[history summary]` literal. Updated to match what `ChatContext._summarize` actually emits; now deterministic since `fake_call_0` survives end-to-end.

## Why this matters

Downstream providers (OpenAI, Anthropic, Gemini, etc.) emit their own `tool_call_id` that we must echo back in `function_call_output` so the provider can correlate the call. Overwriting it silently inverted the invariant from Python.

## Test plan

- [x] `pnpm build:agents && pnpm vitest run examples/src/testing examples/src/frontdesk/test_agent.test.ts examples/src/drive-thru/test_agent.test.ts` — 75/75 pass (was 74/75)
- [x] Full `pnpm test` — no new regressions; remaining failures (AMD logic, plugin TTS VAD setup, missing API keys) reproduce on `main`