### PR TITLE
chore(agents): downgrade ttsPronunciationMap removal changeset to patch

### DIFF
--- a/.changeset/remove-tts-pronunciation-map.md
+++ b/.changeset/remove-tts-pronunciation-map.md
@@ -1,5 +1,5 @@
 ---
-'@livekit/agents': minor
+'@livekit/agents': patch
 ---
 
 Remove the `ttsPronunciationMap` Agent option (and the `TTSPronunciationMap` type). Use the general `tts_text_transforms` / `replace` text transform for pre-TTS pronunciation replacements instead.


### PR DESCRIPTION
## Summary

Addresses review feedback on #1620. The changeset for removing the `ttsPronunciationMap` Agent option was set to `minor`; per @toubatbrian's review comment ("This should be patch?"), this changes the bump to `patch`.

## Changes
- `.changeset/remove-tts-pronunciation-map.md`: `@livekit/agents` bump `minor` → `patch`