### PR TITLE
feat(agents): remove ttsPronunciationMap Agent option

### DIFF
--- a/.changeset/remove-tts-pronunciation-map.md
+++ b/.changeset/remove-tts-pronunciation-map.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': minor
+---
+
+Remove the `ttsPronunciationMap` Agent option (and the `TTSPronunciationMap` type). Use the general `tts_text_transforms` / `replace` text transform for pre-TTS pronunciation replacements instead.

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AudioFrame } from '@livekit/rtc-node';
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { ReadableStream, type ReadableStreamDefaultReader } from 'node:stream/web';
+import { ReadableStream } from 'node:stream/web';
 import {
   LLM as InferenceLLM,
   STT as InferenceSTT,
@@ -114,8 +114,6 @@ export interface ModelSettings {
   toolChoice?: ToolChoice;
 }
 
-export type TTSPronunciationMap = Record<string, string>;
-
 export interface AgentOptions<UserData> {
   id?: string;
   instructions: string | Instructions;
@@ -128,8 +126,6 @@ export interface AgentOptions<UserData> {
   turnHandling?: TurnHandlingOptions;
   minConsecutiveSpeechDelay?: number;
   useTtsAlignedTranscript?: boolean;
-  /** Text replacements applied before TTS synthesis. */
-  ttsPronunciationMap?: TTSPronunciationMap;
   /** @deprecated use turnHandling.turnDetection instead */
   turnDetection?: TurnDetectionMode;
   /** @deprecated use turnHandling.interruption.enabled instead */
@@ -146,7 +142,6 @@ export class Agent<UserData = any> {
 
   private _minConsecutiveSpeechDelay?: number;
   private _useTtsAlignedTranscript?: boolean;
-  private _ttsPronunciationMap?: TTSPronunciationMap;
 
   /** @internal */
   _agentActivity?: AgentActivity;
@@ -174,7 +169,6 @@ export class Agent<UserData = any> {
     turnHandling,
     minConsecutiveSpeechDelay,
     useTtsAlignedTranscript,
-    ttsPronunciationMap,
   }: AgentOptions<UserData>) {
     if (id) {
       this._id = id;
@@ -228,7 +222,6 @@ export class Agent<UserData = any> {
 
     this._minConsecutiveSpeechDelay = minConsecutiveSpeechDelay;
     this._useTtsAlignedTranscript = useTtsAlignedTranscript;
-    this._ttsPronunciationMap = ttsPronunciationMap;
 
     this._agentActivity = undefined;
   }
@@ -251,10 +244,6 @@ export class Agent<UserData = any> {
 
   get useTtsAlignedTranscript(): boolean | undefined {
     return this._useTtsAlignedTranscript;
-  }
-
-  get ttsPronunciationMap(): TTSPronunciationMap | undefined {
-    return this._ttsPronunciationMap;
   }
 
   get chatCtx(): ReadonlyChatContext {
@@ -502,15 +491,14 @@ export class Agent<UserData = any> {
 
       const connOptions = activity.agentSession.connOptions.ttsConnOptions;
       const stream = wrappedTts.stream({ connOptions });
-      const ttsInputStream = createTTSPronunciationMapStream(text, agent.ttsPronunciationMap);
-      stream.updateInputStream(ttsInputStream.stream);
+      stream.updateInputStream(text);
 
       let cleaned = false;
       const cleanup = async () => {
         if (cleaned) return;
         cleaned = true;
         stream.close();
-        await ttsInputStream.cancel('tts node cleanup').catch(() => {});
+        await text.cancel('tts node cleanup').catch(() => {});
         if (wrappedTts !== activity.tts) {
           await wrappedTts.close();
         }
@@ -555,109 +543,6 @@ export class Agent<UserData = any> {
     ): Promise<ReadableStream<AudioFrame> | null> {
       return audio;
     },
-  };
-}
-
-// Wrap the TTS input stream so pronunciation replacements are applied before synthesis,
-// while keeping a direct cancel hook for cleanup when TTS is interrupted.
-function createTTSPronunciationMapStream(
-  text: ReadableStream<string>,
-  pronunciationMap?: TTSPronunciationMap,
-): { stream: ReadableStream<string>; cancel: (reason?: unknown) => Promise<void> } {
-  if (!pronunciationMap || Object.keys(pronunciationMap).length === 0) {
-    return {
-      stream: text,
-      async cancel(reason?: unknown) {
-        await text.cancel(reason);
-      },
-    };
-  }
-
-  const entries = Object.entries(pronunciationMap);
-  let reader: ReadableStreamDefaultReader<string> | undefined;
-  let cancelled = false;
-
-  const cancel = async (reason?: unknown) => {
-    cancelled = true;
-    await reader?.cancel(reason);
-  };
-
-  const stream = new ReadableStream<string>({
-    async start(controller) {
-      reader = text.getReader();
-      let buffer = '';
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) {
-            break;
-          }
-          buffer += value;
-          const drained = drainTTSPronunciationBuffer(buffer, entries);
-          buffer = drained.buffer;
-          if (drained.output) {
-            controller.enqueue(drained.output);
-          }
-        }
-
-        if (buffer) {
-          const drained = drainTTSPronunciationBuffer(buffer, entries, true);
-          if (drained.output) {
-            controller.enqueue(drained.output);
-          }
-        }
-
-        if (!cancelled) {
-          controller.close();
-        }
-      } catch (error) {
-        if (!cancelled) {
-          controller.error(error);
-        }
-      } finally {
-        reader?.releaseLock();
-      }
-    },
-    cancel(reason) {
-      return cancel(reason);
-    },
-  });
-
-  return { stream, cancel };
-}
-
-// Emit only text that can no longer become a pronunciation-map key; the retained
-// buffer lets replacements match terms split across stream chunk boundaries.
-function drainTTSPronunciationBuffer(
-  initialBuffer: string,
-  entries: [string, string][],
-  final = false,
-): { output: string; buffer: string } {
-  let buffer = initialBuffer;
-  let output = '';
-
-  while (buffer.length > 0) {
-    const match = entries.find(([term]) => term.length > 0 && buffer.startsWith(term));
-    if (match) {
-      const [term, pronunciation] = match;
-      output += pronunciation;
-      buffer = buffer.slice(term.length);
-      continue;
-    }
-
-    const mayBecomeMatch =
-      !final && entries.some(([term]) => term.length > 0 && term.startsWith(buffer));
-    if (mayBecomeMatch) {
-      break;
-    }
-
-    output += buffer[0];
-    buffer = buffer.slice(1);
-  }
-
-  return {
-    output,
-    buffer,
   };
 }
 

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -1,14 +1,7 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-export {
-  Agent,
-  AgentTask,
-  StopResponse,
-  type AgentOptions,
-  type ModelSettings,
-  type TTSPronunciationMap,
-} from './agent.js';
+export { Agent, AgentTask, StopResponse, type AgentOptions, type ModelSettings } from './agent.js';
 export * from './amd.js';
 export {
   AgentSession,


### PR DESCRIPTION
## Summary

Removes the `ttsPronunciationMap` Agent option and the `TTSPronunciationMap` type. This feature duplicated the general text-transform mechanism: pre-TTS pronunciation replacements are already covered by `tts_text_transforms` / the `replace` transform (`voice/transcription/text_transforms.ts`), which also matches how the Python `agents` library handles this (it never had a dedicated pronunciation map — it uses `tts_text_transforms` + `text_transforms.replace`).

## Changes (`agents/src/voice/agent.ts`)
- Drop the `TTSPronunciationMap` type and its export from `voice/index.ts`
- Drop the `ttsPronunciationMap` option, private field, constructor wiring, and public getter on `Agent`
- Remove the `createTTSPronunciationMapStream` / `drainTTSPronunciationBuffer` helpers
- Feed `text` straight into the TTS stream in `ttsNode`, preserving the cancel-on-cleanup behavior
- Remove the now-unused `ReadableStreamDefaultReader` import

Net: +4 / −126.

## Migration
Use a text transform instead:

```ts
new Agent({
  // ...
  // ttsPronunciationMap: { LiveKit: 'live kit' },   // removed
})
```

Apply `replace({ LiveKit: 'live kit' })` via the TTS text-transform pipeline instead.

## Test plan
- `pnpm --filter @livekit/agents build` succeeds (incl. `tsc` declaration emit)
- `pnpm --filter @livekit/agents lint` reports no errors on changed files (only pre-existing `any` warnings)
- Added a `minor` changeset