### PR TITLE
fix(voice): propagate job context into tool execute on Node 24

### DIFF
--- a/.changeset/job-context-tool-execute-node-24.md
+++ b/.changeset/job-context-tool-execute-node-24.md
@@ -1,0 +1,12 @@
+---
+"@livekit/agents": patch
+---
+
+fix(voice): propagate job context into tool execute on Node 24
+
+Re-establish `jobContextStorage` inside the per-tool `Task.from()` body in
+`performToolExecutions` so `getJobContext()` works from a tool's `execute()`
+function on Node 24. Node 24's default `AsyncContextFrame` `AsyncLocalStorage`
+implementation does not propagate the job context across the `Task.from()`
+boundary the way the legacy `async_hooks` implementation did, which previously
+caused `getJobContext()` to throw "no job context found" inside tools (#1255).

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -7,6 +7,7 @@ import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import type { Span } from '@opentelemetry/api';
 import { context as otelContext } from '@opentelemetry/api';
 import type { ReadableStream, ReadableStreamDefaultReader } from 'stream/web';
+import { getJobContext, runWithJobContextAsync } from '../job.js';
 import type { Instructions } from '../llm/chat_context.js';
 import {
   type ChatContext,
@@ -974,6 +975,13 @@ export function performToolExecutions({
     const signal = controller.signal;
     const reader = toolCallStream.getReader();
 
+    // Capture the job context synchronously so it can be re-established inside
+    // each toolTask body. Node 24's AsyncContextFrame does not implicitly
+    // propagate AsyncLocalStorage values across the Task.from() boundary the
+    // way legacy async_hooks did, so getJobContext() inside a tool's execute()
+    // would otherwise throw "no job context found" (see #1255).
+    const currentJobContext = getJobContext(false);
+
     const tasks: Task<void>[] = [];
     while (!signal.aborted) {
       const { done, value: toolCall } = await reader.read();
@@ -1135,16 +1143,18 @@ export function performToolExecutions({
             });
           }
 
-          const toolExecution = functionCallStorage.run(
-            { functionCall: toolCall, speechHandle },
-            async () => {
+          const runToolWithFunctionCallStorage = () =>
+            functionCallStorage.run({ functionCall: toolCall, speechHandle }, async () => {
               return await tool.execute(parsedArgs, {
                 ctx: new RunContext(session, speechHandle, toolCall),
                 toolCallId: toolCall.callId,
                 abortSignal: signal,
               });
-            },
-          );
+            });
+
+          const toolExecution = currentJobContext
+            ? runWithJobContextAsync(currentJobContext, runToolWithFunctionCallStorage)
+            : runToolWithFunctionCallStorage();
 
           await tracableToolExecution(toolExecution);
         },


### PR DESCRIPTION
Fixes #1255.

### Problem

On Node 24, `getJobContext()` throws `no job context found` when called inside a tool's `execute()` function. The workaround `NODE_OPTIONS=--no-async-context-frame` reverts Node 24 to the legacy `async_hooks`-based `AsyncLocalStorage`, which propagates the job context through implicitly.

### Root cause

Tool execution constructs a `Task` via `Task.from(async () => …)` that wraps three `AsyncLocalStorage` contexts inside the task body:

- `agentActivityStorage` — wrapped in `agent_activity.ts`
- `speechHandleStorage` — wrapped in `agent_activity.ts`
- `functionCallStorage` — wrapped in `generation.ts`

`jobContextStorage` is not wrapped anywhere along this path. With the old `async_hooks`-based `AsyncLocalStorage` (Node 22 / `--no-async-context-frame`), the job context propagated implicitly across the `Task.from()` boundary. With Node 24's default `AsyncContextFrame` implementation, it does not, so `getJobContext()` returns `undefined` inside tool execute functions. See [nodejs/node#58204](https://github.com/nodejs/node/issues/58204) for background on the `AsyncContextFrame` change.

### Fix

In `performToolExecutions` (`agents/src/voice/generation.ts`):

1. Capture the current `JobContext` synchronously at the top of `executeToolsTask`, where it is still in scope.
2. Wrap each per-tool `Task.from(...)` body in `runWithJobContextAsync(currentJobContext, ...)` so the context is re-established inside the new async scope, alongside the existing `functionCallStorage.run(...)` wrap.

If no job context is in scope (e.g. unit tests calling `performToolExecutions` directly), the wrap is skipped so behaviour is unchanged.

### Test plan

- [x] `pnpm -F @livekit/agents build` succeeds
- [x] `pnpm -w lint:fix` clean (no new warnings)
- [x] `pnpm -w format:check` and `pnpm throws:check` clean
- [x] `pnpm test agents` — full agents suite (60 files / 840 tests) passes on Node 24.10.0
- [ ] Manually validated against a real voice agent on Node 24 without `--no-async-context-frame`: `getJobContext()` inside a tool's `execute()` returns the room name as expected. *(Reporter — please verify with your repro.)*

### Note on CI coverage

The `Build` and `Test` workflows pin `actions/setup-node` to Node **20**, where this bug does not manifest in the first place (Node 20 still uses the `async_hooks`-based `AsyncLocalStorage` that propagates job context implicitly). The fix is a safe no-op on Node 20 — if no job context is in scope at the synchronous capture point, the extra `runWithJobContextAsync(...)` wrap is skipped. So CI going green confirms no regression on Node 20 but cannot confirm the fix is effective on Node 24; that has to come from the reporter's repro.

I tried adding a focused unit-level regression test that wraps `performToolExecutions` in `runWithJobContextAsync` and calls `getJobContext()` from a tool, but the bug does not reproduce in that minimal harness on Node 24 — presumably because the lost-propagation only manifests through the deeper `Task.from()` chain established by the real agent lifecycle. Happy to add a heavier integration-level test if the maintainers can point me at the right harness.