### PR TITLE
update dependencies

### DIFF
--- a/agents/package.json
+++ b/agents/package.json
@@ -57,7 +57,7 @@
     "sharp": "0.34.3",
     "uuid": "^11.1.0",
     "ws": "^8.16.0",
-    "zod": "^3.23.8",
+    "zod": "^3.25.56",
     "zod-to-json-schema": "^3.24.6"
   },
   "peerDependencies": {

--- a/agents/package.json
+++ b/agents/package.json
@@ -57,7 +57,7 @@
     "sharp": "0.34.3",
     "uuid": "^11.1.0",
     "ws": "^8.16.0",
-    "zod": "^3.25.56",
+    "zod": "catalog:",
     "zod-to-json-schema": "^3.24.6"
   },
   "peerDependencies": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -34,6 +34,6 @@
     "@livekit/noise-cancellation-node": "^0.1.9",
     "@livekit/rtc-node": "^0.13.11",
     "livekit-server-sdk": "^2.9.2",
-    "zod": "^3.23.8"
+    "zod": "catalog:"
   }
 }

--- a/plugins/livekit/package.json
+++ b/plugins/livekit/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@huggingface/hub": "2.4.1",
-    "@huggingface/transformers": "3.7.2",
+    "@huggingface/transformers": "3.8.1",
     "onnxruntime-node": "1.21.0"
   }
 }

--- a/plugins/test/package.json
+++ b/plugins/test/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "fastest-levenshtein": "^1.0.16",
     "vitest": "^1.6.0",
-    "zod": "^3.23.8"
+    "zod": "catalog:"
   },
   "peerDependencies": {
     "@livekit/agents": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,11 +129,11 @@ importers:
         specifier: ^8.16.0
         version: 8.17.0
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: ^3.25.56
+        version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.24.6
-        version: 3.24.6(zod@3.23.8)
+        version: 3.24.6(zod@3.25.76)
     devDependencies:
       '@livekit/rtc-node':
         specifier: ^0.13.12
@@ -149,7 +149,7 @@ importers:
         version: 22.15.30
       '@types/ws':
         specifier: ^8.5.10
-        version: 8.5.10
+        version: 8.18.1
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@22.15.30))(postcss@8.4.38)(tsx@4.20.4)(typescript@5.4.5)
@@ -351,8 +351,8 @@ importers:
         specifier: 2.4.1
         version: 2.4.1
       '@huggingface/transformers':
-        specifier: 3.7.2
-        version: 3.7.2
+        specifier: 3.8.1
+        version: 3.8.1
       onnxruntime-node:
         specifier: 1.21.0
         version: 1.21.0
@@ -411,7 +411,7 @@ importers:
         version: 1.1.1
       openai:
         specifier: ^4.91.1
-        version: 4.91.1(ws@8.17.0)(zod@3.23.8)
+        version: 4.91.1(ws@8.17.0)(zod@3.25.76)
       ws:
         specifier: ^8.16.0
         version: 8.17.0
@@ -1154,15 +1154,15 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@huggingface/jinja@0.5.1':
-    resolution: {integrity: sha512-yUZLld4lrM9iFxHCwFQ7D1HW2MWMwSbeB7WzWqFYDWK+rEb+WldkLdAJxUPOmgICMHZLzZGVcVjFh3w/YGubng==}
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
     engines: {node: '>=18'}
 
   '@huggingface/tasks@0.19.36':
     resolution: {integrity: sha512-oBXkEndtoLScX4aljFM1mXlFvAI6kYzCjhLV+2/ekyU1vn4Ypl2csDuAI6PRLGWGW8g0q9uGtBtFHfS4uMiYPQ==}
 
-  '@huggingface/transformers@3.7.2':
-    resolution: {integrity: sha512-6SOxo6XziupnQ5Vs5vbbs74CNB6ViHLHGQJjY6zj88JeiDtJ2d/ADKxaay688Sf2KcjtdF3dyBL11C5pJS2NxQ==}
+  '@huggingface/transformers@3.8.1':
+    resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -4435,6 +4435,9 @@ packages:
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -4954,13 +4957,13 @@ snapshots:
     dependencies:
       '@huggingface/tasks': 0.19.36
 
-  '@huggingface/jinja@0.5.1': {}
+  '@huggingface/jinja@0.5.9': {}
 
   '@huggingface/tasks@0.19.36': {}
 
-  '@huggingface/transformers@3.7.2':
+  '@huggingface/transformers@3.8.1':
     dependencies:
-      '@huggingface/jinja': 0.5.1
+      '@huggingface/jinja': 0.5.9
       onnxruntime-node: 1.21.0
       onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
       sharp: 0.34.3
@@ -7404,7 +7407,7 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.4.0
 
-  openai@4.91.1(ws@8.17.0)(zod@3.23.8):
+  openai@4.91.1(ws@8.17.0)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.64
       '@types/node-fetch': 2.6.11
@@ -7415,7 +7418,7 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.17.0
-      zod: 3.23.8
+      zod: 3.25.76
     transitivePeerDependencies:
       - encoding
 
@@ -8523,8 +8526,10 @@ snapshots:
     optionalDependencies:
       commander: 9.5.0
 
-  zod-to-json-schema@3.24.6(zod@3.23.8):
+  zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
-      zod: 3.23.8
+      zod: 3.25.76
 
   zod@3.23.8: {}
+
+  zod@3.25.76: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    zod:
+      specifier: ^3.25.56
+      version: 3.25.76
+
 importers:
 
   .:
@@ -129,7 +135,7 @@ importers:
         specifier: ^8.16.0
         version: 8.17.0
       zod:
-        specifier: ^3.25.56
+        specifier: 'catalog:'
         version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.24.6
@@ -199,8 +205,8 @@ importers:
         specifier: ^2.9.2
         version: 2.9.2
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: 'catalog:'
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^22.5.5
@@ -512,8 +518,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@22.15.30)
       zod:
-        specifier: ^3.23.8
-        version: 3.23.8
+        specifier: 'catalog:'
+        version: 3.25.76
     devDependencies:
       '@livekit/agents':
         specifier: workspace:*
@@ -4431,9 +4437,6 @@ packages:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
       zod: ^3.24.1
-
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -8529,7 +8532,5 @@ snapshots:
   zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod@3.23.8: {}
 
   zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,6 @@ packages:
   - "agents"
   - "plugins/*"
   - "examples"
+
+catalog:
+  "zod": "^3.25.56"


### PR DESCRIPTION
# Description
Some of the packages are out of date and causes the build to fail.
- Probably relaying on cached packages so the result could be different in different local states.

## Local Build logs
 *  Executing task in folder agents: pnpm run clean:build 
```js
7 import { ZodObject } from 'zod';
           ~~~~~~~~~
Found 5 errors in 3 files.

Errors  Files
     3  src/llm/tool_context.ts:5
     1  src/llm/utils.ts:7
     1  src/voice/generation.ts:7
```
 *  Executing task in folder livekit: pnpm run clean:build 
```js
40     const { AutoTokenizer } = await import('@huggingface/transformers');
Found 3 errors in 2 files.

Errors  Files
     1  src/index.ts:21
     2  src/turn_detector/base.ts:4
```

---

## Changes Made
- zod dependency update
- @huggingface/transformers dependency update

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] ~~**Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable)~~

## Testing
<!-- Describe how you tested these changes -->
- [ ] ~~Automated tests added/updated (if applicable)~~
- [x] All tests pass
- [ ] ~~Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)~~  - I could not get the tests to run, but mostly likely it is not related

#### All tests pass Results

- Most Tests passed
```
 Test Files  8 failed | 18 passed | 1 skipped (27)
      Tests  283 passed | 2 skipped (285)
```

Some unrelated failures - requiring opening several accounts ext.
```
 FAIL   nodejs  plugins/cartesia/src/tts.test.ts [ plugins/cartesia/src/tts.test.ts ]
Error: Cartesia API key is required, whether as an argument or as $CARTESIA_API_KEY

 FAIL   nodejs  plugins/deepgram/src/stt.test.ts [ plugins/deepgram/src/stt.test.ts ]
Error: Deepgram API key is required, whether as an argument or as $DEEPGRAM_API_KEY

 FAIL   nodejs  plugins/elevenlabs/src/tts.test.ts [ plugins/elevenlabs/src/tts.test.ts ]
Error: ElevenLabs API key is required, whether as an argument or as $ELEVEN_API_KEY

 FAIL   nodejs  plugins/google/src/llm.test.ts [ plugins/google/src/llm.test.ts ]
Error: API key is required for Google API either via apiKey or GOOGLE_API_KEY environment variable

 FAIL   nodejs  plugins/neuphonic/src/tts.test.ts [ plugins/neuphonic/src/tts.test.ts ]
Error: Neuphonic API key is required, whether as an argument or as $NEUPHONIC_API_KEY

 FAIL   nodejs  plugins/openai/src/stt.test.ts [ plugins/openai/src/stt.test.ts ]
Error: Load model from /Users/yanivprz/BOT_PULSE/projects/vocoagents/ext-packages/livekit/agents-js/plugins/silero/dist/silero_vad.onnx 

 FAIL   nodejs  plugins/resemble/src/tts.test.ts [ plugins/resemble/src/tts.test.ts ]
Error: Resemble API key is required, whether as an argument or as $RESEMBLE_API_KEY

 FAIL   nodejs  plugins/google/src/beta/gemini_tts.test.ts [ plugins/google/src/beta/gemini_tts.test.ts ]
APIConnectionError: API key is required for Google API either via apiKey or GOOGLE_API_KEY environment variable
```

#### restaurant_agent.ts` and `realtime_agent.ts Tests Results

I could not make these two run (even after running download-files)
but silero_vad is not related to this PR.
log term this test should be simplifed.
I tried: `node ./examples/dist/realtime_agent.js download-files`
- [ ] Ideally, could someone that has the local dev already working double check this? 
```
pnpm i
node --env-file=.env ./examples/dist/realtime_agent.js dev
```

Result:
```
[12:24:03.652] ERROR (216): Load model from /Users/yanivprz/BOT_PULSE/projects/vocoagents/ext-packages/livekit/agents-js/plugins/silero/dist/silero_vad.onnx failed:Protobuf parsing failed.
    err: {
      "type": "Error",
      "message": "Load model from /Users/yanivprz/BOT_PULSE/projects/vocoagents/ext-packages/livekit/agents-js/plugins/silero/dist/silero_vad.onnx failed:Protobuf parsing failed.",
      "stack":
          Error: Load model from /Users/yanivprz/BOT_PULSE/projects/vocoagents/ext-packages/livekit/agents-js/plugins/silero/dist/silero_vad.onnx failed:Protobuf parsing failed.
              at new OnnxruntimeSessionHandler (/Users/yanivprz/BOT_PULSE/projects/vocoagents/ext-packages/livekit/agents-js/node_modules/.pnpm/onnxruntime-node@1.21.0/node_modules/onnxruntime-node/dist/backend.js:25:92)
              at Immediate.<anonymous> (/Users/yanivprz/BOT_PULSE/projects/vocoagents/ext-packages/livekit/agents-js/node_modules/.pnpm/onnxruntime-node@1.21.0/node_modules/onnxruntime-node/dist/backend.js:67:29)
              at process.processImmediate (node:internal/timers:491:21)
    }
```