### PR TITLE
fix(voice): prevent userTurnCompleted from interrupting say() speech

### DIFF
--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -923,6 +923,7 @@ export class AgentActivity implements RecognitionHooks {
 
     const handle = SpeechHandle.create({
       allowInterruptions: allowInterruptions ?? this.allowInterruptions,
+      source: 'say',
     });
 
     this.agentSession.emit(
@@ -1985,15 +1986,22 @@ export class AgentActivity implements RecognitionHooks {
         return;
       }
 
-      await this.cancelSpeechPause();
+      if (this._currentSpeech.source === 'say') {
+        this.logger.debug(
+          { 'speech id': this._currentSpeech.id },
+          'preserving externally queued speech from auto-interrupt on user turn',
+        );
+      } else {
+        await this.cancelSpeechPause();
 
-      this.logger.info(
-        { 'speech id': this._currentSpeech.id },
-        'speech interrupted, new user turn detected',
-      );
+        this.logger.info(
+          { 'speech id': this._currentSpeech.id },
+          'speech interrupted, new user turn detected',
+        );
 
-      this._currentSpeech.interrupt();
-      this.realtimeSession?.interrupt();
+        this._currentSpeech.interrupt();
+        this.realtimeSession?.interrupt();
+      }
     }
 
     let userMessage: ChatMessage | undefined = ChatMessage.create({
@@ -3309,6 +3317,7 @@ export class AgentActivity implements RecognitionHooks {
       allowInterruptions: speechHandle.allowInterruptions,
       stepIndex: speechHandle.numSteps + 1,
       parent: speechHandle,
+      source: 'tool_response',
     });
     this.agentSession.emit(
       AgentSessionEventTypes.SpeechCreated,

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -66,6 +66,9 @@ export interface InputDetails {
 /** Default {@link InputDetails} used when no explicit value is provided. */
 export const DEFAULT_INPUT_DETAILS: InputDetails = { modality: 'audio' };
 
+/** How a {@link SpeechHandle} was created. */
+export type SpeechHandleSource = 'say' | 'generate_reply' | 'tool_response';
+
 export class SpeechHandle {
   /** Priority for messages that should be played after all other messages in the queue */
   static SPEECH_PRIORITY_LOW = 0;
@@ -106,6 +109,7 @@ export class SpeechHandle {
     public _stepIndex: number,
     private _inputDetails: InputDetails = DEFAULT_INPUT_DETAILS,
     readonly parent?: SpeechHandle,
+    private _source: SpeechHandleSource = 'generate_reply',
   ) {
     this.doneFut.await.finally(() => {
       for (const callback of this.doneCallbacks) {
@@ -119,12 +123,14 @@ export class SpeechHandle {
     stepIndex?: number;
     inputDetails?: InputDetails;
     parent?: SpeechHandle;
+    source?: SpeechHandleSource;
   }) {
     const {
       allowInterruptions = true,
       stepIndex = 0,
       inputDetails = DEFAULT_INPUT_DETAILS,
       parent,
+      source = 'generate_reply',
     } = options ?? {};
 
     return new SpeechHandle(
@@ -133,6 +139,7 @@ export class SpeechHandle {
       stepIndex,
       inputDetails,
       parent,
+      source,
     );
   }
 
@@ -158,6 +165,10 @@ export class SpeechHandle {
 
   get allowInterruptions(): boolean {
     return this._allowInterruptions;
+  }
+
+  get source(): SpeechHandleSource {
+    return this._source;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds a `source` property to `SpeechHandle` (`'say' | 'generate_reply' | 'tool_response'`) so the framework can distinguish pipeline-generated speech from externally-queued speech
- `userTurnCompleted` now skips the auto-interrupt when `_currentSpeech.source === 'say'`, preserving the caller's intended response
- Fixes a race condition in BYOLLM setups where `session.say()` speech gets killed ~500ms after queuing because `userTurnCompleted` assumes all current speech is stale and an LLM reply will replace it

## Problem

When using a bring-your-own-LLM setup (no LiveKit LLM pipeline), all responses come through `session.say()`. The flow is:

1. User finishes speaking (STT-final fires)
2. Application calls `session.say(someText)` as the response
3. ~500ms later, `userTurnCompleted` fires and interrupts `_currentSpeech` to make room for an LLM-generated reply
4. But there is no internal LLM — the `say()` call **was** the reply. The speech gets killed before audio plays.

## Fix

`SpeechHandle` now tracks its `source` — how it was created. In `userTurnCompleted`, only pipeline-generated speech (`generate_reply`, `tool_response`) is auto-interrupted. Speech from `say()` is preserved.

- **Backward-compatible**: pipeline users see no behavior change
- **Barge-in still works**: `session.interrupt()` and VAD-triggered interruption work on all speech types regardless of source
- **`allowInterruptions` unchanged**: works independently of the new source check

## Test plan

- [x] All 194 existing voice tests pass
- [x] Build succeeds (`pnpm build:agents`)
- [x] Formatting passes (`pnpm format:write`)
- [x] Linting passes (`pnpm lint:fix`, no new warnings)
- [ ] Verify `restaurant_agent.ts` in Agent Playground (pipeline path unchanged)
- [ ] Verify BYOLLM setup: `session.say()` speech is no longer interrupted by `userTurnCompleted`
- [ ] Verify user barge-in still interrupts `say()` speech when `allowInterruptions: true`