### PR TITLE
fix(telemetry): preserve OTEL logging for stale loggers

### DIFF
--- a/.changeset/stale-loggers-observe.md
+++ b/.changeset/stale-loggers-observe.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(telemetry): export observability logs from logger instances captured before OTEL setup.

--- a/agents/src/log.test.ts
+++ b/agents/src/log.test.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { enableOtelLogging, initializeLogger, log } from './log.js';
+import { PinoCloudExporter, initPinoCloudExporter } from './telemetry/pino_otel_transport.js';
+
+const OTEL_ENABLED_KEY = Symbol.for('@livekit/agents:otelEnabled');
+
+function resetOtelLoggingState() {
+  delete (globalThis as Record<symbol, unknown>)[OTEL_ENABLED_KEY];
+  initializeLogger({ pretty: false, level: 'silent' });
+}
+
+describe('OTEL logging', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetOtelLoggingState();
+  });
+
+  it('exports logs from logger instances captured before OTEL is enabled', async () => {
+    initializeLogger({ pretty: false, level: 'info' });
+    const staleLogger = log().child({ capturedBeforeOtel: true });
+    const emitSpy = vi.spyOn(PinoCloudExporter.prototype, 'emit').mockImplementation(() => {});
+
+    initPinoCloudExporter({
+      cloudHostname: 'example.livekit.cloud',
+      roomId: 'RM_test',
+      jobId: 'AJ_test',
+    });
+    enableOtelLogging();
+
+    staleLogger.info('log from stale logger');
+    log().info('log from fresh logger');
+
+    await vi.waitFor(() => {
+      const messages = emitSpy.mock.calls.map(([logObj]) => logObj.msg);
+      expect(messages).toContain('log from stale logger');
+      expect(messages).toContain('log from fresh logger');
+    });
+  });
+});

--- a/agents/src/log.ts
+++ b/agents/src/log.ts
@@ -40,13 +40,23 @@ export const log = () => {
   return logger;
 };
 
+const createLogger = ({ pretty, level }: LoggerOptions): Logger => {
+  const logLevel = level || 'info';
+  const streams: { stream: DestinationStream; level: string }[] = [
+    { stream: pretty ? pinoPretty({ colorize: true }) : process.stdout, level: logLevel },
+    { stream: new OtelDestination(), level: 'debug' },
+  ];
+
+  return pino(
+    { level: logLevel, serializers: { error: pino.stdSerializers.err } },
+    multistream(streams),
+  );
+};
+
 /** @internal */
 export const initializeLogger = ({ pretty, level }: LoggerOptions) => {
   globals[LOGGER_OPTIONS_KEY] = { pretty, level };
-  globals[LOGGER_KEY] = pino(
-    { level: level || 'info', serializers: { error: pino.stdSerializers.err } },
-    pretty ? pinoPretty({ colorize: true }) : process.stdout,
-  );
+  globals[LOGGER_KEY] = createLogger({ pretty, level });
 };
 
 /**
@@ -56,6 +66,11 @@ export const initializeLogger = ({ pretty, level }: LoggerOptions) => {
 class OtelDestination extends Writable {
   _write(chunk: Buffer, _encoding: string, callback: (error?: Error | null) => void): void {
     try {
+      if (!globals[OTEL_ENABLED_KEY]) {
+        callback();
+        return;
+      }
+
       const line = chunk.toString().trim();
       if (line) {
         const logObj = JSON.parse(line) as PinoLogObject;
@@ -69,8 +84,7 @@ class OtelDestination extends Writable {
 }
 
 /**
- * Enable OTEL logging by reconfiguring the logger with multistream.
- * Uses a custom destination that receives full JSON logs (with msg, level, time).
+ * Enable OTEL logging for the existing logger streams.
  *
  * @internal
  */
@@ -80,18 +94,4 @@ export const enableOtelLogging = () => {
     return;
   }
   globals[OTEL_ENABLED_KEY] = true;
-
-  const opts = globals[LOGGER_OPTIONS_KEY]!;
-  const { pretty, level } = opts;
-
-  const logLevel = level || 'info';
-  const streams: { stream: DestinationStream; level: string }[] = [
-    { stream: pretty ? pinoPretty({ colorize: true }) : process.stdout, level: logLevel },
-    { stream: new OtelDestination(), level: 'debug' },
-  ];
-
-  globals[LOGGER_KEY] = pino(
-    { level: logLevel, serializers: { error: pino.stdSerializers.err } },
-    multistream(streams),
-  );
 };


### PR DESCRIPTION
## Summary

- keep a stable Pino multistream logger from initialization so captured root/child loggers retain the OTEL destination
- make `enableOtelLogging()` flip the OTEL export gate instead of replacing the global logger
- add a minimal regression test proving a logger captured before OTEL setup and a fresh logger both export after enablement
- add a patch changeset

Fixes #1561

## Validation

- `pnpm test agents/src/log.test.ts`
- `pnpm format:check`
- `pnpm exec eslint -f unix "agents/src/log.ts" "agents/src/log.test.ts"`
- `pnpm build:agents`

Note: `pnpm --filter @livekit/agents lint` currently fails on pre-existing warnings across unrelated files after the changed-file Prettier errors were fixed. `pnpm --filter @livekit/agents api:check` currently fails on API Extractor not supporting existing `export * as ___` syntax in `agents/dist/index.d.ts`.