### PR TITLE
fix(tts): treat zero-token tool-only turns as clean end-of-stream in FallbackAdapter

### DIFF
--- a/agents/src/tts/fallback_adapter.test.ts
+++ b/agents/src/tts/fallback_adapter.test.ts
@@ -190,6 +190,49 @@ describe('TTS FallbackAdapter', () => {
     await adapter.close();
   });
 
+  it('should end cleanly when the stream input has zero text tokens', async () => {
+    const primary = new MockTTS('primary');
+    const secondary = new MockTTS('secondary');
+    const adapter = new FallbackAdapter({
+      ttsInstances: [primary, secondary],
+      maxRetryPerTTS: 0,
+      recoveryDelayMs: 60_000,
+    });
+
+    const stream = adapter.stream();
+    stream.updateInputStream(
+      new ReadableStream<string>({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    );
+
+    const iterate = (async () => {
+      let frameCount = 0;
+      for await (const event of stream) {
+        if (event === SynthesizeStream.END_OF_STREAM) break;
+        frameCount++;
+      }
+      return frameCount;
+    })();
+
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('fallback adapter did not end cleanly')), 3000),
+    );
+
+    const frameCount = await Promise.race([iterate, timeout]);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(frameCount).toBe(0);
+    expect(adapter.status[0]!.available).toBe(true);
+    expect(adapter.status[1]!.available).toBe(true);
+
+    stream.close();
+    await adapter.close();
+  });
+
   it('should fall back in the non-streaming (synthesize) path with mismatched sample rates', async () => {
     // FallbackChunkedStream has the same phantom-flush vulnerability as
     // FallbackSynthesizeStream: when the primary's sample rate differs from

--- a/agents/src/tts/fallback_adapter.ts
+++ b/agents/src/tts/fallback_adapter.ts
@@ -425,10 +425,15 @@ class FallbackSynthesizeStream extends SynthesizeStream {
     if (allTTSFailed) {
       this._logger.warn('All fallback TTS instances failed, retrying from first...');
     }
+    let textTokensRead = 0;
+    let inputEnded = false;
     const readInputLLMStream = (async () => {
       try {
         for await (const input of this.input) {
           if (this.abortController.signal.aborted) break;
+          if (typeof input === 'string') {
+            textTokensRead += 1;
+          }
           this.tokenBuffer.push(input);
         }
       } catch (error) {
@@ -436,6 +441,7 @@ class FallbackSynthesizeStream extends SynthesizeStream {
         throw error;
       } finally {
         this.tokenBuffer.push(SynthesizeStream.END_OF_STREAM);
+        inputEnded = true;
       }
     })();
 
@@ -462,6 +468,7 @@ class FallbackSynthesizeStream extends SynthesizeStream {
 
         const stream = tts.stream({ connOptions });
         let bufferIndex = 0;
+        let tokensPushed = 0;
         let streamOutputCompleted = false;
         const forwardBufferToTTS = async () => {
           while (true) {
@@ -474,6 +481,7 @@ class FallbackSynthesizeStream extends SynthesizeStream {
                 return;
               } else {
                 stream.pushText(token);
+                tokensPushed += 1;
               }
             }
             await new ThrowsPromise<void, never>((resolve) => setTimeout(resolve, FORWARD_POLL_MS));
@@ -565,6 +573,12 @@ class FallbackSynthesizeStream extends SynthesizeStream {
         // Silent failures must trigger fallback. See `sawRawAudio` above for
         // why we don't check `audioPushed` here.
         if (!sawRawAudio) {
+          if (tokensPushed === 0 && inputEnded && textTokensRead === 0) {
+            this.queue.put(SynthesizeStream.END_OF_STREAM);
+            await readInputLLMStream.catch(() => {});
+            return;
+          }
+
           throw new APIConnectionError({
             message: 'TTS stream completed but no audio was received',
           });


### PR DESCRIPTION
## Summary
- Track whether the streaming fallback adapter actually forwarded any text tokens to the active TTS provider.
- Treat a completed stream with zero input text tokens as an empty, successful end-of-stream instead of a provider failure.
- Add a regression test for a zero-token streaming TTS turn to ensure providers remain available and fallback does not cascade.

## Root Cause
Tool-only LLM turns can finish without emitting any spoken text. In that case, `FallbackSynthesizeStream` reached the no-audio guard and threw `TTS stream completed but no audio was received`. The fallback adapter then marked the provider unavailable and moved through every configured TTS instance, eventually surfacing `all TTS instances failed` even though empty audio was the correct response.

## Fix
The streaming forwarding path now counts text tokens pushed to the provider. If no audio is received and the adapter input has ended with zero text tokens, it emits the end-of-stream sentinel, waits for the input reader to settle, and returns successfully. If text was present but no audio came back, the existing fallback error path is preserved.

## Validation
- `pnpm exec prettier --write agents/src/tts/fallback_adapter.ts agents/src/tts/fallback_adapter.test.ts`
- `pnpm exec vitest run agents/src/tts/fallback_adapter.test.ts`
- `pnpm --dir agents exec eslint -f unix src/tts/fallback_adapter.ts src/tts/fallback_adapter.test.ts`
- `pnpm --dir agents exec throws-check src/tts/fallback_adapter.ts`