### PR TITLE
feat(voice): support granular RecordingOptions in session.start

### DIFF
--- a/.changeset/granular-recording-options.md
+++ b/.changeset/granular-recording-options.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Support granular recording options in `AgentSession.start`. The `record` option now accepts `boolean | RecordingOptions` (`{ audio, traces, logs, transcript }`); a boolean maps to all-on/all-off and a partial object merges onto all-on, so omitted keys default to `true`. Each category independently gates audio capture, trace export, log export, and transcript upload, mirroring the Python SDK and matching the documented granular form.

--- a/agents/src/job.ts
+++ b/agents/src/job.ts
@@ -21,7 +21,7 @@ import type { InferenceExecutor } from './ipc/inference_executor.js';
 import { log } from './log.js';
 import { flushOtelLogs, setupCloudTracer, uploadSessionReport } from './telemetry/index.js';
 import { isCloud } from './utils.js';
-import type { AgentSession } from './voice/agent_session.js';
+import type { AgentSession, ResolvedRecordingOptions } from './voice/agent_session.js';
 import { type SessionReport, createSessionReport } from './voice/report.js';
 
 // AsyncLocalStorage for job context, similar to Python's contextvars
@@ -321,6 +321,7 @@ export class JobContext<ProcessUserData = Record<string, unknown>> {
       options: targetSession.sessionOptions,
       events: targetSession._recordedEvents,
       enableRecording: targetSession._enableRecording,
+      recordingOptions: targetSession._recordingOptions,
       chatHistory: targetSession.history.copy(),
       startedAt: targetSession._startedAt,
       audioRecordingPath: recorderIO?.outputPath,
@@ -425,9 +426,15 @@ export class JobContext<ProcessUserData = Record<string, unknown>> {
     this.#participantEntrypoints.push(callback);
   }
 
-  async initRecording() {
+  async initRecording(options: ResolvedRecordingOptions) {
     const url = new URL(this.#info.url);
     if (!isCloud(url)) {
+      return;
+    }
+
+    // The cloud tracer handles trace spans and OTel logs; only configure it
+    // when at least one of those categories is enabled.
+    if (!options.traces && !options.logs) {
       return;
     }
 
@@ -436,6 +443,8 @@ export class JobContext<ProcessUserData = Record<string, unknown>> {
       roomId: this.job.room!.sid,
       jobId: this.job.id,
       cloudHostname: url.hostname,
+      enableTraces: options.traces,
+      enableLogs: options.logs,
     });
   }
 }

--- a/agents/src/telemetry/traces.ts
+++ b/agents/src/telemetry/traces.ts
@@ -215,8 +215,10 @@ export async function setupCloudTracer(options: {
   roomId: string;
   jobId: string;
   cloudHostname: string;
+  enableTraces?: boolean;
+  enableLogs?: boolean;
 }): Promise<void> {
-  const { roomId, jobId, cloudHostname } = options;
+  const { roomId, jobId, cloudHostname, enableTraces = true, enableLogs = true } = options;
 
   const apiKey = process.env.LIVEKIT_API_KEY;
   const apiSecret = process.env.LIVEKIT_API_SECRET;
@@ -249,31 +251,35 @@ export async function setupCloudTracer(options: {
       job_id: jobId,
     });
 
-    // Configure OTLP exporter to send traces to LiveKit Cloud
-    const spanExporter = new OTLPTraceExporter({
-      url: `https://${cloudHostname}/observability/traces/otlp/v0`,
-      headers,
-      compression: CompressionAlgorithm.GZIP,
-    });
+    if (enableTraces) {
+      // Configure OTLP exporter to send traces to LiveKit Cloud
+      const spanExporter = new OTLPTraceExporter({
+        url: `https://${cloudHostname}/observability/traces/otlp/v0`,
+        headers,
+        compression: CompressionAlgorithm.GZIP,
+      });
 
-    const tracerProvider = new NodeTracerProvider({
-      resource,
-      spanProcessors: [new MetadataSpanProcessor(metadata), new BatchSpanProcessor(spanExporter)],
-    });
-    // register() installs an AsyncLocalStorageContextManager (needed for span nesting)
-    // and sets the global tracer provider. Both use set-once semantics in the OTel API,
-    // so if the user already called NodeSDK.start(), these are safe no-ops.
-    tracerProvider.register();
-    setTracerProvider(tracerProvider);
+      const tracerProvider = new NodeTracerProvider({
+        resource,
+        spanProcessors: [new MetadataSpanProcessor(metadata), new BatchSpanProcessor(spanExporter)],
+      });
+      // register() installs an AsyncLocalStorageContextManager (needed for span nesting)
+      // and sets the global tracer provider. Both use set-once semantics in the OTel API,
+      // so if the user already called NodeSDK.start(), these are safe no-ops.
+      tracerProvider.register();
+      setTracerProvider(tracerProvider);
+    }
 
-    // Initialize standalone Pino cloud exporter (no OTEL SDK dependency)
-    initPinoCloudExporter({
-      cloudHostname,
-      roomId,
-      jobId,
-    });
+    if (enableLogs) {
+      // Initialize standalone Pino cloud exporter (no OTEL SDK dependency)
+      initPinoCloudExporter({
+        cloudHostname,
+        roomId,
+        jobId,
+      });
 
-    enableOtelLogging();
+      enableOtelLogging();
+    }
   } catch (error) {
     console.error('Failed to setup cloud tracer:', error);
     throw error;
@@ -551,7 +557,8 @@ export async function uploadSessionReport(options: {
   // This fixes the issue where function_call and function_call_output with same timestamp
   // get reordered by the dashboard
   let lastTimestamp = 0;
-  for (const item of report.chatHistory.items) {
+  const chatItems = report.recordingOptions.transcript ? report.chatHistory.items : [];
+  for (const item of chatItems) {
     // Skip null/undefined items
     if (!item) continue;
 
@@ -585,6 +592,15 @@ export async function uploadSessionReport(options: {
   }
 
   await logExporter.export(logRecords);
+
+  const hasAudio = Boolean(
+    report.recordingOptions.audio && report.audioRecordingPath && report.audioRecordingStartedAt,
+  );
+  // Nothing to send to the recordings endpoint when neither the transcript nor
+  // audio is being captured.
+  if (!report.recordingOptions.transcript && !hasAudio) {
+    return;
+  }
 
   const apiKey = process.env.LIVEKIT_API_KEY;
   const apiSecret = process.env.LIVEKIT_API_SECRET;
@@ -621,21 +637,27 @@ export async function uploadSessionReport(options: {
     },
   });
 
-  // Add chat_history JSON
-  const chatHistoryJson = JSON.stringify(report.chatHistory.toJSON({ excludeTimestamp: false }));
-  const chatHistoryBuffer = Buffer.from(chatHistoryJson, 'utf-8');
-  formData.append('chat_history', chatHistoryBuffer, {
-    filename: 'chat_history.json',
-    contentType: 'application/json',
-    knownLength: chatHistoryBuffer.length,
-    header: {
-      'Content-Type': 'application/json',
-      'Content-Length': chatHistoryBuffer.length.toString(),
-    },
-  });
+  // Add chat_history JSON (only when transcript recording is enabled)
+  if (report.recordingOptions.transcript) {
+    const chatHistoryJson = JSON.stringify(report.chatHistory.toJSON({ excludeTimestamp: false }));
+    const chatHistoryBuffer = Buffer.from(chatHistoryJson, 'utf-8');
+    formData.append('chat_history', chatHistoryBuffer, {
+      filename: 'chat_history.json',
+      contentType: 'application/json',
+      knownLength: chatHistoryBuffer.length,
+      header: {
+        'Content-Type': 'application/json',
+        'Content-Length': chatHistoryBuffer.length.toString(),
+      },
+    });
+  }
 
   // Add audio recording file if available
-  if (report.audioRecordingPath && report.audioRecordingStartedAt) {
+  if (
+    report.recordingOptions.audio &&
+    report.audioRecordingPath &&
+    report.audioRecordingStartedAt
+  ) {
     let audioBytes: Buffer;
     try {
       audioBytes = await fs.readFile(report.audioRecordingPath);

--- a/agents/src/voice/agent_session.test.ts
+++ b/agents/src/voice/agent_session.test.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it, vi } from 'vitest';
-import { AgentSession } from './agent_session.js';
+import { AgentSession, resolveRecordingOptions } from './agent_session.js';
 import { SpeechHandle } from './speech_handle.js';
 
 describe('AgentSession.run', () => {
@@ -20,5 +20,66 @@ describe('AgentSession.run', () => {
         inputModality: 'audio',
       });
     });
+  });
+});
+
+describe('resolveRecordingOptions', () => {
+  it('treats a boolean as all-on or all-off', () => {
+    expect(resolveRecordingOptions(true)).toEqual({
+      audio: true,
+      traces: true,
+      logs: true,
+      transcript: true,
+    });
+    expect(resolveRecordingOptions(false)).toEqual({
+      audio: false,
+      traces: false,
+      logs: false,
+      transcript: false,
+    });
+  });
+
+  it('defaults omitted keys to true when given a partial object', () => {
+    expect(resolveRecordingOptions({ audio: false })).toEqual({
+      audio: false,
+      traces: true,
+      logs: true,
+      transcript: true,
+    });
+
+    // The granular form from the docs: keep audio, drop everything else.
+    expect(
+      resolveRecordingOptions({ audio: true, traces: false, logs: false, transcript: false }),
+    ).toEqual({
+      audio: true,
+      traces: false,
+      logs: false,
+      transcript: false,
+    });
+  });
+
+  it('returns a fresh object so callers cannot corrupt the shared defaults', () => {
+    const opts = resolveRecordingOptions(true);
+    opts.audio = false;
+    expect(resolveRecordingOptions(true).audio).toBe(true);
+  });
+});
+
+describe('AgentSession recording state', () => {
+  it('_enableRecording is true when any category is on and false when all are off', () => {
+    const session = new AgentSession();
+    // Defaults to all-off until start() resolves the record argument.
+    expect(session._enableRecording).toBe(false);
+
+    session._recordingOptions = resolveRecordingOptions({
+      audio: false,
+      traces: false,
+      logs: true,
+      transcript: false,
+    });
+    expect(session._enableRecording).toBe(true);
+
+    session._recordingOptions = resolveRecordingOptions(false);
+    expect(session._enableRecording).toBe(false);
   });
 });

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -104,6 +104,60 @@ export interface AgentSessionUsage {
   modelUsage: Array<Partial<ModelUsage>>;
 }
 
+/**
+ * Granular control over which recording features are active.
+ *
+ * All keys default to `true` when omitted, so `{ logs: false }` means "record
+ * everything except logs". Pass to {@link AgentSession.start} as `record`:
+ *
+ * - `record: true` — all on (backward compatible)
+ * - `record: false` — all off (backward compatible)
+ * - `record: { audio: true, traces: false }` — granular
+ */
+export interface RecordingOptions {
+  /** Record session audio. Defaults to `true`. */
+  audio?: boolean;
+  /** Export OpenTelemetry trace spans. Defaults to `true`. */
+  traces?: boolean;
+  /** Export OpenTelemetry logs. Defaults to `true`. */
+  logs?: boolean;
+  /** Upload the conversation transcript (chat history). Defaults to `true`. */
+  transcript?: boolean;
+}
+
+/** @internal Recording options with every category resolved to a boolean. */
+export type ResolvedRecordingOptions = Required<RecordingOptions>;
+
+const RECORDING_ALL_ON: ResolvedRecordingOptions = {
+  audio: true,
+  traces: true,
+  logs: true,
+  transcript: true,
+};
+
+const RECORDING_ALL_OFF: ResolvedRecordingOptions = {
+  audio: false,
+  traces: false,
+  logs: false,
+  transcript: false,
+};
+
+/**
+ * Resolve a `record` argument into explicit per-category flags. A boolean turns
+ * every category on or off; a partial object is merged onto all-on so omitted
+ * keys default to `true`.
+ *
+ * @internal
+ */
+export function resolveRecordingOptions(
+  record: boolean | RecordingOptions,
+): ResolvedRecordingOptions {
+  if (typeof record === 'boolean') {
+    return { ...(record ? RECORDING_ALL_ON : RECORDING_ALL_OFF) };
+  }
+  return { ...RECORDING_ALL_ON, ...record };
+}
+
 export interface InternalSessionOptions<UserData> extends AgentSessionOptions<UserData> {
   turnHandling: InternalTurnHandlingOptions;
   useTtsAlignedTranscript: boolean;
@@ -333,8 +387,18 @@ export class AgentSession<
   /** @internal */
   _recordedEvents: AgentEvent[] = [];
 
-  /** @internal */
-  _enableRecording = false;
+  /** @internal Resolved per-category recording options for this session. */
+  _recordingOptions: ResolvedRecordingOptions = { ...RECORDING_ALL_OFF };
+
+  /** @internal True when any recording category is enabled. */
+  get _enableRecording(): boolean {
+    return (
+      this._recordingOptions.audio ||
+      this._recordingOptions.traces ||
+      this._recordingOptions.logs ||
+      this._recordingOptions.transcript
+    );
+  }
 
   /** @internal - Timestamp when the session started (milliseconds) */
   _startedAt?: number;
@@ -541,7 +605,7 @@ export class AgentSession<
         );
       }
 
-      if (this.input.audio && this.output.audio && this._enableRecording) {
+      if (this.input.audio && this.output.audio && this._recordingOptions.audio) {
         this._recorderIO = new RecorderIO({ agentSession: this });
         this.input.audio = this._recorderIO.recordInput(this.input.audio);
         this.output.audio = this._recorderIO.recordOutput(this.output.audio);
@@ -602,7 +666,7 @@ export class AgentSession<
     room?: Room;
     inputOptions?: Partial<RoomInputOptions>;
     outputOptions?: Partial<RoomOutputOptions>;
-    record?: boolean;
+    record?: boolean | RecordingOptions;
   }): Promise<void> {
     if (this.started) {
       return;
@@ -618,10 +682,10 @@ export class AgentSession<
         record = ctx.job.enableRecording;
       }
 
-      this._enableRecording = record;
+      this._recordingOptions = resolveRecordingOptions(record);
 
       if (this._enableRecording) {
-        await ctx.initRecording();
+        await ctx.initRecording(this._recordingOptions);
       }
     }
 

--- a/agents/src/voice/report.test.ts
+++ b/agents/src/voice/report.test.ts
@@ -4,7 +4,11 @@
 import { describe, expect, it } from 'vitest';
 import { ChatContext } from '../llm/chat_context.js';
 import type { ModelUsage } from '../metrics/model_usage.js';
-import type { AgentSessionOptions, VoiceOptions } from './agent_session.js';
+import type {
+  AgentSessionOptions,
+  ResolvedRecordingOptions,
+  VoiceOptions,
+} from './agent_session.js';
 import { AgentSessionEventTypes, createSessionUsageUpdatedEvent } from './events.js';
 import type { AgentSessionUsage } from './index.js';
 import { createSessionReport, sessionReportToJSON } from './report.js';
@@ -211,5 +215,38 @@ describe('sessionReportToJSON', () => {
     const eventType: AgentSessionEventTypes = AgentSessionEventTypes.SessionUsageUpdated;
     expect(usage.modelUsage).toEqual([]);
     expect(eventType).toBe('session_usage_updated');
+  });
+});
+
+describe('createSessionReport recordingOptions', () => {
+  function makeReport(recordingOptions?: ResolvedRecordingOptions) {
+    return createSessionReport({
+      jobId: 'job',
+      roomId: 'room-id',
+      room: 'room',
+      options: baseOptions(),
+      events: [],
+      chatHistory: ChatContext.empty(),
+      recordingOptions,
+    });
+  }
+
+  it('defaults every recording category to off when omitted', () => {
+    expect(makeReport().recordingOptions).toEqual({
+      audio: false,
+      traces: false,
+      logs: false,
+      transcript: false,
+    });
+  });
+
+  it('passes provided recording options through', () => {
+    const recordingOptions: ResolvedRecordingOptions = {
+      audio: true,
+      traces: false,
+      logs: true,
+      transcript: false,
+    };
+    expect(makeReport(recordingOptions).recordingOptions).toEqual(recordingOptions);
   });
 });

--- a/agents/src/voice/report.ts
+++ b/agents/src/voice/report.ts
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ChatContext } from '../llm/chat_context.js';
 import { type ModelUsage, filterZeroValues } from '../metrics/model_usage.js';
-import type { AgentSessionOptions, VoiceOptions } from './agent_session.js';
+import type {
+  AgentSessionOptions,
+  ResolvedRecordingOptions,
+  VoiceOptions,
+} from './agent_session.js';
 import type { AgentEvent } from './events.js';
 
 type ReportOptions = AgentSessionOptions & Partial<VoiceOptions>;
@@ -16,6 +20,8 @@ export interface SessionReport {
   events: AgentEvent[];
   chatHistory: ChatContext;
   enableRecording: boolean;
+  /** Resolved per-category recording options for this session. */
+  recordingOptions: ResolvedRecordingOptions;
   /** Timestamp when the session started (milliseconds) */
   startedAt: number;
   /** Timestamp when the session report was created (milliseconds), typically at the end of the session */
@@ -38,6 +44,8 @@ export interface SessionReportOptions {
   events: AgentEvent[];
   chatHistory: ChatContext;
   enableRecording?: boolean;
+  /** Resolved per-category recording options for this session. */
+  recordingOptions?: ResolvedRecordingOptions;
   /** Timestamp when the session started (milliseconds) */
   startedAt?: number;
   /** Timestamp when the session report was created (milliseconds) */
@@ -62,6 +70,12 @@ export function createSessionReport(opts: SessionReportOptions): SessionReport {
     events: opts.events,
     chatHistory: opts.chatHistory,
     enableRecording: opts.enableRecording ?? false,
+    recordingOptions: opts.recordingOptions ?? {
+      audio: false,
+      traces: false,
+      logs: false,
+      transcript: false,
+    },
     startedAt: opts.startedAt ?? Date.now(),
     timestamp,
     audioRecordingPath: opts.audioRecordingPath,


### PR DESCRIPTION
## What

`AgentSession.start` currently accepts `record?: boolean` only. This PR lets it also accept a granular object so callers can toggle individual recording categories:

```ts
// all on / all off (unchanged)
await session.start({ agent, record: true });
await session.start({ agent, record: false });

// granular — omitted keys default to true
await session.start({ agent, record: { audio: false } }); // drop audio, keep traces/logs/transcript
await session.start({
  agent,
  record: { audio: true, traces: false, logs: false, transcript: false },
});
```

`record` now accepts `boolean | RecordingOptions`, where each key gates one part of the pipeline:

| key | gates |
|-----|-------|
| `audio` | the audio `RecorderIO` / uploaded `recording.ogg` |
| `traces` | the OTLP trace exporter (cloud tracer) |
| `logs` | the OTel / pino log exporter |
| `transcript` | the chat-history upload |

A boolean still maps to all-on / all-off, so this is fully backward compatible.

## Why

The observability docs already document this granular form **for Node** — [docs.livekit.io/deploy/observability/insights/#recording-options](https://docs.livekit.io/deploy/observability/insights/#recording-options) shows:

```ts
await session.start({
  agent,
  record: { audio: true, traces: false, logs: false, transcript: false },
});
```

…but the JS SDK only supports `record?: boolean` (every published version through `1.4.5`, plus the canary). So the documented API doesn't type-check, and passing the object silently *enables* recording (a non-empty object is truthy). This PR makes the SDK match the docs.

## Approach

Direct port of the Python implementation (`livekit/agents` → `livekit-agents/livekit/agents/voice/agent_session.py`: `RecordingOptions` / `_resolve_recording_options`, plus the per-category gating in `job.py` and `telemetry/traces.py`). Same semantics: a partial object is merged onto all-on, so omitted keys default to `true`.

**Two paths — your call:**
1. **Land this** to give JS parity with Python and make the existing docs correct, or
2. if granular control isn't wanted in JS yet, I'm happy to instead open a docs PR correcting the Node example back to `record: boolean`.

## Tests

Added unit tests for `resolveRecordingOptions` (bool → all-on/off, partial-merge incl. the exact docs example, and mutation-safety) and for the report's `recordingOptions` default/passthrough + the `_enableRecording` derivation.

Verified:
- `pnpm --filter @livekit/agents build:types` — ✅ typechecks
- `eslint` on changed files — ✅ no new errors
- `prettier --write` — ✅
- `vitest run` (agent_session + report) — ✅ 14 passed
- **Live LiveKit Cloud check** — ran the patched `uploadSessionReport` against a real LiveKit Cloud project across the matrix: all-on, `audio:false` *with an audio file present locally*, `transcript:false` + audio, transcript-only, and logs/traces-only (→ early return). The observability logs endpoint and the recordings multipart endpoint **accept every partial-upload shape the change produces** — including audio omitted while a recording file exists — **5/5 accepted**. (The baseline `record:true` case behaves identically, confirming no regression in the upload path.)
