### PR TITLE
fix(llm): make ToolOptions.abortSignal required

### DIFF
--- a/.changeset/tool-options-abort-signal-required.md
+++ b/.changeset/tool-options-abort-signal-required.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Make `ToolOptions.abortSignal` required. The framework always provides an `AbortSignal` to tool execution, so the field is no longer optional. Tool authors can rely on `abortSignal` always being defined and drop defensive `if (abortSignal)` checks.

--- a/agents/src/llm/tool_context.ts
+++ b/agents/src/llm/tool_context.ts
@@ -122,9 +122,9 @@ export interface ToolOptions<UserData = UnknownUserData> {
   toolCallId: string;
 
   /**
-   * An optional abort signal that indicates that the overall operation should be aborted.
+   * An abort signal that indicates that the overall operation should be aborted.
    */
-  abortSignal?: AbortSignal;
+  abortSignal: AbortSignal;
 }
 
 export type ToolExecuteFunction<

--- a/agents/src/llm/utils.ts
+++ b/agents/src/llm/utils.ts
@@ -147,7 +147,11 @@ export const createToolOptions = <UserData extends UnknownUserData>(
   toolCallId: string,
   userData: UserData = {} as UserData,
 ): ToolOptions<UserData> => {
-  return { ctx: { userData }, toolCallId } as unknown as ToolOptions<UserData>;
+  return {
+    ctx: { userData },
+    toolCallId,
+    abortSignal: new AbortController().signal,
+  } as unknown as ToolOptions<UserData>;
 };
 
 /** @internal */

--- a/agents/src/voice/amd.ts
+++ b/agents/src/voice/amd.ts
@@ -1048,7 +1048,7 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
         await fnTool.execute(parsedArgs as any, {
           ctx: undefined as never,
           toolCallId: tc.callId,
-          abortSignal: undefined as unknown as AbortSignal,
+          abortSignal: new AbortController().signal,
         });
       } catch (error) {
         this._log.warn({ error, toolName: tc.name }, 'AMD tool execution failed');

--- a/agents/src/voice/generation_tools.test.ts
+++ b/agents/src/voice/generation_tools.test.ts
@@ -68,11 +68,9 @@ describe('Generation + Tool Execution', () => {
       description: 'weather',
       parameters: z.object({ location: z.string() }),
       execute: async ({ location }, { abortSignal }) => {
-        if (abortSignal) {
-          abortSignal.addEventListener('abort', () => {
-            toolAborted = true;
-          });
-        }
+        abortSignal.addEventListener('abort', () => {
+          toolAborted = true;
+        });
         // 6s delay
         await delay(6000);
         return `Sunny in ${location}`;
@@ -186,11 +184,9 @@ describe('Generation + Tool Execution', () => {
       description: 'longOp',
       parameters: z.object({ ms: z.number() }),
       execute: async ({ ms }, { abortSignal }) => {
-        if (abortSignal) {
-          abortSignal.addEventListener('abort', () => {
-            aborted = true;
-          });
-        }
+        abortSignal.addEventListener('abort', () => {
+          aborted = true;
+        });
         await delay(ms);
         return 'done';
       },


### PR DESCRIPTION
## Summary

Makes `ToolOptions.abortSignal` **required** instead of optional, per the team discussion ([context: PR #438 thread](https://github.com/livekit/agents-js/pull/438)).

The original `abortSignal?` was added as optional out of parity caution (Python tool calls weren't cancelled on interrupt at the time, and there was open discussion about whether tools should always be cancellable). The framework already constructs and passes a real `AbortSignal` on the main voice path, so consumers should never have to defensively check it.

Runtime behavior is unchanged; this is purely a type/contract change so tool authors can rely on `abortSignal` always being defined and drop defensive `if (abortSignal)` checks.

## Changes

- `agents/src/llm/tool_context.ts` — `abortSignal?: AbortSignal` → `abortSignal: AbortSignal` (+ JSDoc reworded)
- `agents/src/llm/utils.ts` — `createToolOptions` now supplies a real (never-aborted) `new AbortController().signal` instead of omitting the field
- `agents/src/voice/amd.ts` — replaced the `undefined as unknown as AbortSignal` cast with a real signal
- `agents/src/voice/generation_tools.test.ts` — dropped now-redundant `if (abortSignal)` guards

The main voice path (`generation.ts`) already passed a real signal — no change needed.

## Out of scope

- Implementing actual abort/cancellation wiring for the non-voice/AMD paths (the signal is still never triggered there

## Test plan

- [x] `pnpm build:agents` — passes (incl. `tsc --declaration`)
- [x] Tests — 76/76 pass across `tool_context`, `utils`, `generation_tools`
- [x] Lint — 0 errors on changed files
- [x] Format — clean
- [x] Changeset added (`@livekit/agents`: patch)