### PR TITLE
fix(silero): include prefix-padding pre-roll in VAD speech buffer frame

### DIFF
--- a/.changeset/silero-vad-speech-buffer-frame.md
+++ b/.changeset/silero-vad-speech-buffer-frame.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-silero": patch
+---
+
+Fix VAD speech buffer AudioFrame to include the prefix-padding pre-roll so START_OF_SPEECH / END_OF_SPEECH events deliver the full pre-rolled audio to downstream consumers (STT, transcription) and `samplesPerChannel` matches the data length.

--- a/plugins/silero/src/vad.ts
+++ b/plugins/silero/src/vad.ts
@@ -303,7 +303,7 @@ export class VADStream extends baseStream {
           const copySpeechBuffer = (): AudioFrame => {
             if (!this.#speechBuffer) throw new Error('speechBuffer is empty');
             return new AudioFrame(
-              this.#speechBuffer.subarray(this.#prefixPaddingSamples, speechBufferIndex),
+              this.#speechBuffer.subarray(0, speechBufferIndex),
               this.#inputSampleRate,
               1,
               speechBufferIndex,


### PR DESCRIPTION
## Summary

- The `AudioFrame` emitted on `START_OF_SPEECH` / `END_OF_SPEECH` in the silero VAD sliced off the prefix-padding samples (`subarray(prefixPaddingSamples, speechBufferIndex)`) but still reported `samplesPerChannel = speechBufferIndex`. Result: frame metadata claimed more samples than its data contained, and the pre-roll audio that the buffer machinery deliberately preserves was discarded before reaching downstream consumers (STT, transcription).
- Slice from `0` instead so data length matches `samplesPerChannel` and the pre-roll is delivered. Matches the Python original (`livekit-agents/livekit/agents/inference/vad.py`: `self._speech_buffer[:speech_buffer_index]`).

The same bug exists in `agents/src/inference/vad.ts` on the `feat/AGT-2520-multimodal-eou` branch and will be fixed there before that PR merges — the file does not yet exist on main.

## Test plan

- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes
- [ ] Smoke test silero VAD: confirm `START_OF_SPEECH` AudioFrame data length equals `samplesPerChannel` and includes pre-roll
- [ ] Run an STT-driven example to confirm transcription quality is unchanged (pre-roll now restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)