### PR TITLE
Fix Deepgram audio frame validation

### DIFF
--- a/plugins/deepgram/src/stt.ts
+++ b/plugins/deepgram/src/stt.ts
@@ -309,7 +309,7 @@ export class SpeechStream extends stt.SpeechStream {
             frames = stream.flush();
             this.#audioDurationCollector.flush();
           } else if (
-            data.sampleRate === this.#opts.sampleRate ||
+            data.sampleRate === this.#opts.sampleRate &&
             data.channels === this.#opts.numChannels
           ) {
             frames = stream.write(data.data.buffer as ArrayBuffer);


### PR DESCRIPTION
## Summary
- Reject Deepgram STT audio frames unless both sample rate and channel count match the configured stream
- Prevent frames with only one matching dimension from being forwarded with incompatible audio settings