### PR TITLE
fix(openai): support `http://` baseURL by mapping to `ws://` (not `wss://`) on WebSocket URLs

### DIFF
--- a/.changeset/openai-ws-url-http-scheme.md
+++ b/.changeset/openai-ws-url-http-scheme.md
@@ -1,0 +1,16 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+fix(openai): map `http://` baseURL to `ws://` (not `wss://`) on WebSocket URLs
+
+The Responses-API LLM (`ws/llm.ts`), realtime STT (`stt.ts`), and
+conversational Realtime endpoint (`realtime/realtime_model.ts`) all
+build their upgrade URL from `baseURL`, but force-mapped (or only
+half-mapped) the scheme to `wss://`. With a plain-HTTP baseURL (e.g.
+an in-cluster LiteLLM proxy at `http://litellm:4000`), this produced
+a `wss://litellm:4000/...` URL, attempted a TLS handshake against a
+non-TLS listener, and failed with `tls_get_more_records:packet length
+too long`. The fix maps `http://` → `ws://` and `https://` → `wss://`.
+OpenAI's native endpoint is always HTTPS, so this is a no-op for
+direct connections.

--- a/.changeset/openai-ws-url-http-scheme.md
+++ b/.changeset/openai-ws-url-http-scheme.md
@@ -2,15 +2,13 @@
 '@livekit/agents-plugin-openai': patch
 ---
 
-fix(openai): map `http://` baseURL to `ws://` (not `wss://`) on WebSocket URLs
+fix(openai): respect `baseURL` scheme when building WebSocket URLs
 
 The Responses-API LLM (`ws/llm.ts`), realtime STT (`stt.ts`), and
 conversational Realtime endpoint (`realtime/realtime_model.ts`) all
-build their upgrade URL from `baseURL`, but force-mapped (or only
-half-mapped) the scheme to `wss://`. With a plain-HTTP baseURL (e.g.
-an in-cluster LiteLLM proxy at `http://litellm:4000`), this produced
-a `wss://litellm:4000/...` URL, attempted a TLS handshake against a
-non-TLS listener, and failed with `tls_get_more_records:packet length
-too long`. The fix maps `http://` → `ws://` and `https://` → `wss://`.
-OpenAI's native endpoint is always HTTPS, so this is a no-op for
-direct connections.
+build their upgrade URL from `baseURL` but either force-mapped
+`http://` to `wss://` (LLM) or left `http://` unchanged (STT, Realtime),
+producing an invalid WebSocket URL or a spurious TLS handshake against
+a plain-HTTP listener. The scheme of `baseURL` is now respected:
+`http://` maps to `ws://` and `https://` maps to `wss://`. OpenAI's
+native endpoint is HTTPS, so this is a no-op for direct connections.

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -348,17 +348,17 @@ describe('processBaseURL', () => {
     expect(url.searchParams.get('model')).toBe('gpt-4o-realtime-preview');
   });
 
-  it('downgrades http baseURL to ws (not wss) for plain-HTTP gateways', () => {
+  it('downgrades http baseURL to ws (not wss)', () => {
     const url = new URL(
       processBaseURL({
-        baseURL: 'http://litellm:4000/v1',
+        baseURL: 'http://gateway.example.com/v1',
         model: 'gpt-4o-realtime-preview',
         isAzure: false,
       }),
     );
 
     expect(url.protocol).toBe('ws:');
-    expect(url.host).toBe('litellm:4000');
+    expect(url.host).toBe('gateway.example.com');
     expect(url.pathname).toBe('/v1/realtime');
     expect(url.searchParams.get('model')).toBe('gpt-4o-realtime-preview');
   });
@@ -379,7 +379,7 @@ describe('processBaseURL', () => {
   it('passes through an already-ws baseURL unchanged', () => {
     const url = new URL(
       processBaseURL({
-        baseURL: 'ws://litellm:4000/v1',
+        baseURL: 'ws://gateway.example.com/v1',
         model: 'gpt-4o-realtime-preview',
         isAzure: false,
       }),

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -4,7 +4,7 @@
 import { llm } from '@livekit/agents';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type * as api_proto from './api_proto.js';
-import { RealtimeModel, livekitItemToOpenAIItem } from './realtime_model.js';
+import { RealtimeModel, livekitItemToOpenAIItem, processBaseURL } from './realtime_model.js';
 
 describe('livekitItemToOpenAIItem', () => {
   describe('message items', () => {
@@ -329,5 +329,63 @@ describe('RealtimeSession.updateOptions', () => {
 
     sessionB.updateOptions({ toolChoice: 'required' });
     expect(sendEventSpyB).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('processBaseURL', () => {
+  it('upgrades https baseURL to wss and appends /realtime with model', () => {
+    const url = new URL(
+      processBaseURL({
+        baseURL: 'https://gateway.example.com/v1',
+        model: 'gpt-4o-realtime-preview',
+        isAzure: false,
+      }),
+    );
+
+    expect(url.protocol).toBe('wss:');
+    expect(url.host).toBe('gateway.example.com');
+    expect(url.pathname).toBe('/v1/realtime');
+    expect(url.searchParams.get('model')).toBe('gpt-4o-realtime-preview');
+  });
+
+  it('downgrades http baseURL to ws (not wss) for plain-HTTP gateways', () => {
+    const url = new URL(
+      processBaseURL({
+        baseURL: 'http://litellm:4000/v1',
+        model: 'gpt-4o-realtime-preview',
+        isAzure: false,
+      }),
+    );
+
+    expect(url.protocol).toBe('ws:');
+    expect(url.host).toBe('litellm:4000');
+    expect(url.pathname).toBe('/v1/realtime');
+    expect(url.searchParams.get('model')).toBe('gpt-4o-realtime-preview');
+  });
+
+  it('passes through an already-wss baseURL unchanged', () => {
+    const url = new URL(
+      processBaseURL({
+        baseURL: 'wss://gateway.example.com/v1',
+        model: 'gpt-4o-realtime-preview',
+        isAzure: false,
+      }),
+    );
+
+    expect(url.protocol).toBe('wss:');
+    expect(url.pathname).toBe('/v1/realtime');
+  });
+
+  it('passes through an already-ws baseURL unchanged', () => {
+    const url = new URL(
+      processBaseURL({
+        baseURL: 'ws://litellm:4000/v1',
+        model: 'gpt-4o-realtime-preview',
+        isAzure: false,
+      }),
+    );
+
+    expect(url.protocol).toBe('ws:');
+    expect(url.pathname).toBe('/v1/realtime');
   });
 });

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -353,9 +353,8 @@ function normalizeAzureClientEvent(event: Record<string, unknown>): void {
 /**
  * Build the conversational Realtime API WebSocket URL.
  *
- * Maps `http://` → `ws://` and `https://` → `wss://` so plain-HTTP
- * baseURLs (e.g. an in-cluster LiteLLM proxy) connect without a
- * spurious TLS handshake.
+ * The scheme of `baseURL` is respected: `http://` maps to `ws://`
+ * and `https://` maps to `wss://`.
  *
  * @internal
  */

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -350,7 +350,16 @@ function normalizeAzureClientEvent(event: Record<string, unknown>): void {
   }
 }
 
-function processBaseURL({
+/**
+ * Build the conversational Realtime API WebSocket URL.
+ *
+ * Maps `http://` → `ws://` and `https://` → `wss://` so plain-HTTP
+ * baseURLs (e.g. an in-cluster LiteLLM proxy) connect without a
+ * spurious TLS handshake.
+ *
+ * @internal
+ */
+export function processBaseURL({
   baseURL,
   model,
   isAzure = false,
@@ -369,6 +378,8 @@ function processBaseURL({
 
   if (url.protocol === 'https:') {
     url.protocol = 'wss:';
+  } else if (url.protocol === 'http:') {
+    url.protocol = 'ws:';
   }
 
   // ensure "/realtime" is added if the path is empty OR "/v1"

--- a/plugins/openai/src/stt.test.ts
+++ b/plugins/openai/src/stt.test.ts
@@ -114,11 +114,13 @@ describe('buildRealtimeSttUrl', () => {
     expect(url.searchParams.get('model')).toBe('gpt-realtime-whisper');
   });
 
-  it('downgrades http baseURL to ws (not wss) for plain-HTTP gateways', () => {
-    const url = new URL(buildRealtimeSttUrl('http://litellm:4000/v1', 'gpt-realtime-whisper'));
+  it('downgrades http baseURL to ws (not wss)', () => {
+    const url = new URL(
+      buildRealtimeSttUrl('http://gateway.example.com/v1', 'gpt-realtime-whisper'),
+    );
 
     expect(url.protocol).toBe('ws:');
-    expect(url.host).toBe('litellm:4000');
+    expect(url.host).toBe('gateway.example.com');
     expect(url.pathname).toBe('/v1/realtime');
     expect(url.searchParams.get('intent')).toBe('transcription');
     expect(url.searchParams.get('model')).toBe('gpt-realtime-whisper');

--- a/plugins/openai/src/stt.test.ts
+++ b/plugins/openai/src/stt.test.ts
@@ -113,6 +113,25 @@ describe('buildRealtimeSttUrl', () => {
     expect(url.searchParams.get('intent')).toBe('transcription');
     expect(url.searchParams.get('model')).toBe('gpt-realtime-whisper');
   });
+
+  it('downgrades http baseURL to ws (not wss) for plain-HTTP gateways', () => {
+    const url = new URL(buildRealtimeSttUrl('http://litellm:4000/v1', 'gpt-realtime-whisper'));
+
+    expect(url.protocol).toBe('ws:');
+    expect(url.host).toBe('litellm:4000');
+    expect(url.pathname).toBe('/v1/realtime');
+    expect(url.searchParams.get('intent')).toBe('transcription');
+    expect(url.searchParams.get('model')).toBe('gpt-realtime-whisper');
+  });
+
+  it('downgrades http baseURL with a trailing slash to ws', () => {
+    const url = new URL(
+      buildRealtimeSttUrl('http://gateway.example.com/v1/', 'gpt-realtime-whisper'),
+    );
+
+    expect(url.protocol).toBe('ws:');
+    expect(url.pathname).toBe('/v1/realtime');
+  });
 });
 
 if (hasOpenAIApiKey) {

--- a/plugins/openai/src/stt.ts
+++ b/plugins/openai/src/stt.ts
@@ -35,9 +35,8 @@ const DEFAULT_REALTIME_MODEL = 'gpt-realtime-whisper';
  * Realtime API. OpenAI's native endpoint accepts and ignores the
  * parameter, so this is a no-op for direct connections.
  *
- * Maps `http://` → `ws://` and `https://` → `wss://` so plain-HTTP
- * baseURLs (e.g. an in-cluster LiteLLM proxy) connect without a
- * spurious TLS handshake.
+ * The scheme of `baseURL` is respected: `http://` maps to `ws://`
+ * and `https://` maps to `wss://`.
  *
  * @internal
  */

--- a/plugins/openai/src/stt.ts
+++ b/plugins/openai/src/stt.ts
@@ -35,12 +35,18 @@ const DEFAULT_REALTIME_MODEL = 'gpt-realtime-whisper';
  * Realtime API. OpenAI's native endpoint accepts and ignores the
  * parameter, so this is a no-op for direct connections.
  *
+ * Maps `http://` → `ws://` and `https://` → `wss://` so plain-HTTP
+ * baseURLs (e.g. an in-cluster LiteLLM proxy) connect without a
+ * spurious TLS handshake.
+ *
  * @internal
  */
 export function buildRealtimeSttUrl(baseURL: string | undefined, model: string): string {
   const url = new URL(baseURL || 'https://api.openai.com/v1');
   if (url.protocol === 'https:') {
     url.protocol = 'wss:';
+  } else if (url.protocol === 'http:') {
+    url.protocol = 'ws:';
   }
 
   const path = url.pathname.replace(/\/$/, '');

--- a/plugins/openai/src/ws/llm.test.ts
+++ b/plugins/openai/src/ws/llm.test.ts
@@ -36,6 +36,23 @@ describe('buildResponsesWsUrl', () => {
     expect(url.pathname).toBe('/v1/responses');
     expect(url.searchParams.get('model')).toBe('gpt-4o-mini');
   });
+
+  it('rewrites http baseURL to ws (not wss) for plain-HTTP gateways', () => {
+    const url = new URL(buildResponsesWsUrl('http://litellm:4000/v1', 'gpt-4o-mini'));
+
+    expect(url.protocol).toBe('ws:');
+    expect(url.host).toBe('litellm:4000');
+    expect(url.pathname).toBe('/v1/responses');
+    expect(url.searchParams.get('model')).toBe('gpt-4o-mini');
+  });
+
+  it('strips a trailing slash on an http baseURL before appending /responses', () => {
+    const url = new URL(buildResponsesWsUrl('http://gateway.example.com/v1/', 'gpt-4o-mini'));
+
+    expect(url.protocol).toBe('ws:');
+    expect(url.pathname).toBe('/v1/responses');
+    expect(url.searchParams.get('model')).toBe('gpt-4o-mini');
+  });
 });
 
 if (hasOpenAIApiKey) {

--- a/plugins/openai/src/ws/llm.test.ts
+++ b/plugins/openai/src/ws/llm.test.ts
@@ -37,11 +37,11 @@ describe('buildResponsesWsUrl', () => {
     expect(url.searchParams.get('model')).toBe('gpt-4o-mini');
   });
 
-  it('rewrites http baseURL to ws (not wss) for plain-HTTP gateways', () => {
-    const url = new URL(buildResponsesWsUrl('http://litellm:4000/v1', 'gpt-4o-mini'));
+  it('rewrites http baseURL to ws (not wss)', () => {
+    const url = new URL(buildResponsesWsUrl('http://gateway.example.com/v1', 'gpt-4o-mini'));
 
     expect(url.protocol).toBe('ws:');
-    expect(url.host).toBe('litellm:4000');
+    expect(url.host).toBe('gateway.example.com');
     expect(url.pathname).toBe('/v1/responses');
     expect(url.searchParams.get('model')).toBe('gpt-4o-mini');
   });

--- a/plugins/openai/src/ws/llm.ts
+++ b/plugins/openai/src/ws/llm.ts
@@ -41,11 +41,15 @@ const WS_MAX_SESSION_DURATION = 3_600_000;
  * Realtime API. OpenAI's native endpoint accepts and ignores the
  * parameter, so this is a no-op for direct connections.
  *
+ * Maps `http://` → `ws://` and `https://` → `wss://` so plain-HTTP
+ * baseURLs (e.g. an in-cluster LiteLLM proxy) connect without a
+ * spurious TLS handshake.
+ *
  * @internal
  */
 export function buildResponsesWsUrl(baseURL: string | undefined, model: string): string {
   const base = baseURL
-    ? `${baseURL.replace(/^https?/, 'wss').replace(/\/+$/, '')}/responses`
+    ? `${baseURL.replace(/^http(s?):/, 'ws$1:').replace(/\/+$/, '')}/responses`
     : OPENAI_RESPONSES_WS_URL;
   const url = new URL(base);
   url.searchParams.set('model', model);

--- a/plugins/openai/src/ws/llm.ts
+++ b/plugins/openai/src/ws/llm.ts
@@ -41,9 +41,8 @@ const WS_MAX_SESSION_DURATION = 3_600_000;
  * Realtime API. OpenAI's native endpoint accepts and ignores the
  * parameter, so this is a no-op for direct connections.
  *
- * Maps `http://` → `ws://` and `https://` → `wss://` so plain-HTTP
- * baseURLs (e.g. an in-cluster LiteLLM proxy) connect without a
- * spurious TLS handshake.
+ * The scheme of `baseURL` is respected: `http://` maps to `ws://`
+ * and `https://` maps to `wss://`.
  *
  * @internal
  */


### PR DESCRIPTION
## Summary

The OpenAI plugin's three WebSocket URL builders (Responses-API LLM, realtime STT, conversational Realtime) all derive their upgrade URL from `baseURL` but assumed the scheme was always HTTPS — either by force-mapping `http://` and `https://` to `wss://` via regex, or by only handling `https:` → `wss:` and leaving `http:` unchanged. With a plain-HTTP `baseURL`, this produced either an invalid WebSocket URL or a spurious TLS handshake against a non-TLS listener.

The scheme of `baseURL` is now respected: `http://` maps to `ws://` and `https://` maps to `wss://`. OpenAI's native endpoint is HTTPS, so this is a no-op for direct connections; the change unbreaks OpenAI-compatible proxy / gateway setups (which might be in-cluster, no TLS), which are an explicit design goal of `baseURL` parameter support.

### Files

- `plugins/openai/src/ws/llm.ts` — `buildResponsesWsUrl`: regex `/^https?/, 'wss'` → `/^http(s?):/, 'ws$1:'`
- `plugins/openai/src/stt.ts` — `buildRealtimeSttUrl`: add `else if (url.protocol === 'http:') url.protocol = 'ws:'`
- `plugins/openai/src/realtime/realtime_model.ts` — `processBaseURL`: same `http:` → `ws:` branch; exported for unit testing

### Prior art

#1467 added gateway routing via `?model=` to these same builders. This PR addresses a separate assumption (`baseURL` is always HTTPS) inherited from before #1467 — same proxy use case, complementary fix.

## Test plan

- [x] `pnpm install`
- [x] `pnpm build:agents && pnpm --filter "@livekit/agents-plugin-openai..." build` — succeeds
- [x] `pnpm test -- --run plugins/openai` — 35 passed, 7 skipped (require `OPENAI_API_KEY`)
- [x] `pnpm --filter @livekit/agents-plugin-openai lint` — only pre-existing warnings; no new findings
- [x] `pnpm format:check` — clean
- [x] Unit tests added for `http://` baseURLs in all three builders, plus regression guards for `https://` / `wss://` / `ws://` passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)