### PR TITLE
fix(voice): port pause/resume audio + sync gating from Python, fix userTurnCompleted race

### DIFF
--- a/.changeset/shaggy-heads-listen.md
+++ b/.changeset/shaggy-heads-listen.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+fix(voice): make ParticipantAudioOutput.pause() actually gate audio (port _playback_enabled + synchronizer pause)

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1974,8 +1974,11 @@ export class AgentActivity implements RecognitionHooks {
       this.realtimeSession?.commitAudio();
     }
 
-    if (this._currentSpeech) {
-      if (!this._currentSpeech.allowInterruptions) {
+    // Capture into a local before awaiting cancelSpeechPause: the main scheduling
+    // loop can reset this._currentSpeech = undefined during the await (#1430).
+    const currentSpeech = this._currentSpeech;
+    if (currentSpeech) {
+      if (!currentSpeech.allowInterruptions) {
         this.logger.warn(
           { user_input: info.newTranscript },
           'skipping user input, current speech generation cannot be interrupted',
@@ -1986,11 +1989,11 @@ export class AgentActivity implements RecognitionHooks {
       await this.cancelSpeechPause();
 
       this.logger.info(
-        { 'speech id': this._currentSpeech.id },
+        { 'speech id': currentSpeech.id },
         'speech interrupted, new user turn detected',
       );
 
-      this._currentSpeech.interrupt();
+      currentSpeech.interrupt();
       this.realtimeSession?.interrupt();
     }
 

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -382,13 +382,8 @@ export class ParticipantAudioOutput extends AudioOutput {
   private startedFuture: Future<void> = new Future();
   private interruptedFuture: Future<void> = new Future();
   private firstFrameEmitted: boolean = false;
-  // Gates audio frame forwarding while the output is paused.
-  // Ref: livekit-agents/livekit/agents/voice/room_io/_output.py `_playback_enabled`
-  private playbackEnabledFuture: Future<void> = (() => {
-    const f = new Future<void>();
-    f.resolve();
-    return f;
-  })();
+  /** Gate held closed while the output is paused; frame forwarding awaits it. */
+  private playbackEnabledFuture: Future<void> = new Future();
 
   constructor(room: Room, options: AudioOutputOptions) {
     super(options.sampleRate, undefined, { pause: true });
@@ -399,20 +394,18 @@ export class ParticipantAudioOutput extends AudioOutput {
       options.numChannels,
       options.queueSizeMs,
     );
+    this.playbackEnabledFuture.resolve();
   }
 
-  // Ref: livekit-agents/livekit/agents/voice/room_io/_output.py `ParticipantAudioOutput.pause`
   pause(): void {
     if (this.playbackEnabledFuture.done) {
       this.playbackEnabledFuture = new Future();
     }
-    // Drop any audio already buffered in the WebRTC source so playback stops
-    // promptly instead of draining the prebuffer.
+    // Drop already-buffered audio so playback stops promptly instead of draining the prebuffer.
     this.audioSource.clearQueue();
     super.pause();
   }
 
-  // Ref: livekit-agents/livekit/agents/voice/room_io/_output.py `ParticipantAudioOutput.resume`
   resume(): void {
     if (!this.playbackEnabledFuture.done) {
       this.playbackEnabledFuture.resolve();
@@ -434,13 +427,9 @@ export class ParticipantAudioOutput extends AudioOutput {
 
     super.captureFrame(frame);
 
-    // Gate the forwarded frame on the pause state. Ref:
-    // livekit-agents/livekit/agents/voice/room_io/_output.py `_forward_audio`
     if (!this.playbackEnabledFuture.done) {
       this.audioSource.clearQueue();
-      // Race the gate against interruption so a cancel-while-paused can't deadlock
-      // an in-flight frame (`cancelSpeechPause` calls `resume()` after interrupt,
-      // but we still want a clean bail-out if the speech was already interrupted).
+      // Race against interruption so a cancel-while-paused can't deadlock an in-flight frame.
       await Promise.race([this.playbackEnabledFuture.await, this.interruptedFuture.await]);
       if (this.interruptedFuture.done) {
         return;

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -450,6 +450,8 @@ export class ParticipantAudioOutput extends AudioOutput {
     // Snapshot duration for this flush so overlapping next-segment frames are not erased on completion.
     const accountedDuration = this.pushedDuration;
     const abortFuture = new Future<boolean>();
+    // Reset before the race so a stale clearBuffer() from before this segment doesn't fire it.
+    this.interruptedFuture = new Future();
 
     const resolveAbort = () => {
       if (!abortFuture.done) abortFuture.resolve(true);
@@ -475,7 +477,6 @@ export class ParticipantAudioOutput extends AudioOutput {
     }
 
     this.pushedDuration = 0;
-    this.interruptedFuture = new Future();
     this.firstFrameEmitted = false;
 
     this.onPlaybackFinished({
@@ -516,11 +517,10 @@ export class ParticipantAudioOutput extends AudioOutput {
   }
 
   clearBuffer(): void {
-    if (!this.pushedDuration) {
-      return;
+    // Signal interruption even if no frame has been pushed yet, so a gated captureFrame can bail.
+    if (!this.interruptedFuture.done) {
+      this.interruptedFuture.resolve();
     }
-
-    this.interruptedFuture.resolve();
   }
 
   private async publishTrack(signal: AbortSignal) {

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -382,6 +382,13 @@ export class ParticipantAudioOutput extends AudioOutput {
   private startedFuture: Future<void> = new Future();
   private interruptedFuture: Future<void> = new Future();
   private firstFrameEmitted: boolean = false;
+  // Gates audio frame forwarding while the output is paused.
+  // Ref: livekit-agents/livekit/agents/voice/room_io/_output.py `_playback_enabled`
+  private playbackEnabledFuture: Future<void> = (() => {
+    const f = new Future<void>();
+    f.resolve();
+    return f;
+  })();
 
   constructor(room: Room, options: AudioOutputOptions) {
     super(options.sampleRate, undefined, { pause: true });
@@ -392,6 +399,26 @@ export class ParticipantAudioOutput extends AudioOutput {
       options.numChannels,
       options.queueSizeMs,
     );
+  }
+
+  // Ref: livekit-agents/livekit/agents/voice/room_io/_output.py `ParticipantAudioOutput.pause`
+  pause(): void {
+    if (this.playbackEnabledFuture.done) {
+      this.playbackEnabledFuture = new Future();
+    }
+    // Drop any audio already buffered in the WebRTC source so playback stops
+    // promptly instead of draining the prebuffer.
+    this.audioSource.clearQueue();
+    super.pause();
+  }
+
+  // Ref: livekit-agents/livekit/agents/voice/room_io/_output.py `ParticipantAudioOutput.resume`
+  resume(): void {
+    if (!this.playbackEnabledFuture.done) {
+      this.playbackEnabledFuture.resolve();
+    }
+    this.firstFrameEmitted = false;
+    super.resume();
   }
 
   get subscribed(): boolean {
@@ -406,6 +433,19 @@ export class ParticipantAudioOutput extends AudioOutput {
     await this.startedFuture.await;
 
     super.captureFrame(frame);
+
+    // Gate the forwarded frame on the pause state. Ref:
+    // livekit-agents/livekit/agents/voice/room_io/_output.py `_forward_audio`
+    if (!this.playbackEnabledFuture.done) {
+      this.audioSource.clearQueue();
+      // Race the gate against interruption so a cancel-while-paused can't deadlock
+      // an in-flight frame (`cancelSpeechPause` calls `resume()` after interrupt,
+      // but we still want a clean bail-out if the speech was already interrupted).
+      await Promise.race([this.playbackEnabledFuture.await, this.interruptedFuture.await]);
+      if (this.interruptedFuture.done) {
+        return;
+      }
+    }
 
     if (!this.firstFrameEmitted) {
       this.firstFrameEmitted = true;

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -156,6 +156,21 @@ class SegmentSynchronizerImpl {
   private startFuture: Future = new Future();
   private closedFuture: Future = new Future();
   private playbackCompleted: boolean = false;
+  private interrupted: boolean = false;
+
+  // Tracks accumulated pause time so wall-clock-based elapsed calculations don't
+  // advance the transcript during pauses. Mirrors Python's
+  // `_paused_wall_time` / `_paused_duration` in `_SegmentSynchronizerImpl`.
+  private pausedWallTime?: number;
+  /** Accumulated paused time in milliseconds (subtracted from elapsed). */
+  private pausedDuration: number = 0;
+  // Gate that holds the main task between words while paused. Mirrors
+  // Python's `_output_enabled_ev` event.
+  private outputEnabledFuture: Future<void> = (() => {
+    const f = new Future<void>();
+    f.resolve();
+    return f;
+  })();
 
   private logger = log();
 
@@ -307,12 +322,49 @@ class SegmentSynchronizerImpl {
     }
   }
 
+  // Ref: livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+  // `_SegmentSynchronizerImpl.pause`
+  pause(): void {
+    if (this.closed) {
+      this.logger.warn('SegmentSynchronizerImpl.pause called after close');
+      return;
+    }
+    if (this.pausedWallTime === undefined) {
+      this.pausedWallTime = Date.now();
+    }
+    if (this.outputEnabledFuture.done) {
+      this.outputEnabledFuture = new Future();
+    }
+  }
+
+  // Ref: livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+  // `_SegmentSynchronizerImpl.resume`
+  resume(): void {
+    if (this.closed) {
+      this.logger.warn('SegmentSynchronizerImpl.resume called after close');
+      return;
+    }
+    if (this.pausedWallTime !== undefined) {
+      if (this.startWallTime !== undefined) {
+        // max() handles the case where pause() was called before the first audio
+        // frame was pushed (i.e., before startWallTime was set). This can happen when
+        // a new impl is created while the synchronizer is already paused.
+        this.pausedDuration += Date.now() - Math.max(this.startWallTime, this.pausedWallTime);
+      }
+      this.pausedWallTime = undefined;
+    }
+    if (!this.outputEnabledFuture.done) {
+      this.outputEnabledFuture.resolve();
+    }
+  }
+
   markPlaybackFinished(_playbackPosition: number, interrupted: boolean) {
     if (this.closed) {
       this.logger.warn('SegmentSynchronizerImpl.markPlaybackFinished called after close');
       return;
     }
 
+    this.interrupted = interrupted;
     if (!this.textData.done || !this.audioData.done) {
       this.logger.warn(
         { textDone: this.textData.done, audioDone: this.audioData.done },
@@ -369,6 +421,16 @@ class SegmentSynchronizerImpl {
     for await (const wordToken of this.textData.wordStream) {
       const word = wordToken.token;
 
+      // Gate the per-word forwarding while paused. Ref:
+      // livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+      // `_SegmentSynchronizerImpl._main_task` `_output_enabled_ev` check.
+      if (!this.outputEnabledFuture.done) {
+        await this.outputEnabledFuture.await;
+        if (this.interrupted) {
+          return;
+        }
+      }
+
       if (this.closed && !this.playbackCompleted) {
         return;
       }
@@ -405,7 +467,9 @@ class SegmentSynchronizerImpl {
       const cleanWords = this.options.splitWords(word);
       const cleanWord = cleanWords.length > 0 ? cleanWords[0]![0] : word;
       const wordHyphens = this.options.hyphenateWord(cleanWord).length;
-      const elapsedSeconds = (Date.now() - this.startWallTime) / 1000;
+      // Subtract accumulated paused time so the transcript doesn't race ahead
+      // of the audio after a pause/resume cycle.
+      const elapsedSeconds = (Date.now() - this.startWallTime - this.pausedDuration) / 1000;
 
       let dHyphens = 0;
       const annotated = this.audioData.annotatedRate;
@@ -487,6 +551,11 @@ class SegmentSynchronizerImpl {
     }
 
     this.startFuture.resolve(); // avoid deadlock of mainTaskImpl in case it never started
+    // Release the pause gate so mainTask can observe `closed` and exit instead of
+    // hanging forever if close() is called while paused.
+    if (!this.outputEnabledFuture.done) {
+      this.outputEnabledFuture.resolve();
+    }
     // Close the writer if endTextInput hasn't already done so (e.g. on interruption)
     if (!this.enabled && !this.textData.done) {
       this.outputStreamWriter.close();
@@ -532,6 +601,13 @@ export class TranscriptionSynchronizer {
   // the synchronizer transitions back to enabled
   /** @internal */
   _warnedAsymmetricDetach: boolean = false;
+
+  // Track pause state at the synchronizer level so it can be reapplied to new
+  // impls after segment rotation. Ref:
+  // livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+  // `TranscriptSynchronizer._paused`.
+  /** @internal */
+  _paused: boolean = false;
 
   private logger = log();
 
@@ -629,6 +705,13 @@ export class TranscriptionSynchronizer {
 
     await this._impl.close();
     this._impl = new SegmentSynchronizerImpl(this.options, this.textOutput.nextInChain, true);
+
+    // Re-apply the current pause state to the new impl. Ref:
+    // livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+    // `TranscriptSynchronizer._rotate_segment_task`.
+    if (this._paused) {
+      this._impl.pause();
+    }
   }
 }
 
@@ -640,6 +723,27 @@ class SyncedAudioOutput extends AudioOutput {
     private nextInChainAudio: AudioOutput,
   ) {
     super(nextInChainAudio.sampleRate, nextInChainAudio, { pause: true });
+  }
+
+  // Ref: livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+  // `_SyncedAudioOutput.pause`.
+  pause(): void {
+    super.pause(); // forwards to nextInChainAudio (e.g. ParticipantAudioOutput)
+    // Track pause state at the synchronizer level so it persists across segment rotations
+    this.synchronizer._paused = true;
+    if (!this.synchronizer._impl.closed) {
+      this.synchronizer._impl.pause();
+    }
+  }
+
+  // Ref: livekit-agents/livekit/agents/voice/transcription/synchronizer.py
+  // `_SyncedAudioOutput.resume`.
+  resume(): void {
+    super.resume();
+    this.synchronizer._paused = false;
+    if (!this.synchronizer._impl.closed) {
+      this.synchronizer._impl.resume();
+    }
   }
 
   async captureFrame(frame: AudioFrame): Promise<void> {

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -439,7 +439,7 @@ class SegmentSynchronizerImpl {
         this.outputStreamWriter.write(
           createTimedString({
             text: forwardedWord,
-            endTime: this.startWallTime ? (Date.now() - this.startWallTime) / 1000 : undefined,
+            endTime: this.synchronizedElapsedSeconds(),
           }),
         );
         const cleanWords = this.options.splitWords(word);
@@ -452,8 +452,7 @@ class SegmentSynchronizerImpl {
       const cleanWords = this.options.splitWords(word);
       const cleanWord = cleanWords.length > 0 ? cleanWords[0]![0] : word;
       const wordHyphens = this.options.hyphenateWord(cleanWord).length;
-      // Subtract paused time so the transcript doesn't race ahead of the audio after resume.
-      const elapsedSeconds = (Date.now() - this.startWallTime - this.pausedDuration) / 1000;
+      const elapsedSeconds = this.synchronizedElapsedSeconds()!;
 
       let dHyphens = 0;
       const annotated = this.audioData.annotatedRate;
@@ -486,7 +485,7 @@ class SegmentSynchronizerImpl {
       this.outputStreamWriter.write(
         createTimedString({
           text: forwardedWord,
-          endTime: this.startWallTime ? (Date.now() - this.startWallTime) / 1000 : undefined,
+          endTime: this.synchronizedElapsedSeconds(),
         }),
       );
       await this.sleepIfNotClosed(delayTime / 2);
@@ -500,11 +499,19 @@ class SegmentSynchronizerImpl {
       this.outputStreamWriter.write(
         createTimedString({
           text: remaining,
-          endTime: this.startWallTime ? (Date.now() - this.startWallTime) / 1000 : undefined,
+          endTime: this.synchronizedElapsedSeconds(),
         }),
       );
       this.textData.forwardedText += remaining;
     }
+  }
+
+  /** Elapsed audio-playback time in seconds — wall-clock minus paused time. */
+  private synchronizedElapsedSeconds(): number | undefined {
+    if (this.startWallTime === undefined) {
+      return undefined;
+    }
+    return (Date.now() - this.startWallTime - this.pausedDuration) / 1000;
   }
 
   private calcHyphens(text: string): string[] {

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -158,19 +158,11 @@ class SegmentSynchronizerImpl {
   private playbackCompleted: boolean = false;
   private interrupted: boolean = false;
 
-  // Tracks accumulated pause time so wall-clock-based elapsed calculations don't
-  // advance the transcript during pauses. Mirrors Python's
-  // `_paused_wall_time` / `_paused_duration` in `_SegmentSynchronizerImpl`.
   private pausedWallTime?: number;
-  /** Accumulated paused time in milliseconds (subtracted from elapsed). */
+  /** Accumulated paused time in milliseconds; subtracted from wall-clock elapsed. */
   private pausedDuration: number = 0;
-  // Gate that holds the main task between words while paused. Mirrors
-  // Python's `_output_enabled_ev` event.
-  private outputEnabledFuture: Future<void> = (() => {
-    const f = new Future<void>();
-    f.resolve();
-    return f;
-  })();
+  /** Gate held closed while paused; the main task awaits it between words. */
+  private outputEnabledFuture: Future<void> = new Future();
 
   private logger = log();
 
@@ -205,6 +197,7 @@ class SegmentSynchronizerImpl {
     };
     this.outputStream = new IdentityTransform();
     this.outputStreamWriter = this.outputStream.writable.getWriter();
+    this.outputEnabledFuture.resolve();
 
     if (this.enabled) {
       this.mainTask()
@@ -322,8 +315,6 @@ class SegmentSynchronizerImpl {
     }
   }
 
-  // Ref: livekit-agents/livekit/agents/voice/transcription/synchronizer.py
-  // `_SegmentSynchronizerImpl.pause`
   pause(): void {
     if (this.closed) {
       this.logger.warn('SegmentSynchronizerImpl.pause called after close');
@@ -337,8 +328,6 @@ class SegmentSynchronizerImpl {
     }
   }
 
-  // Ref: livekit-agents/livekit/agents/voice/transcription/synchronizer.py
-  // `_SegmentSynchronizerImpl.resume`
   resume(): void {
     if (this.closed) {
       this.logger.warn('SegmentSynchronizerImpl.resume called after close');
@@ -346,9 +335,8 @@ class SegmentSynchronizerImpl {
     }
     if (this.pausedWallTime !== undefined) {
       if (this.startWallTime !== undefined) {
-        // max() handles the case where pause() was called before the first audio
-        // frame was pushed (i.e., before startWallTime was set). This can happen when
-        // a new impl is created while the synchronizer is already paused.
+        // max() guards the case where pause() ran before startWallTime was set
+        // (e.g. a new impl is created while the synchronizer is already paused).
         this.pausedDuration += Date.now() - Math.max(this.startWallTime, this.pausedWallTime);
       }
       this.pausedWallTime = undefined;
@@ -421,9 +409,6 @@ class SegmentSynchronizerImpl {
     for await (const wordToken of this.textData.wordStream) {
       const word = wordToken.token;
 
-      // Gate the per-word forwarding while paused. Ref:
-      // livekit-agents/livekit/agents/voice/transcription/synchronizer.py
-      // `_SegmentSynchronizerImpl._main_task` `_output_enabled_ev` check.
       if (!this.outputEnabledFuture.done) {
         await this.outputEnabledFuture.await;
         if (this.interrupted) {
@@ -467,8 +452,7 @@ class SegmentSynchronizerImpl {
       const cleanWords = this.options.splitWords(word);
       const cleanWord = cleanWords.length > 0 ? cleanWords[0]![0] : word;
       const wordHyphens = this.options.hyphenateWord(cleanWord).length;
-      // Subtract accumulated paused time so the transcript doesn't race ahead
-      // of the audio after a pause/resume cycle.
+      // Subtract paused time so the transcript doesn't race ahead of the audio after resume.
       const elapsedSeconds = (Date.now() - this.startWallTime - this.pausedDuration) / 1000;
 
       let dHyphens = 0;
@@ -551,8 +535,7 @@ class SegmentSynchronizerImpl {
     }
 
     this.startFuture.resolve(); // avoid deadlock of mainTaskImpl in case it never started
-    // Release the pause gate so mainTask can observe `closed` and exit instead of
-    // hanging forever if close() is called while paused.
+    // Release the pause gate so mainTask can observe `closed` and exit if close() ran while paused.
     if (!this.outputEnabledFuture.done) {
       this.outputEnabledFuture.resolve();
     }
@@ -602,11 +585,8 @@ export class TranscriptionSynchronizer {
   /** @internal */
   _warnedAsymmetricDetach: boolean = false;
 
-  // Track pause state at the synchronizer level so it can be reapplied to new
-  // impls after segment rotation. Ref:
-  // livekit-agents/livekit/agents/voice/transcription/synchronizer.py
-  // `TranscriptSynchronizer._paused`.
-  /** @internal */
+  /** Pause state tracked at the synchronizer level so it can be reapplied across segment rotations.
+   * @internal */
   _paused: boolean = false;
 
   private logger = log();
@@ -706,9 +686,6 @@ export class TranscriptionSynchronizer {
     await this._impl.close();
     this._impl = new SegmentSynchronizerImpl(this.options, this.textOutput.nextInChain, true);
 
-    // Re-apply the current pause state to the new impl. Ref:
-    // livekit-agents/livekit/agents/voice/transcription/synchronizer.py
-    // `TranscriptSynchronizer._rotate_segment_task`.
     if (this._paused) {
       this._impl.pause();
     }
@@ -725,19 +702,14 @@ class SyncedAudioOutput extends AudioOutput {
     super(nextInChainAudio.sampleRate, nextInChainAudio, { pause: true });
   }
 
-  // Ref: livekit-agents/livekit/agents/voice/transcription/synchronizer.py
-  // `_SyncedAudioOutput.pause`.
   pause(): void {
-    super.pause(); // forwards to nextInChainAudio (e.g. ParticipantAudioOutput)
-    // Track pause state at the synchronizer level so it persists across segment rotations
+    super.pause();
     this.synchronizer._paused = true;
     if (!this.synchronizer._impl.closed) {
       this.synchronizer._impl.pause();
     }
   }
 
-  // Ref: livekit-agents/livekit/agents/voice/transcription/synchronizer.py
-  // `_SyncedAudioOutput.resume`.
   resume(): void {
     super.resume();
     this.synchronizer._paused = false;


### PR DESCRIPTION
## Summary

Fixes two regressions introduced by #1320 ("resume false interruption"). Both were caused by the JS port omitting subtle pieces of the Python original:

1. **Audio output pause was a no-op.** `ParticipantAudioOutput` declared the `pause` capability but never overrode `pause()` / `resume()`. The base class `AudioOutput.pause()` only delegates to `nextInChain`, which is `undefined` on the leaf, so audio kept streaming through "pauses". The agent only stopped when the user produced a final transcript and `cancelSpeechPause` ran `handle.interrupt()` — matching the user-reported symptom "agent keeps speaking until I finish".
2. **#1430: `userTurnCompleted` race.** Python uses `(current_speech := self._current_speech)` to bind a local before `await self._cancel_speech_pause(...)`. The JS port expanded that into raw `this._currentSpeech` access. When a fast barge-in awaits `cancelSpeechPause()` (which itself awaits `_waitForGeneration()`), the main scheduling loop can complete and reset `_currentSpeech = undefined`. The subsequent `this._currentSpeech.id` then throws a TypeError that gets swallowed by the EOU handler's outer `.catch`, the new turn is never scheduled, and `userAwayTimeout` fires ~10s later.

## Changes

**`agents/src/voice/room_io/_output.ts` — `ParticipantAudioOutput`**
- Adds `playbackEnabledFuture` gate (resolved initially) — equivalent to Python's `_playback_enabled` event.
- `pause()`: replaces the future with an unresolved one and calls `audioSource.clearQueue()` so the WebRTC prebuffer doesn't drain after pause.
- `resume()`: resolves the gate, resets `firstFrameEmitted` so the next frame re-emits `onPlaybackStarted`.
- `captureFrame()`: when paused, races `playbackEnabledFuture.await` against `interruptedFuture.await` so a cancel-while-paused can't deadlock an in-flight frame. Bails out cleanly if interrupted.

**`agents/src/voice/transcription/synchronizer.ts`**
- `SegmentSynchronizerImpl`: adds `pausedWallTime`, `pausedDuration` (ms), `outputEnabledFuture`, `interrupted` fields; new `pause()`/`resume()`; main task gates word-forwarding and subtracts paused time from elapsed; `markPlaybackFinished` tracks interrupted state; `close()` releases the gate so the task can observe close and exit.
- `TranscriptionSynchronizer`: adds `_paused` field, reapplied to the new impl after segment rotation.
- `SyncedAudioOutput`: overrides `pause()` / `resume()` to set `synchronizer._paused` and forward to `_impl.pause()` / `_impl.resume()`.

**`agents/src/voice/agent_activity.ts` — `AgentActivity.userTurnCompleted` (fix #1430)**
- Captures `_currentSpeech` into a local `currentSpeech` before `await this.cancelSpeechPause()`. All subsequent dereferences (`allowInterruptions`, `id`, `interrupt()`) use the local, mirroring Python's walrus-bound `current_speech`. Eliminates the TypeError → swallowed-turn → `userAwayTimeout` symptom.

## Realtime model impact

None for the common case. When using a `RealtimeModel` with server-side turn detection, `interruptByAudioActivity` early-returns before calling `pause()` — the server handles interruption directly. For realtime models with client-side turn detection (rare), the same correct gating now applies. The #1430 fix is independent of model type.

## Test plan

- [x] `pnpm build:agents` — clean
- [x] 31 `synchronizer.test.ts` tests — pass
- [x] 3 `_output.test.ts` tests — pass
- [x] Voice subsystem unaffected tests — pass (8 pre-existing `amd.test.ts` failures on `main` are unrelated)
- [x] Manual repro of audio-pause fix with `basic_agent` + Inference STT/LLM/TTS, validated via runtime logging across two pause/cancel cycles
- [x] PR validation in Agent Playground with `restaurant_agent.ts` and `realtime_agent.ts` (CI requirement)

## Verification (runtime evidence)

Two pause/resume repro sessions plus a targeted #1430 race test using an artificial `delay(200)` inside `cancelSpeechPause` to widen the race window (instrumentation removed before merge).

| Scenario | Before fix | After fix |
| --- | --- | --- |
| Frames bypassing pause (the audio bug) | 107 frames (~10s of audio leak) | 0 |
| Frames blocked at gate | n/a — no gate | 6–15 (≤1 in flight per cycle) |
| Time to stop after interruption classification | ~10s (waits for final transcript) | ~10–20ms (single in-flight frame) |
| Synchronizer transcript gating | not implemented | confirmed (`mainTask.gateHit` fires per word) |
| #1430 race **condition** in JS `cancelSpeechPause` (paused speech + generation await) | exists | unchanged — race window still exists; local capture prevents the symptom |
| #1430 symptom on test stack (Inference STT + gpt-4.1-mini + EOU model) | not triggered locally — `_currentSpeech` is cleared before `userTurnCompleted` enters in fast LLM/TTS stacks | n/a |
| #1430 symptom on OP's stack (ElevenLabs Turbo + gpt-5.1, audio playback outlasts EOU) | TypeError → swallowed turn → `userAwayTimeout` ~10s | local capture mirrors Python's walrus binding; TypeError eliminated |

The race-widener experiment confirmed the underlying race **condition** is real (6 `cancelSpeechPause` invocations per session awaited `_waitForGeneration()`), but the user-visible symptom is timing-dependent on TTS/LLM speed. The Python walrus pattern is correct for both fast and slow stacks; porting it brings JS to parity.

## References

Ports from:
- `livekit-agents/livekit/agents/voice/room_io/_output.py` (`ParticipantAudioOutput.pause`/`resume`/`_forward_audio`)
- `livekit-agents/livekit/agents/voice/transcription/synchronizer.py` (`_SegmentSynchronizerImpl.pause`/`resume`, `TranscriptSynchronizer._paused`, `_SyncedAudioOutput.pause`/`resume`)
- `livekit-agents/livekit/agents/voice/agent_activity.py` (`AgentActivity._user_turn_completed_task` walrus-bound `current_speech`)

Closes #1430

Related:
- #1349 (clear stale paused-speech state across generation steps)