### PR TITLE
Dispatch downstream version bumps on npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,3 +71,18 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_DEPLOY_AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_DEPLOY_AWS_API_SECRET }}
           AWS_DEFAULT_REGION: 'us-east-1'
+      - name: Dispatch downstream bumps
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_DISPATCH_TOKEN }}
+          TARGET_REPO: ${{ vars.TARGET_REPO }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          jq -n \
+            --arg source_repo "$SOURCE_REPO" \
+            --arg source_sha "$SOURCE_SHA" \
+            --argjson published_packages "$PUBLISHED_PACKAGES" \
+            '{event_type: "agents-js-published", client_payload: {source_repo: $source_repo, source_sha: $source_sha, published_packages: $published_packages}}' \
+            | gh api -X POST "repos/${TARGET_REPO}/dispatches" --input -


### PR DESCRIPTION
## Description

After changesets/action successfully publishes one or more packages, fires a repository_dispatch to TARGET_REPO with the publishedPackages JSON payload so we can open a PR bumping the pinned @livekit/agents-js versions in downstream consumers (agent-starter-node).

Only fires when steps.changesets.outputs.published == 'true', i.e. on the publish run that follows a merged release PR — not on runs that only open/update the release PR.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.