### PR TITLE
feat(inference): add agent ID header to inference requests

### DIFF
--- a/.changeset/agent-id-inference-header.md
+++ b/.changeset/agent-id-inference-header.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Add the agent participant SID as an `X-LiveKit-Agent-Id` header on inference requests, alongside the existing room and job ID headers, when running inside a job context.

--- a/agents/src/inference/utils.ts
+++ b/agents/src/inference/utils.ts
@@ -55,7 +55,7 @@ export async function createAccessToken(
 
 /**
  * Build metadata headers for inference requests.
- * Includes SDK version/platform, and optionally room/job IDs from the current job context.
+ * Includes SDK version/platform, and optionally room/job/agent IDs from the current job context.
  */
 export function buildMetadataHeaders(): Record<string, string> {
   const headers: Record<string, string> = {
@@ -70,6 +70,10 @@ export function buildMetadataHeaders(): Record<string, string> {
     }
     if (ctx.job.id) {
       headers['X-LiveKit-Job-Id'] = ctx.job.id;
+    }
+    const agentSid = ctx.agent?.sid;
+    if (agentSid) {
+      headers['X-LiveKit-Agent-Id'] = agentSid;
     }
   }
 


### PR DESCRIPTION
## Summary

Ports [livekit/agents#5937](https://github.com/livekit/agents/pull/5937) to the JS/TS repo.

Adds the agent's participant SID as a new `X-LiveKit-Agent-Id` header in `buildMetadataHeaders` (the JS equivalent of Python's `get_inference_headers`), alongside the existing `X-LiveKit-Room-Id` and `X-LiveKit-Job-Id` headers. The header is only emitted when running inside a job context and when the SID is set, so console mode and tests are unaffected.

This lets the inference gateway attribute requests to the specific running agent instance, not just the room and job. Because the headers are built in `buildMetadataHeaders`, the agent ID automatically flows to every call site the room/job headers already reach — `connectWs`, `inference/llm.ts`, and the interruption HTTP/WS transports.

## Changes

- `agents/src/inference/utils.ts`
  - Emit `X-LiveKit-Agent-Id` from `ctx.agent?.sid` when present
  - Update the `buildMetadataHeaders` JSDoc to mention the agent ID

## Porting notes

- **Header casing** uses `-Id` (not Python's `-ID`) to match this repo's existing `X-LiveKit-Room-Id` / `X-LiveKit-Job-Id`. HTTP header names are case-insensitive, and the existing headers already work against the same gateway.
- **`ctx.agent?.sid`** is the JS equivalent of Python's `ctx.agent.sid`. The JS `JobContext.agent` getter returns `LocalParticipant | undefined`, so the optional chain is load-bearing; the `if (agentSid)` guard mirrors Python's walrus assignment (omits the header when the SID is empty/unset).
- The PR's second change (a Python `ruff` formatting fix in `recorder_io.py`) is Python-tooling-specific and has no JS counterpart, so it was not ported.

## Testing

- `pnpm build:agents` — succeeds (type-check + bundle)
- `prettier --check` and `eslint` — pass (no new issues)
- Runtime check: `buildMetadataHeaders()` returns only `User-Agent` outside a job context and omits the room/job/agent headers without throwing

No unit test was added: the upstream PR ships none, and there is no job-context mock harness in the inference test files. A changeset (`@livekit/agents: patch`) is included.

> Note: `pnpm api:check` fails locally, but this is **pre-existing and environmental** — it reproduces identically on a clean `main` tree (api-extractor's bundled TS 5.4.2 vs the project's 5.9.3, on `export * as` in `index.d.ts:10`). This change is API-surface-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)