### PR TITLE
fix(voice): align session.start recording with Python primary-session semantics

### DIFF
--- a/.changeset/recording-primary-session-alignment.md
+++ b/.changeset/recording-primary-session-alignment.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Align `AgentSession.start` recording with the Python SDK's primary-session behavior. The primary/secondary designation now happens in `start()` before `initRecording`, so a demoted secondary session never configures cloud recording. A non-primary session whose `record` argument was not explicitly given now silently disables its recording (instead of throwing); it still throws only when `record` was passed explicitly, matching Python's `record_is_given` semantics.

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -597,14 +597,6 @@ export class AgentSession<
         tasks.push(ctx.connect());
       }
 
-      if (ctx._primaryAgentSession === undefined) {
-        ctx._primaryAgentSession = this;
-      } else if (this._enableRecording) {
-        throw new Error(
-          'Only one `AgentSession` can be the primary at a time. If you want to ignore primary designation, use `session.start({ record: false })`.',
-        );
-      }
-
       if (this.input.audio && this.output.audio && this._recordingOptions.audio) {
         this._recorderIO = new RecorderIO({ agentSession: this });
         this.input.audio = this._recorderIO.recordInput(this.input.audio);
@@ -678,11 +670,28 @@ export class AgentSession<
     const ctx = getJobContext(false);
 
     if (ctx) {
+      const recordIsGiven = record !== undefined;
       if (record === undefined) {
+        // defer to the server-side setting for recording
         record = ctx.job.enableRecording;
       }
 
       this._recordingOptions = resolveRecordingOptions(record);
+
+      // Only one AgentSession per job can be the primary (and therefore record).
+      // Designate the primary before initRecording so a demoted secondary session
+      // never configures cloud recording. Mirrors Python's start() ordering.
+      if (ctx._primaryAgentSession === undefined || ctx._primaryAgentSession === this) {
+        ctx._primaryAgentSession = this;
+      } else if (this._enableRecording) {
+        if (recordIsGiven) {
+          throw new Error(
+            'Only one `AgentSession` can be the primary at a time. If you want to ignore primary designation, use `session.start({ record: false })`.',
+          );
+        }
+        // record was not given: silently disable recording for the secondary session
+        this._recordingOptions = resolveRecordingOptions(false);
+      }
 
       if (this._enableRecording) {
         await ctx.initRecording(this._recordingOptions);


### PR DESCRIPTION
## Summary

Follow-up to #1702 (granular `RecordingOptions`). That PR ported the recording-options model but left the **primary-session designation** out of parity with the Python SDK. This aligns it:

- The primary/secondary `AgentSession` designation now happens in `start()` **before** `initRecording`, so a demoted secondary session never configures cloud recording. (Previously the designation lived in `_startImpl`, which runs *after* `start()` already called `initRecording`.)
- A non-primary session whose `record` was **not explicitly given** now **silently disables** its recording, instead of throwing. It still throws only when `record` was passed explicitly — mirroring Python's `record_is_given` logic in `agent_session.py:629-655`.
- Added the `ctx._primaryAgentSession === this` re-entry case to match Python's `is None or is self`.

### Why this matters

`record` defaults to the server-side `job.enableRecording` (often `true`). Before this change, a **second** `AgentSession` in the same job would **throw** on `start()` even though the user never asked to record it. Python avoids this by auto-disabling the secondary session; this PR brings JS to parity.

## Test plan

Verified end-to-end by driving a real agent through `agents-cli` against LiveKit Cloud (voice mode), with temporary instrumentation on every recording gate. Confirmed via runtime logs:

| `record` | local audio (`audio.ogg`) | cloud tracer | upload | parts attached |
| --- | --- | --- | --- | --- |
| `true` | started | yes | yes | chat_history + audio |
| `false` | none | skipped | **none** | — |
| `{audio-only}` | started | skipped | yes | audio only |
| `{transcript-only}` | none | skipped | yes | chat_history only |

- [x] `pnpm build:agents` passes
- [x] `agent_session` unit tests pass
- [x] Lint clean