### PR TITLE
(openai realtime 2): fix message playout

### DIFF
--- a/.changeset/realtime-multi-message-ordering.md
+++ b/.changeset/realtime-multi-message-ordering.md
@@ -1,0 +1,16 @@
+---
+'@livekit/agents': patch
+---
+
+fix(realtime): process all messages in multi-message realtime generations
+
+Reorders audio/text forwarding setup inside `processOneMessage` to match the
+Python source order (audio first, then text), and tightens the playout-await
+guard so `playoutPromise` is only awaited when not interrupted. This fixes a
+case where the second message in a multi-message realtime response (e.g.
+`gpt-realtime-2` preambles) could be dropped.
+
+Also stamps assistant `ChatMessage.createdAt` with `startedSpeakingAt` (the
+first frame's playback start) instead of defaulting to `Date.now()` at
+end-of-generation. This preserves correct user/assistant ordering in
+`ChatContext` when user transcription items land during agent playout.

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2964,17 +2964,6 @@ export class AgentActivity implements RecognitionHooks {
           trTextInput = msg.textStream;
         }
 
-        const trNodeResult = await this.agent.transcriptionNode(trTextInput, modelSettings);
-        if (trNodeResult) {
-          const [textForwardTask, textOut] = performTextForwarding(
-            trNodeResult,
-            messageAbortController,
-            textOutput,
-          );
-          forwardTasks.push(textForwardTask);
-          output.textOut = textOut;
-        }
-
         if (audioOutput) {
           let realtimeAudioResult: ReadableStream<AudioFrame> | null = null;
 
@@ -3021,17 +3010,33 @@ export class AgentActivity implements RecognitionHooks {
               .then((ts) => onFirstFrame(ts))
               .catch(() => this.logger.debug('firstFrameFut cancelled before first frame'));
           }
-        } else if (output.textOut) {
+        }
+
+        const trNodeResult = await this.agent.transcriptionNode(trTextInput, modelSettings);
+        if (trNodeResult) {
+          const [textForwardTask, textOut] = performTextForwarding(
+            trNodeResult,
+            messageAbortController,
+            textOutput,
+          );
+          forwardTasks.push(textForwardTask);
+          output.textOut = textOut;
+        }
+
+        if (!output.audioOut && output.textOut) {
           output.textOut.firstTextFut.await
             .then(() => onFirstFrame())
             .catch(() => this.logger.debug('firstTextFut cancelled before first frame'));
         }
 
-        let playoutPromise: Promise<PlaybackFinishedEvent> | null = null;
+        let playoutEv: PlaybackFinishedEvent | undefined;
         await speechHandle.waitIfNotInterrupted(forwardTasks.map((task) => task.result));
         if (!speechHandle.interrupted && audioOutput) {
-          playoutPromise = audioOutput.waitForPlayout();
+          const playoutPromise = audioOutput.waitForPlayout();
           await speechHandle.waitIfNotInterrupted([playoutPromise]);
+          if (!speechHandle.interrupted) {
+            playoutEv = await playoutPromise;
+          }
         }
 
         if (speechHandle.interrupted) {
@@ -3050,11 +3055,10 @@ export class AgentActivity implements RecognitionHooks {
           return output;
         }
 
-        if (audioOutput) {
-          const playbackEv = await playoutPromise!;
+        if (audioOutput && playoutEv) {
           output.played = 'full';
-          output.playbackPositionInS = playbackEv.playbackPosition;
-          output.synchronizedTranscript = playbackEv.synchronizedTranscript;
+          output.playbackPositionInS = playoutEv.playbackPosition;
+          output.synchronizedTranscript = playoutEv.synchronizedTranscript;
         } else if (output.textOut?.text) {
           output.played = 'full';
         }
@@ -3121,6 +3125,7 @@ export class AgentActivity implements RecognitionHooks {
             content: forwardedText,
             id: output.message.messageId,
             interrupted,
+            createdAt: startedSpeakingAt,
           });
           this.agent._chatCtx.insert(message);
           speechHandle._itemAdded([message]);


### PR DESCRIPTION
previously if there was a second message within one generation, it would not be played out

it seems there is no transcript pacing but that may be a pre existing issue ?

## Summary
1. Reorder audio/text forwarding setup in processOneMessage
  Moved the if (audioOutput) { ... } block above the transcriptionNode / performTextForwarding block to match the Python source order. Also changed the first-text-fut fallback condition
   from else if (output.textOut) (gated on audioOutput being null) to a standalone if (!output.audioOut && output.textOut) — so it triggers whenever audio forwarding wasn't actually set
   up, matching Python's if audio_out is None and text_out is not None.

  2. Tighten the playout-await guard
  Replaced let playoutPromise: Promise<...> | null = null plus the trailing await playoutPromise! non-null assertion with a captured playoutEv: PlaybackFinishedEvent | undefined, only
  assigned when the await completes without interruption. Avoids re-awaiting an already-resolved promise and removes the !.
  
  3. Stamp createdAt explicitly when inserting assistant messages
  In addRealtimeMessageOutputs, added createdAt: startedSpeakingAt to the ChatMessage.create call. Previously createdAt defaulted to Date.now() at end-of-generation, so a user STT
  commit landing during agent playout would sort before msg1/msg2 in ChatContext. Now both assistant messages get stamped with the first-frame timestamp, matching Python's
  msg.created_at = started_speaking_at.