### PR TITLE
Surface AssemblyAI language confidence metadata

### DIFF
--- a/.changeset/assemblyai-language-confidence.md
+++ b/.changeset/assemblyai-language-confidence.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-assemblyai': patch
+---
+
+Surface AssemblyAI language confidence on speech event metadata.

--- a/plugins/assemblyai/src/stt-metadata.test.ts
+++ b/plugins/assemblyai/src/stt-metadata.test.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { stt as sttLib } from '@livekit/agents';
+import { AudioFrame } from '@livekit/rtc-node';
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
+import { describe, expect, it } from 'vitest';
+import { WebSocketServer } from 'ws';
+import { STT } from './stt.js';
+
+function makeFrame(samplesPerChannel = 800, sampleRate = 16000): AudioFrame {
+  const data = new Int16Array(samplesPerChannel);
+  data.fill(1);
+  return new AudioFrame(data, sampleRate, 1, samplesPerChannel);
+}
+
+async function startWebSocketServer() {
+  const wss = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  await once(wss, 'listening');
+  const address = wss.address() as AddressInfo;
+  return { wss, baseUrl: `ws://127.0.0.1:${address.port}` };
+}
+
+async function closeWebSocketServer(wss: WebSocketServer): Promise<void> {
+  await new Promise<void>((resolve) => wss.close(() => resolve()));
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+async function collectUntilEnd(stream: sttLib.SpeechStream): Promise<sttLib.SpeechEvent[]> {
+  const events: sttLib.SpeechEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+    if (event.type === sttLib.SpeechEventType.END_OF_SPEECH) break;
+  }
+  return events;
+}
+
+describe('AssemblyAI STT metadata', () => {
+  it('maps turn confidence fields onto speech data metadata', async () => {
+    const { wss, baseUrl } = await startWebSocketServer();
+    let requestUrl = '';
+
+    wss.on('connection', (ws, req) => {
+      requestUrl = req.url ?? '';
+      ws.on('message', () => {
+        ws.send(
+          JSON.stringify({
+            type: 'Turn',
+            transcript: 'hola mundo',
+            utterance: 'hola mundo',
+            end_of_turn: true,
+            language_code: 'es',
+            language_confidence: 0.94,
+            words: [
+              { text: 'hola', start: 0, end: 200, confidence: 0.96 },
+              { text: 'mundo', start: 200, end: 500, confidence: 0.98 },
+            ],
+          }),
+        );
+      });
+    });
+
+    try {
+      const assemblyai = new STT({
+        apiKey: 'test-key',
+        baseUrl,
+        speechModel: 'u3-rt-pro',
+      });
+      const stream = assemblyai.stream({
+        connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1000 },
+      });
+
+      await waitUntil(() => requestUrl !== '');
+
+      stream.pushFrame(makeFrame());
+      stream.endInput();
+
+      const events = await collectUntilEnd(stream);
+      stream.close();
+
+      expect(new URL(`ws://127.0.0.1${requestUrl}`).pathname).toBe('/v3/ws');
+      expect(
+        events
+          .filter((event) => event.alternatives?.[0])
+          .map((event) => ({
+            type: event.type,
+            language: event.alternatives?.[0]?.language,
+            metadata: event.alternatives?.[0]?.metadata,
+          })),
+      ).toEqual([
+        {
+          type: sttLib.SpeechEventType.INTERIM_TRANSCRIPT,
+          language: 'es',
+          metadata: {
+            assemblyai: {
+              languageConfidence: 0.94,
+            },
+          },
+        },
+        {
+          type: sttLib.SpeechEventType.PREFLIGHT_TRANSCRIPT,
+          language: 'es',
+          metadata: {
+            assemblyai: {
+              languageConfidence: 0.94,
+            },
+          },
+        },
+        {
+          type: sttLib.SpeechEventType.FINAL_TRANSCRIPT,
+          language: 'es',
+          metadata: {
+            assemblyai: {
+              languageConfidence: 0.94,
+            },
+          },
+        },
+      ]);
+    } finally {
+      await closeWebSocketServer(wss);
+    }
+  });
+});

--- a/plugins/assemblyai/src/stt.ts
+++ b/plugins/assemblyai/src/stt.ts
@@ -40,6 +40,7 @@ interface StreamEventMessage {
   end_of_turn_confidence?: number;
   turn_is_formatted?: boolean;
   language_code?: string;
+  language_confidence?: number;
   speaker_label?: string;
   words?: Array<{
     text?: string;
@@ -51,6 +52,18 @@ interface StreamEventMessage {
   // Termination
   audio_duration_seconds?: number;
   session_duration_seconds?: number;
+}
+
+function speechDataMetadata(data: StreamEventMessage): stt.SpeechData['metadata'] | undefined {
+  const assemblyai: Record<string, number> = {};
+
+  if (typeof data.language_confidence === 'number') {
+    assemblyai.languageConfidence = data.language_confidence;
+  }
+
+  if (Object.keys(assemblyai).length === 0) return undefined;
+
+  return { assemblyai };
 }
 
 export interface STTOptions {
@@ -522,6 +535,7 @@ export class SpeechStream extends stt.SpeechStream {
     const utterance = data.utterance ?? '';
     const transcript = data.transcript ?? '';
     const language = normalizeLanguage(data.language_code ?? 'en');
+    const metadata = speechDataMetadata(data);
 
     // Word timestamps are in milliseconds:
     // https://www.assemblyai.com/docs/api-reference/streaming-api/streaming-api#receive.receiveTurn.words
@@ -556,6 +570,7 @@ export class SpeechStream extends stt.SpeechStream {
             endTime,
             confidence,
             words: timedWords,
+            ...(metadata ? { metadata } : {}),
           },
         ],
       });
@@ -583,6 +598,7 @@ export class SpeechStream extends stt.SpeechStream {
             endTime,
             confidence: utteranceConfidence,
             words: utteranceWords,
+            ...(metadata ? { metadata } : {}),
           },
         ],
       });
@@ -603,6 +619,7 @@ export class SpeechStream extends stt.SpeechStream {
             endTime,
             confidence,
             words: timedWords,
+            ...(metadata ? { metadata } : {}),
           },
         ],
       });


### PR DESCRIPTION
## Summary

- Parse `language_confidence` from AssemblyAI Universal Streaming `Turn` messages.
- Attach the value to emitted transcript alternatives as `metadata.assemblyai.languageConfidence`.
- Cover interim, preflight, and final transcript events with a local WebSocket unit test.

## Why

The AssemblyAI stream already returns both `language_code` and `language_confidence` on turn events when language detection is active. The JS plugin currently maps `language_code` into the standard `SpeechData.language` field but drops the accompanying confidence score.

Keeping the confidence in provider-specific metadata gives applications a practical signal for routing, language-switch detection, analytics, and debugging without changing the framework's core `SpeechData` shape. It also follows the existing `SpeechData.metadata` contract for provider diagnostics that do not map to standard fields.

The metadata is nested under `assemblyai` so it remains clearly provider-specific and does not collide with metadata from other STT providers.

## Validation

- `pnpm exec vitest run plugins/assemblyai/src/stt-metadata.test.ts`
- `pnpm --filter @livekit/agents-plugin-assemblyai lint`
- `pnpm exec prettier --check plugins/assemblyai/src/stt.ts plugins/assemblyai/src/stt-metadata.test.ts .changeset/assemblyai-language-confidence.md`
- `pnpm --filter @livekit/agents-plugin-assemblyai build`

I also ran `pnpm --filter @livekit/agents-plugin-assemblyai api:check`; it reached API Extractor but exited nonzero on the existing missing API report/release-tag/unresolved-link warnings for this plugin rather than a new type error.
