### PR TITLE
feat(plugin-openai): stream input_audio_transcription delta events

### DIFF
--- a/.changeset/streaming-input-audio-transcription-delta.md
+++ b/.changeset/streaming-input-audio-transcription-delta.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-openai": patch
+---
+
+feat(plugin-openai): stream `input_audio_transcription.delta` events on the OpenAI Realtime API as `UserInputTranscribed` partials (`isFinal: false`). Enables word-by-word user transcripts with `gpt-realtime-whisper` and any future delta-emitting transcription model. Accumulators are cleared on `.completed`, `.failed`, `conversation.item.deleted`, session close, and reconnect; `.failed` now emits a closing `isFinal: true` event when partials had streamed so consumers don't hang.

--- a/examples/src/realtime_streaming_transcript.ts
+++ b/examples/src/realtime_streaming_transcript.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Requires a .env at the repo root with LIVEKIT_URL, LIVEKIT_API_KEY,
+// LIVEKIT_API_SECRET, and OPENAI_API_KEY.
+//
+// Run: pnpm build && node --env-file=.env ./examples/src/realtime_streaming_transcript.ts dev
+import { type JobContext, ServerOptions, cli, defineAgent, log, voice } from '@livekit/agents';
+import * as openai from '@livekit/agents-plugin-openai';
+import { fileURLToPath } from 'node:url';
+
+export default defineAgent({
+  entry: async (ctx: JobContext) => {
+    const logger = log();
+    await ctx.connect();
+
+    const session = new voice.AgentSession({
+      llm: new openai.realtime.RealtimeModel({
+        inputAudioTranscription: { model: 'gpt-realtime-whisper' },
+      }),
+    });
+
+    let lastPartialLength = 0;
+    session.on(voice.AgentSessionEventTypes.UserInputTranscribed, (ev) => {
+      if (ev.isFinal) {
+        logger.info({ transcript: ev.transcript }, '[user transcript FINAL]');
+        lastPartialLength = 0;
+        return;
+      }
+      if (ev.transcript.length - lastPartialLength >= 6) {
+        logger.info({ transcript: ev.transcript }, '[user transcript partial]');
+        lastPartialLength = ev.transcript.length;
+      }
+    });
+
+    await session.start({
+      agent: new voice.Agent({
+        instructions:
+          'You are a helpful assistant for a streaming-transcript demo. ' +
+          'Keep every reply to one short sentence so the user stays the focus. ' +
+          'Ask the user to read a long sentence or two aloud so they can see their own words streaming live.',
+      }),
+      room: ctx.room,
+    });
+
+    session.generateReply({
+      instructions:
+        'Greet the user briefly and ask them to say a long sentence so they can watch their own words appear live on screen as they speak.',
+    });
+  },
+});
+
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/plugins/openai/src/realtime/api_proto.ts
+++ b/plugins/openai/src/realtime/api_proto.ts
@@ -58,6 +58,7 @@ export type ServerEventType =
   | 'input_audio_buffer.speech_stopped'
   | 'conversation.item.added' // GA: renamed from conversation.item.created
   | 'conversation.item.created' // Beta: kept for backward compatibility
+  | 'conversation.item.input_audio_transcription.delta'
   | 'conversation.item.input_audio_transcription.completed'
   | 'conversation.item.input_audio_transcription.failed'
   | 'conversation.item.truncated'
@@ -509,6 +510,13 @@ export interface ConversationItemAddedEvent extends BaseServerEvent {
   item: ItemResource;
 }
 
+export interface ConversationItemInputAudioTranscriptionDeltaEvent extends BaseServerEvent {
+  type: 'conversation.item.input_audio_transcription.delta';
+  item_id: string;
+  content_index?: number;
+  delta?: string;
+}
+
 export interface ConversationItemInputAudioTranscriptionCompletedEvent extends BaseServerEvent {
   type: 'conversation.item.input_audio_transcription.completed';
   item_id: string;
@@ -670,6 +678,7 @@ export type ServerEvent =
   | InputAudioBufferSpeechStoppedEvent
   | ConversationItemCreatedEvent
   | ConversationItemAddedEvent // GA: renamed from conversation.item.created
+  | ConversationItemInputAudioTranscriptionDeltaEvent
   | ConversationItemInputAudioTranscriptionCompletedEvent
   | ConversationItemInputAudioTranscriptionFailedEvent
   | ConversationItemTruncatedEvent

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -43,6 +43,248 @@ describe('RealtimeSession.generateReply', () => {
   });
 });
 
+describe('RealtimeSession input_audio_transcription delta handling', () => {
+  type TranscriptionInternals = {
+    handleConversationItemInputAudioTranscriptionDelta: (
+      ev: api_proto.ConversationItemInputAudioTranscriptionDeltaEvent,
+    ) => void;
+    handleConversationItemInputAudioTranscriptionCompleted: (
+      ev: api_proto.ConversationItemInputAudioTranscriptionCompletedEvent,
+    ) => void;
+    finalizePartialOnTranscriptionFailure: (itemId: string, contentIndex: number) => void;
+    handleConversationItemDeleted: (ev: api_proto.ConversationItemDeletedEvent) => void;
+    inputTranscriptAccumulators: Map<string, Map<number, string>>;
+    audioCapableItemIds: Set<string>;
+    itemDeleteFutures: Record<string, never>;
+    remoteChatCtx: {
+      get: (id: string) => { item: llm.ChatMessage } | undefined;
+      delete: (id: string) => void;
+    };
+    on: (event: string, listener: (payload: llm.InputTranscriptionCompleted) => void) => void;
+  };
+
+  function createTranscriptSession(opts?: {
+    chatItems?: Record<string, llm.ChatMessage>;
+  }): TranscriptionInternals {
+    const session = Object.create(RealtimeSession.prototype) as TranscriptionInternals;
+    session.inputTranscriptAccumulators = new Map<string, Map<number, string>>();
+    session.audioCapableItemIds = new Set<string>();
+    session.itemDeleteFutures = {};
+    const chatItems = new Map<string, llm.ChatMessage>(Object.entries(opts?.chatItems ?? {}));
+    session.remoteChatCtx = {
+      get: (id) => {
+        const item = chatItems.get(id);
+        return item ? { item } : undefined;
+      },
+      delete: (id) => {
+        chatItems.delete(id);
+      },
+    };
+    return session;
+  }
+
+  function delta(
+    item_id: string,
+    delta: string,
+    content_index = 0,
+  ): api_proto.ConversationItemInputAudioTranscriptionDeltaEvent {
+    return {
+      type: 'conversation.item.input_audio_transcription.delta',
+      event_id: `evt_${item_id}_${delta}_${content_index}`,
+      item_id,
+      content_index,
+      delta,
+    };
+  }
+
+  function completed(
+    item_id: string,
+    transcript: string,
+    content_index = 0,
+  ): api_proto.ConversationItemInputAudioTranscriptionCompletedEvent {
+    return {
+      type: 'conversation.item.input_audio_transcription.completed',
+      event_id: `evt_${item_id}_done`,
+      item_id,
+      content_index,
+      transcript,
+    };
+  }
+
+  it('accumulates partial transcripts across delta events for the same item_id', () => {
+    const session = createTranscriptSession();
+    const emissions: llm.InputTranscriptionCompleted[] = [];
+    session.on('input_audio_transcription_completed', (ev) => emissions.push(ev));
+
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'Hello'));
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', ', world'));
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', '!'));
+
+    expect(emissions).toEqual([
+      { itemId: 'item_a', transcript: 'Hello', isFinal: false },
+      { itemId: 'item_a', transcript: 'Hello, world', isFinal: false },
+      { itemId: 'item_a', transcript: 'Hello, world!', isFinal: false },
+    ]);
+  });
+
+  it('keeps accumulators isolated across concurrent item_ids', () => {
+    const session = createTranscriptSession();
+    const emissions: llm.InputTranscriptionCompleted[] = [];
+    session.on('input_audio_transcription_completed', (ev) => emissions.push(ev));
+
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'Aaa'));
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_b', 'Bbb'));
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'Aaa'));
+
+    expect(emissions).toEqual([
+      { itemId: 'item_a', transcript: 'Aaa', isFinal: false },
+      { itemId: 'item_b', transcript: 'Bbb', isFinal: false },
+      { itemId: 'item_a', transcript: 'AaaAaa', isFinal: false },
+    ]);
+  });
+
+  it('keeps accumulators isolated across content_index within the same item_id', () => {
+    const session = createTranscriptSession();
+    const emissions: llm.InputTranscriptionCompleted[] = [];
+    session.on('input_audio_transcription_completed', (ev) => emissions.push(ev));
+
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'idx0-', 0));
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'idx1-', 1));
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'more0', 0));
+
+    expect(emissions).toEqual([
+      { itemId: 'item_a', transcript: 'idx0-', isFinal: false },
+      { itemId: 'item_a', transcript: 'idx1-', isFinal: false },
+      { itemId: 'item_a', transcript: 'idx0-more0', isFinal: false },
+    ]);
+  });
+
+  it('clears the accumulator on .completed so a subsequent delta does not inherit prior state', () => {
+    const session = createTranscriptSession({
+      chatItems: { item_a: new llm.ChatMessage({ role: 'user', content: '', id: 'item_a' }) },
+    });
+    const emissions: llm.InputTranscriptionCompleted[] = [];
+    session.on('input_audio_transcription_completed', (ev) => emissions.push(ev));
+
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'first turn '));
+    session.handleConversationItemInputAudioTranscriptionCompleted(
+      completed('item_a', 'first turn complete.'),
+    );
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'second'));
+
+    expect(session.inputTranscriptAccumulators.get('item_a')?.get(0)).toBe('second');
+    expect(emissions).toEqual([
+      { itemId: 'item_a', transcript: 'first turn ', isFinal: false },
+      { itemId: 'item_a', transcript: 'first turn complete.', isFinal: true },
+      { itemId: 'item_a', transcript: 'second', isFinal: false },
+    ]);
+  });
+
+  it('pushes the final transcript onto the matching ChatMessage exactly once on .completed', () => {
+    const chatMessage = new llm.ChatMessage({ role: 'user', content: '', id: 'item_a' });
+    const session = createTranscriptSession({ chatItems: { item_a: chatMessage } });
+
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'partial-only'));
+    expect(chatMessage.content).toEqual(['']);
+
+    session.handleConversationItemInputAudioTranscriptionCompleted(completed('item_a', 'final.'));
+    expect(chatMessage.content).toEqual(['', 'final.']);
+  });
+
+  it('emits isFinal:true on .completed even when remoteChatCtx has no matching item', () => {
+    const session = createTranscriptSession();
+    const emissions: llm.InputTranscriptionCompleted[] = [];
+    session.on('input_audio_transcription_completed', (ev) => emissions.push(ev));
+
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'partial'));
+    session.handleConversationItemInputAudioTranscriptionCompleted(completed('item_a', 'final.'));
+
+    expect(emissions).toEqual([
+      { itemId: 'item_a', transcript: 'partial', isFinal: false },
+      { itemId: 'item_a', transcript: 'final.', isFinal: true },
+    ]);
+    expect(session.inputTranscriptAccumulators.size).toBe(0);
+  });
+
+  it('treats .completed as a no-op cleanup when no deltas preceded it (non-streaming STT model)', () => {
+    const session = createTranscriptSession({
+      chatItems: { item_a: new llm.ChatMessage({ role: 'user', content: '', id: 'item_a' }) },
+    });
+    const emissions: llm.InputTranscriptionCompleted[] = [];
+    session.on('input_audio_transcription_completed', (ev) => emissions.push(ev));
+
+    session.handleConversationItemInputAudioTranscriptionCompleted(
+      completed('item_a', 'one-shot whisper-1 transcript'),
+    );
+
+    expect(session.inputTranscriptAccumulators.size).toBe(0);
+    expect(emissions).toEqual([
+      { itemId: 'item_a', transcript: 'one-shot whisper-1 transcript', isFinal: true },
+    ]);
+  });
+
+  it('skips emission for empty or missing deltas and does not create an accumulator', () => {
+    const session = createTranscriptSession();
+    const emissions: llm.InputTranscriptionCompleted[] = [];
+    session.on('input_audio_transcription_completed', (ev) => emissions.push(ev));
+
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', ''));
+    session.handleConversationItemInputAudioTranscriptionDelta({
+      type: 'conversation.item.input_audio_transcription.delta',
+      event_id: 'evt_no_delta',
+      item_id: 'item_a',
+    });
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'real'));
+
+    expect(session.inputTranscriptAccumulators.get('item_a')?.get(0)).toBe('real');
+    expect(emissions).toEqual([{ itemId: 'item_a', transcript: 'real', isFinal: false }]);
+  });
+
+  it('clears the accumulator and emits a closing isFinal:true on transcription failure when partials had streamed', () => {
+    const session = createTranscriptSession();
+    const emissions: llm.InputTranscriptionCompleted[] = [];
+    session.on('input_audio_transcription_completed', (ev) => emissions.push(ev));
+
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'partial '));
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'text'));
+    session.finalizePartialOnTranscriptionFailure('item_a', 0);
+
+    expect(session.inputTranscriptAccumulators.size).toBe(0);
+    expect(emissions).toEqual([
+      { itemId: 'item_a', transcript: 'partial ', isFinal: false },
+      { itemId: 'item_a', transcript: 'partial text', isFinal: false },
+      { itemId: 'item_a', transcript: 'partial text', isFinal: true },
+    ]);
+  });
+
+  it('emits nothing on transcription failure when no partials had streamed for that item', () => {
+    const session = createTranscriptSession();
+    const emissions: llm.InputTranscriptionCompleted[] = [];
+    session.on('input_audio_transcription_completed', (ev) => emissions.push(ev));
+
+    session.finalizePartialOnTranscriptionFailure('item_a', 0);
+
+    expect(emissions).toEqual([]);
+    expect(session.inputTranscriptAccumulators.size).toBe(0);
+  });
+
+  it('clears the accumulator when the conversation item is deleted', () => {
+    const session = createTranscriptSession();
+
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'partial '));
+    session.handleConversationItemInputAudioTranscriptionDelta(delta('item_a', 'more', 1));
+    expect(session.inputTranscriptAccumulators.get('item_a')?.size).toBe(2);
+
+    session.handleConversationItemDeleted({
+      type: 'conversation.item.deleted',
+      event_id: 'evt_del',
+      item_id: 'item_a',
+    });
+
+    expect(session.inputTranscriptAccumulators.has('item_a')).toBe(false);
+  });
+});
+
 describe('livekitItemToOpenAIItem', () => {
   describe('message items', () => {
     it('should use output_text type for assistant messages', async () => {

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -441,6 +441,8 @@ export class RealtimeSession extends llm.RealtimeSession {
   private itemCreateFutures: { [id: string]: Future } = {};
   private itemDeleteFutures: { [id: string]: Future } = {};
 
+  private inputTranscriptAccumulators = new Map<string, Map<number, string>>();
+
   // Track items that have real server-side audio (created in current session, not restored)
   // Items restored after reconnection are text-only and cannot be truncated
   private audioCapableItemIds: Set<string> = new Set();
@@ -1030,6 +1032,7 @@ export class RealtimeSession extends llm.RealtimeSession {
 
       // Clear audio-capable item tracking - restored items are text-only on the server
       this.audioCapableItemIds.clear();
+      this.inputTranscriptAccumulators.clear();
 
       const events: api_proto.ClientEvent[] = [];
 
@@ -1198,6 +1201,9 @@ export class RealtimeSession extends llm.RealtimeSession {
         case 'conversation.item.deleted':
           this.handleConversationItemDeleted(event);
           break;
+        case 'conversation.item.input_audio_transcription.delta':
+          this.handleConversationItemInputAudioTranscriptionDelta(event);
+          break;
         case 'conversation.item.input_audio_transcription.completed':
           this.handleConversationItemInputAudioTranscriptionCompleted(event);
           break;
@@ -1312,6 +1318,8 @@ export class RealtimeSession extends llm.RealtimeSession {
       }
     }
     this.itemDeleteFutures = {};
+
+    this.inputTranscriptAccumulators.clear();
 
     // Clean up current generation if exists
     if (this.currentGeneration) {
@@ -1470,6 +1478,7 @@ export class RealtimeSession extends llm.RealtimeSession {
 
     // Clean up audio-capable tracking for deleted items
     this.audioCapableItemIds.delete(event.item_id);
+    this.inputTranscriptAccumulators.delete(event.item_id);
 
     try {
       this.remoteChatCtx.delete(event.item_id);
@@ -1484,26 +1493,56 @@ export class RealtimeSession extends llm.RealtimeSession {
     }
   }
 
+  private handleConversationItemInputAudioTranscriptionDelta(
+    event: api_proto.ConversationItemInputAudioTranscriptionDeltaEvent,
+  ): void {
+    if (!event.delta) return;
+
+    const contentIndex = event.content_index ?? 0;
+    let byIndex = this.inputTranscriptAccumulators.get(event.item_id);
+    if (!byIndex) {
+      byIndex = new Map();
+      this.inputTranscriptAccumulators.set(event.item_id, byIndex);
+    }
+    const accumulated = (byIndex.get(contentIndex) ?? '') + event.delta;
+    byIndex.set(contentIndex, accumulated);
+
+    this.emit('input_audio_transcription_completed', {
+      itemId: event.item_id,
+      transcript: accumulated,
+      isFinal: false,
+    });
+  }
+
+  private clearAccumulator(itemId: string, contentIndex: number): string | undefined {
+    const byIndex = this.inputTranscriptAccumulators.get(itemId);
+    if (!byIndex) return undefined;
+    const partial = byIndex.get(contentIndex);
+    byIndex.delete(contentIndex);
+    if (byIndex.size === 0) this.inputTranscriptAccumulators.delete(itemId);
+    return partial;
+  }
+
   private handleConversationItemInputAudioTranscriptionCompleted(
     event: api_proto.ConversationItemInputAudioTranscriptionCompletedEvent,
   ): void {
-    const remoteItem = this.remoteChatCtx.get(event.item_id);
-    if (!remoteItem) {
-      return;
-    }
+    this.clearAccumulator(event.item_id, event.content_index ?? 0);
 
-    const item = remoteItem.item;
-    if (item instanceof llm.ChatMessage) {
-      item.content.push(event.transcript);
-    } else {
-      throw new Error('item is not a chat message');
+    const remoteItem = this.remoteChatCtx.get(event.item_id);
+    if (remoteItem) {
+      const item = remoteItem.item;
+      if (item instanceof llm.ChatMessage) {
+        item.content.push(event.transcript);
+      } else {
+        throw new Error('item is not a chat message');
+      }
     }
 
     this.emit('input_audio_transcription_completed', {
       itemId: event.item_id,
       transcript: event.transcript,
       isFinal: true,
-    } as llm.InputTranscriptionCompleted);
+    });
   }
 
   private handleConversationItemInputAudioTranscriptionFailed(
@@ -1513,6 +1552,18 @@ export class RealtimeSession extends llm.RealtimeSession {
       { error: event.error },
       'OpenAI Realtime API failed to transcribe input audio',
     );
+    this.finalizePartialOnTranscriptionFailure(event.item_id, event.content_index ?? 0);
+  }
+
+  // Close any open partial stream so consumers waiting for isFinal don't hang.
+  private finalizePartialOnTranscriptionFailure(itemId: string, contentIndex: number): void {
+    const partial = this.clearAccumulator(itemId, contentIndex);
+    if (partial === undefined) return;
+    this.emit('input_audio_transcription_completed', {
+      itemId,
+      transcript: partial,
+      isFinal: true,
+    });
   }
 
   private handleResponseContentPartAdded(event: api_proto.ResponseContentPartAddedEvent): void {


### PR DESCRIPTION
 ## Description

  Adds support for `conversation.item.input_audio_transcription.delta` events on the OpenAI Realtime API. These are emitted by the new `gpt-realtime-whisper` transcription model (and any future delta-emitting STT model) as audio is processed. Today the plugin's `RealtimeSession` event switch only handles `.completed` and `.failed`, so deltas are silently dropped and user transcripts surface to the client only after the entire utterance finalizes.

## Changes Made

-  `plugins/openai/src/realtime/api_proto.ts`: add `ConversationItemInputAudioTranscriptionDeltaEvent` to `ServerEventType` / `ServerEvent`.
 -  `plugins/openai/src/realtime/realtime_model.ts`: add per-item delta accumulator (`inputTranscriptAccumulators`), wire `.delta` into the event switch, emit accumulated text as `isFinal: false`, and clear the accumulator on `.completed`. `remoteChatCtx` is intentionally only updated on `.completed` — partials shouldn't mutate persistent chat history.
 - `plugins/openai/src/realtime/realtime_model.test.ts`: 177 lines of new tests covering delta accumulation, ordering, accumulator cleanup on completion, mixed delta/non-delta sessions, and the back-compat path for models that only emit `.completed`.
- `examples/src/realtime_streaming_transcript.ts`: runnable demo using `gpt-realtime-whisper`, with inline notes on how partials replace (not append to) prior text per turn.

## Pre-Review Checklist

- [X] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [X] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [X] **Changes explained**: All changes are properly documented and justified above
- [X] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing

- [X] Automated tests added/updated (if applicable)
- [X] All tests pass
- [X] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

Manual repro: `pnpm build && node ./examples/dist/realtime_streaming_transcript.js dev`, join the agent's room from the Playground, and speak a long sentence. Expect `[user transcript partial]` lines streaming to stdout as you speak, ending with one `[user transcript FINAL]`.


```
[21:06:59.936] INFO (47252): playout completed with interrupt
    speech_id: "speech_73d3d7b6-440"
    message: "Hello! Please say a long sentence, and you’ll see your words appear on the screen as you speak."
[21:06:59.937] DEBUG (47252): Task.runTask: task AgentActivity.realtimeReply done
[21:07:01.446] INFO (47252): [user transcript partial]
    transcript: " Hey, um"
[21:07:02.242] INFO (47252): [user transcript partial]
    transcript: " Hey, um yes, so"
[21:07:03.231] INFO (47252): [user transcript partial]
    transcript: " Hey, um yes, so the quick"
[21:07:03.832] INFO (47252): [user transcript partial]
    transcript: " Hey, um yes, so the quick brown"
[21:07:04.433] INFO (47252): [user transcript partial]
    transcript: " Hey, um yes, so the quick brown fox jumped"
[21:07:05.031] INFO (47252): [user transcript partial]
    transcript: " Hey, um yes, so the quick brown fox jumped over the"
[21:07:06.229] INFO (47252): [user transcript partial]
    transcript: " Hey, um yes, so the quick brown fox jumped over the lazy dog"
[21:07:07.021] INFO (47252): [user transcript partial]
    transcript: " Hey, um yes, so the quick brown fox jumped over the lazy dog as the"
[21:07:08.225] INFO (47252): [user transcript partial]
    transcript: " Hey, um yes, so the quick brown fox jumped over the lazy dog as the text streamed"
[21:07:08.635] INFO (47252): [user transcript partial]
    transcript: " Hey, um yes, so the quick brown fox jumped over the lazy dog as the text streamed on the"
[21:07:09.024] INFO (47252): [user transcript partial]
    transcript: " Hey, um yes, so the quick brown fox jumped over the lazy dog as the text streamed on the screen"
[21:07:09.245] INFO (47252): onInputSpeechStopped
    userTranscriptionEnabled: true
[21:07:09.262] INFO (47252): Creating speech handle
    speech_id: "speech_73fc4af8-cf9"
[21:07:09.262] DEBUG (47252): Task.runTask: task AgentActivity.realtimeGeneration started
[21:07:09.263] DEBUG (47252): realtime generation started
    speech_id: "speech_73fc4af8-cf9"
    stepIndex: 1
[21:07:09.264] DEBUG (47252): Task.runTask: task AgentActivity.realtime_generation.read_messages started
[21:07:09.264] DEBUG (47252): Task.runTask: task AgentActivity.realtime_generation.read_tool_stream started
[21:07:09.264] DEBUG (47252): Task.runTask: task performToolExecutions started
[21:07:09.545] DEBUG (47252): Task.runTask: task performTextForwarding started
[21:07:09.546] DEBUG (47252): Task.runTask: task performAudioForwarding started
[21:07:09.704] INFO (47252): [user transcript FINAL]
    transcript: "Hey, um yes, so the quick brown fox jumped over the lazy dog as the text streamed on the screen"
[21:07:10.688] DEBUG (47252): Task.runTask: task performTextForwarding done
[21:07:10.689] DEBUG (47252): Closing generation channels in handleResponseDone
    messageCount: 1
[21:07:10.693] DEBUG (47252): Task.runTask: task AgentActivity.realtime_generation.read_tool_stream done
[21:07:10.698] DEBUG (47252): Task.runTask: task performToolExecutions done
[21:07:14.309] DEBUG (47252): Task.runTask: task performAudioForwarding done
[21:07:14.312] DEBUG (47252): Task.runTask: task AgentActivity.realtime_generation.read_messages done

```

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.