### PR TITLE
fix(interruption): honor LIVEKIT_INFERENCE_API_KEY over LIVEKIT_API_KEY

### DIFF
--- a/agents/src/inference/interruption/defaults.ts
+++ b/agents/src/inference/interruption/defaults.ts
@@ -35,9 +35,11 @@ export function intervalForRetry(
   return exponentialDelay + jitter;
 }
 
-// baseUrl and useProxy are resolved dynamically in the constructor
-// to respect LIVEKIT_REMOTE_EOT_URL environment variable
-export const interruptionOptionDefaults: Omit<InterruptionOptions, 'baseUrl' | 'useProxy'> = {
+// env-derived fields are resolved in the constructor, not at module load.
+export const interruptionOptionDefaults: Omit<
+  InterruptionOptions,
+  'baseUrl' | 'useProxy' | 'apiKey' | 'apiSecret'
+> = {
   sampleRate: SAMPLE_RATE,
   threshold: THRESHOLD,
   minFrames: Math.ceil(MIN_INTERRUPTION_DURATION_IN_S * FRAMES_PER_SECOND),
@@ -45,7 +47,5 @@ export const interruptionOptionDefaults: Omit<InterruptionOptions, 'baseUrl' | '
   audioPrefixDurationInS: AUDIO_PREFIX_DURATION_IN_S,
   detectionIntervalInS: DETECTION_INTERVAL_IN_S,
   inferenceTimeout: REMOTE_INFERENCE_TIMEOUT_IN_S * 1_000,
-  apiKey: process.env.LIVEKIT_API_KEY || '',
-  apiSecret: process.env.LIVEKIT_API_SECRET || '',
   minInterruptionDurationInS: MIN_INTERRUPTION_DURATION_IN_S,
 } as const;

--- a/agents/src/inference/interruption/interruption_detector.ts
+++ b/agents/src/inference/interruption/interruption_detector.ts
@@ -34,22 +34,21 @@ export class AdaptiveInterruptionDetector extends (EventEmitter as new () => Typ
     const {
       maxAudioDurationInS,
       baseUrl,
-      apiKey,
-      apiSecret,
       audioPrefixDurationInS,
       threshold,
       detectionIntervalInS,
       inferenceTimeout,
       minInterruptionDurationInS,
     } = { ...interruptionOptionDefaults, ...options };
+    const { apiKey, apiSecret } = options;
 
     if (maxAudioDurationInS > 3.0) {
       throw new RangeError('maxAudioDurationInS must be less than or equal to 3.0 seconds');
     }
 
     const lkBaseUrl = baseUrl ?? process.env.LIVEKIT_REMOTE_EOT_URL ?? getDefaultInferenceUrl();
-    let lkApiKey = apiKey ?? '';
-    let lkApiSecret = apiSecret ?? '';
+    let lkApiKey = apiKey || '';
+    let lkApiSecret = apiSecret || '';
     let useProxy: boolean;
 
     // Use LiveKit credentials if using the inference service (production or staging)
@@ -57,7 +56,7 @@ export class AdaptiveInterruptionDetector extends (EventEmitter as new () => Typ
       lkBaseUrl === DEFAULT_INFERENCE_URL || lkBaseUrl === STAGING_INFERENCE_URL;
     if (isInferenceUrl) {
       lkApiKey =
-        apiKey ?? process.env.LIVEKIT_INFERENCE_API_KEY ?? process.env.LIVEKIT_API_KEY ?? '';
+        apiKey || process.env.LIVEKIT_INFERENCE_API_KEY || process.env.LIVEKIT_API_KEY || '';
       if (!lkApiKey) {
         throw new TypeError(
           'apiKey is required, either as argument or set LIVEKIT_API_KEY environmental variable',
@@ -65,9 +64,9 @@ export class AdaptiveInterruptionDetector extends (EventEmitter as new () => Typ
       }
 
       lkApiSecret =
-        apiSecret ??
-        process.env.LIVEKIT_INFERENCE_API_SECRET ??
-        process.env.LIVEKIT_API_SECRET ??
+        apiSecret ||
+        process.env.LIVEKIT_INFERENCE_API_SECRET ||
+        process.env.LIVEKIT_API_SECRET ||
         '';
       if (!lkApiSecret) {
         throw new TypeError(


### PR DESCRIPTION
## Summary
Fixes [#1353](https://github.com/livekit/agents-js/issues/1353): `AdaptiveInterruptionDetector` ignores `LIVEKIT_INFERENCE_API_KEY` when `LIVEKIT_API_KEY` is also set.

## Root cause
`interruptionOptionDefaults` in `defaults.ts` was initialized at module load with:

```ts
apiKey: process.env.LIVEKIT_API_KEY || '',
apiSecret: process.env.LIVEKIT_API_SECRET || '',
```

Those values flowed into the constructor via `{ ...interruptionOptionDefaults, ...options }`, so the later `apiKey ?? process.env.LIVEKIT_INFERENCE_API_KEY ?? ...` chain never fell through — the JWT for the inference gateway was signed with self-hosted-SFU creds, producing a 401 and VAD fallback.

## Fix
- Removed `apiKey` / `apiSecret` from `interruptionOptionDefaults` so env vars aren't captured at module load.
- Read `apiKey` / `apiSecret` directly from caller `options` in the constructor.
- Switched the precedence chain from `??` to `||` so empty strings fall through, matching the pattern already used in `stt.ts` / `llm.ts` / `tts.ts`.

## Test plan
- [x] `tsc --noEmit` passes.
- [ ] Verify against a self-hosted SFU + LK Cloud inference setup with distinct `LIVEKIT_API_KEY` and `LIVEKIT_INFERENCE_API_KEY` — adaptive interruption connects without 401.