### PR TITLE
Subscribe to tracks published after connect with AUDIO_ONLY/VIDEO_ONLY

### DIFF
--- a/.changeset/forty-memes-sin.md
+++ b/.changeset/forty-memes-sin.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+subscribe to tracks published after connect with AUDIO_ONLY/VIDEO_ONLY

--- a/agents/src/job.ts
+++ b/agents/src/job.ts
@@ -6,6 +6,7 @@ import type {
   E2EEOptions,
   LocalParticipant,
   RemoteParticipant,
+  RemoteTrackPublication,
   Room,
   RtcConfiguration,
 } from '@livekit/rtc-node';
@@ -261,16 +262,24 @@ export class JobContext<ProcessUserData = Record<string, unknown>> {
     this.#room.remoteParticipants.forEach(this.onParticipantConnected);
 
     if ([AutoSubscribe.AUDIO_ONLY, AutoSubscribe.VIDEO_ONLY].includes(autoSubscribe)) {
+      const desiredKind =
+        autoSubscribe === AutoSubscribe.AUDIO_ONLY ? TrackKind.KIND_AUDIO : TrackKind.KIND_VIDEO;
+      const subscribeIfMatch = (pub: RemoteTrackPublication) => {
+        if (pub.kind === desiredKind) {
+          pub.setSubscribed(true);
+        }
+      };
+
+      // Subscribe to tracks already published at connect time.
       this.#room.remoteParticipants.forEach((p) => {
-        p.trackPublications.forEach((pub) => {
-          if (
-            (autoSubscribe === AutoSubscribe.AUDIO_ONLY && pub.kind === TrackKind.KIND_AUDIO) ||
-            (autoSubscribe === AutoSubscribe.VIDEO_ONLY && pub.kind === TrackKind.KIND_VIDEO)
-          ) {
-            pub.setSubscribed(true);
-          }
-        });
+        p.trackPublications.forEach(subscribeIfMatch);
       });
+
+      // Server-side autosubscribe is disabled for AUDIO_ONLY/VIDEO_ONLY, so
+      // subscribe to matching tracks published AFTER connect as well (e.g. a
+      // participant that unmutes or joins later). Without this, late-published
+      // tracks are never subscribed. Mirrors Python's _apply_auto_subscribe_opts.
+      this.#room.on(RoomEvent.TrackPublished, subscribeIfMatch);
     }
     this.connected = true;
   }


### PR DESCRIPTION
## Problem

  When a job connects with `AutoSubscribe.AUDIO_ONLY` (or `VIDEO_ONLY`), the agent
  only subscribes to tracks that already exist **at connect time**. Any track a
  participant publishes **after** the agent connects — e.g. a participant who
  unmutes or joins late, or a client that publishes its mic track shortly after
  the agent — is never subscribed, so the agent silently never receives that
  audio/video.

  Root cause in `JobContext.connect()`:

  - Server-side autosubscribe is disabled for these modes
    (`autoSubscribe: autoSubscribe == AutoSubscribe.SUBSCRIBE_ALL` is `false`), so
    the server doesn't push late tracks.
  - The manual subscription only walked `room.remoteParticipants` **once**, at
    connect time. There was no `RoomEvent.TrackPublished` listener, so later
    publications were missed.

  This is a port gap: Python's `JobContext.connect` (`_apply_auto_subscribe_opts`)
  registers a `track_published` handler for exactly this case; the JS port only
  handled connect-time tracks.

  ## Fix

  Register a `RoomEvent.TrackPublished` listener for `AUDIO_ONLY`/`VIDEO_ONLY` that
  subscribes matching tracks as they're published, in addition to the existing
  connect-time pass. The shared kind-matching logic is extracted into a small
  `subscribeIfMatch` helper used by both paths.

  ```ts
  const desiredKind =
    autoSubscribe === AutoSubscribe.AUDIO_ONLY ? TrackKind.KIND_AUDIO : TrackKind.KIND_VIDEO;
  const subscribeIfMatch = (pub: RemoteTrackPublication) => {
    if (pub.kind === desiredKind) pub.setSubscribed(true);
  };
  // existing tracks
  this.#room.remoteParticipants.forEach((p) => p.trackPublications.forEach(subscribeIfMatch));
  // tracks published after connect
  this.#room.on(RoomEvent.TrackPublished, subscribeIfMatch);
  ```