### PR TITLE
fix(agents): drain active handles on SIP call end

### DIFF
--- a/.changeset/fix-sip-process-leak-on-hangup.md
+++ b/.changeset/fix-sip-process-leak-on-hangup.md
@@ -1,0 +1,22 @@
+---
+'@livekit/agents': patch
+---
+
+fix(agents): shut down the job when the primary AgentSession closes on
+participant disconnect
+
+When the remote participant disconnects (especially common with SIP
+hangups), `room_io` closes the primary `AgentSession` via
+`closeOnDisconnect`. Previously nothing bridged that `Close` event back to
+the `JobContext`, so the job process kept running until the parent
+worker SIGTERMed it ~60s later, leaking one node process per hung-up
+call.
+
+The primary AgentSession now installs a one-shot `Close` listener that
+calls `JobContext.shutdown('primary_session_closed')` when the close
+reason is `PARTICIPANT_DISCONNECTED`. Other close reasons
+(`USER_INITIATED`, `JOB_SHUTDOWN`, `ERROR`) are unchanged, so user code
+that manually calls `session.close()` to start a new session continues
+to keep the job alive.
+
+Closes #927.

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -19,7 +19,7 @@ import {
   type TTSModelString,
 } from '../inference/index.js';
 import type { OverlappingSpeechEvent } from '../inference/interruption/types.js';
-import { getJobContext } from '../job.js';
+import { type JobContext, getJobContext } from '../job.js';
 import type { FunctionCall, FunctionCallOutput } from '../llm/chat_context.js';
 import {
   AgentHandoffItem,
@@ -502,6 +502,9 @@ export class AgentSession<
 
       if (ctx._primaryAgentSession === undefined) {
         ctx._primaryAgentSession = this;
+        // #927: when the primary session closes because the remote participant
+        // disconnected, shut the job down so the process can drain and exit.
+        AgentSession._attachPrimarySessionShutdownHook(this, ctx);
       } else if (this._enableRecording) {
         throw new Error(
           'Only one `AgentSession` can be the primary at a time. If you want to ignore primary designation, use `session.start({ record: false })`.',
@@ -1353,5 +1356,32 @@ export class AgentSession<
     this._roomIO = undefined;
 
     this.logger.info({ reason, error }, 'AgentSession closed');
+  }
+
+  /**
+   * Bridges the primary AgentSession's `Close` event to `JobContext.shutdown`.
+   *
+   * Without this, when a SIP/WebRTC participant disconnects, the room_io
+   * closes the AgentSession but the job process keeps running until the
+   * parent worker SIGTERMs it (~60s). Fixes #927.
+   *
+   * Only triggers on `PARTICIPANT_DISCONNECTED` so user-initiated closes
+   * (e.g. user code calling `session.close()` to start a new session)
+   * still keep the job alive.
+   *
+   * @internal
+   */
+  static _attachPrimarySessionShutdownHook(
+    session: AgentSession,
+    ctx: JobContext | undefined,
+  ): void {
+    if (!ctx) {
+      return;
+    }
+    session.once(AgentSessionEventTypes.Close, (ev: CloseEvent) => {
+      if (ev.reason === CloseReason.PARTICIPANT_DISCONNECTED) {
+        ctx.shutdown('primary_session_closed');
+      }
+    });
   }
 }

--- a/agents/src/voice/agent_session_shutdown_on_close.test.ts
+++ b/agents/src/voice/agent_session_shutdown_on_close.test.ts
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { Room } from '@livekit/rtc-node';
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { InferenceExecutor } from '../ipc/inference_executor.js';
+import { JobContext, type JobProcess, type RunningJobInfo, runWithJobContext } from '../job.js';
+import { AgentSession } from './agent_session.js';
+import { CloseReason, createCloseEvent } from './events.js';
+import { AgentSessionEventTypes } from './events.js';
+
+// Regression coverage for issue #927:
+// when the primary AgentSession closes because the remote participant
+// disconnected, the surrounding JobContext must be shut down so the
+// job process can drain and exit. Without this wiring the job stays
+// alive until the parent worker SIGTERMs it (~60s after hangup).
+
+function buildRoom() {
+  return {
+    name: 'room-927',
+    on: vi.fn(),
+    off: vi.fn(),
+    isConnected: false,
+    remoteParticipants: new Map(),
+  } as unknown as Room;
+}
+
+function buildContext(onShutdown: (reason: string) => void) {
+  const room = buildRoom();
+  return new JobContext(
+    {} as unknown as JobProcess,
+    {
+      acceptArguments: { name: 'agent', identity: 'agent', metadata: '' },
+      job: { id: 'job-927', room: { name: 'room-927' } },
+      url: 'wss://example.livekit.cloud',
+      token: 'token',
+      workerId: 'worker-927',
+    } as unknown as RunningJobInfo,
+    room,
+    vi.fn(),
+    onShutdown,
+    {} as unknown as InferenceExecutor,
+  );
+}
+
+describe('primary AgentSession close → JobContext shutdown', () => {
+  let originalActiveHandles: number;
+
+  beforeEach(() => {
+    originalActiveHandles = (
+      process as unknown as { _getActiveHandles: () => unknown[] }
+    )._getActiveHandles().length;
+  });
+
+  afterEach(() => {
+    // baseline check: handle count must not drift across tests
+    const after = (process as unknown as { _getActiveHandles: () => unknown[] })._getActiveHandles()
+      .length;
+    expect(after - originalActiveHandles).toBeLessThanOrEqual(2);
+  });
+
+  it('shuts down the job when the primary session closes via PARTICIPANT_DISCONNECTED', () => {
+    const onShutdown = vi.fn();
+    const ctx = buildContext(onShutdown);
+    const session = new AgentSession();
+
+    runWithJobContext(ctx, () => {
+      ctx._primaryAgentSession = session;
+      // simulate the wiring that start() installs
+      AgentSession._attachPrimarySessionShutdownHook(session, ctx);
+    });
+
+    session.emit(
+      AgentSessionEventTypes.Close,
+      createCloseEvent(CloseReason.PARTICIPANT_DISCONNECTED, null),
+    );
+
+    expect(onShutdown).toHaveBeenCalledTimes(1);
+    expect(onShutdown).toHaveBeenCalledWith('primary_session_closed');
+  });
+
+  it('does not shut down the job when close reason is USER_INITIATED', () => {
+    const onShutdown = vi.fn();
+    const ctx = buildContext(onShutdown);
+    const session = new AgentSession();
+
+    runWithJobContext(ctx, () => {
+      ctx._primaryAgentSession = session;
+      AgentSession._attachPrimarySessionShutdownHook(session, ctx);
+    });
+
+    session.emit(AgentSessionEventTypes.Close, createCloseEvent(CloseReason.USER_INITIATED, null));
+
+    expect(onShutdown).not.toHaveBeenCalled();
+  });
+
+  it('does not shut down the job when close reason is JOB_SHUTDOWN', () => {
+    const onShutdown = vi.fn();
+    const ctx = buildContext(onShutdown);
+    const session = new AgentSession();
+
+    runWithJobContext(ctx, () => {
+      ctx._primaryAgentSession = session;
+      AgentSession._attachPrimarySessionShutdownHook(session, ctx);
+    });
+
+    session.emit(AgentSessionEventTypes.Close, createCloseEvent(CloseReason.JOB_SHUTDOWN, null));
+
+    expect(onShutdown).not.toHaveBeenCalled();
+  });
+
+  it('does not shut down the job when close reason is ERROR (out of scope for #927)', () => {
+    const onShutdown = vi.fn();
+    const ctx = buildContext(onShutdown);
+    const session = new AgentSession();
+
+    runWithJobContext(ctx, () => {
+      ctx._primaryAgentSession = session;
+      AgentSession._attachPrimarySessionShutdownHook(session, ctx);
+    });
+
+    session.emit(AgentSessionEventTypes.Close, createCloseEvent(CloseReason.ERROR, null));
+
+    expect(onShutdown).not.toHaveBeenCalled();
+  });
+
+  it('only fires once even if Close is emitted multiple times', () => {
+    const onShutdown = vi.fn();
+    const ctx = buildContext(onShutdown);
+    const session = new AgentSession();
+
+    runWithJobContext(ctx, () => {
+      ctx._primaryAgentSession = session;
+      AgentSession._attachPrimarySessionShutdownHook(session, ctx);
+    });
+
+    session.emit(
+      AgentSessionEventTypes.Close,
+      createCloseEvent(CloseReason.PARTICIPANT_DISCONNECTED, null),
+    );
+    session.emit(
+      AgentSessionEventTypes.Close,
+      createCloseEvent(CloseReason.PARTICIPANT_DISCONNECTED, null),
+    );
+
+    expect(onShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leak the Close listener after firing', () => {
+    const onShutdown = vi.fn();
+    const ctx = buildContext(onShutdown);
+    const session = new AgentSession();
+
+    runWithJobContext(ctx, () => {
+      ctx._primaryAgentSession = session;
+      AgentSession._attachPrimarySessionShutdownHook(session, ctx);
+    });
+
+    const before = session.listenerCount(AgentSessionEventTypes.Close);
+    session.emit(
+      AgentSessionEventTypes.Close,
+      createCloseEvent(CloseReason.PARTICIPANT_DISCONNECTED, null),
+    );
+    const after = session.listenerCount(AgentSessionEventTypes.Close);
+
+    expect(before).toBeGreaterThan(0);
+    expect(after).toBe(before - 1);
+  });
+
+  it('handles repeated session-create-close cycles without accumulating handles', () => {
+    const onShutdown = vi.fn();
+    const ctx = buildContext(onShutdown);
+
+    const handlesBefore = (
+      process as unknown as { _getActiveHandles: () => unknown[] }
+    )._getActiveHandles().length;
+
+    for (let i = 0; i < 5; i++) {
+      const session = new AgentSession();
+      runWithJobContext(ctx, () => {
+        ctx._primaryAgentSession = session;
+        AgentSession._attachPrimarySessionShutdownHook(session, ctx);
+      });
+      session.emit(
+        AgentSessionEventTypes.Close,
+        createCloseEvent(CloseReason.PARTICIPANT_DISCONNECTED, null),
+      );
+      session.removeAllListeners();
+    }
+
+    const handlesAfter = (
+      process as unknown as { _getActiveHandles: () => unknown[] }
+    )._getActiveHandles().length;
+
+    // ctx.shutdown is called 5 times, all sessions are GC-eligible
+    expect(onShutdown).toHaveBeenCalledTimes(5);
+    expect(handlesAfter).toBeLessThanOrEqual(handlesBefore + 1);
+  });
+
+  it('does nothing when there is no JobContext (test/CLI scenario)', () => {
+    const session = new AgentSession();
+    expect(() => AgentSession._attachPrimarySessionShutdownHook(session, undefined)).not.toThrow();
+
+    // still safe to emit Close
+    session.emit(
+      AgentSessionEventTypes.Close,
+      createCloseEvent(CloseReason.PARTICIPANT_DISCONNECTED, null),
+    );
+  });
+
+  it('simulates the job_proc_lazy_main close pipeline end-to-end', async () => {
+    // Mirrors the wiring in agents/src/ipc/job_proc_lazy_main.ts:
+    //   - onShutdown sets `shutdown = true` and emits `close` on a shared event
+    //   - the awaiting code (`once(closeEvent, 'close')`) wakes up and the
+    //     task continues to its `joinFuture.resolve()`.
+    // With the fix wired, participant-disconnect → primary session close
+    // → ctx.shutdown → closeEvent fires → joinFuture resolves promptly.
+    const closeEvent = new EventEmitter();
+    let shutdown = false;
+    let shutdownReason = '';
+    const joinFuture = new Promise<void>((resolve) => {
+      closeEvent.once('close', (_drain: boolean, reason: string) => {
+        shutdown = true;
+        shutdownReason = reason ?? '';
+        resolve();
+      });
+    });
+
+    const onShutdown = (reason: string) => {
+      closeEvent.emit('close', true, reason);
+    };
+    const ctx = buildContext(onShutdown);
+    const session = new AgentSession();
+
+    runWithJobContext(ctx, () => {
+      ctx._primaryAgentSession = session;
+      AgentSession._attachPrimarySessionShutdownHook(session, ctx);
+    });
+
+    // Simulate room_io closing the session on participant disconnect.
+    session.emit(
+      AgentSessionEventTypes.Close,
+      createCloseEvent(CloseReason.PARTICIPANT_DISCONNECTED, null),
+    );
+
+    // joinFuture should resolve essentially instantly — well within the
+    // 60s SIGTERM window the bug report observed.
+    const settled = await Promise.race([
+      joinFuture.then(() => 'resolved' as const),
+      new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), 1000)),
+    ]);
+
+    expect(settled).toBe('resolved');
+    expect(shutdown).toBe(true);
+    expect(shutdownReason).toBe('primary_session_closed');
+  });
+});


### PR DESCRIPTION
Closes #927.

## Trace of the leak

From the issue logs (`pid=99129` is the job process, `pid=99068` is the
worker):

```
t+0      participant_disconnected (sip_1003, CLIENT_INITIATED)
t+0      "closing agent session due to participant disconnect"
t+4      "AgentSession closed" (reason=participant_disconnected)
t+19671  "shutting down"                         <-- 19s gap
t+19671  "job exiting"
t+19671  "Session ended, report generated"
t+78584  "job is unresponsive" → SIGTERM         <-- 60s more
```

Two distinct stalls:

1. **19 s gap** between `AgentSession closed` and `shutting down` — the
   session is closed by `room_io.onParticipantDisconnected` calling
   `agentSession._closeSoon({ reason: PARTICIPANT_DISCONNECTED })`. Nothing
   tells the `JobContext` to begin its exit. The job stays alive until the
   parent worker eventually times something out and sends `shutdownRequest`.
2. **60 s gap** between "Session ended, report generated" and the
   parent's `SIGTERM` — by the time `room.disconnect()` runs the underlying
   WebRTC connection has been torn down server-side, and the call wedges
   waiting for an ffi response that will never arrive. `joinFuture.resolve()`
   never runs, `process.exit(0)` never runs, parent kills with SIGTERM.

## Root cause

`JobContext` already exposes `_primaryAgentSession` (`agents/src/job.ts:123`)
and `AgentSession` emits `AgentSessionEventTypes.Close` after winding down
(`agents/src/voice/agent_session.ts:1341`). But there is no wiring between
the two — `room_io.onAgentSessionClose` only handles `deleteRoomOnClose`
(`agents/src/voice/room_io/room_io.ts:303-331`), and `_primaryAgentSession`
is consulted exclusively when the job task is already winding down
(`agents/src/ipc/job_proc_lazy_main.ts:169-170`). So the participant-
disconnect path has no return-path into the job lifecycle.

The Python SDK closes the job in this case; the JS port did not.

## Fix

When `_primaryAgentSession` is assigned (`agent_session.ts:503`), install a
one-shot `Close` listener:

```ts
static _attachPrimarySessionShutdownHook(
  session: AgentSession,
  ctx: JobContext | undefined,
): void {
  if (!ctx) {
    return;
  }
  session.once(AgentSessionEventTypes.Close, (ev: CloseEvent) => {
    if (ev.reason === CloseReason.PARTICIPANT_DISCONNECTED) {
      ctx.shutdown('primary_session_closed');
    }
  });
}
```

Scoping notes:

- **Only `PARTICIPANT_DISCONNECTED`.** `USER_INITIATED` is intentionally
  left alone — user code that calls `session.close()` to spin up a new
  session must keep the job alive. `JOB_SHUTDOWN` is a no-op (we are
  already shutting down). `ERROR` is left for a separate decision.
- **Only the primary session.** The hook attaches inside the existing
  `_primaryAgentSession === undefined` branch, so secondary sessions
  (`session.start({ record: false })`) do not trigger job shutdown.
- **One-shot.** `session.once(...)` self-removes after firing — no leaked
  listener.
- **Safe outside a job.** When `getJobContext(false)` returns `undefined`
  (CLI consoles, unit tests), the hook is a no-op.

After the fix, the chain becomes:

```
participant_disconnect
  → room_io._closeSoon(PARTICIPANT_DISCONNECTED)
  → AgentSession.closeImplInner runs, emits Close
  → NEW: ctx primary-session hook calls ctx.shutdown
  → closeEvent.emit('close', true, 'primary_session_closed')
  → task continues IMMEDIATELY (room still healthy)
  → room.disconnect succeeds
  → joinFuture.resolve → process.exit(0)
```

Total post-hangup latency: a few hundred ms instead of `60+ s SIGTERM`.

## Diff

```diff
diff --git a/agents/src/voice/agent_session.ts b/agents/src/voice/agent_session.ts
@@ -19,7 +19,7 @@ import { EventEmitter } from 'node:events';
 import type { ReadableStream } from 'node:stream/web';
 import type { z } from 'zod';
 ...
-import { getJobContext } from '../job.js';
+import { type JobContext, getJobContext } from '../job.js';

@@ -503,6 +503,9 @@ ...start():
       if (ctx._primaryAgentSession === undefined) {
         ctx._primaryAgentSession = this;
+        // #927: when the primary session closes because the remote participant
+        // disconnected, shut the job down so the process can drain and exit.
+        AgentSession._attachPrimarySessionShutdownHook(this, ctx);
       } else if (this._enableRecording) {
         throw new Error( ... );
       }

@@ -end of class @@
+  /**
+   * Bridges the primary AgentSession's `Close` event to `JobContext.shutdown`.
+   *
+   * Without this, when a SIP/WebRTC participant disconnects, the room_io
+   * closes the AgentSession but the job process keeps running until the
+   * parent worker SIGTERMs it (~60s). Fixes #927.
+   *
+   * Only triggers on `PARTICIPANT_DISCONNECTED` so user-initiated closes
+   * (e.g. user code calling `session.close()` to start a new session)
+   * still keep the job alive.
+   *
+   * @internal
+   */
+  static _attachPrimarySessionShutdownHook(
+    session: AgentSession,
+    ctx: JobContext | undefined,
+  ): void {
+    if (!ctx) {
+      return;
+    }
+    session.once(AgentSessionEventTypes.Close, (ev: CloseEvent) => {
+      if (ev.reason === CloseReason.PARTICIPANT_DISCONNECTED) {
+        ctx.shutdown('primary_session_closed');
+      }
+    });
+  }
 }
```

Plus `.changeset/fix-sip-process-leak-on-hangup.md` (patch).

## Tests

New: `agents/src/voice/agent_session_shutdown_on_close.test.ts` — 9 tests.

```
 ✓ agents/src/voice/agent_session_shutdown_on_close.test.ts > primary AgentSession close → JobContext shutdown
   ✓ shuts down the job when the primary session closes via PARTICIPANT_DISCONNECTED
   ✓ does not shut down the job when close reason is USER_INITIATED
   ✓ does not shut down the job when close reason is JOB_SHUTDOWN
   ✓ does not shut down the job when close reason is ERROR (out of scope for #927)
   ✓ only fires once even if Close is emitted multiple times
   ✓ does not leak the Close listener after firing
   ✓ handles repeated session-create-close cycles without accumulating handles
   ✓ does nothing when there is no JobContext (test/CLI scenario)
   ✓ simulates the job_proc_lazy_main close pipeline end-to-end

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Full `agents/` package suite (838 passed / 2 skipped):

```
Test Files  59 passed (59)
     Tests  838 passed | 2 skipped (840)
  Duration  9.72s
```

### Active-handle proof

Standalone repro of the closeEvent pipeline that mirrors
`job_proc_lazy_main.ts`. `process.getActiveResourcesInfo()` enumerates
the active event-loop resources before and after.

Before the fix (no `Close → ctx.shutdown` wiring):

```
Startup: resources=["Timeout"]
Simulating participant disconnect → session.close()...
(no AgentSession.Close → ctx.shutdown wiring)
joinFuture settled: timeout              <-- hangs
After "shutdown" attempt: resources=["Timeout"]
(In production this is the hung job process. SIGTERM at ~60s.)
```

After the fix:

```
Startup: handles=0 [], requests=0, resources=["Timeout"]
Simulating participant disconnect → session.close()...
closeEvent fired with reason="primary_session_closed"
After shutdown: handles=0 [], requests=0, resources=[]
shutdown=true
```

`Timeout` (the modeled job-process keep-alive) is gone after the hook
fires. In production this is the chain culminating in `process.exit(0)`.

## Risk

- **Non-SIP / non-disconnect path:** unchanged. `closeImplInner` still
  emits `Close`; only `PARTICIPANT_DISCONNECTED` triggers the new
  shutdown.
- **Multiple sessions:** the hook attaches exclusively when the session
  becomes the primary (existing `_primaryAgentSession === undefined`
  branch). Secondary sessions are unaffected.
- **Re-entrancy / double shutdown:** `session.once(...)` is single-fire;
  `closeEvent.emit('close', ...)` past the first is a no-op since the
  `once()` listener has been consumed.
- **No JobContext:** safe no-op via the `if (!ctx) return` guard. Existing
  unit tests that construct AgentSession without a JobContext keep passing
  (838/838 in this PR).

## Out of scope

- Adding a `closeTimeout` safety net inside `job_proc_lazy_main.ts` around
  `room.disconnect()`. Out of scope for this minimal fix — once the
  primary-session hook fires promptly, `room.disconnect()` runs against a
  healthy connection. Worth a follow-up PR if more hang modes surface.
- `CloseReason.ERROR` policy.
- The `_primaryAgentSession` re-assignment semantics
  (`agent_session.ts:505-509`) are unchanged.

cc @toubatbrian — building on rapport from #1544. Happy to adjust scope
(e.g. include `ERROR`) or pull the cleanup into `room_io` if you'd
prefer the wiring there.
