### PR TITLE
docs(cartesia): add cartesia stt to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Currently, only the following plugins are supported:
 | [@livekit/agents-plugin-google](https://www.npmjs.com/package/@livekit/agents-plugin-google)         | LLM, TTS      |
 | [@livekit/agents-plugin-deepgram](https://www.npmjs.com/package/@livekit/agents-plugin-deepgram)     | STT, TTS      |
 | [@livekit/agents-plugin-elevenlabs](https://www.npmjs.com/package/@livekit/agents-plugin-elevenlabs) | TTS           |
-| [@livekit/agents-plugin-cartesia](https://www.npmjs.com/package/@livekit/agents-plugin-cartesia)     | TTS           |
+| [@livekit/agents-plugin-cartesia](https://www.npmjs.com/package/@livekit/agents-plugin-cartesia)     | STT, TTS      |
 | [@livekit/agents-plugin-neuphonic](https://www.npmjs.com/package/@livekit/agents-plugin-neuphonic)   | TTS           |
 | [@livekit/agents-plugin-resemble](https://www.npmjs.com/package/@livekit/agents-plugin-resemble)     | TTS           |
 | [@livekit/agents-plugin-rime](https://www.npmjs.com/package/@livekit/agents-plugin-rime)             | TTS           |


### PR DESCRIPTION
This change adds Cartesia STT to the list of plugins ported from `agents`, done in #1587.

I suppose the npm package doesn't actually support Cartesia STT yet since a new release is required. Let me know if you prefer to keep the README in sync with the latest released package rather than what's implemented in `main`.
