### PR TITLE
fix(inference): correct barge-in WS error attribution

### DIFF
--- a/.changeset/interruption-ws-parse-warning.md
+++ b/.changeset/interruption-ws-parse-warning.md
@@ -1,0 +1,7 @@
+---
+"@livekit/agents": patch
+---
+
+fix(inference): stop mislabeling barge-in handler errors as parse failures
+
+The interruption WebSocket handler wrapped both `wsMessageSchema.parse` and `handleMessage` in one `try`, so a handler throw (e.g. a late `bargein_detected` prediction enqueued after the readable side was errored/closed) was logged as "Failed to parse WebSocket message" with the real error discarded. Parse and handler errors are now caught separately and log the actual error, and the late barge-in event is dropped quietly (`desiredSize === null`) instead of throwing into a dead stream.

--- a/agents/src/inference/interruption/ws_transport.ts
+++ b/agents/src/inference/interruption/ws_transport.ts
@@ -146,11 +146,25 @@ export function createWsTransport(
 
   function setupMessageHandler(socket: WebSocket): void {
     socket.on('message', (data: WebSocket.Data) => {
+      let message: WsMessage;
       try {
-        const message = wsMessageSchema.parse(JSON.parse(data.toString()));
+        message = wsMessageSchema.parse(JSON.parse(data.toString()));
+      } catch (err) {
+        logger.warn(
+          { data: data.toString(), err: err instanceof Error ? err.message : String(err) },
+          'Failed to parse WebSocket message',
+        );
+        return;
+      }
+      // Keep handler errors distinct from parse errors — a thrown handler must
+      // not be mislabeled as a malformed payload (and its real cause dropped).
+      try {
         handleMessage(message);
-      } catch {
-        logger.warn({ data: data.toString() }, 'Failed to parse WebSocket message');
+      } catch (err) {
+        logger.warn(
+          { type: message.type, err: err instanceof Error ? err.message : String(err) },
+          'Failed to handle WebSocket message',
+        );
       }
     });
 
@@ -247,7 +261,15 @@ export function createWsTransport(
             numRequests: getAndResetNumRequests?.() ?? 0,
           };
 
-          outputController?.enqueue(event);
+          // `desiredSize === null` means the readable side is errored or
+          // closed (e.g. a prior inference timeout, or session teardown). A
+          // late prediction can still arrive on the socket; drop it quietly
+          // rather than throwing on `enqueue` into a dead stream.
+          if (outputController !== null && outputController.desiredSize !== null) {
+            outputController.enqueue(event);
+          } else {
+            logger.debug('interruption output stream closed; dropping late bargein event');
+          }
           setState({ overlapSpeechStarted: false });
         }
         break;


### PR DESCRIPTION

## Description

The interruption WebSocket message handler wrapped both schema parsing and `handleMessage` in a single try/catch, so any handler throw was logged as "Failed to parse WebSocket message" with the real error swallowed. The most common trigger is a late `bargein_detected` prediction arriving after the output stream's readable side was errored or closed (e.g. an inference timeout or session teardown), which makes `outputController.enqueue` throw.


## Changes Made
- Split parsing and handling into separate try/catch blocks; each now logs the actual error (parse failures stay "Failed to parse", handler failures log as "Failed to handle WebSocket message").
- Guard the barge-in enqueue with `desiredSize !== null` so a late event on a closed/errored stream is dropped at debug level instead of throwing.

## Pre-Review Checklist
- [ ] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [ ] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.