### PR TITLE
fix(soniox): exclude test files from dist build

### DIFF
--- a/.changeset/soniox-exclude-test-files.md
+++ b/.changeset/soniox-exclude-test-files.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-soniox': patch
+---
+
+Exclude test files from the published Soniox plugin build.

--- a/plugins/soniox/tsconfig.json
+++ b/plugins/soniox/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src"],
+  "exclude": ["./src/**/*.test.ts"],
   "compilerOptions": {
     "rootDir": "./src",
     "declarationDir": "./dist",

--- a/plugins/soniox/tsup.config.ts
+++ b/plugins/soniox/tsup.config.ts
@@ -1,7 +1,11 @@
-import { defineConfig } from 'tsup';
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
 
+import { defineConfig } from 'tsup';
 import defaults from '../../tsup.config';
 
 export default defineConfig({
   ...defaults,
+  entry: ['src/**/*.ts', '!src/**/*.test.ts'],
 });


### PR DESCRIPTION
The Soniox plugin compiled stt.test.ts into dist/ (both the tsup JS bundle and the tsc type declarations), shipping test artifacts in the published package. 

Mirror the mistralai plugin config: exclude *.test.ts from the tsup entry and add a tsconfig exclude so build:types skips them.