### PR TITLE
feat(voice): add TCP Transport Audio IO and SessionHost audio routing

### DIFF
--- a/.changeset/console-audio-io.md
+++ b/.changeset/console-audio-io.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Add `TcpAudioInput`/`TcpAudioOutput` for console-mode sessions, porting the Python `tcp_console` audio IO: inbound `audio_input` frames are resampled from the 48 kHz wire rate to the 24 kHz agent rate and fed to the STT pipeline, while the agent's TTS frames are resampled back up and streamed as `audio_output` messages. The output drives the flush/clear playout handshake, blocking the agent turn until the broker reports `audio_playback_finished` (or reporting an interruption when the buffer is cleared). `SessionHost` now accepts optional audio IO and routes inbound `audio_input`/`audio_playback_finished` messages to it.

--- a/agents/src/voice/console_io.test.ts
+++ b/agents/src/voice/console_io.test.ts
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AgentSession as pb } from '@livekit/protocol';
+import { AudioFrame } from '@livekit/rtc-node';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { TcpAudioInput, TcpAudioOutput } from './console_io.js';
+import { SessionHost, SessionTransport } from './remote_session.js';
+
+beforeAll(() => {
+  initializeLogger({ pretty: true, level: 'info' });
+});
+
+/** Captures outbound messages and lets a test push inbound ones. */
+class FakeTransport extends SessionTransport {
+  readonly sent: pb.AgentSessionMessage[] = [];
+  private readonly inbound: pb.AgentSessionMessage[] = [];
+  private waitingResolve: ((value: IteratorResult<pb.AgentSessionMessage>) => void) | null = null;
+  private closed = false;
+
+  push(msg: pb.AgentSessionMessage): void {
+    if (this.waitingResolve) {
+      const resolve = this.waitingResolve;
+      this.waitingResolve = null;
+      resolve({ value: msg, done: false });
+    } else {
+      this.inbound.push(msg);
+    }
+  }
+
+  override async sendMessage(msg: pb.AgentSessionMessage): Promise<void> {
+    this.sent.push(msg);
+  }
+
+  override async close(): Promise<void> {
+    this.closed = true;
+    if (this.waitingResolve) {
+      const resolve = this.waitingResolve;
+      this.waitingResolve = null;
+      resolve({ value: undefined as unknown as pb.AgentSessionMessage, done: true });
+    }
+  }
+
+  override [Symbol.asyncIterator](): AsyncIterator<pb.AgentSessionMessage> {
+    return {
+      next: () => {
+        const pending = this.inbound.shift();
+        if (pending) return Promise.resolve({ value: pending, done: false });
+        if (this.closed) {
+          return Promise.resolve({
+            value: undefined as unknown as pb.AgentSessionMessage,
+            done: true,
+          });
+        }
+        return new Promise((resolve) => {
+          this.waitingResolve = resolve;
+        });
+      },
+    };
+  }
+}
+
+function consoleFrame(
+  sampleRate: number,
+  samples: number,
+): pb.AgentSessionMessage_ConsoleIO_AudioFrame {
+  return new pb.AgentSessionMessage_ConsoleIO_AudioFrame({
+    data: new Uint8Array(samples * 2),
+    sampleRate,
+    numChannels: 1,
+    samplesPerChannel: samples,
+  });
+}
+
+describe('TcpAudioInput', () => {
+  it('resamples wire frames to the agent rate and exposes them on the stream', async () => {
+    const input = new TcpAudioInput();
+    const reader = input.stream.getReader();
+
+    // 1s @ 48 kHz in -> 24 kHz out
+    input.pushFrame(consoleFrame(48000, 48000));
+
+    const { value, done } = await reader.read();
+    expect(done).toBe(false);
+    expect(value.sampleRate).toBe(24000);
+    expect(value.channels).toBe(1);
+
+    reader.releaseLock();
+    await input.close();
+  });
+
+  it('drops frames pushed after close', async () => {
+    const input = new TcpAudioInput();
+    await input.close();
+    expect(() => input.pushFrame(consoleFrame(48000, 48000))).not.toThrow();
+  });
+});
+
+describe('TcpAudioOutput', () => {
+  function agentFrame(seconds: number): AudioFrame {
+    const samples = 24000 * seconds;
+    return new AudioFrame(new Int16Array(samples), 24000, 1, samples);
+  }
+
+  it('streams resampled frames and completes the flush handshake on playout finished', async () => {
+    const transport = new FakeTransport();
+    const out = new TcpAudioOutput(transport);
+
+    await out.captureFrame(agentFrame(1));
+    out.flush();
+
+    const playout = out.waitForPlayout();
+    out.notifyPlayoutFinished();
+    const ev = await playout;
+
+    expect(ev.interrupted).toBe(false);
+    expect(ev.playbackPosition).toBeCloseTo(1, 1);
+
+    expect(transport.sent.some((m) => m.message.case === 'audioOutput')).toBe(true);
+    expect(transport.sent.some((m) => m.message.case === 'audioPlaybackFlush')).toBe(true);
+  });
+
+  it('reports interruption when the buffer is cleared mid-playout', async () => {
+    const transport = new FakeTransport();
+    const out = new TcpAudioOutput(transport);
+
+    await out.captureFrame(agentFrame(1));
+    out.flush();
+
+    const playout = out.waitForPlayout();
+    out.clearBuffer();
+    const ev = await playout;
+
+    expect(ev.interrupted).toBe(true);
+    expect(ev.playbackPosition).toBeLessThan(1);
+    expect(transport.sent.some((m) => m.message.case === 'audioPlaybackClear')).toBe(true);
+  });
+});
+
+describe('SessionHost audio routing', () => {
+  it('routes audioInput to pushFrame and audioPlaybackFinished to notifyPlayoutFinished', async () => {
+    const transport = new FakeTransport();
+    const pushFrame = vi.fn();
+    const notifyPlayoutFinished = vi.fn();
+    const audioInput = { pushFrame } as unknown as TcpAudioInput;
+    const audioOutput = { notifyPlayoutFinished } as unknown as TcpAudioOutput;
+
+    const host = new SessionHost(transport, audioInput, audioOutput);
+    await host.start();
+
+    transport.push(
+      new pb.AgentSessionMessage({
+        message: { case: 'audioInput', value: consoleFrame(48000, 480) },
+      }),
+    );
+    transport.push(
+      new pb.AgentSessionMessage({
+        message: {
+          case: 'audioPlaybackFinished',
+          value: new pb.AgentSessionMessage_ConsoleIO_AudioPlaybackFinished(),
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(pushFrame).toHaveBeenCalledTimes(1);
+      expect(notifyPlayoutFinished).toHaveBeenCalledTimes(1);
+    });
+
+    await host.close();
+  });
+});

--- a/agents/src/voice/console_io.ts
+++ b/agents/src/voice/console_io.ts
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AgentSession as pb } from '@livekit/protocol';
+import { AudioFrame, AudioResampler } from '@livekit/rtc-node';
+import { log } from '../log.js';
+import { createStreamChannel } from '../stream/stream_channel.js';
+import { Future, Task } from '../utils.js';
+import { AudioInput, AudioOutput } from './io.js';
+import type { SessionTransport } from './remote_session.js';
+
+// The Go CLI / browser broker speaks 48 kHz on the wire; the agent pipeline
+// runs at 24 kHz. Resample on the way in and out.
+const WIRE_SAMPLE_RATE = 48000;
+const AGENT_SAMPLE_RATE = 24000;
+
+function consoleFrameToRtc(frame: pb.AgentSessionMessage_ConsoleIO_AudioFrame): AudioFrame {
+  // Copy into a fresh, 2-byte-aligned buffer; the protobuf bytes may start at an
+  // odd offset, which would make an Int16Array view throw.
+  const aligned = new ArrayBuffer(frame.data.byteLength);
+  new Uint8Array(aligned).set(frame.data);
+  return new AudioFrame(
+    new Int16Array(aligned),
+    frame.sampleRate,
+    frame.numChannels,
+    frame.samplesPerChannel,
+  );
+}
+
+function rtcFrameToConsole(frame: AudioFrame): pb.AgentSessionMessage_ConsoleIO_AudioFrame {
+  return new pb.AgentSessionMessage_ConsoleIO_AudioFrame({
+    data: new Uint8Array(frame.data.buffer, frame.data.byteOffset, frame.data.byteLength),
+    sampleRate: frame.sampleRate,
+    numChannels: frame.channels,
+    samplesPerChannel: frame.samplesPerChannel,
+  });
+}
+
+/**
+ * Audio input fed by inbound `audio_input` console messages. Frames arrive at
+ * the wire rate, are resampled to the agent rate, and pushed into the base
+ * {@link AudioInput} stream that the STT pipeline reads from.
+ *
+ * Unlike the python port, no cross-thread queue is needed: the JS console job
+ * runs in-process on a single event loop, so a stream channel is sufficient.
+ *
+ * @experimental
+ */
+export class TcpAudioInput extends AudioInput {
+  private readonly channel = createStreamChannel<AudioFrame>();
+  private readonly resampler = new AudioResampler(WIRE_SAMPLE_RATE, AGENT_SAMPLE_RATE, 1);
+  private closed = false;
+
+  constructor() {
+    super();
+    this.multiStream.addInputStream(this.channel.stream());
+  }
+
+  pushFrame(frame: pb.AgentSessionMessage_ConsoleIO_AudioFrame): void {
+    if (this.closed) return;
+    for (const resampled of this.resampler.push(consoleFrameToRtc(frame))) {
+      void this.channel.write(resampled);
+    }
+  }
+
+  override async close(): Promise<void> {
+    this.closed = true;
+    await this.channel.close();
+    await super.close();
+  }
+}
+
+/**
+ * Audio output that streams the agent's TTS frames to the broker as
+ * `audio_output` console messages (resampled to the wire rate) and drives the
+ * flush/clear playout handshake. A flush blocks the agent turn until the broker
+ * reports `audio_playback_finished` (or the buffer is cleared on interruption).
+ *
+ * @experimental
+ */
+export class TcpAudioOutput extends AudioOutput {
+  private readonly transport: SessionTransport;
+  private readonly resampler = new AudioResampler(AGENT_SAMPLE_RATE, WIRE_SAMPLE_RATE, 1);
+
+  private pushedDurationMs = 0;
+  private captureStartedAt = 0;
+  private flushTask?: Task<void>;
+  private playoutDone = new Future();
+  private interrupted = new Future();
+
+  constructor(transport: SessionTransport) {
+    super(AGENT_SAMPLE_RATE, undefined, { pause: true });
+    this.transport = transport;
+  }
+
+  override async captureFrame(frame: AudioFrame): Promise<void> {
+    await super.captureFrame(frame);
+
+    if (this.flushTask && !this.flushTask.done) {
+      log().error('captureFrame called while previous flush is in progress');
+      await this.flushTask.result;
+    }
+
+    if (this.pushedDurationMs === 0) {
+      this.captureStartedAt = Date.now();
+      this.onPlaybackStarted(Date.now());
+    }
+
+    this.pushedDurationMs += (frame.samplesPerChannel / frame.sampleRate) * 1000;
+
+    for (const resampled of this.resampler.push(frame)) {
+      await this.transport.sendMessage(
+        new pb.AgentSessionMessage({
+          message: { case: 'audioOutput', value: rtcFrameToConsole(resampled) },
+        }),
+      );
+    }
+  }
+
+  override flush(): void {
+    super.flush();
+    void this.transport.sendMessage(
+      new pb.AgentSessionMessage({
+        message: {
+          case: 'audioPlaybackFlush',
+          value: new pb.AgentSessionMessage_ConsoleIO_AudioPlaybackFlush(),
+        },
+      }),
+    );
+
+    if (this.pushedDurationMs > 0) {
+      if (this.flushTask && !this.flushTask.done) {
+        log().error('flush called while previous flush is in progress');
+        this.flushTask.cancel();
+      }
+      this.playoutDone = new Future();
+      this.interrupted = new Future();
+      this.flushTask = Task.from(() => this.runPlayoutHandshake());
+    }
+  }
+
+  override clearBuffer(): void {
+    void this.transport.sendMessage(
+      new pb.AgentSessionMessage({
+        message: {
+          case: 'audioPlaybackClear',
+          value: new pb.AgentSessionMessage_ConsoleIO_AudioPlaybackClear(),
+        },
+      }),
+    );
+
+    if (this.pushedDurationMs > 0) {
+      this.interrupted.resolve();
+    }
+  }
+
+  /** Called by {@link SessionHost} when the broker reports playout finished. */
+  notifyPlayoutFinished(): void {
+    if (!this.playoutDone.done) {
+      this.playoutDone.resolve();
+    }
+  }
+
+  private async runPlayoutHandshake(): Promise<void> {
+    try {
+      await Promise.race([this.playoutDone.await, this.interrupted.await]);
+    } catch {
+      return; // cancelled by a subsequent flush
+    }
+    const interrupted = this.interrupted.done && !this.playoutDone.done;
+
+    let playedMs: number;
+    if (interrupted) {
+      const elapsed = Date.now() - this.captureStartedAt;
+      playedMs = Math.min(Math.max(0, elapsed), this.pushedDurationMs);
+    } else {
+      playedMs = this.pushedDurationMs;
+    }
+
+    this.onPlaybackFinished({ playbackPosition: playedMs / 1000, interrupted });
+
+    this.pushedDurationMs = 0;
+    this.interrupted = new Future();
+  }
+}

--- a/agents/src/voice/console_io.ts
+++ b/agents/src/voice/console_io.ts
@@ -131,6 +131,10 @@ export class TcpAudioOutput extends AudioOutput {
     if (this.pushedDurationMs > 0) {
       if (this.flushTask && !this.flushTask.done) {
         log().error('flush called while previous flush is in progress');
+        // TODO(follow-up PR): cancel() is currently a no-op here. runPlayoutHandshake
+        // awaits Futures that are never rejected and ignores the AbortController, so
+        // the previous handshake leaks instead of being cancelled (unlike Python's
+        // asyncio.Task.cancel). Make the handshake abort-aware before relying on this.
         this.flushTask.cancel();
       }
       this.playoutDone = new Future();
@@ -165,7 +169,10 @@ export class TcpAudioOutput extends AudioOutput {
     try {
       await Promise.race([this.playoutDone.await, this.interrupted.await]);
     } catch {
-      return; // cancelled by a subsequent flush
+      // TODO(follow-up PR): unreachable today — the raced Futures are only ever
+      // resolved, never rejected. Becomes the cancellation path once the handshake
+      // is made abort-aware (see flush()).
+      return;
     }
     const interrupted = this.interrupted.done && !this.playoutDone.done;
 

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -11,6 +11,7 @@ export {
 } from './agent_session.js';
 export * from './avatar/index.js';
 export * from './background_audio.js';
+export { TcpAudioInput, TcpAudioOutput } from './console_io.js';
 export {
   type TextInputCallback,
   type TextInputEvent,

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -28,6 +28,7 @@ import { Future, Task, shortuuid } from '../utils.js';
 import { version } from '../version.js';
 import type { AgentSession, AgentSessionUsage } from './agent_session.js';
 import { AMDCategory, type AMDPredictionEvent } from './amd.js';
+import type { TcpAudioInput, TcpAudioOutput } from './console_io.js';
 import {
   AgentSessionEventTypes,
   type AgentState,
@@ -618,6 +619,8 @@ function protoSerializeOptions(opts: {
 // ===========================================================================
 export class SessionHost {
   private readonly transport: SessionTransport;
+  private readonly audioInput: TcpAudioInput | undefined;
+  private readonly audioOutput: TcpAudioOutput | undefined;
   private session: AgentSession | undefined;
   private started = false;
   private eventsRegistered = false;
@@ -625,8 +628,14 @@ export class SessionHost {
   private readonly tasks = new Set<Task<void>>();
   private textInputCb: TextInputCallback | undefined;
 
-  constructor(transport: SessionTransport) {
+  constructor(
+    transport: SessionTransport,
+    audioInput?: TcpAudioInput,
+    audioOutput?: TcpAudioOutput,
+  ) {
     this.transport = transport;
+    this.audioInput = audioInput;
+    this.audioOutput = audioOutput;
   }
 
   registerSession(session: AgentSession): void {
@@ -686,12 +695,22 @@ export class SessionHost {
   private async recvLoop(): Promise<void> {
     try {
       for await (const msg of this.transport) {
-        if (msg.message.case === 'request') {
-          if (this.session) {
-            this.trackTask(
-              Task.from(async () => this.handleRequestSafe(msg.message.value as pb.SessionRequest)),
-            );
-          }
+        switch (msg.message.case) {
+          case 'request':
+            if (this.session) {
+              this.trackTask(
+                Task.from(async () =>
+                  this.handleRequestSafe(msg.message.value as pb.SessionRequest),
+                ),
+              );
+            }
+            break;
+          case 'audioInput':
+            this.audioInput?.pushFrame(msg.message.value);
+            break;
+          case 'audioPlaybackFinished':
+            this.audioOutput?.notifyPlayoutFinished();
+            break;
         }
       }
     } catch (e) {


### PR DESCRIPTION
## Summary

Second PR in the series porting Python's TCP console session support to `agents-js` (follows #1693, the transport + `updateIo` plumbing). This adds the audio IO that lets a console-mode session exchange audio with a local broker (the LiveKit CLI `lk session` daemon).

- **`TcpAudioInput`** (`agents/src/voice/console_io.ts`) — resamples inbound `audio_input` frames from the 48 kHz wire rate to the 24 kHz agent rate and feeds them into the base `AudioInput` stream the STT pipeline reads from.
- **`TcpAudioOutput`** — resamples the agent's TTS frames back up to the wire rate, streams them as `audio_output` messages, and drives the flush/clear playout handshake: a flush blocks the agent turn until the broker reports `audio_playback_finished`, or reports an interruption (with a clamped playback position) when the buffer is cleared.
- **`SessionHost`** now accepts optional `audioInput`/`audioOutput` and routes inbound `audio_input` / `audio_playback_finished` messages to them in `recvLoop`.

## Notes / divergences from the Python port

- Python's `TcpAudioInput` uses a stdlib queue + `run_in_executor` to bridge the producer and consumer event loops under `JobExecutorType.THREAD`. The JS console job runs in-process on a single event loop, so a `StreamChannel` is sufficient — no cross-thread queue.
- Time is tracked in milliseconds per the JS conventions; `PlaybackFinishedEvent.playbackPosition` is reported in seconds to match the base `AudioOutput` contract.
- The `SessionHost` audio fields are typed via `import type` from `console_io.ts` (the TS equivalent of Python's `TYPE_CHECKING` import) so there's no runtime import cycle.

## Reference

Ports from Python `livekit-agents` `cli/tcp_console.py` (`TcpAudioInput`/`TcpAudioOutput`) and `voice/remote_session.py` (`SessionHost._dispatch_transport_message`).

## Test plan

New `agents/src/voice/console_io.test.ts` (5 cases, all green):

- [x] `TcpAudioInput` resamples 48 kHz wire frames to 24 kHz and exposes them on the stream
- [x] `TcpAudioInput` drops frames pushed after close
- [x] `TcpAudioOutput` streams resampled `audio_output` + `audio_playback_flush`, and the flush handshake completes (uninterrupted) on `notifyPlayoutFinished`
- [x] `TcpAudioOutput` reports interruption (clamped position) when the buffer is cleared mid-playout
- [x] `SessionHost` routes `audio_input` -> `pushFrame` and `audio_playback_finished` -> `notifyPlayoutFinished`

Also verified: `pnpm build:agents`, ESLint, and Prettier clean on the changed files. The existing room-based path is untouched.

## Follow-up (next stacked PR)

- PR3: unregistered/console run path on the worker + `JobContext` fake-job support + CLI `console` subcommand wiring the transport + audio IO + `SessionHost` together.