### PR TITLE
fix(google): surface empty Gemini realtime turnComplete as recoverable error

### DIFF
--- a/.changeset/google-realtime-empty-turn-complete.md
+++ b/.changeset/google-realtime-empty-turn-complete.md
@@ -1,0 +1,15 @@
+---
+'@livekit/agents-plugin-google': patch
+---
+
+fix(google): surface empty Gemini realtime turnComplete as recoverable error
+
+Gemini's Live API occasionally emits a `turnComplete` with no audio, no
+text, and no tool calls (upstream bug
+[googleapis/python-genai#2117](https://github.com/googleapis/python-genai/issues/2117)),
+leaving the agent in `speaking` state with nothing to play. The realtime
+plugin now emits a recoverable `APIStatusError` on those turns so the
+upstream `AgentActivity` can retry, matching the intent of the Python
+sibling fix in [livekit/agents#4249](https://github.com/livekit/agents/pull/4249).
+Tool-call-only turns and turns with any audio or text output are
+unaffected. Closes [#1450](https://github.com/livekit/agents-js/issues/1450).

--- a/plugins/google/src/beta/realtime/realtime_api.test.ts
+++ b/plugins/google/src/beta/realtime/realtime_api.test.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { Behavior, FunctionResponseScheduling } from '@google/genai';
-import { llm } from '@livekit/agents';
+import { APIStatusError, llm } from '@livekit/agents';
 import { describe, expect, it, vi } from 'vitest';
 import { RealtimeSession } from './realtime_api.js';
 
@@ -13,23 +13,32 @@ type ToolCallStatus = {
   createdAt: number;
 };
 
+type GenerationLike = {
+  functionChannel: {
+    closed: boolean;
+    write: ReturnType<typeof vi.fn>;
+  };
+  outputText?: string;
+  _firstTokenTimestamp?: number;
+  _hadToolCall?: boolean;
+  responseId?: string;
+};
+
 type RealtimeSessionInternals = {
   options: {
     toolBehavior?: Behavior;
     toolResponseScheduling?: FunctionResponseScheduling;
     vertexai?: boolean;
   };
-  currentGeneration?: {
-    functionChannel: {
-      closed: boolean;
-      write: ReturnType<typeof vi.fn>;
-    };
-  };
+  currentGeneration?: GenerationLike;
+  generationPendingTurnComplete?: GenerationLike;
+  earlyCompletionPending?: boolean;
   pendingToolCallIds: Set<string>;
   toolCallStatuses: Map<string, ToolCallStatus>;
   toolResponseCallIds: WeakMap<Record<string, unknown>, string>;
   sendClientEvent: ReturnType<typeof vi.fn>;
   markCurrentGenerationDone: ReturnType<typeof vi.fn>;
+  emitError: ReturnType<typeof vi.fn>;
   getToolResultsForRealtime(
     ctx: llm.ChatContext,
     vertexai: boolean,
@@ -40,6 +49,11 @@ type RealtimeSessionInternals = {
       name?: string;
       args?: Record<string, unknown>;
     }>;
+  }): void;
+  handleServerContent(serverContent: {
+    turnComplete?: boolean;
+    generationComplete?: boolean;
+    interrupted?: boolean;
   }): void;
   clearPendingToolCallIdsForResponses(functionResponses: Array<Record<string, unknown>>): void;
 };
@@ -178,5 +192,122 @@ describe('Google Realtime non-blocking tool scheduling', () => {
     session.clearPendingToolCallIdsForResponses(result?.functionResponses ?? []);
 
     expect(session.pendingToolCallIds.has('call_123')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1450 — Gemini realtime empty turnComplete handling
+// ---------------------------------------------------------------------------
+
+function makeGen(overrides: Partial<GenerationLike> = {}): GenerationLike {
+  return {
+    functionChannel: { closed: false, write: vi.fn() },
+    outputText: '',
+    _hadToolCall: false,
+    responseId: 'GR_test',
+    ...overrides,
+  };
+}
+
+function createEmptyTurnSession(): RealtimeSessionInternals {
+  const session = Object.create(RealtimeSession.prototype) as RealtimeSessionInternals;
+  session.options = { toolBehavior: Behavior.NON_BLOCKING, vertexai: false };
+  session.pendingToolCallIds = new Set();
+  session.toolCallStatuses = new Map();
+  session.toolResponseCallIds = new WeakMap();
+  session.sendClientEvent = vi.fn();
+  session.markCurrentGenerationDone = vi.fn();
+  session.emitError = vi.fn();
+  session.earlyCompletionPending = false;
+  return session;
+}
+
+describe('Google Realtime empty turnComplete handling (#1450)', () => {
+  it('emits recoverable error when turnComplete arrives with no audio, text, or tool calls', () => {
+    const session = createEmptyTurnSession();
+    session.currentGeneration = makeGen({ responseId: 'GR_empty' });
+
+    session.handleServerContent({ turnComplete: true });
+
+    expect(session.emitError).toHaveBeenCalledTimes(1);
+    const [errorArg, recoverableArg] = session.emitError.mock.calls[0]!;
+    expect(recoverableArg).toBe(true);
+    expect(errorArg).toBeInstanceOf(APIStatusError);
+    expect((errorArg as APIStatusError).message).toContain(
+      'no audio, text, or tool call output',
+    );
+    expect((errorArg as APIStatusError).retryable).toBe(true);
+    expect((errorArg as APIStatusError).requestId).toBe('GR_empty');
+    expect(session.markCurrentGenerationDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit error when turnComplete arrives after audio output', () => {
+    const session = createEmptyTurnSession();
+    session.currentGeneration = makeGen({ _firstTokenTimestamp: Date.now() });
+
+    session.handleServerContent({ turnComplete: true });
+
+    expect(session.emitError).not.toHaveBeenCalled();
+    expect(session.markCurrentGenerationDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit error when text output was emitted', () => {
+    const session = createEmptyTurnSession();
+    session.currentGeneration = makeGen({ outputText: 'hi' });
+
+    session.handleServerContent({ turnComplete: true });
+
+    expect(session.emitError).not.toHaveBeenCalled();
+    expect(session.markCurrentGenerationDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit error when toolCall arrived in the same LiveServerMessage', () => {
+    // Catches C1: handleServerContent runs *before* handleToolCall inside
+    // onReceiveMessage, so _hadToolCall must be set synchronously up-front.
+    // We simulate that synchronous set here: the fix marks the flag the moment
+    // onReceiveMessage sees response.toolCall, before delegating to
+    // handleServerContent. Without that pre-set, the empty-turnComplete check
+    // below would fire a false positive.
+    const session = createEmptyTurnSession();
+    const gen = makeGen({ responseId: 'GR_tool' });
+    session.currentGeneration = gen;
+
+    // Synchronous set mirroring the new code in onReceiveMessage:
+    //   if (response.toolCall && this.currentGeneration) {
+    //     this.currentGeneration._hadToolCall = true;
+    //   }
+    if (session.currentGeneration) {
+      session.currentGeneration._hadToolCall = true;
+    }
+
+    session.handleServerContent({ turnComplete: true });
+
+    expect(session.emitError).not.toHaveBeenCalled();
+    expect(session.markCurrentGenerationDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks the stashed pending generation when generationPendingTurnComplete is set', () => {
+    // Catches C3: when a previous gen is stashed in generationPendingTurnComplete,
+    // the next turnComplete belongs to *that* stashed gen, not the active one.
+    const session = createEmptyTurnSession();
+    const stashed = makeGen({
+      responseId: 'GR_stashed_empty',
+      outputText: '',
+      _hadToolCall: false,
+    });
+    const active = makeGen({
+      responseId: 'GR_active_with_tool',
+      _hadToolCall: true,
+    });
+    session.generationPendingTurnComplete = stashed;
+    session.currentGeneration = active;
+
+    session.handleServerContent({ turnComplete: true });
+
+    expect(session.emitError).toHaveBeenCalledTimes(1);
+    const [errorArg] = session.emitError.mock.calls[0]!;
+    expect(errorArg).toBeInstanceOf(APIStatusError);
+    // requestId points at the *stashed* gen, not the active currentGeneration.
+    expect((errorArg as APIStatusError).requestId).toBe('GR_stashed_empty');
   });
 });

--- a/plugins/google/src/beta/realtime/realtime_api.test.ts
+++ b/plugins/google/src/beta/realtime/realtime_api.test.ts
@@ -233,9 +233,7 @@ describe('Google Realtime empty turnComplete handling (#1450)', () => {
     const [errorArg, recoverableArg] = session.emitError.mock.calls[0]!;
     expect(recoverableArg).toBe(true);
     expect(errorArg).toBeInstanceOf(APIStatusError);
-    expect((errorArg as APIStatusError).message).toContain(
-      'no audio, text, or tool call output',
-    );
+    expect((errorArg as APIStatusError).message).toContain('no audio, text, or tool call output');
     expect((errorArg as APIStatusError).retryable).toBe(true);
     expect((errorArg as APIStatusError).requestId).toBe('GR_empty');
     expect(session.markCurrentGenerationDone).toHaveBeenCalledTimes(1);

--- a/plugins/google/src/beta/realtime/realtime_api.ts
+++ b/plugins/google/src/beta/realtime/realtime_api.ts
@@ -137,6 +137,13 @@ interface ResponseGeneration {
   _completedTimestamp?: number;
   /** @internal */
   _done: boolean;
+  /**
+   * Whether a tool call has been seen on this generation. Used to avoid
+   * false-positive empty-turnComplete errors on tool-call-only turns
+   * (see livekit/agents-js#1450).
+   * @internal
+   */
+  _hadToolCall?: boolean;
 }
 
 interface ToolCallStatus {
@@ -1249,6 +1256,14 @@ export class RealtimeSession extends llm.RealtimeSession {
     }
 
     try {
+      // A single LiveServerMessage can carry both serverContent.turnComplete
+      // and toolCall. Mark _hadToolCall up-front so the empty-turnComplete
+      // check inside handleServerContent (below) does not fire a false
+      // positive for tool-call-only turns. See livekit/agents-js#1450.
+      if (response.toolCall && this.currentGeneration) {
+        this.currentGeneration._hadToolCall = true;
+      }
+
       if (response.serverContent) {
         this.handleServerContent(response.serverContent);
       }
@@ -1512,6 +1527,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       outputText: '',
       _createdTimestamp: Date.now(),
       _done: false,
+      _hadToolCall: false,
     };
 
     // Close audio stream if audio output is not supported by the model
@@ -1652,6 +1668,33 @@ export class RealtimeSession extends llm.RealtimeSession {
     }
 
     if (serverContent.turnComplete && !this.earlyCompletionPending) {
+      // Gemini occasionally emits a premature turnComplete with no audio, no
+      // text, and no tool calls (upstream bug googleapis/python-genai#2117).
+      // Surface as a recoverable error so the upstream agent activity can
+      // retry, mirroring the Python sibling fix in livekit/agents#4249.
+      // The check must run against the generation that *owns* this
+      // turnComplete: when a previous gen is stashed as
+      // generationPendingTurnComplete, that stashed gen owns the turnComplete,
+      // not currentGeneration. See livekit/agents-js#1450.
+      const completingGen = this.generationPendingTurnComplete ?? this.currentGeneration;
+      if (
+        completingGen &&
+        !this.generationHasOutput(completingGen) &&
+        !completingGen._hadToolCall
+      ) {
+        this.emitError(
+          new APIStatusError({
+            message:
+              'Gemini realtime: turn completed with no audio, text, or tool call output (see livekit/agents-js#1450)',
+            options: {
+              retryable: true,
+              requestId: completingGen.responseId,
+            },
+          }),
+          true,
+        );
+      }
+
       if (this.generationPendingTurnComplete) {
         this.markCurrentGenerationDone(false, this.generationPendingTurnComplete);
         this.generationPendingTurnComplete = undefined;
@@ -1727,6 +1770,10 @@ export class RealtimeSession extends llm.RealtimeSession {
         }),
       );
     }
+    // Track that this generation had at least one tool call so that any
+    // subsequent empty turnComplete does not surface as a recoverable error.
+    // See livekit/agents-js#1450.
+    gen._hadToolCall = true;
     // This closes message/text/audio/function streams so the consumer can continue.
     this.markCurrentGenerationDone();
   }


### PR DESCRIPTION
## Summary

Closes #1450.

Gemini's Live API occasionally emits a `turnComplete` for a generation that produced no audio, no text, and no tool calls (upstream bug [googleapis/python-genai#2117](https://github.com/googleapis/python-genai/issues/2117)). When that happens today, `@livekit/agents-plugin-google` silently marks the generation done; the agent enters `speaking` state with nothing to play, the turn ends, and downstream `AgentActivity` retry/fallback never kicks in. The issue reporter sees this on ~50% of production phone-call turns against `gemini-3.1-flash-live-preview`.

This PR ports the *intent* of the already-merged Python sibling fix [livekit/agents#4249](https://github.com/livekit/agents/pull/4249) — surface the empty response as a retryable error — to the JS realtime streaming model, where the analog of `raise APIStatusError(retryable=True)` is `emit('error', { recoverable: true })`.

## The fix

```ts
// realtime_api.ts: handleServerContent turnComplete branch
const completingGen = this.generationPendingTurnComplete ?? this.currentGeneration;
if (
  completingGen &&
  !this.generationHasOutput(completingGen) &&
  !completingGen._hadToolCall
) {
  this.emitError(
    new APIStatusError({
      message:
        'Gemini realtime: turn completed with no audio, text, or tool call output (see livekit/agents-js#1450)',
      options: { retryable: true, requestId: completingGen.responseId },
    }),
    true,
  );
}
```

Plus the two false-positive guards described next.

## False-positive guards

1. **Tool-call-only turns.** A valid generation can emit zero audio and zero text when the model only produces a function call. We track this with a new `_hadToolCall?: boolean` field on `ResponseGeneration`, initialized to `false` in `startNewGeneration` and set to `true` inside `handleToolCall`.

2. **Same-message ordering race.** A single `LiveServerMessage` can carry both `serverContent.turnComplete` and `toolCall`. Inside `onReceiveMessage`, `handleServerContent` runs **before** `handleToolCall`, so the empty check would see `_hadToolCall === false` and emit a false-positive error. We fix this by setting `_hadToolCall = true` synchronously in `onReceiveMessage` the moment we see `response.toolCall`, before delegating to `handleServerContent`:

   ```ts
   if (response.toolCall && this.currentGeneration) {
     this.currentGeneration._hadToolCall = true;
   }
   ```

3. **Stashed pending generation.** When `startNewGeneration` runs while the previous gen still has an open function channel, it stashes the previous gen as `generationPendingTurnComplete`. The next `turnComplete` belongs to that **stashed** gen, not `currentGeneration`. The check resolves the correct generation as `this.generationPendingTurnComplete ?? this.currentGeneration` and emits the error with the stashed gen's `responseId`.

## Test plan

Five new tests in `plugins/google/src/beta/realtime/realtime_api.test.ts` under `describe('Google Realtime empty turnComplete handling (#1450)')`:

- `emits recoverable error when turnComplete arrives with no audio, text, or tool calls` — asserts `APIStatusError`, `recoverable: true`, `retryable: true`, `requestId` matches the empty gen.
- `does not emit error when turnComplete arrives after audio output` — `_firstTokenTimestamp` set.
- `does not emit error when text output was emitted` — `outputText: 'hi'`.
- `does not emit error when toolCall arrived in the same LiveServerMessage` — verifies the C1 guard: with `_hadToolCall` set synchronously before `handleServerContent` runs, no error fires.
- `checks the stashed pending generation when generationPendingTurnComplete is set` — verifies the C3 fix: when the active `currentGeneration` has tool calls but the stashed gen is empty, the error fires against the stashed gen's `responseId`, not the active one's.

```
$ npx vitest run plugins/google/src/beta/realtime/realtime_api.test.ts

 RUN  v4.0.17

 ✓ plugins/google/src/beta/realtime/realtime_api.test.ts (12 tests) 5ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Verification commands run locally (Node 22, pnpm 9.7):

- `npx vitest run plugins/google/src/beta/realtime/realtime_api.test.ts` — green.
- `npx vitest run plugins/google/src/llm.test.ts` — green (1 skipped, no API key).
- `pnpm format:check` — green.
- `pnpm lint` (google plugin) — clean for changed files; preexisting `no-explicit-any` warnings on `loggableClientEvent`/`loggableServerMessage` (lines 1307/1336/1344) are untouched by this PR.
- `pnpm api:check` (google plugin) — same preexisting api-extractor incompatibility with TS 5.9 that exists on `main` (unrelated `export * as` syntax error in generated `dist/index.d.ts`). No new public surface added by this PR.
- `pnpm changeset` added as patch on `@livekit/agents-plugin-google`.

## Backwards compatibility

- No public API change. No new exports, no new options.
- Consumers of `'error'` events on the realtime session will now see one recoverable error on previously-silent empty `turnComplete` events — the desired behavior per the issue.
- Audio, text, tool-call-only, and mixed turns are unaffected.

## Out of scope

- Suppression config option (no demand; Python fix doesn't have one either).
- Porting the LLM-side empty-response check from livekit/agents#4249 to `plugins/google/src/llm.ts`. Happy to file as a follow-up.
- Symmetric handling of `generationComplete` (Python fix didn't either).

cc @toubatbrian
