### PR TITLE
feat(llm): add LLMStream.collect() to await full response

### DIFF
--- a/.changeset/llm-stream-collect.md
+++ b/.changeset/llm-stream-collect.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Add `LLMStream.collect()` for awaiting the full response of a chat stream as a single object (text, tool calls, usage, extra).

--- a/agents/src/llm/index.ts
+++ b/agents/src/llm/index.ts
@@ -66,6 +66,7 @@ export {
   LLMStream,
   type ChatChunk,
   type ChoiceDelta,
+  type CollectedResponse,
   type CompletionUsage,
   type LLMCallbacks,
 } from './llm.js';

--- a/agents/src/llm/llm.test.ts
+++ b/agents/src/llm/llm.test.ts
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initializeLogger } from '../log.js';
+import type { APIConnectOptions } from '../types.js';
+import { delay } from '../utils.js';
+import { type ChatContext, FunctionCall } from './chat_context.js';
+import { type ChatChunk, LLM, LLMStream } from './llm.js';
+import type { ToolChoice, ToolContext } from './tool_context.js';
+
+class MockLLMStream extends LLMStream {
+  constructor(
+    llm: LLM,
+    opts: {
+      chatCtx: ChatContext;
+      toolCtx?: ToolContext;
+      connOptions: APIConnectOptions;
+    },
+    private chunks: ChatChunk[],
+  ) {
+    super(llm, opts);
+  }
+
+  protected async run(): Promise<void> {
+    for (const chunk of this.chunks) {
+      this.queue.put(chunk);
+      await delay(1);
+    }
+  }
+}
+
+class MockLLM extends LLM {
+  constructor(private chunks: ChatChunk[]) {
+    super();
+  }
+
+  label(): string {
+    return 'mock-llm';
+  }
+
+  chat(opts: {
+    chatCtx: ChatContext;
+    toolCtx?: ToolContext;
+    connOptions?: APIConnectOptions;
+    parallelToolCalls?: boolean;
+    toolChoice?: ToolChoice;
+    extraKwargs?: Record<string, unknown>;
+  }): LLMStream {
+    return new MockLLMStream(
+      this,
+      {
+        chatCtx: opts.chatCtx,
+        toolCtx: opts.toolCtx,
+        connOptions: opts.connOptions ?? ({ maxRetry: 0 } as APIConnectOptions),
+      },
+      this.chunks,
+    );
+  }
+}
+
+describe('LLMStream.collect', () => {
+  beforeAll(() => {
+    initializeLogger({ pretty: false });
+    process.on('unhandledRejection', () => {});
+  });
+
+  it('joins content parts and trims surrounding whitespace', async () => {
+    const llm = new MockLLM([
+      { id: '1', delta: { role: 'assistant', content: '  Hello' } },
+      { id: '1', delta: { role: 'assistant', content: ', ' } },
+      { id: '1', delta: { role: 'assistant', content: 'world!  ' } },
+    ]);
+
+    const response = await llm.chat({ chatCtx: {} as ChatContext }).collect();
+
+    expect(response.text).toBe('Hello, world!');
+    expect(response.toolCalls).toHaveLength(0);
+    expect(response.usage).toBeUndefined();
+    expect(response.extra).toEqual({});
+  });
+
+  it('accumulates tool calls across chunks', async () => {
+    const callA = new FunctionCall({
+      callId: 'call_a',
+      name: 'get_weather',
+      args: '{"city":"SF"}',
+    });
+    const callB = new FunctionCall({
+      callId: 'call_b',
+      name: 'play_song',
+      args: '{"name":"x"}',
+    });
+    const llm = new MockLLM([
+      { id: '1', delta: { role: 'assistant', toolCalls: [callA] } },
+      { id: '1', delta: { role: 'assistant', toolCalls: [callB] } },
+    ]);
+
+    const response = await llm.chat({ chatCtx: {} as ChatContext }).collect();
+
+    expect(response.text).toBe('');
+    expect(response.toolCalls).toHaveLength(2);
+    expect(response.toolCalls[0]!.callId).toBe('call_a');
+    expect(response.toolCalls[1]!.callId).toBe('call_b');
+  });
+
+  it('captures the latest usage and merges extra data', async () => {
+    const llm = new MockLLM([
+      { id: '1', delta: { role: 'assistant', content: 'hi', extra: { a: 1 } } },
+      {
+        id: '1',
+        delta: { role: 'assistant', content: ' there', extra: { b: 2 } },
+        usage: {
+          completionTokens: 2,
+          promptTokens: 5,
+          promptCachedTokens: 0,
+          totalTokens: 7,
+        },
+      },
+      {
+        id: '1',
+        usage: {
+          completionTokens: 3,
+          promptTokens: 5,
+          promptCachedTokens: 0,
+          totalTokens: 8,
+        },
+      },
+    ]);
+
+    const response = await llm.chat({ chatCtx: {} as ChatContext }).collect();
+
+    expect(response.text).toBe('hi there');
+    expect(response.usage?.completionTokens).toBe(3);
+    expect(response.usage?.totalTokens).toBe(8);
+    expect(response.extra).toEqual({ a: 1, b: 2 });
+  });
+
+  it('returns empty response for an empty stream', async () => {
+    const llm = new MockLLM([]);
+
+    const response = await llm.chat({ chatCtx: {} as ChatContext }).collect();
+
+    expect(response.text).toBe('');
+    expect(response.toolCalls).toHaveLength(0);
+    expect(response.usage).toBeUndefined();
+    expect(response.extra).toEqual({});
+  });
+});

--- a/agents/src/llm/llm.test.ts
+++ b/agents/src/llm/llm.test.ts
@@ -3,18 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 import { beforeAll, describe, expect, it } from 'vitest';
 import { initializeLogger } from '../log.js';
-import type { APIConnectOptions } from '../types.js';
+import { type APIConnectOptions, DEFAULT_API_CONNECT_OPTIONS } from '../types.js';
 import { delay } from '../utils.js';
-import { type ChatContext, FunctionCall } from './chat_context.js';
+import { ChatContext, FunctionCall } from './chat_context.js';
 import { type ChatChunk, LLM, LLMStream } from './llm.js';
-import type { ToolChoice, ToolContext } from './tool_context.js';
+import type { ToolChoice, ToolCtxInput } from './tool_context.js';
 
 class MockLLMStream extends LLMStream {
   constructor(
     llm: LLM,
     opts: {
       chatCtx: ChatContext;
-      toolCtx?: ToolContext;
+      toolCtx?: ToolCtxInput;
       connOptions: APIConnectOptions;
     },
     private chunks: ChatChunk[],
@@ -41,7 +41,7 @@ class MockLLM extends LLM {
 
   chat(opts: {
     chatCtx: ChatContext;
-    toolCtx?: ToolContext;
+    toolCtx?: ToolCtxInput;
     connOptions?: APIConnectOptions;
     parallelToolCalls?: boolean;
     toolChoice?: ToolChoice;
@@ -52,7 +52,7 @@ class MockLLM extends LLM {
       {
         chatCtx: opts.chatCtx,
         toolCtx: opts.toolCtx,
-        connOptions: opts.connOptions ?? ({ maxRetry: 0 } as APIConnectOptions),
+        connOptions: opts.connOptions ?? DEFAULT_API_CONNECT_OPTIONS,
       },
       this.chunks,
     );
@@ -72,7 +72,7 @@ describe('LLMStream.collect', () => {
       { id: '1', delta: { role: 'assistant', content: 'world!  ' } },
     ]);
 
-    const response = await llm.chat({ chatCtx: {} as ChatContext }).collect();
+    const response = await llm.chat({ chatCtx: new ChatContext() }).collect();
 
     expect(response.text).toBe('Hello, world!');
     expect(response.toolCalls).toHaveLength(0);
@@ -96,7 +96,7 @@ describe('LLMStream.collect', () => {
       { id: '1', delta: { role: 'assistant', toolCalls: [callB] } },
     ]);
 
-    const response = await llm.chat({ chatCtx: {} as ChatContext }).collect();
+    const response = await llm.chat({ chatCtx: new ChatContext() }).collect();
 
     expect(response.text).toBe('');
     expect(response.toolCalls).toHaveLength(2);
@@ -128,7 +128,7 @@ describe('LLMStream.collect', () => {
       },
     ]);
 
-    const response = await llm.chat({ chatCtx: {} as ChatContext }).collect();
+    const response = await llm.chat({ chatCtx: new ChatContext() }).collect();
 
     expect(response.text).toBe('hi there');
     expect(response.usage?.completionTokens).toBe(3);
@@ -139,7 +139,7 @@ describe('LLMStream.collect', () => {
   it('returns empty response for an empty stream', async () => {
     const llm = new MockLLM([]);
 
-    const response = await llm.chat({ chatCtx: {} as ChatContext }).collect();
+    const response = await llm.chat({ chatCtx: new ChatContext() }).collect();
 
     expect(response.text).toBe('');
     expect(response.toolCalls).toHaveLength(0);

--- a/agents/src/llm/llm.ts
+++ b/agents/src/llm/llm.ts
@@ -40,6 +40,17 @@ export interface ChatChunk {
   usage?: CompletionUsage;
 }
 
+export interface CollectedResponse {
+  text: string;
+  toolCalls: FunctionCall[];
+  usage?: CompletionUsage;
+  /**
+   * Provider-specific extra data accumulated across chunks
+   * (e.g., xAI encrypted reasoning, Google thought signatures).
+   */
+  extra: Record<string, unknown>;
+}
+
 export interface LLMError {
   type: 'llm_error';
   timestamp: number;
@@ -339,6 +350,53 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
 
   close() {
     this.abortController.abort();
+  }
+
+  /**
+   * Collect the entire stream into a single response.
+   *
+   * @example
+   * ```ts
+   * const response = await myLlm.chat({ chatCtx, toolCtx }).collect();
+   *
+   * for (const tc of response.toolCalls) {
+   *   // execute the tool call...
+   * }
+   * ```
+   */
+  async collect(): Promise<CollectedResponse> {
+    const textParts: string[] = [];
+    const toolCalls: FunctionCall[] = [];
+    let usage: CompletionUsage | undefined;
+    const extra: Record<string, unknown> = {};
+
+    try {
+      for await (const chunk of this) {
+        if (chunk.delta) {
+          if (chunk.delta.content) {
+            textParts.push(chunk.delta.content);
+          }
+          if (chunk.delta.toolCalls) {
+            toolCalls.push(...chunk.delta.toolCalls);
+          }
+          if (chunk.delta.extra) {
+            Object.assign(extra, chunk.delta.extra);
+          }
+        }
+        if (chunk.usage !== undefined) {
+          usage = chunk.usage;
+        }
+      }
+    } finally {
+      this.close();
+    }
+
+    return {
+      text: textParts.join('').trim(),
+      toolCalls,
+      usage,
+      extra,
+    };
   }
 
   [Symbol.asyncIterator](): LLMStream {


### PR DESCRIPTION
## Summary

Ports the async `collect()` helper from Python `livekit-agents` (`llm/llm.py`) to `LLMStream` in `@livekit/agents`.

`collect()` iterates the chat stream once and accumulates the result into a single `CollectedResponse`:

- `text` — joined `delta.content` with surrounding whitespace trimmed
- `toolCalls` — every `delta.toolCalls` entry, in order
- `usage` — the latest `chunk.usage` seen
- `extra` — provider-specific extras merged across chunks

The stream is closed in a `finally` block to mirror Python's `async with self:` semantics.

```ts
const response = await myLlm.chat({ chatCtx, toolCtx }).collect();

for (const tc of response.toolCalls) {
  // execute the tool call...
}
```

## Changes

- `agents/src/llm/llm.ts`: add `CollectedResponse` interface and `LLMStream.collect()` method
- `agents/src/llm/index.ts`: export `CollectedResponse`
- `agents/src/llm/llm.test.ts`: unit tests covering content, tool calls, usage/extra accumulation, and empty stream

## Test plan

- [x] `pnpm test agents/src/llm/llm.test.ts` (4 passed)
- [x] `pnpm build:agents`
- [x] `pnpm lint --filter @livekit/agents` (no new errors in touched files)
- [x] `pnpm format:check`

---
_Generated by [Claude Code](https://claude.ai/code/session_016bmXqj7ixLAQ9mmH6Dwpi9)_