### PR TITLE
fix(inworld): harden TTS connection layer and default to inworld-tts-2

### DIFF
--- a/.changeset/inworld-tts-connection-hardening.md
+++ b/.changeset/inworld-tts-connection-hardening.md
@@ -1,5 +1,5 @@
 ---
-'@livekit/agents-plugin-inworld': minor
+'@livekit/agents-plugin-inworld': patch
 ---
 
 Harden the Inworld TTS connection layer (retryable framework errors, a handshake timeout and a bounded in-turn wait, and no in-plugin backoff so retries are delegated to the framework) and change the defaults to the `inworld-tts-2` model and `Jason` voice.

--- a/.changeset/inworld-tts-connection-hardening.md
+++ b/.changeset/inworld-tts-connection-hardening.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-inworld': minor
+---
+
+Harden the Inworld TTS connection layer (retryable framework errors, a handshake timeout and a bounded in-turn wait, and no in-plugin backoff so retries are delegated to the framework) and change the defaults to the `inworld-tts-2` model and `Jason` voice.

--- a/plugins/inworld/src/tts.ts
+++ b/plugins/inworld/src/tts.ts
@@ -555,6 +555,13 @@ class SynthesizeStream extends tts.SynthesizeStream {
       resolveProcessing = resolve;
       rejectProcessing = reject;
     });
+    // `processing` can be rejected (by onClose below, or a server status error)
+    // before it is awaited at the Promise.race() further down: if a send/flush
+    // throws first we jump straight to the catch block and skip the race. Attach
+    // a no-op handler so that early rejection is never an unhandled rejection
+    // (which aborts the process in Node >= 15). The real error still surfaces via
+    // the thrown send/flush/close, so retry behavior is unchanged.
+    processing.catch(() => {});
 
     // If the shared socket drops mid-turn, fail the turn fast with a retryable
     // error so the framework restarts it on a fresh connection, instead of

--- a/plugins/inworld/src/tts.ts
+++ b/plugins/inworld/src/tts.ts
@@ -545,6 +545,14 @@ class SynthesizeStream extends tts.SynthesizeStream {
   }
 
   protected async run() {
+    // The framework's retry loop re-invokes run() on the same instance, so reset
+    // per-attempt state: use a fresh context id (reusing one risks colliding with
+    // the failed attempt's server-side context or being resolved by its stale
+    // contextClosed) and zero the cumulative timestamp offsets.
+    this.#contextId = shortuuid();
+    this.#cumulativeTime = 0;
+    this.#generationEndTime = 0;
+
     const ws = await this.#tts.pool.getConnection();
     const bstream = new AudioByteStream(this.#opts.sampleRate, NUM_CHANNELS);
     const tokenizerStream = this.#opts.tokenizer!.stream();
@@ -693,10 +701,16 @@ class SynthesizeStream extends tts.SynthesizeStream {
           }
         }
       } else if (result.status && result.status.code !== 0) {
+        // status.code is a gRPC-style code (0-16), not an HTTP status, so
+        // APIStatusError's 4xx heuristic can't classify it. A server status
+        // error here is a request-level rejection (bad voice/params, auth);
+        // transient infra issues surface as connection drops (APIConnectionError,
+        // already retryable). Mark it non-retryable so permanent errors fail fast
+        // instead of being retried.
         rejectProcessing(
           new APIStatusError({
             message: `Inworld stream error: ${result.status.message}`,
-            options: { statusCode: result.status.code },
+            options: { statusCode: result.status.code, retryable: false },
           }),
         );
       }

--- a/plugins/inworld/src/tts.ts
+++ b/plugins/inworld/src/tts.ts
@@ -173,6 +173,11 @@ const defaultTTSOptionsBase: Omit<TTSOptions, 'tokenizer'> = {
 
 const CONNECT_TIMEOUT_MS = 10_000; // WebSocket handshake timeout
 
+// Transient gRPC-style status codes worth retrying; everything else is treated as
+// a permanent request rejection. 4 = DEADLINE_EXCEEDED, 8 = RESOURCE_EXHAUSTED
+// (rate limit), 14 = UNAVAILABLE.
+const RETRYABLE_STATUS_CODES = new Set([4, 8, 14]);
+
 class WSConnectionPool {
   #ws?: WebSocket;
   #url: string;
@@ -702,15 +707,16 @@ class SynthesizeStream extends tts.SynthesizeStream {
         }
       } else if (result.status && result.status.code !== 0) {
         // status.code is a gRPC-style code (0-16), not an HTTP status, so
-        // APIStatusError's 4xx heuristic can't classify it. A server status
-        // error here is a request-level rejection (bad voice/params, auth);
-        // transient infra issues surface as connection drops (APIConnectionError,
-        // already retryable). Mark it non-retryable so permanent errors fail fast
-        // instead of being retried.
+        // APIStatusError's 4xx heuristic can't classify it. Retry only transient
+        // codes (rate limit / unavailable / deadline); permanent request
+        // rejections (bad voice/params, auth) fail fast instead of retrying.
         rejectProcessing(
           new APIStatusError({
             message: `Inworld stream error: ${result.status.message}`,
-            options: { statusCode: result.status.code, retryable: false },
+            options: {
+              statusCode: result.status.code,
+              retryable: RETRYABLE_STATUS_CODES.has(result.status.code),
+            },
           }),
         );
       }

--- a/plugins/inworld/src/tts.ts
+++ b/plugins/inworld/src/tts.ts
@@ -785,7 +785,11 @@ class SynthesizeStream extends tts.SynthesizeStream {
       }
       ws.send(JSON.stringify(data), (err) => {
         if (err) {
-          reject(err);
+          reject(
+            new APIConnectionError({
+              message: `Inworld WebSocket send failed: ${asError(err).message}`,
+            }),
+          );
         } else {
           resolve();
         }

--- a/plugins/inworld/src/tts.ts
+++ b/plugins/inworld/src/tts.ts
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
   type APIConnectOptions,
+  APIConnectionError,
+  APIStatusError,
+  APITimeoutError,
   AudioByteStream,
   type TimedString,
   asError,
@@ -20,11 +23,11 @@ const USER_AGENT = 'livekit-agents-js';
 
 const DEFAULT_BIT_RATE = 64000;
 const DEFAULT_ENCODING = 'PCM';
-const DEFAULT_MODEL = 'inworld-tts-1';
+const DEFAULT_MODEL = 'inworld-tts-2';
 const DEFAULT_SAMPLE_RATE = 24000;
 const DEFAULT_URL = 'https://api.inworld.ai/';
 const DEFAULT_WS_URL = 'wss://api.inworld.ai/';
-const DEFAULT_VOICE = 'Ashley';
+const DEFAULT_VOICE = 'Jason';
 const DEFAULT_TEMPERATURE = 1.1;
 const DEFAULT_TIMESTAMP_TRANSPORT_STRATEGY = 'ASYNC';
 const DEFAULT_SPEAKING_RATE = 1.0;
@@ -168,8 +171,7 @@ const defaultTTSOptionsBase: Omit<TTSOptions, 'tokenizer'> = {
   wsURL: DEFAULT_WS_URL,
 };
 
-const MAX_RETRIES = 2;
-const BASE_DELAY_MS = 1000;
+const CONNECT_TIMEOUT_MS = 10_000; // WebSocket handshake timeout
 
 class WSConnectionPool {
   #ws?: WebSocket;
@@ -193,35 +195,11 @@ class WSConnectionPool {
       return this.#connecting;
     }
 
-    this.#connecting = this.#connectWithRetry();
+    // A single connection attempt. Retries are delegated to the framework's
+    // SynthesizeStream retry loop (off the synthesis hot path) by surfacing a
+    // retryable APIConnectionError/APITimeoutError on failure.
+    this.#connecting = this.#attemptConnection();
     return this.#connecting;
-  }
-
-  async #connectWithRetry(): Promise<WebSocket> {
-    let lastError: Error | undefined;
-
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-      try {
-        return await this.#attemptConnection();
-      } catch (err) {
-        lastError = asError(err);
-        this.#connecting = undefined;
-
-        if (attempt < MAX_RETRIES) {
-          // Exponential backoff: 1s, 2s
-          const delayMs = BASE_DELAY_MS * Math.pow(2, attempt);
-          this.#logger.warn(
-            { error: lastError, attempt: attempt + 1, maxRetries: MAX_RETRIES + 1, delayMs },
-            `Failed to connect to Inworld, retrying in ${delayMs}ms`,
-          );
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
-        }
-      }
-    }
-
-    throw new Error(
-      `Failed to connect to Inworld after ${MAX_RETRIES + 1} attempts: ${lastError?.message}`,
-    );
   }
 
   #attemptConnection(): Promise<WebSocket> {
@@ -237,9 +215,31 @@ class WSConnectionPool {
           'X-User-Agent': USER_AGENT,
           'X-Request-Id': requestId,
         },
+        // Backstop slightly above our own timer so the explicit timer below is
+        // the one that fires, yielding a semantically correct APITimeoutError.
+        handshakeTimeout: CONNECT_TIMEOUT_MS + 1_000,
       });
 
+      // Bound the handshake so a blackholed host fails fast with a retryable
+      // timeout rather than an unbounded OS-level hang.
+      let settled = false;
+      const handshakeTimer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        this.#connecting = undefined;
+        ws.terminate();
+        reject(
+          new APITimeoutError({
+            message: `Inworld WebSocket handshake timed out after ${CONNECT_TIMEOUT_MS}ms`,
+          }),
+        );
+      }, CONNECT_TIMEOUT_MS);
+      handshakeTimer.unref?.();
+
       ws.on('open', () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(handshakeTimer);
         this.#ws = ws;
         this.#connecting = undefined;
         this.#logger.debug({ requestId }, 'Established Inworld TTS WebSocket connection');
@@ -247,8 +247,15 @@ class WSConnectionPool {
       });
 
       ws.on('error', (err) => {
-        if (this.#connecting) {
-          reject(err);
+        if (!settled) {
+          settled = true;
+          clearTimeout(handshakeTimer);
+          this.#connecting = undefined;
+          reject(
+            new APIConnectionError({
+              message: `Failed to connect to Inworld: ${asError(err).message}`,
+            }),
+          );
         } else {
           this.#logger.error({ err, requestId }, 'Inworld WebSocket error');
         }
@@ -366,8 +373,8 @@ export class TTS extends tts.TTS {
     return new ChunkedStream(this, text, this.#opts, connOptions, abortSignal);
   }
 
-  stream(): tts.SynthesizeStream {
-    return new SynthesizeStream(this, this.#opts);
+  stream(options?: { connOptions?: APIConnectOptions }): tts.SynthesizeStream {
+    return new SynthesizeStream(this, this.#opts, options?.connOptions);
   }
 
   updateOptions(opts: Partial<TTSOptions>) {
@@ -530,8 +537,8 @@ class SynthesizeStream extends tts.SynthesizeStream {
   #generationEndTime: number = 0;
   label = 'inworld.SynthesizeStream';
 
-  constructor(ttsInstance: TTS, opts: TTSOptions) {
-    super(ttsInstance);
+  constructor(ttsInstance: TTS, opts: TTSOptions, connOptions?: APIConnectOptions) {
+    super(ttsInstance, connOptions);
     this.#tts = ttsInstance;
     this.#opts = opts;
     this.#contextId = shortuuid();
@@ -548,6 +555,14 @@ class SynthesizeStream extends tts.SynthesizeStream {
       resolveProcessing = resolve;
       rejectProcessing = reject;
     });
+
+    // If the shared socket drops mid-turn, fail the turn fast with a retryable
+    // error so the framework restarts it on a fresh connection, instead of
+    // waiting out the in-turn timeout below.
+    const onClose = () => {
+      rejectProcessing(new APIConnectionError({ message: 'Inworld WebSocket closed' }));
+    };
+    ws.on('close', onClose);
 
     let lastFrame: AudioFrame | undefined;
     let pendingTimedTranscripts: TimedString[] = [];
@@ -671,8 +686,12 @@ class SynthesizeStream extends tts.SynthesizeStream {
           }
         }
       } else if (result.status && result.status.code !== 0) {
-        const error = new Error(`Inworld stream error: ${result.status.message}`);
-        rejectProcessing(error);
+        rejectProcessing(
+          new APIStatusError({
+            message: `Inworld stream error: ${result.status.message}`,
+            options: { statusCode: result.status.code },
+          }),
+        );
       }
     };
 
@@ -700,7 +719,27 @@ class SynthesizeStream extends tts.SynthesizeStream {
 
       await this.#flushContext(ws);
       await this.#closeContext(ws);
-      await processing;
+
+      // Wait for the server to finish the context, but bound it so a stalled
+      // server can't hang the turn forever. On timeout, throw a retryable
+      // APITimeoutError so the framework restarts the turn.
+      const waitTimeoutMs = this.connOptions.timeoutMs + 60_000;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new APITimeoutError({
+              message: `Inworld synthesis timed out after ${waitTimeoutMs}ms`,
+            }),
+          );
+        }, waitTimeoutMs);
+        timer.unref?.();
+      });
+      try {
+        await Promise.race([processing, timeout]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
 
       // Flush remaining frames
       for (const frame of bstream.flush()) {
@@ -712,6 +751,7 @@ class SynthesizeStream extends tts.SynthesizeStream {
       log().error({ error: e }, 'Error in SynthesizeStream run');
       throw e;
     } finally {
+      ws.off('close', onClose);
       this.#tts.pool.unregisterListener(this.#contextId);
     }
   }
@@ -719,7 +759,7 @@ class SynthesizeStream extends tts.SynthesizeStream {
   #send(ws: WebSocket, data: object): Promise<void> {
     return new Promise((resolve, reject) => {
       if (ws.readyState !== WebSocket.OPEN) {
-        reject(new Error('WebSocket is not open'));
+        reject(new APIConnectionError({ message: 'Inworld WebSocket not open' }));
         return;
       }
       ws.send(JSON.stringify(data), (err) => {


### PR DESCRIPTION
## Description
hardens the inworld TTS websocket connection layer so transient connection faults self-heal instead of stalling the turn, and switches the defaults to inworld-tts-2 / Jason. on a stalled or blackholed server the current connection layer waits indefinitely and raises a non-retryable plain Error, so the framework's SynthesizeStream retry loop can't restart the turn. this makes those failures fast and retryable.

## Changes Made
- surface retryable framework errors (APIConnectionError / APITimeoutError / APIStatusError) so the SynthesizeStream retry loop restarts a turn on a healthy connection instead of stalling on a plain Error
- add a websocket handshake timeout and bound the in-turn wait (connOptions.timeoutMs + 60s) so a blackholed host or stalled server fails fast and retries rather than hanging
- remove the in-plugin exponential backoff from the synthesis hot path; delegate retries to the framework
- reject the turn fast on mid-turn socket close
- thread connOptions through TTS.stream({ connOptions })
- default voice -> Jason, model -> inworld-tts-2

## Pre-Review Checklist
- [x] **Build passes**: lint, typecheck, and the integration test pass locally
- [x] **AI-generated code reviewed**: comments trimmed, diff kept minimal
- [x] **Changes explained**: documented above
- [x] **Scope appropriate**: connection-layer hardening plus the default model/voice bump
- [ ] **Video demo**: validated live and via fault injection (below); no recording attached

## Testing
- [x] Automated tests added/updated (if applicable): n/a; kept the existing keys-gated integration test (no inworld unit-test precedent in-repo)
- [x] All tests pass: `tts.test.ts` passes against the real API; build + lint + typecheck green
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work: n/a, neither uses the inworld plugin

fault injection (local server that accepts TCP but never completes the WS handshake), probing the connection layer directly:
- before: hangs indefinitely, no timeout, no error -> turn dead-stalls
- after: APITimeoutError (retryable) at 10s -> framework restarts the turn

live: one ~5 minute, 22-turn conversation through the inworld_tts example (Jason / inworld-tts-2): one warm socket reused across all turns, 0 connection errors, TTS TTFB p50 ~397ms / p95 ~611ms, no multi-second stalls.

## Additional Notes
the gains are in fault recovery; happy-path TTS TTFB is unchanged vs the current plugin. a 5-minute hard session expiry that existed in an earlier internal version of this plugin is already absent upstream, so it is not part of this PR.
