### PR TITLE
feat(agents): add attachOtelTracer helper for OpenTelemetry span emission

### DIFF
--- a/.changeset/attach-otel-tracer.md
+++ b/.changeset/attach-otel-tracer.md
@@ -1,0 +1,10 @@
+---
+'@livekit/agents': patch
+---
+
+feat(agents): add `metrics.attachOtelTracer(session, tracer)` helper
+
+Subscribes to an `AgentSession`'s `metrics_collected` events and emits OpenTelemetry
+spans following the `gen_ai.*` semantic conventions for LLM, STT, TTS, Realtime, EOU,
+Interruption, and VAD metrics. Returns an unsubscribe function. Resolves #1407 (related
+to #757).

--- a/agents/src/metrics/index.ts
+++ b/agents/src/metrics/index.ts
@@ -22,5 +22,6 @@ export {
   type STTModelUsage,
   type TTSModelUsage,
 } from './model_usage.js';
+export { attachOtelTracer, type AttachOtelTracerOptions, type OtelSpanVariant } from './otel.js';
 export { UsageCollector, type UsageSummary } from './usage_collector.js';
 export { logMetrics } from './utils.js';

--- a/agents/src/metrics/otel.test.ts
+++ b/agents/src/metrics/otel.test.ts
@@ -382,6 +382,150 @@ describe('attachOtelTracer', () => {
     expect(span!.attributes['gen_ai.response.id']).toBe('req-no-meta');
   });
 
+  it('span startTime and endTime are within +/-5s of the metric timestamp (Devin AI #1545)', () => {
+    // Regression for the ~51-year-future bug: OTel's timeInputToHrTime treats a
+    // plain number as a performance.now() value and adds timeOrigin to it. Plain
+    // Date.now() epoch ms therefore landed in year ~2075. Wrapping in new Date()
+    // routes through millisToHrTime, which is the correct path for epoch ms.
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const now = Date.now();
+    const metrics: LLMMetrics = {
+      type: 'llm_metrics',
+      label: 'openai.LLM',
+      requestId: 'req-time',
+      timestamp: now,
+      durationMs: 250,
+      ttftMs: 80,
+      cancelled: false,
+      completionTokens: 1,
+      promptTokens: 1,
+      promptCachedTokens: 0,
+      totalTokens: 2,
+      tokensPerSecond: 10,
+      metadata: { modelProvider: 'openai', modelName: 'gpt-4o-mini' },
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span).toBeDefined();
+    // hrTime is [seconds, nanoseconds]; convert to epoch ms.
+    const startMs = span!.startTime[0] * 1000 + span!.startTime[1] / 1e6;
+    const endMs = span!.endTime[0] * 1000 + span!.endTime[1] / 1e6;
+    // Without the fix, startMs/endMs land ~ Date.now() + (Date.now() - performance.now())
+    // which is roughly 2 * Date.now(), i.e. year ~2075 (>1.6e12 ms in the future).
+    expect(Math.abs(startMs - (now - metrics.durationMs))).toBeLessThan(5_000);
+    expect(Math.abs(endMs - now)).toBeLessThan(5_000);
+  });
+
+  it('captures Date instances at the OTel boundary for every metric type (regression for #1545)', () => {
+    const session = makeFakeSession();
+    const captured: { startTime?: unknown; endTime?: unknown }[] = [];
+    const fakeTracer = {
+      startSpan: (_name: string, opts?: { startTime?: unknown }) => {
+        const entry: { startTime?: unknown; endTime?: unknown } = { startTime: opts?.startTime };
+        captured.push(entry);
+        return {
+          setStatus: () => {},
+          end: (endTime?: unknown) => {
+            entry.endTime = endTime;
+          },
+        };
+      },
+    } as unknown as Parameters<typeof attachOtelTracer>[1];
+    attachOtelTracer(session, fakeTracer);
+
+    const now = Date.now();
+    const base = {
+      timestamp: now,
+      durationMs: 100,
+      ttftMs: 50,
+      cancelled: false,
+    } as const;
+    // Cover all 7 metric variants.
+    emit(session, {
+      ...base,
+      type: 'llm_metrics',
+      label: 'l',
+      requestId: 'r',
+      completionTokens: 1,
+      promptTokens: 1,
+      promptCachedTokens: 0,
+      totalTokens: 2,
+      tokensPerSecond: 10,
+    });
+    emit(session, {
+      type: 'stt_metrics',
+      label: 's',
+      requestId: 'r',
+      timestamp: now,
+      durationMs: 100,
+      audioDurationMs: 500,
+      streamed: false,
+    });
+    emit(session, {
+      type: 'tts_metrics',
+      label: 't',
+      requestId: 'r',
+      timestamp: now,
+      ttfbMs: 50,
+      durationMs: 100,
+      audioDurationMs: 500,
+      cancelled: false,
+      charactersCount: 10,
+      streamed: false,
+    });
+    emit(session, {
+      type: 'realtime_model_metrics',
+      label: 'rt',
+      requestId: 'r',
+      timestamp: now,
+      durationMs: 100,
+      ttftMs: 50,
+      cancelled: false,
+      inputTokens: 1,
+      outputTokens: 1,
+      totalTokens: 2,
+      tokensPerSecond: 10,
+      inputTokenDetails: { audioTokens: 0, textTokens: 1, imageTokens: 0, cachedTokens: 0 },
+      outputTokenDetails: { textTokens: 1, audioTokens: 0, imageTokens: 0 },
+    });
+    emit(session, {
+      type: 'eou_metrics',
+      timestamp: now,
+      endOfUtteranceDelayMs: 1,
+      transcriptionDelayMs: 1,
+      onUserTurnCompletedDelayMs: 1,
+      lastSpeakingTimeMs: now,
+    });
+    emit(session, {
+      type: 'interruption_metrics',
+      timestamp: now,
+      totalDuration: 1,
+      predictionDuration: 1,
+      detectionDelay: 1,
+      numInterruptions: 0,
+      numBackchannels: 0,
+      numRequests: 0,
+    });
+    emit(session, {
+      type: 'vad_metrics',
+      label: 'v',
+      timestamp: now,
+      idleTimeMs: 0,
+      inferenceDurationTotalMs: 0,
+      inferenceCount: 0,
+    });
+
+    expect(captured).toHaveLength(7);
+    for (const entry of captured) {
+      expect(entry.startTime).toBeInstanceOf(Date);
+      expect(entry.endTime).toBeInstanceOf(Date);
+    }
+  });
+
   it('respects custom spanNames override', () => {
     const session = makeFakeSession();
     const tracer = provider.getTracer('test');

--- a/agents/src/metrics/otel.test.ts
+++ b/agents/src/metrics/otel.test.ts
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { SpanStatusCode, context as otelContext, trace } from '@opentelemetry/api';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { AgentSession } from '../voice/agent_session.js';
+import { createMetricsCollectedEvent } from '../voice/events.js';
+import type {
+  EOUMetrics,
+  InterruptionMetrics,
+  LLMMetrics,
+  RealtimeModelMetrics,
+  STTMetrics,
+  TTSMetrics,
+  VADMetrics,
+} from './base.js';
+import { attachOtelTracer } from './otel.js';
+
+/** Build a minimal fake session that quacks like an EventEmitter. */
+function makeFakeSession(): AgentSession {
+  const emitter = new EventEmitter();
+  return emitter as unknown as AgentSession;
+}
+
+function emit(
+  session: AgentSession,
+  metrics: Parameters<typeof createMetricsCollectedEvent>[0]['metrics'],
+) {
+  (session as unknown as EventEmitter).emit(
+    'metrics_collected',
+    createMetricsCollectedEvent({ metrics }),
+  );
+}
+
+describe('attachOtelTracer', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    otelContext.disable();
+    trace.disable();
+  });
+
+  it('emits gen_ai.chat span for llm_metrics with all gen_ai attributes', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const metrics: LLMMetrics = {
+      type: 'llm_metrics',
+      label: 'openai.LLM',
+      requestId: 'req-llm-1',
+      timestamp: Date.now(),
+      durationMs: 250,
+      ttftMs: 80,
+      cancelled: false,
+      completionTokens: 42,
+      promptTokens: 100,
+      promptCachedTokens: 10,
+      totalTokens: 142,
+      tokensPerSecond: 168,
+      speechId: 'speech-1',
+      metadata: { modelProvider: 'openai', modelName: 'gpt-4o-mini' },
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span).toBeDefined();
+    expect(span!.name).toBe('gen_ai.chat');
+    expect(span!.attributes['gen_ai.operation.name']).toBe('chat');
+    expect(span!.attributes['gen_ai.provider.name']).toBe('openai');
+    expect(span!.attributes['gen_ai.request.model']).toBe('gpt-4o-mini');
+    expect(span!.attributes['gen_ai.response.id']).toBe('req-llm-1');
+    expect(span!.attributes['gen_ai.usage.input_tokens']).toBe(100);
+    expect(span!.attributes['gen_ai.usage.output_tokens']).toBe(42);
+    expect(span!.attributes['lk.speech_id']).toBe('speech-1');
+    expect(span!.status.code).toBe(SpanStatusCode.UNSET);
+  });
+
+  it('emits gen_ai.transcribe span for stt_metrics with all gen_ai attributes', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const metrics: STTMetrics = {
+      type: 'stt_metrics',
+      label: 'deepgram.STT',
+      requestId: 'req-stt-1',
+      timestamp: Date.now(),
+      durationMs: 120,
+      audioDurationMs: 4500,
+      inputTokens: 30,
+      outputTokens: 12,
+      streamed: true,
+      metadata: { modelProvider: 'deepgram', modelName: 'nova-2' },
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span!.name).toBe('gen_ai.transcribe');
+    expect(span!.attributes['gen_ai.operation.name']).toBe('transcribe');
+    expect(span!.attributes['gen_ai.provider.name']).toBe('deepgram');
+    expect(span!.attributes['gen_ai.request.model']).toBe('nova-2');
+    expect(span!.attributes['gen_ai.response.id']).toBe('req-stt-1');
+    expect(span!.attributes['gen_ai.usage.input_tokens']).toBe(30);
+    expect(span!.attributes['gen_ai.usage.output_tokens']).toBe(12);
+  });
+
+  it('emits gen_ai.synthesize span for tts_metrics with all gen_ai attributes', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const metrics: TTSMetrics = {
+      type: 'tts_metrics',
+      label: 'elevenlabs.TTS',
+      requestId: 'req-tts-1',
+      timestamp: Date.now(),
+      ttfbMs: 60,
+      durationMs: 320,
+      audioDurationMs: 2800,
+      cancelled: false,
+      charactersCount: 145,
+      streamed: false,
+      speechId: 'speech-2',
+      metadata: { modelProvider: 'elevenlabs', modelName: 'eleven_turbo_v2' },
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span!.name).toBe('gen_ai.synthesize');
+    expect(span!.attributes['gen_ai.operation.name']).toBe('synthesize');
+    expect(span!.attributes['gen_ai.provider.name']).toBe('elevenlabs');
+    expect(span!.attributes['gen_ai.request.model']).toBe('eleven_turbo_v2');
+    expect(span!.attributes['lk.speech_id']).toBe('speech-2');
+  });
+
+  it('emits gen_ai.realtime span for realtime_model_metrics', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const metrics: RealtimeModelMetrics = {
+      type: 'realtime_model_metrics',
+      label: 'openai.Realtime',
+      requestId: 'req-rt-1',
+      timestamp: Date.now(),
+      durationMs: 800,
+      ttftMs: 120,
+      cancelled: false,
+      inputTokens: 200,
+      outputTokens: 80,
+      totalTokens: 280,
+      tokensPerSecond: 100,
+      inputTokenDetails: { audioTokens: 150, textTokens: 50, imageTokens: 0, cachedTokens: 20 },
+      outputTokenDetails: { textTokens: 30, audioTokens: 50, imageTokens: 0 },
+      metadata: { modelProvider: 'openai', modelName: 'gpt-4o-realtime' },
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span!.name).toBe('gen_ai.realtime');
+    expect(span!.attributes['gen_ai.provider.name']).toBe('openai');
+    expect(span!.attributes['gen_ai.request.model']).toBe('gpt-4o-realtime');
+    expect(span!.attributes['gen_ai.usage.input_tokens']).toBe(200);
+    expect(span!.attributes['gen_ai.usage.output_tokens']).toBe(80);
+  });
+
+  it('emits lk.eou span for eou_metrics', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const metrics: EOUMetrics = {
+      type: 'eou_metrics',
+      timestamp: Date.now(),
+      endOfUtteranceDelayMs: 180,
+      transcriptionDelayMs: 90,
+      onUserTurnCompletedDelayMs: 12,
+      lastSpeakingTimeMs: Date.now() - 200,
+      speechId: 'speech-3',
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span!.name).toBe('lk.eou');
+    expect(span!.attributes['lk.eou.end_of_utterance_delay_ms']).toBe(180);
+    expect(span!.attributes['lk.eou.transcription_delay_ms']).toBe(90);
+    expect(span!.attributes['lk.speech_id']).toBe('speech-3');
+  });
+
+  it('emits lk.interruption span for interruption_metrics', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const metrics: InterruptionMetrics = {
+      type: 'interruption_metrics',
+      timestamp: Date.now(),
+      totalDuration: 45,
+      predictionDuration: 30,
+      detectionDelay: 12,
+      numInterruptions: 2,
+      numBackchannels: 1,
+      numRequests: 5,
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span!.name).toBe('lk.interruption');
+    expect(span!.attributes['lk.interruption.total_duration_ms']).toBe(45);
+    expect(span!.attributes['lk.interruption.num_interruptions']).toBe(2);
+  });
+
+  it('emits lk.vad span for vad_metrics', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const metrics: VADMetrics = {
+      type: 'vad_metrics',
+      label: 'silero',
+      timestamp: Date.now(),
+      idleTimeMs: 1000,
+      inferenceDurationTotalMs: 50,
+      inferenceCount: 25,
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span!.name).toBe('lk.vad');
+    expect(span!.attributes['lk.vad.idle_time_ms']).toBe(1000);
+    expect(span!.attributes['lk.vad.inference_count']).toBe(25);
+  });
+
+  it('marks span status ERROR when cancelled is true', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const metrics: LLMMetrics = {
+      type: 'llm_metrics',
+      label: 'openai.LLM',
+      requestId: 'req-cancel',
+      timestamp: Date.now(),
+      durationMs: 50,
+      ttftMs: 0,
+      cancelled: true,
+      completionTokens: 0,
+      promptTokens: 10,
+      promptCachedTokens: 0,
+      totalTokens: 10,
+      tokensPerSecond: 0,
+      metadata: { modelProvider: 'openai', modelName: 'gpt-4o-mini' },
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span!.status.code).toBe(SpanStatusCode.ERROR);
+  });
+
+  it('emits independent spans for multiple metrics in sequence', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const base = {
+      timestamp: Date.now(),
+      durationMs: 100,
+      ttftMs: 50,
+      cancelled: false,
+      completionTokens: 1,
+      promptTokens: 1,
+      promptCachedTokens: 0,
+      totalTokens: 2,
+      tokensPerSecond: 10,
+    } as const;
+    emit(session, { ...base, type: 'llm_metrics', label: 'llm', requestId: 'a' });
+    emit(session, { ...base, type: 'llm_metrics', label: 'llm', requestId: 'b' });
+    emit(session, { ...base, type: 'llm_metrics', label: 'llm', requestId: 'c' });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(3);
+    const ids = spans.map((s) => s.attributes['gen_ai.response.id']);
+    expect(ids).toEqual(['a', 'b', 'c']);
+    const spanIds = new Set(spans.map((s) => s.spanContext().spanId));
+    expect(spanIds.size).toBe(3); // each span has a unique span id
+  });
+
+  it('unsubscribe stops emitting spans', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    const unsubscribe = attachOtelTracer(session, tracer);
+
+    const metrics: LLMMetrics = {
+      type: 'llm_metrics',
+      label: 'openai.LLM',
+      requestId: 'req-1',
+      timestamp: Date.now(),
+      durationMs: 100,
+      ttftMs: 50,
+      cancelled: false,
+      completionTokens: 1,
+      promptTokens: 1,
+      promptCachedTokens: 0,
+      totalTokens: 2,
+      tokensPerSecond: 10,
+    };
+    emit(session, metrics);
+    expect(exporter.getFinishedSpans()).toHaveLength(1);
+
+    unsubscribe();
+    emit(session, { ...metrics, requestId: 'req-2' });
+    expect(exporter.getFinishedSpans()).toHaveLength(1); // no new span
+  });
+
+  it('does not propagate when tracer.startSpan throws', () => {
+    const session = makeFakeSession();
+    const brokenTracer = {
+      startSpan: () => {
+        throw new Error('tracer is broken');
+      },
+    } as unknown as Parameters<typeof attachOtelTracer>[1];
+
+    attachOtelTracer(session, brokenTracer);
+
+    const metrics: LLMMetrics = {
+      type: 'llm_metrics',
+      label: 'openai.LLM',
+      requestId: 'req-throw',
+      timestamp: Date.now(),
+      durationMs: 100,
+      ttftMs: 50,
+      cancelled: false,
+      completionTokens: 1,
+      promptTokens: 1,
+      promptCachedTokens: 0,
+      totalTokens: 2,
+      tokensPerSecond: 10,
+    };
+    // Must not throw — telemetry failure should never disrupt the session.
+    expect(() => emit(session, metrics)).not.toThrow();
+  });
+
+  it('omits gen_ai.* attrs when metadata is missing', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer);
+
+    const metrics: LLMMetrics = {
+      type: 'llm_metrics',
+      label: 'unknown.LLM',
+      requestId: 'req-no-meta',
+      timestamp: Date.now(),
+      durationMs: 100,
+      ttftMs: 50,
+      cancelled: false,
+      completionTokens: 1,
+      promptTokens: 1,
+      promptCachedTokens: 0,
+      totalTokens: 2,
+      tokensPerSecond: 10,
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span!.attributes['gen_ai.operation.name']).toBe('chat');
+    expect(span!.attributes['gen_ai.provider.name']).toBeUndefined();
+    expect(span!.attributes['gen_ai.request.model']).toBeUndefined();
+    expect(span!.attributes['gen_ai.response.id']).toBe('req-no-meta');
+  });
+
+  it('respects custom spanNames override', () => {
+    const session = makeFakeSession();
+    const tracer = provider.getTracer('test');
+    attachOtelTracer(session, tracer, { spanNames: { llm: 'my.custom.llm' } });
+
+    const metrics: LLMMetrics = {
+      type: 'llm_metrics',
+      label: 'openai.LLM',
+      requestId: 'req-custom',
+      timestamp: Date.now(),
+      durationMs: 100,
+      ttftMs: 50,
+      cancelled: false,
+      completionTokens: 1,
+      promptTokens: 1,
+      promptCachedTokens: 0,
+      totalTokens: 2,
+      tokensPerSecond: 10,
+    };
+    emit(session, metrics);
+
+    const [span] = exporter.getFinishedSpans();
+    expect(span!.name).toBe('my.custom.llm');
+  });
+});

--- a/agents/src/metrics/otel.ts
+++ b/agents/src/metrics/otel.ts
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { SpanStatusCode, type Tracer } from '@opentelemetry/api';
+import { log } from '../log.js';
+import {
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_PROVIDER_NAME,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  ATTR_LLM_METRICS,
+  ATTR_REALTIME_MODEL_METRICS,
+  ATTR_SPEECH_ID,
+  ATTR_TTS_METRICS,
+} from '../telemetry/trace_types.js';
+import type { AgentSession } from '../voice/agent_session.js';
+import { AgentSessionEventTypes, type MetricsCollectedEvent } from '../voice/events.js';
+import type { AgentMetrics } from './base.js';
+
+/** Distinct metric variants that map to OTel spans. */
+export type OtelSpanVariant = 'llm' | 'stt' | 'tts' | 'eou' | 'realtime' | 'interruption' | 'vad';
+
+export interface AttachOtelTracerOptions {
+  /** Override default span names per metric variant. */
+  spanNames?: Partial<Record<OtelSpanVariant, string>>;
+}
+
+const DEFAULT_SPAN_NAMES: Record<OtelSpanVariant, string> = {
+  llm: 'gen_ai.chat',
+  stt: 'gen_ai.transcribe',
+  tts: 'gen_ai.synthesize',
+  realtime: 'gen_ai.realtime',
+  eou: 'lk.eou',
+  interruption: 'lk.interruption',
+  vad: 'lk.vad',
+};
+
+const GEN_AI_RESPONSE_ID = 'gen_ai.response.id';
+
+/**
+ * Subscribe to a session's `metrics_collected` events and emit OpenTelemetry spans
+ * using the gen_ai semantic conventions.
+ *
+ * The helper picks up the active OTel context automatically, so wrapping calls in
+ * `tracer.startActiveSpan(...)` produces per-turn parent spans.
+ *
+ * @param session - The AgentSession to observe.
+ * @param tracer - An OpenTelemetry Tracer (e.g. from `trace.getTracer('voice-agent')`).
+ * @param options - Optional overrides (currently: custom span names).
+ * @returns Unsubscribe function. Call it to detach the listener.
+ *
+ * @example
+ * ```ts
+ * import { trace } from '@opentelemetry/api';
+ * import { metrics } from '@livekit/agents';
+ *
+ * const tracer = trace.getTracer('voice-agent');
+ * const detach = metrics.attachOtelTracer(session, tracer);
+ * // ... later:
+ * detach();
+ * ```
+ */
+export function attachOtelTracer(
+  session: AgentSession,
+  tracer: Tracer,
+  options: AttachOtelTracerOptions = {},
+): () => void {
+  const spanNames = { ...DEFAULT_SPAN_NAMES, ...options.spanNames };
+
+  const handler = (ev: MetricsCollectedEvent) => {
+    try {
+      emitSpan(tracer, spanNames, ev.metrics);
+    } catch (err) {
+      // Resolve the logger lazily so callers don't have to initialize logging
+      // just to attach a tracer.
+      try {
+        log().child({ err }).warn('attachOtelTracer: failed to emit span');
+      } catch {
+        // logger not initialized — swallow; telemetry must never disrupt the session.
+      }
+    }
+  };
+
+  session.on(AgentSessionEventTypes.MetricsCollected, handler);
+  return () => {
+    session.off(AgentSessionEventTypes.MetricsCollected, handler);
+  };
+}
+
+function emitSpan(
+  tracer: Tracer,
+  spanNames: Record<OtelSpanVariant, string>,
+  m: AgentMetrics,
+): void {
+  switch (m.type) {
+    case 'llm_metrics': {
+      const startTime = Math.max(0, m.timestamp - m.durationMs);
+      const span = tracer.startSpan(spanNames.llm, {
+        startTime,
+        attributes: {
+          [ATTR_GEN_AI_OPERATION_NAME]: 'chat',
+          ...(m.metadata?.modelProvider && {
+            [ATTR_GEN_AI_PROVIDER_NAME]: m.metadata.modelProvider,
+          }),
+          ...(m.metadata?.modelName && {
+            [ATTR_GEN_AI_REQUEST_MODEL]: m.metadata.modelName,
+          }),
+          [GEN_AI_RESPONSE_ID]: m.requestId,
+          [ATTR_GEN_AI_USAGE_INPUT_TOKENS]: m.promptTokens,
+          [ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]: m.completionTokens,
+          'lk.gen_ai.ttft_ms': m.ttftMs,
+          'lk.gen_ai.tokens_per_second': m.tokensPerSecond,
+          'lk.gen_ai.prompt_cached_tokens': m.promptCachedTokens,
+          ...(m.speechId && { [ATTR_SPEECH_ID]: m.speechId }),
+          [ATTR_LLM_METRICS]: JSON.stringify(m),
+        },
+      });
+      if (m.cancelled) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: 'cancelled' });
+      }
+      span.end(m.timestamp);
+      return;
+    }
+    case 'stt_metrics': {
+      const startTime = Math.max(0, m.timestamp - m.durationMs);
+      const span = tracer.startSpan(spanNames.stt, {
+        startTime,
+        attributes: {
+          [ATTR_GEN_AI_OPERATION_NAME]: 'transcribe',
+          ...(m.metadata?.modelProvider && {
+            [ATTR_GEN_AI_PROVIDER_NAME]: m.metadata.modelProvider,
+          }),
+          ...(m.metadata?.modelName && {
+            [ATTR_GEN_AI_REQUEST_MODEL]: m.metadata.modelName,
+          }),
+          [GEN_AI_RESPONSE_ID]: m.requestId,
+          ...(m.inputTokens !== undefined && {
+            [ATTR_GEN_AI_USAGE_INPUT_TOKENS]: m.inputTokens,
+          }),
+          ...(m.outputTokens !== undefined && {
+            [ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]: m.outputTokens,
+          }),
+          'lk.stt.audio_duration_ms': m.audioDurationMs,
+          'lk.stt.streamed': m.streamed,
+        },
+      });
+      span.end(m.timestamp);
+      return;
+    }
+    case 'tts_metrics': {
+      const startTime = Math.max(0, m.timestamp - m.durationMs);
+      const span = tracer.startSpan(spanNames.tts, {
+        startTime,
+        attributes: {
+          [ATTR_GEN_AI_OPERATION_NAME]: 'synthesize',
+          ...(m.metadata?.modelProvider && {
+            [ATTR_GEN_AI_PROVIDER_NAME]: m.metadata.modelProvider,
+          }),
+          ...(m.metadata?.modelName && {
+            [ATTR_GEN_AI_REQUEST_MODEL]: m.metadata.modelName,
+          }),
+          [GEN_AI_RESPONSE_ID]: m.requestId,
+          ...(m.inputTokens !== undefined && {
+            [ATTR_GEN_AI_USAGE_INPUT_TOKENS]: m.inputTokens,
+          }),
+          ...(m.outputTokens !== undefined && {
+            [ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]: m.outputTokens,
+          }),
+          'lk.tts.ttfb_ms': m.ttfbMs,
+          'lk.tts.audio_duration_ms': m.audioDurationMs,
+          'lk.tts.characters_count': m.charactersCount,
+          'lk.tts.streamed': m.streamed,
+          ...(m.speechId && { [ATTR_SPEECH_ID]: m.speechId }),
+          [ATTR_TTS_METRICS]: JSON.stringify(m),
+        },
+      });
+      if (m.cancelled) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: 'cancelled' });
+      }
+      span.end(m.timestamp);
+      return;
+    }
+    case 'realtime_model_metrics': {
+      const startTime = Math.max(0, m.timestamp - m.durationMs);
+      const span = tracer.startSpan(spanNames.realtime, {
+        startTime,
+        attributes: {
+          [ATTR_GEN_AI_OPERATION_NAME]: 'chat',
+          ...(m.metadata?.modelProvider && {
+            [ATTR_GEN_AI_PROVIDER_NAME]: m.metadata.modelProvider,
+          }),
+          ...(m.metadata?.modelName && {
+            [ATTR_GEN_AI_REQUEST_MODEL]: m.metadata.modelName,
+          }),
+          [GEN_AI_RESPONSE_ID]: m.requestId,
+          [ATTR_GEN_AI_USAGE_INPUT_TOKENS]: m.inputTokens,
+          [ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]: m.outputTokens,
+          'lk.realtime.ttft_ms': m.ttftMs,
+          'lk.realtime.tokens_per_second': m.tokensPerSecond,
+          ...(m.sessionDurationMs !== undefined && {
+            'lk.realtime.session_duration_ms': m.sessionDurationMs,
+          }),
+          'lk.realtime.input_audio_tokens': m.inputTokenDetails.audioTokens,
+          'lk.realtime.input_text_tokens': m.inputTokenDetails.textTokens,
+          'lk.realtime.input_cached_tokens': m.inputTokenDetails.cachedTokens,
+          'lk.realtime.output_audio_tokens': m.outputTokenDetails.audioTokens,
+          'lk.realtime.output_text_tokens': m.outputTokenDetails.textTokens,
+          [ATTR_REALTIME_MODEL_METRICS]: JSON.stringify(m),
+        },
+      });
+      if (m.cancelled) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: 'cancelled' });
+      }
+      span.end(m.timestamp);
+      return;
+    }
+    case 'eou_metrics': {
+      const span = tracer.startSpan(spanNames.eou, {
+        startTime: m.timestamp,
+        attributes: {
+          'lk.eou.end_of_utterance_delay_ms': m.endOfUtteranceDelayMs,
+          'lk.eou.transcription_delay_ms': m.transcriptionDelayMs,
+          'lk.eou.on_user_turn_completed_delay_ms': m.onUserTurnCompletedDelayMs,
+          'lk.eou.last_speaking_time_ms': m.lastSpeakingTimeMs,
+          ...(m.speechId && { [ATTR_SPEECH_ID]: m.speechId }),
+        },
+      });
+      span.end(m.timestamp);
+      return;
+    }
+    case 'interruption_metrics': {
+      const span = tracer.startSpan(spanNames.interruption, {
+        startTime: m.timestamp,
+        attributes: {
+          'lk.interruption.total_duration_ms': m.totalDuration,
+          'lk.interruption.prediction_duration_ms': m.predictionDuration,
+          'lk.interruption.detection_delay_ms': m.detectionDelay,
+          'lk.interruption.num_interruptions': m.numInterruptions,
+          'lk.interruption.num_backchannels': m.numBackchannels,
+          'lk.interruption.num_requests': m.numRequests,
+        },
+      });
+      span.end(m.timestamp);
+      return;
+    }
+    case 'vad_metrics': {
+      const span = tracer.startSpan(spanNames.vad, {
+        startTime: m.timestamp,
+        attributes: {
+          'lk.vad.idle_time_ms': m.idleTimeMs,
+          'lk.vad.inference_duration_total_ms': m.inferenceDurationTotalMs,
+          'lk.vad.inference_count': m.inferenceCount,
+        },
+      });
+      span.end(m.timestamp);
+      return;
+    }
+  }
+}

--- a/agents/src/metrics/otel.ts
+++ b/agents/src/metrics/otel.ts
@@ -95,7 +95,9 @@ function emitSpan(
 ): void {
   switch (m.type) {
     case 'llm_metrics': {
-      const startTime = Math.max(0, m.timestamp - m.durationMs);
+      // Wrap epoch-ms in Date so OTel's timeInputToHrTime uses millisToHrTime,
+      // not performance.now() + timeOrigin (which yields ~2x Date.now()).
+      const startTime = new Date(Math.max(0, m.timestamp - m.durationMs));
       const span = tracer.startSpan(spanNames.llm, {
         startTime,
         attributes: {
@@ -119,11 +121,11 @@ function emitSpan(
       if (m.cancelled) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: 'cancelled' });
       }
-      span.end(m.timestamp);
+      span.end(new Date(m.timestamp));
       return;
     }
     case 'stt_metrics': {
-      const startTime = Math.max(0, m.timestamp - m.durationMs);
+      const startTime = new Date(Math.max(0, m.timestamp - m.durationMs));
       const span = tracer.startSpan(spanNames.stt, {
         startTime,
         attributes: {
@@ -145,11 +147,11 @@ function emitSpan(
           'lk.stt.streamed': m.streamed,
         },
       });
-      span.end(m.timestamp);
+      span.end(new Date(m.timestamp));
       return;
     }
     case 'tts_metrics': {
-      const startTime = Math.max(0, m.timestamp - m.durationMs);
+      const startTime = new Date(Math.max(0, m.timestamp - m.durationMs));
       const span = tracer.startSpan(spanNames.tts, {
         startTime,
         attributes: {
@@ -178,11 +180,11 @@ function emitSpan(
       if (m.cancelled) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: 'cancelled' });
       }
-      span.end(m.timestamp);
+      span.end(new Date(m.timestamp));
       return;
     }
     case 'realtime_model_metrics': {
-      const startTime = Math.max(0, m.timestamp - m.durationMs);
+      const startTime = new Date(Math.max(0, m.timestamp - m.durationMs));
       const span = tracer.startSpan(spanNames.realtime, {
         startTime,
         attributes: {
@@ -212,12 +214,12 @@ function emitSpan(
       if (m.cancelled) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: 'cancelled' });
       }
-      span.end(m.timestamp);
+      span.end(new Date(m.timestamp));
       return;
     }
     case 'eou_metrics': {
       const span = tracer.startSpan(spanNames.eou, {
-        startTime: m.timestamp,
+        startTime: new Date(m.timestamp),
         attributes: {
           'lk.eou.end_of_utterance_delay_ms': m.endOfUtteranceDelayMs,
           'lk.eou.transcription_delay_ms': m.transcriptionDelayMs,
@@ -226,12 +228,12 @@ function emitSpan(
           ...(m.speechId && { [ATTR_SPEECH_ID]: m.speechId }),
         },
       });
-      span.end(m.timestamp);
+      span.end(new Date(m.timestamp));
       return;
     }
     case 'interruption_metrics': {
       const span = tracer.startSpan(spanNames.interruption, {
-        startTime: m.timestamp,
+        startTime: new Date(m.timestamp),
         attributes: {
           'lk.interruption.total_duration_ms': m.totalDuration,
           'lk.interruption.prediction_duration_ms': m.predictionDuration,
@@ -241,19 +243,19 @@ function emitSpan(
           'lk.interruption.num_requests': m.numRequests,
         },
       });
-      span.end(m.timestamp);
+      span.end(new Date(m.timestamp));
       return;
     }
     case 'vad_metrics': {
       const span = tracer.startSpan(spanNames.vad, {
-        startTime: m.timestamp,
+        startTime: new Date(m.timestamp),
         attributes: {
           'lk.vad.idle_time_ms': m.idleTimeMs,
           'lk.vad.inference_duration_total_ms': m.inferenceDurationTotalMs,
           'lk.vad.inference_count': m.inferenceCount,
         },
       });
-      span.end(m.timestamp);
+      span.end(new Date(m.timestamp));
       return;
     }
   }


### PR DESCRIPTION
Closes #1407. Related: #757.

## Summary

Adds `metrics.attachOtelTracer(session, tracer)` — a small, opt-in helper that subscribes to an `AgentSession`'s `metrics_collected` events and emits OpenTelemetry spans following the [gen_ai semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). Returns an unsubscribe function.

The issue's three open questions are deferred (this PR is the minimum-viable cut to unblock the common case — happy to iterate on distribution / attribute renamer / activeContext in review):

- **Distribution**: kept under `metrics.attachOtelTracer` (no subpath export yet) so the package surface stays unchanged.
- **Attribute naming**: pure `gen_ai.*` for the standardized fields, `lk.*` prefix (matching the existing `agents/src/telemetry/trace_types.ts` convention) for everything else.
- **Parent-context propagation**: `tracer.startSpan()` picks up `context.active()` automatically, so wrapping calls in `tracer.startActiveSpan(...)` produces per-turn grouping with no API needed.

## Public API

```ts
import { trace } from '@opentelemetry/api';
import { metrics } from '@livekit/agents';

const tracer = trace.getTracer('voice-agent');
const detach = metrics.attachOtelTracer(session, tracer);
// optional override:
metrics.attachOtelTracer(session, tracer, {
  spanNames: { llm: 'my.llm', stt: 'my.stt' },
});
detach(); // unsubscribe
```

`@opentelemetry/api` is already in `dependencies` (used by `agents/src/telemetry/`), so there's no new peer-dep contract.

## gen_ai semconv mapping

| Metric variant       | Span name           | gen_ai.* attributes                                                                                                                              | lk.* attributes                                                                                                          | Status        |
| -------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ | ------------- |
| `llm_metrics`        | `gen_ai.chat`       | `operation.name=chat`, `provider.name`, `request.model`, `response.id`, `usage.input_tokens`, `usage.output_tokens`                              | `lk.gen_ai.ttft_ms`, `tokens_per_second`, `prompt_cached_tokens`, `lk.speech_id`, `lk.llm_metrics` (JSON)                | ERROR if cancelled |
| `stt_metrics`        | `gen_ai.transcribe` | `operation.name=transcribe`, `provider.name`, `request.model`, `response.id`, `usage.input_tokens?`, `usage.output_tokens?`                       | `lk.stt.audio_duration_ms`, `lk.stt.streamed`                                                                            | UNSET         |
| `tts_metrics`        | `gen_ai.synthesize` | `operation.name=synthesize`, `provider.name`, `request.model`, `response.id`, `usage.input_tokens?`, `usage.output_tokens?`                       | `lk.tts.ttfb_ms`, `audio_duration_ms`, `characters_count`, `streamed`, `lk.speech_id`, `lk.tts_metrics` (JSON)            | ERROR if cancelled |
| `realtime_model_metrics` | `gen_ai.realtime` | `operation.name=chat`, `provider.name`, `request.model`, `response.id`, `usage.input_tokens`, `usage.output_tokens`                              | `lk.realtime.ttft_ms`, `tokens_per_second`, `input_audio_tokens`, `input_text_tokens`, `input_cached_tokens`, output counterparts, `lk.realtime_model_metrics` (JSON) | ERROR if cancelled |
| `eou_metrics`        | `lk.eou`            | -                                                                                                                                                | `lk.eou.end_of_utterance_delay_ms`, `transcription_delay_ms`, `on_user_turn_completed_delay_ms`, `last_speaking_time_ms`, `lk.speech_id` | UNSET         |
| `interruption_metrics` | `lk.interruption` | -                                                                                                                                                | `total_duration_ms`, `prediction_duration_ms`, `detection_delay_ms`, `num_interruptions`, `num_backchannels`, `num_requests` | UNSET         |
| `vad_metrics`        | `lk.vad`            | -                                                                                                                                                | `lk.vad.idle_time_ms`, `inference_duration_total_ms`, `inference_count`                                                  | UNSET         |

All `gen_ai.*` and shared `lk.*` keys are imported from the existing `agents/src/telemetry/trace_types.ts` so naming stays consistent with the rest of in-tree telemetry.

## Span lifecycle

One span per metric event (not per-turn). The session does not currently expose a turn-complete boundary, and a single turn can include multiple LLM calls (tool loops). Per-metric spans match the semconv intent (`gen_ai.chat` = one model call). Users who want per-turn grouping can wrap their session run in `tracer.startActiveSpan(...)` — the helper inherits `context.active()` automatically.

Spans are retroactive: `startTime = max(0, timestamp - durationMs)`, `endTime = timestamp`. No open spans tracked.

## Error handling

- `tracer.startSpan` throws -> caught and logged at `warn`. Session emission is never disrupted.
- Logger not initialized -> swallowed (telemetry must never disrupt the session).
- Unknown metric types -> silently ignored (forward-compat with new metric variants).
- Missing metadata -> `gen_ai.provider.name` and `gen_ai.request.model` omitted, not set as `undefined`.

## Test coverage

13 tests in `agents/src/metrics/otel.test.ts`, using `InMemorySpanExporter` + `NodeTracerProvider` (the same pattern as the existing `agents/src/telemetry/traces.test.ts`):

```
 ✓ attachOtelTracer > emits gen_ai.chat span for llm_metrics with all gen_ai attributes 3ms
 ✓ attachOtelTracer > emits gen_ai.transcribe span for stt_metrics with all gen_ai attributes 2ms
 ✓ attachOtelTracer > emits gen_ai.synthesize span for tts_metrics with all gen_ai attributes 1ms
 ✓ attachOtelTracer > emits gen_ai.realtime span for realtime_model_metrics 1ms
 ✓ attachOtelTracer > emits lk.eou span for eou_metrics 0ms
 ✓ attachOtelTracer > emits lk.interruption span for interruption_metrics 0ms
 ✓ attachOtelTracer > emits lk.vad span for vad_metrics 0ms
 ✓ attachOtelTracer > marks span status ERROR when cancelled is true 0ms
 ✓ attachOtelTracer > emits independent spans for multiple metrics in sequence 2ms
 ✓ attachOtelTracer > unsubscribe stops emitting spans 1ms
 ✓ attachOtelTracer > does not propagate when tracer.startSpan throws 1ms
 ✓ attachOtelTracer > omits gen_ai.* attrs when metadata is missing 0ms
 ✓ attachOtelTracer > respects custom spanNames override 0ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Full `agents/` test suite still green: **842 passed, 2 skipped** (preexisting).

## Captured span (live OTel emission, real `NodeTracerProvider`)

Output of a minimal end-to-end script emitting one `llm_metrics` event through the helper and dumping the resulting span:

```json
{
  "name": "gen_ai.chat",
  "kind": 0,
  "status": { "code": 0 },
  "startTime": [1779206533, 622000000],
  "endTime":   [1779206533, 872000000],
  "duration":  [0, 250000000],
  "attributes": {
    "gen_ai.operation.name": "chat",
    "gen_ai.provider.name": "openai",
    "gen_ai.request.model": "gpt-4o-mini",
    "gen_ai.response.id": "req-llm-DEMO",
    "gen_ai.usage.input_tokens": 100,
    "gen_ai.usage.output_tokens": 42,
    "lk.gen_ai.ttft_ms": 80,
    "lk.gen_ai.tokens_per_second": 168,
    "lk.gen_ai.prompt_cached_tokens": 10,
    "lk.speech_id": "speech-DEMO",
    "lk.llm_metrics": "{...full original payload as JSON for forensic recovery...}"
  },
  "spanContext": {
    "traceId": "9935813756cd6ea99279e8bbff95b476",
    "spanId":  "998bbe319b343864"
  }
}
```

## Diff stat

```
 .changeset/attach-otel-tracer.md |  10 +
 agents/src/metrics/index.ts      |   1 +
 agents/src/metrics/otel.test.ts  | 409 +++++++++++++++++++++++++++++++++++++++
 agents/src/metrics/otel.ts       | 260 +++++++++++++++++++++++++
 4 files changed, 680 insertions(+)
```

## Risk

Low. Net-new public symbol, no existing behavior changes. The helper only listens; it never writes to the session. Telemetry failures are caught and logged.

## Out of scope

- Per-turn grouping span (users wrap themselves)
- Custom `attributes` remapper from the issue (cleaner public surface; happy to add if requested)
- `activeContext: () => Context | undefined` callback (`tracer.startSpan` already inherits `context.active()`)
- Subpath export `@livekit/agents/otel` (deferred — symbol stays under `metrics.*` until distribution is decided)
- Token-level events (only span-per-call)

## Local verification

```bash
pnpm test -- agents/src/metrics/otel.test.ts      # 13/13 passed
pnpm test -- agents/                              # 842 passed, 2 skipped
pnpm format:check                                 # clean
pnpm lint                                         # clean (no new warnings)
pnpm build:agents                                 # build clean
```

`pnpm api:check` currently fails on `main` too (preexisting issue with `export * as ___` syntax in `agents/src/index.ts`) — unrelated to this PR.
