### PR TITLE
Explain why ca-certificates is required in the example Dockerfile

### DIFF
--- a/examples/src/Dockerfile-example
+++ b/examples/src/Dockerfile-example
@@ -15,12 +15,9 @@ FROM node:${NODE_VERSION}-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
-# Install ca-certificates (required) and pnpm, then clean the apt cache for a smaller image.
-# @livekit/rtc-node ships a native Rust core that reads the system trust store, not Node's
-# bundled CA roots. Slim Debian images don't include /etc/ssl/certs/ca-certificates.crt by
-# default, so without this package, calls into LiveKit Cloud fail with a misleading
-# "failed to retrieve region info" error.
-# --no-install-recommends keeps the image minimal.
+# Install ca-certificates and pnpm, then clean the apt cache.
+# ca-certificates is required: the LiveKit SDK needs the system CA bundle at
+# runtime, and node:22-slim doesn't ship one.
 RUN apt-get update -qq && apt-get install --no-install-recommends -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Pin pnpm version for reproducible builds

--- a/examples/src/Dockerfile-example
+++ b/examples/src/Dockerfile-example
@@ -15,9 +15,12 @@ FROM node:${NODE_VERSION}-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
-# Install required system packages and pnpm, then clean up the apt cache for a smaller image
-# ca-certificates: enables TLS/SSL for securely fetching dependencies and calling HTTPS services
-# --no-install-recommends keeps the image minimal
+# Install ca-certificates (required) and pnpm, then clean the apt cache for a smaller image.
+# @livekit/rtc-node ships a native Rust core that reads the system trust store, not Node's
+# bundled CA roots. Slim Debian images don't include /etc/ssl/certs/ca-certificates.crt by
+# default, so without this package, calls into LiveKit Cloud fail with a misleading
+# "failed to retrieve region info" error.
+# --no-install-recommends keeps the image minimal.
 RUN apt-get update -qq && apt-get install --no-install-recommends -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Pin pnpm version for reproducible builds

--- a/examples/src/Dockerfile-example
+++ b/examples/src/Dockerfile-example
@@ -15,9 +15,10 @@ FROM node:${NODE_VERSION}-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
-# Install ca-certificates and pnpm, then clean the apt cache.
-# ca-certificates is required: the LiveKit SDK needs the system CA bundle at
-# runtime, and node:22-slim doesn't ship one.
+# Install ca-certificates (the system CA bundle used for TLS), then clean
+# the apt cache. Required by the LiveKit SDK: the native Rust core reads
+# the system trust store at runtime, which the slim base image doesn't ship.
+# --no-install-recommends keeps the image minimal.
 RUN apt-get update -qq && apt-get install --no-install-recommends -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Pin pnpm version for reproducible builds


### PR DESCRIPTION
Rewrite the in-Dockerfile `ca-certificates` comment in `examples/src/Dockerfile-example` to explain why the line is load-bearing.

`node:22-slim` doesn't ship the system CA bundle, so Node agents on it fail with a misleading `failed to retrieve region info` error. The previous comment ("enables TLS/SSL for securely fetching dependencies") implied this was generic Docker hygiene that could be trimmed, and users were doing exactly that. Reproduced and verified end-to-end against a live LiveKit Cloud project.

No functional change. Filed against [DOCS-1454](https://linear.app/livekit/issue/DOCS-1454).

## Related PRs

Same change applied across the docs partial and sibling repos so they stay aligned:

- [livekit/web#4552](https://github.com/livekit/web/pull/4552) — docs page bullet + Dockerfile partial
- [livekit/livekit-cli#849](https://github.com/livekit/livekit-cli/pull/849) — `pkg/agentfs/examples/node.Dockerfile`
- [livekit-examples/agent-starter-node#50](https://github.com/livekit-examples/agent-starter-node/pull/50) — starter `Dockerfile`
