### PR TITLE
fix(voice): don't strand playback-segment counter on interrupted-while-paused frame

### DIFF
--- a/.changeset/audiooutput-segment-counter-hang.md
+++ b/.changeset/audiooutput-segment-counter-hang.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Fix ParticipantAudioOutput stranding its playback-segment counter when a frame is interrupted while paused. `captureFrame` registered the segment (via `super.captureFrame`) before the pause/interrupt gate, so a frame that bailed at the gate left `playbackSegmentsCount` ahead of `playbackFinishedCount` forever — every subsequent `waitForPlayout()` then blocked, which could hang the agent's main loop (the stalled turn is never interrupted, so `mainTask` parks on `_waitForGeneration()`). The segment is now counted only after the gate is cleared.

--- a/agents/src/voice/room_io/_output.test.ts
+++ b/agents/src/voice/room_io/_output.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { Future } from '../../utils.js';
 import { ParticipantAudioOutput } from './_output.js';
 
+type CaptureFrameArg = Parameters<ParticipantAudioOutput['captureFrame']>[0];
+
 const nextTick = () => new Promise<void>((resolve) => setImmediate(resolve));
 
 describe('ParticipantAudioOutput waitForPlayoutTask', () => {
@@ -150,5 +152,78 @@ describe('ParticipantAudioOutput waitForPlayoutTask', () => {
       interrupted: false,
     });
     expect(output.logger.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('ParticipantAudioOutput captureFrame segment accounting', () => {
+  type TestOutput = ParticipantAudioOutput & {
+    startedFuture: Future<void>;
+    playbackEnabledFuture: Future<void>;
+    interruptedFuture: Future<void>;
+    firstFrameEmitted: boolean;
+    pushedDuration: number;
+    _capturing: boolean;
+    playbackSegmentsCount: number;
+    playbackFinishedCount: number;
+    playbackFinishedFuture: Future<void>;
+    onPlaybackStarted: (createdAt: number) => void;
+    audioSource: {
+      clearQueue: () => void;
+      captureFrame: (frame: CaptureFrameArg) => Promise<void>;
+    };
+  };
+
+  const makeOutput = (opts: { paused: boolean }): TestOutput => {
+    const output = Object.create(ParticipantAudioOutput.prototype) as TestOutput;
+    output.startedFuture = new Future<void>();
+    output.startedFuture.resolve();
+    output.playbackEnabledFuture = new Future<void>();
+    if (!opts.paused) output.playbackEnabledFuture.resolve();
+    output.interruptedFuture = new Future<void>();
+    output.firstFrameEmitted = false;
+    output.pushedDuration = 0;
+    // Base-class (AudioOutput) playback-segment counters, normally initialized by its constructor.
+    output._capturing = false;
+    output.playbackSegmentsCount = 0;
+    output.playbackFinishedCount = 0;
+    output.playbackFinishedFuture = new Future<void>();
+    output.onPlaybackStarted = vi.fn();
+    output.audioSource = { clearQueue: vi.fn(), captureFrame: vi.fn(async () => {}) };
+    return output;
+  };
+
+  const frame = () => ({ samplesPerChannel: 480, sampleRate: 24000 }) as unknown as CaptureFrameArg;
+
+  it('does not strand the segment counter when a frame is interrupted while paused', async () => {
+    const output = makeOutput({ paused: true });
+
+    const capture = output.captureFrame(frame());
+    // Barge-in: the tentative pause resolves into an interruption while the frame waits at the gate.
+    output.interruptedFuture.resolve();
+    await capture;
+
+    // A bailed frame must not register a playback segment. Counting it (super.captureFrame before
+    // the gate) leaves playbackSegmentsCount permanently ahead of playbackFinishedCount.
+    expect(output.playbackSegmentsCount).toBe(0);
+    expect(output.audioSource.captureFrame).not.toHaveBeenCalled();
+
+    // Observable consequence: a following turn's waitForPlayout() resolves instead of hanging.
+    let resolved = false;
+    void output.waitForPlayout().then(() => {
+      resolved = true;
+    });
+    await nextTick();
+    await nextTick();
+    expect(resolved).toBe(true);
+  });
+
+  it('registers a segment on the normal (non-paused) path', async () => {
+    const output = makeOutput({ paused: false });
+
+    await output.captureFrame(frame());
+
+    expect(output.playbackSegmentsCount).toBe(1);
+    expect(output.audioSource.captureFrame).toHaveBeenCalledTimes(1);
+    expect(output.pushedDuration).toBeGreaterThan(0);
   });
 });

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -425,8 +425,6 @@ export class ParticipantAudioOutput extends AudioOutput {
   async captureFrame(frame: AudioFrame): Promise<void> {
     await this.startedFuture.await;
 
-    super.captureFrame(frame);
-
     if (!this.playbackEnabledFuture.done) {
       this.audioSource.clearQueue();
       // Race against interruption so a cancel-while-paused can't deadlock an in-flight frame.
@@ -435,6 +433,11 @@ export class ParticipantAudioOutput extends AudioOutput {
         return;
       }
     }
+
+    // Count the segment only after the pause/interrupt gate: a frame that bails here (interrupted
+    // while paused) must not bump playbackSegmentsCount, or it stays ahead of playbackFinishedCount
+    // forever and the next waitForPlayout() hangs.
+    super.captureFrame(frame);
 
     if (!this.firstFrameEmitted) {
       this.firstFrameEmitted = true;


### PR DESCRIPTION
## Summary

`ParticipantAudioOutput.captureFrame` can permanently desync its playback-segment counter when a frame arrives while the output is paused (interruption detection) and is then interrupted. Afterwards every `waitForPlayout()` on that output blocks forever, which can hang the agent.

## Root cause

`captureFrame` calls `super.captureFrame(frame)` — which bumps the base `AudioOutput`'s `playbackSegmentsCount` — *before* the pause/interrupt gate:

```ts
super.captureFrame(frame);            // playbackSegmentsCount++

if (!this.playbackEnabledFuture.done) {
  this.audioSource.clearQueue();
  await Promise.race([this.playbackEnabledFuture.await, this.interruptedFuture.await]);
  if (this.interruptedFuture.done) {
    return;                           // pushedDuration is never incremented
  }
}
```

When a frame bails at that early `return` (interrupted while paused), the segment was already counted, but:

- `pushedDuration` is never incremented, so
- `flush()` short-circuits on `if (!this.pushedDuration) return` and never starts `waitForPlayoutTask`, so
- `onPlaybackFinished` is never called and `playbackFinishedCount` never catches up.

`playbackSegmentsCount` is now permanently ahead of `playbackFinishedCount`, so the next segment's `waitForPlayout()` (`while (playbackFinishedCount < playbackSegmentsCount) await ...`) never resolves.

### Why it can hang the agent

The stalled turn's reply pipeline awaits `audioOutput.waitForPlayout()` and so never reaches `_markGenerationDone()`. Because the speech handle is also never interrupted, `AgentActivity.mainTask`'s `await speechHandle.waitIfNotInterrupted([speechHandle._waitForGeneration()])` has neither of its two exit conditions and parks forever — the agent goes silent until the participant disconnects. This is easiest to hit when a tool-call-only turn (no spoken text) immediately follows a barge-in. (Same hang surface as the `mainTask` issues #836 / #1089, but a distinct root cause in the audio output.)

## Fix

Register the playback segment (`super.captureFrame`) only after the pause/interrupt gate is cleared, so a frame that bails never counts a segment.

## Test

Adds a `ParticipantAudioOutput captureFrame segment accounting` suite to `_output.test.ts`:

- a frame interrupted while paused must not register a segment, and a following `waitForPlayout()` resolves (this fails before the fix — `playbackSegmentsCount` is left at 1 and `waitForPlayout()` hangs);
- the normal (non-paused) path still registers and pushes the frame.