### PR TITLE
Fix Resemble final audio frame

### DIFF
--- a/plugins/resemble/src/tts.ts
+++ b/plugins/resemble/src/tts.ts
@@ -133,25 +133,31 @@ export class ChunkedStream extends tts.ChunkedStream {
             }
 
             const audioBytes = Buffer.from(audioContentB64, 'base64');
+            let lastFrame: AudioFrame | undefined;
+            const sendLastFrame = (final: boolean) => {
+              if (lastFrame) {
+                this.queue.put({
+                  requestId,
+                  frame: lastFrame,
+                  final,
+                  segmentId: requestId,
+                });
+                lastFrame = undefined;
+              }
+            };
 
             for (const frame of bstream.write(audioBytes)) {
-              this.queue.put({
-                requestId,
-                frame,
-                final: false,
-                segmentId: requestId,
-              });
+              sendLastFrame(false);
+              lastFrame = frame;
             }
 
             for (const frame of bstream.flush()) {
-              this.queue.put({
-                requestId,
-                frame,
-                final: false,
-                segmentId: requestId,
-              });
+              if (frame.samplesPerChannel === 0) continue;
+              sendLastFrame(false);
+              lastFrame = frame;
             }
 
+            sendLastFrame(true);
             this.queue.close();
             doneFut.resolve();
           } catch (error) {


### PR DESCRIPTION
Resemble ChunkedStream now retains the last synthesized frame and emits it with final: true at completion, matching the provider stream contract used elsewhere in the TTS stack.