### PR TITLE
feat(voice): add TcpSessionTransport and updateIo session handler

### DIFF
--- a/.changeset/tcp-session-transport.md
+++ b/.changeset/tcp-session-transport.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Add `TcpSessionTransport`, a `SessionTransport` that frames protobuf session messages over a raw TCP socket (4-byte big-endian length prefix, 1 MiB cap, `TCP_NODELAY`), mirroring the Python implementation. Also handle the `updateIo` session request in `SessionHost`, toggling input/output audio and transcription. This is the transport plumbing that lets a local broker (e.g. the LiveKit CLI session daemon) drive a Node agent over TCP.

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -20,6 +20,7 @@ export {
   SessionHost,
   SessionTransport,
   RoomSessionTransport,
+  TcpSessionTransport,
 } from './remote_session.js';
 export * from './events.js';
 export {

--- a/agents/src/voice/remote_session.test.ts
+++ b/agents/src/voice/remote_session.test.ts
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AgentSession as pb } from '@livekit/protocol';
+import * as net from 'node:net';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { initializeLogger } from '../log.js';
+import type { AgentSession } from './agent_session.js';
+import { SessionHost, SessionTransport, TcpSessionTransport } from './remote_session.js';
+
+beforeAll(() => {
+  initializeLogger({ pretty: true, level: 'info' });
+});
+
+function frame(msg: pb.AgentSessionMessage): Buffer {
+  const data = msg.toBinary();
+  const header = Buffer.allocUnsafe(4);
+  header.writeUInt32BE(data.length, 0);
+  return Buffer.concat([header, Buffer.from(data)]);
+}
+
+function pingMessage(requestId: string): pb.AgentSessionMessage {
+  return new pb.AgentSessionMessage({
+    message: {
+      case: 'request',
+      value: new pb.SessionRequest({
+        requestId,
+        request: { case: 'ping', value: new pb.SessionRequest_Ping() },
+      }),
+    },
+  });
+}
+
+async function listen(server: net.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return (server.address() as net.AddressInfo).port;
+}
+
+describe('TcpSessionTransport framing', () => {
+  let server: net.Server | undefined;
+  let transport: TcpSessionTransport | undefined;
+
+  afterEach(async () => {
+    await transport?.close();
+    transport = undefined;
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+  });
+
+  it('decodes a single framed message', async () => {
+    server = net.createServer((sock) => {
+      sock.write(frame(pingMessage('r1')));
+    });
+    const port = await listen(server);
+
+    transport = new TcpSessionTransport('127.0.0.1', port);
+    await transport.start();
+
+    const it = transport[Symbol.asyncIterator]();
+    const { value, done } = await it.next();
+    expect(done).toBe(false);
+    expect(value.message.case).toBe('request');
+    expect((value.message.value as pb.SessionRequest).requestId).toBe('r1');
+  });
+
+  it('reassembles a frame delivered across multiple chunks', async () => {
+    const buf = frame(pingMessage('split'));
+    server = net.createServer((sock) => {
+      // header + 1 byte, then the remainder after a tick
+      sock.write(buf.subarray(0, 5));
+      setTimeout(() => sock.write(buf.subarray(5)), 10);
+    });
+    const port = await listen(server);
+
+    transport = new TcpSessionTransport('127.0.0.1', port);
+    await transport.start();
+
+    const it = transport[Symbol.asyncIterator]();
+    const { value } = await it.next();
+    expect((value.message.value as pb.SessionRequest).requestId).toBe('split');
+  });
+
+  it('decodes multiple frames coalesced into one chunk', async () => {
+    server = net.createServer((sock) => {
+      sock.write(Buffer.concat([frame(pingMessage('a')), frame(pingMessage('b'))]));
+    });
+    const port = await listen(server);
+
+    transport = new TcpSessionTransport('127.0.0.1', port);
+    await transport.start();
+
+    const it = transport[Symbol.asyncIterator]();
+    const first = await it.next();
+    const second = await it.next();
+    expect((first.value.message.value as pb.SessionRequest).requestId).toBe('a');
+    expect((second.value.message.value as pb.SessionRequest).requestId).toBe('b');
+  });
+
+  it('round-trips a sent message back through the wire', async () => {
+    const received: Buffer[] = [];
+    const sawFullFrame = new Promise<void>((resolve) => {
+      server = net.createServer((sock) => {
+        sock.on('data', (d) => {
+          received.push(d);
+          resolve();
+        });
+      });
+    });
+    const port = await listen(server!);
+
+    transport = new TcpSessionTransport('127.0.0.1', port);
+    await transport.start();
+    await transport.sendMessage(pingMessage('outbound'));
+
+    await sawFullFrame;
+    const wire = Buffer.concat(received);
+    const length = wire.readUInt32BE(0);
+    const decoded = pb.AgentSessionMessage.fromBinary(wire.subarray(4, 4 + length));
+    expect((decoded.message.value as pb.SessionRequest).requestId).toBe('outbound');
+  });
+
+  it('rejects start() when nothing is listening', async () => {
+    // ephemeral port that is (almost certainly) closed
+    const t = new TcpSessionTransport('127.0.0.1', 1);
+    await expect(t.start()).rejects.toThrow();
+  });
+});
+
+/** In-memory transport so SessionHost can be driven without a socket. */
+class FakeTransport extends SessionTransport {
+  readonly sent: pb.AgentSessionMessage[] = [];
+  private readonly inbound: pb.AgentSessionMessage[] = [];
+  private waitingResolve: ((value: IteratorResult<pb.AgentSessionMessage>) => void) | null = null;
+  private closed = false;
+
+  push(msg: pb.AgentSessionMessage): void {
+    if (this.waitingResolve) {
+      const resolve = this.waitingResolve;
+      this.waitingResolve = null;
+      resolve({ value: msg, done: false });
+    } else {
+      this.inbound.push(msg);
+    }
+  }
+
+  override async sendMessage(msg: pb.AgentSessionMessage): Promise<void> {
+    this.sent.push(msg);
+  }
+
+  override async close(): Promise<void> {
+    this.closed = true;
+    if (this.waitingResolve) {
+      const resolve = this.waitingResolve;
+      this.waitingResolve = null;
+      resolve({ value: undefined as unknown as pb.AgentSessionMessage, done: true });
+    }
+  }
+
+  override [Symbol.asyncIterator](): AsyncIterator<pb.AgentSessionMessage> {
+    return {
+      next: () => {
+        const pending = this.inbound.shift();
+        if (pending) return Promise.resolve({ value: pending, done: false });
+        if (this.closed) {
+          return Promise.resolve({
+            value: undefined as unknown as pb.AgentSessionMessage,
+            done: true,
+          });
+        }
+        return new Promise((resolve) => {
+          this.waitingResolve = resolve;
+        });
+      },
+    };
+  }
+}
+
+describe('SessionHost updateIo', () => {
+  it('toggles input/output enabled flags and acks', async () => {
+    const setInputAudio = vi.fn();
+    const setOutputAudio = vi.fn();
+    const setTranscription = vi.fn();
+    const fakeSession = {
+      on: () => {},
+      off: () => {},
+      input: { setAudioEnabled: setInputAudio },
+      output: {
+        setAudioEnabled: setOutputAudio,
+        setTranscriptionEnabled: setTranscription,
+      },
+    } as unknown as AgentSession;
+
+    const transport = new FakeTransport();
+    const host = new SessionHost(transport);
+    host.registerSession(fakeSession);
+    await host.start();
+
+    transport.push(
+      new pb.AgentSessionMessage({
+        message: {
+          case: 'request',
+          value: new pb.SessionRequest({
+            requestId: 'io1',
+            request: {
+              case: 'updateIo',
+              value: new pb.SessionRequest_UpdateIO({
+                input: new pb.SessionRequest_UpdateIO_Input({ audioEnabled: false }),
+                output: new pb.SessionRequest_UpdateIO_Output({
+                  audioEnabled: true,
+                  transcriptionEnabled: false,
+                }),
+              }),
+            },
+          }),
+        },
+      }),
+    );
+
+    // wait for the tracked task to send the response
+    await vi.waitFor(() => expect(transport.sent.length).toBe(1));
+
+    expect(setInputAudio).toHaveBeenCalledWith(false);
+    expect(setOutputAudio).toHaveBeenCalledWith(true);
+    expect(setTranscription).toHaveBeenCalledWith(false);
+
+    const resp = transport.sent[0]!.message.value as pb.SessionResponse;
+    expect(resp.requestId).toBe('io1');
+    expect(resp.response.case).toBe('updateIo');
+
+    await host.close();
+  });
+
+  it('ignores unset optional fields', async () => {
+    const setInputAudio = vi.fn();
+    const setOutputAudio = vi.fn();
+    const setTranscription = vi.fn();
+    const fakeSession = {
+      on: () => {},
+      off: () => {},
+      input: { setAudioEnabled: setInputAudio },
+      output: {
+        setAudioEnabled: setOutputAudio,
+        setTranscriptionEnabled: setTranscription,
+      },
+    } as unknown as AgentSession;
+
+    const transport = new FakeTransport();
+    const host = new SessionHost(transport);
+    host.registerSession(fakeSession);
+    await host.start();
+
+    transport.push(
+      new pb.AgentSessionMessage({
+        message: {
+          case: 'request',
+          value: new pb.SessionRequest({
+            requestId: 'io2',
+            request: {
+              case: 'updateIo',
+              value: new pb.SessionRequest_UpdateIO({
+                output: new pb.SessionRequest_UpdateIO_Output({ transcriptionEnabled: true }),
+              }),
+            },
+          }),
+        },
+      }),
+    );
+
+    await vi.waitFor(() => expect(transport.sent.length).toBe(1));
+
+    expect(setInputAudio).not.toHaveBeenCalled();
+    expect(setOutputAudio).not.toHaveBeenCalled();
+    expect(setTranscription).toHaveBeenCalledWith(true);
+
+    await host.close();
+  });
+});

--- a/agents/src/voice/remote_session.test.ts
+++ b/agents/src/voice/remote_session.test.ts
@@ -126,6 +126,44 @@ describe('TcpSessionTransport framing', () => {
     const t = new TcpSessionTransport('127.0.0.1', 1);
     await expect(t.start()).rejects.toThrow();
   });
+
+  it('unblocks a backpressured sendMessage when the transport closes', async () => {
+    // Self-contained: a non-reading server leaves its connection open, so we
+    // manage its lifecycle here rather than via the shared afterEach.
+    let serverSocket: net.Socket | undefined;
+    const localServer = net.createServer((sock) => {
+      serverSocket = sock; // intentionally never consume incoming data
+    });
+    const port = await listen(localServer);
+
+    const t = new TcpSessionTransport('127.0.0.1', port);
+    await t.start();
+    try {
+      // 4 MiB payload guarantees we exceed the 64 KiB drain threshold and park
+      // in waitForDrain (the peer never reads, so no natural 'drain').
+      const huge = 'x'.repeat(4 * 1024 * 1024);
+      const msg = new pb.AgentSessionMessage({
+        message: {
+          case: 'request',
+          value: new pb.SessionRequest({
+            requestId: huge,
+            request: { case: 'ping', value: new pb.SessionRequest_Ping() },
+          }),
+        },
+      });
+
+      const sendPromise = t.sendMessage(msg);
+      await new Promise((r) => setTimeout(r, 50)); // ensure we're parked in the drain wait
+      await t.close();
+
+      // Without the close/error race this would hang until the test times out.
+      await expect(sendPromise).resolves.toBeUndefined();
+    } finally {
+      await t.close();
+      serverSocket?.destroy();
+      await new Promise<void>((resolve) => localServer.close(() => resolve()));
+    }
+  });
 });
 
 /** In-memory transport so SessionHost can be driven without a socket. */

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -7,6 +7,7 @@ import type { ByteStreamReader, Room, TextStreamInfo } from '@livekit/rtc-node';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import type { TypedEventEmitter } from '@livekit/typed-emitter';
 import EventEmitter from 'events';
+import * as net from 'node:net';
 import { TOPIC_SESSION_MESSAGES } from '../constants.js';
 import type { OverlappingSpeechEvent } from '../inference/interruption/types.js';
 import type {
@@ -228,6 +229,103 @@ export class RoomSessionTransport extends SessionTransport {
         });
       },
     };
+  }
+}
+
+const TCP_HEADER_SIZE = 4;
+const TCP_MAX_MESSAGE_SIZE = 1 << 20; // 1 MiB
+const TCP_DRAIN_THRESHOLD = 64 * 1024; // 64 KiB
+
+/**
+ * {@link SessionTransport} that frames protobuf messages over a raw TCP socket.
+ *
+ * @experimental
+ */
+export class TcpSessionTransport extends SessionTransport {
+  private readonly host: string;
+  private readonly port: number;
+  private socket: net.Socket | null = null;
+  private closed = false;
+  private readonly _logger = log();
+
+  constructor(host: string, port: number) {
+    super();
+    this.host = host;
+    this.port = port;
+  }
+
+  override async start(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const socket = net.createConnection({ host: this.host, port: this.port }, () => {
+        socket.setNoDelay(true);
+        socket.removeListener('error', onConnectError);
+        this.socket = socket;
+        resolve();
+      });
+      const onConnectError = (err: Error) => {
+        socket.destroy();
+        reject(err);
+      };
+      socket.once('error', onConnectError);
+    });
+  }
+
+  override async sendMessage(msg: pb.AgentSessionMessage): Promise<void> {
+    if (this.closed || this.socket === null) return;
+
+    const data = msg.toBinary();
+    const header = Buffer.allocUnsafe(TCP_HEADER_SIZE);
+    header.writeUInt32BE(data.length, 0);
+    const flushed = this.socket.write(Buffer.concat([header, data]));
+
+    // Only block on backpressure once the write buffer is backed up.
+    if (!flushed && this.socket.writableLength > TCP_DRAIN_THRESHOLD) {
+      await new Promise<void>((resolve) => this.socket!.once('drain', resolve));
+    }
+  }
+
+  override async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.socket?.destroy();
+    this.socket = null;
+  }
+
+  override async *[Symbol.asyncIterator](): AsyncIterableIterator<pb.AgentSessionMessage> {
+    const socket = this.socket;
+    if (socket === null) return;
+
+    let buffer = Buffer.alloc(0);
+    try {
+      for await (const chunk of socket) {
+        buffer = buffer.length === 0 ? chunk : Buffer.concat([buffer, chunk]);
+
+        while (buffer.length >= TCP_HEADER_SIZE) {
+          const length = buffer.readUInt32BE(0);
+          if (length > TCP_MAX_MESSAGE_SIZE) {
+            this._logger.error({ length }, 'TCP session message too large, closing transport');
+            return;
+          }
+          if (buffer.length < TCP_HEADER_SIZE + length) break;
+
+          const payload = buffer.subarray(TCP_HEADER_SIZE, TCP_HEADER_SIZE + length);
+          buffer = buffer.subarray(TCP_HEADER_SIZE + length);
+
+          let msg: pb.AgentSessionMessage;
+          try {
+            msg = pb.AgentSessionMessage.fromBinary(payload);
+          } catch (e) {
+            this._logger.warn({ error: e }, 'failed to parse TCP session message');
+            continue;
+          }
+          yield msg;
+        }
+      }
+    } catch (e) {
+      if (!this.closed) {
+        this._logger.warn({ error: e }, 'TCP session transport read error');
+      }
+    }
   }
 }
 
@@ -795,7 +893,34 @@ export class SessionHost {
             sdkVersion: version,
           }),
         });
+      case 'updateIo':
+        return this.handleUpdateIo(req.requestId, req.request.value);
     }
+  }
+
+  private async handleUpdateIo(
+    requestId: string,
+    update: pb.SessionRequest_UpdateIO,
+  ): Promise<void> {
+    const session = this.session!;
+    // Each field is proto3 `optional`; only apply the ones the peer actually set.
+    // JS `AgentInput`/`AgentOutput` expose no video toggle, so video_enabled is ignored.
+    if (update.input?.audioEnabled !== undefined) {
+      session.input.setAudioEnabled(update.input.audioEnabled);
+    }
+    if (update.output) {
+      if (update.output.audioEnabled !== undefined) {
+        session.output.setAudioEnabled(update.output.audioEnabled);
+      }
+      if (update.output.transcriptionEnabled !== undefined) {
+        session.output.setTranscriptionEnabled(update.output.transcriptionEnabled);
+      }
+    }
+
+    return this.sendResponse(requestId, {
+      case: 'updateIo',
+      value: new pb.SessionResponse_UpdateIOResponse(),
+    });
   }
 
   private async handleGetChatHistory(requestId: string): Promise<void> {

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -237,6 +237,25 @@ const TCP_MAX_MESSAGE_SIZE = 1 << 20; // 1 MiB
 const TCP_DRAIN_THRESHOLD = 64 * 1024; // 64 KiB
 
 /**
+ * Resolve once the socket's write buffer drains, or when the socket closes or
+ * errors. Unlike a bare `once('drain')`, this can't hang forever if the peer
+ * stops reading and the socket is then torn down.
+ */
+function waitForDrain(socket: net.Socket): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const done = () => {
+      socket.removeListener('drain', done);
+      socket.removeListener('close', done);
+      socket.removeListener('error', done);
+      resolve();
+    };
+    socket.once('drain', done);
+    socket.once('close', done);
+    socket.once('error', done);
+  });
+}
+
+/**
  * {@link SessionTransport} that frames protobuf messages over a raw TCP socket.
  *
  * @experimental
@@ -271,16 +290,18 @@ export class TcpSessionTransport extends SessionTransport {
   }
 
   override async sendMessage(msg: pb.AgentSessionMessage): Promise<void> {
-    if (this.closed || this.socket === null) return;
+    const socket = this.socket;
+    if (this.closed || socket === null) return;
 
     const data = msg.toBinary();
     const header = Buffer.allocUnsafe(TCP_HEADER_SIZE);
     header.writeUInt32BE(data.length, 0);
-    const flushed = this.socket.write(Buffer.concat([header, data]));
+    const flushed = socket.write(Buffer.concat([header, data]));
 
-    // Only block on backpressure once the write buffer is backed up.
-    if (!flushed && this.socket.writableLength > TCP_DRAIN_THRESHOLD) {
-      await new Promise<void>((resolve) => this.socket!.once('drain', resolve));
+    // Only block on backpressure once the write buffer is backed up. The wait
+    // also settles on close/error so a stalled reader can't hang teardown.
+    if (!flushed && socket.writableLength > TCP_DRAIN_THRESHOLD) {
+      await waitForDrain(socket);
     }
   }
 

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -265,7 +265,6 @@ export class TcpSessionTransport extends SessionTransport {
   private readonly port: number;
   private socket: net.Socket | null = null;
   private closed = false;
-  private readonly _logger = log();
 
   constructor(host: string, port: number) {
     super();
@@ -324,7 +323,7 @@ export class TcpSessionTransport extends SessionTransport {
         while (buffer.length >= TCP_HEADER_SIZE) {
           const length = buffer.readUInt32BE(0);
           if (length > TCP_MAX_MESSAGE_SIZE) {
-            this._logger.error({ length }, 'TCP session message too large, closing transport');
+            log().error({ length }, 'TCP session message too large, closing transport');
             return;
           }
           if (buffer.length < TCP_HEADER_SIZE + length) break;
@@ -336,7 +335,7 @@ export class TcpSessionTransport extends SessionTransport {
           try {
             msg = pb.AgentSessionMessage.fromBinary(payload);
           } catch (e) {
-            this._logger.warn({ error: e }, 'failed to parse TCP session message');
+            log().warn({ error: e }, 'failed to parse TCP session message');
             continue;
           }
           yield msg;
@@ -344,7 +343,7 @@ export class TcpSessionTransport extends SessionTransport {
       }
     } catch (e) {
       if (!this.closed) {
-        this._logger.warn({ error: e }, 'TCP session transport read error');
+        log().warn({ error: e }, 'TCP session transport read error');
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds the TCP transport plumbing that lets a local broker (e.g. the LiveKit CLI `lk session` daemon) drive a Node agent over a raw socket, plus the missing `updateIo` request handler. This is the first of a stacked series porting Python's TCP session support to `agents-js`; it contains no behavior change for the existing room-based path.

- **`TcpSessionTransport`** — a `SessionTransport` that frames protobuf `AgentSessionMessage`s over a raw TCP socket, mirroring the Python `TcpSessionTransport`:
  - 4-byte big-endian length prefix, 1 MiB message cap, `TCP_NODELAY`.
  - Outbound writes only block on backpressure once Node's write buffer exceeds 64 KiB (matches Python's drain heuristic, so small messages stay synchronous).
- **`SessionHost` `updateIo` handler** — applies the proto3-`optional` fields the peer set (`input.audioEnabled`, `output.audioEnabled`, `output.transcriptionEnabled`) and acks with `UpdateIOResponse`. Video toggles are intentionally skipped since JS `AgentInput`/`AgentOutput` expose none.

## Reference

Ports from Python `livekit-agents` `voice/remote_session.py` (`TcpSessionTransport`, `SessionHost.update_io`).

## Test plan

New `agents/src/voice/remote_session.test.ts` (7 cases, all green):

- [x] decodes a single framed message
- [x] reassembles a frame split across multiple TCP chunks
- [x] decodes multiple frames coalesced into one chunk
- [x] round-trips a sent message back through the wire (verifies the length-prefix framing)
- [x] `start()` rejects when nothing is listening
- [x] `updateIo` toggles input/output audio + transcription and acks
- [x] `updateIo` ignores unset optional fields

Also verified: `pnpm build:agents`, ESLint, and Prettier all clean on the changed files. The existing room-based transport path is untouched.

## Follow-ups (stacked PRs)

- PR2: console audio IO (`TcpAudioInput`/`TcpAudioOutput`, 48k<->24k resample, playback flush/clear/finished handshake) + audio routing in `SessionHost`.
- PR3: unregistered/console run path on the worker + `JobContext` fake-job support + CLI `console` subcommand.