### PR TITLE
feat(google): add RealtimeSession.sendText() for realtime text input

### DIFF
--- a/.changeset/google-realtime-send-text.md
+++ b/.changeset/google-realtime-send-text.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-google': minor
+---
+
+Add `RealtimeSession.sendText()` to the Google plugin for sending a text turn as realtime input. Unlike `generateReply()`, this works with models that do not support mid-session client content updates (e.g. `gemini-3.1` live models): the text is delivered via the Live API's `send_realtime_input({ text })` and treated by the model as a completed user turn. Under manual activity detection the text is wrapped in activity markers so it forms a complete turn.

--- a/plugins/google/src/realtime/realtime_api.test.ts
+++ b/plugins/google/src/realtime/realtime_api.test.ts
@@ -180,3 +180,63 @@ describe('Google Realtime non-blocking tool scheduling', () => {
     expect(session.pendingToolCallIds.has('call_123')).toBe(false);
   });
 });
+
+type SendTextSession = RealtimeSessionInternals & {
+  inUserActivity: boolean;
+  options: RealtimeSessionInternals['options'] & {
+    realtimeInputConfig?: { automaticActivityDetection?: { disabled?: boolean } };
+  };
+  sendText(text: string): void;
+};
+
+function createSendTextSession(): SendTextSession {
+  const session = createSessionForTest(
+    FunctionResponseScheduling.WHEN_IDLE,
+  ) as unknown as SendTextSession;
+  session.inUserActivity = false;
+  return session;
+}
+
+describe('Google Realtime sendText', () => {
+  it('sends text as a single realtime_input turn', () => {
+    const session = createSendTextSession();
+
+    session.sendText('are you still there?');
+
+    expect(session.sendClientEvent).toHaveBeenCalledTimes(1);
+    expect(session.sendClientEvent).toHaveBeenCalledWith({
+      type: 'realtime_input',
+      value: { text: 'are you still there?' },
+    });
+  });
+
+  it('does not send while blocking tools are pending', () => {
+    const session = createSendTextSession();
+    session.options.toolBehavior = Behavior.BLOCKING;
+    session.pendingToolCallIds.add('call_123');
+
+    session.sendText('are you still there?');
+
+    expect(session.sendClientEvent).not.toHaveBeenCalled();
+  });
+
+  it('wraps the text in activity markers under manual activity detection', () => {
+    const session = createSendTextSession();
+    session.options.realtimeInputConfig = { automaticActivityDetection: { disabled: true } };
+
+    session.sendText('are you still there?');
+
+    expect(session.sendClientEvent).toHaveBeenNthCalledWith(1, {
+      type: 'realtime_input',
+      value: { activityStart: {} },
+    });
+    expect(session.sendClientEvent).toHaveBeenNthCalledWith(2, {
+      type: 'realtime_input',
+      value: { text: 'are you still there?' },
+    });
+    expect(session.sendClientEvent).toHaveBeenNthCalledWith(3, {
+      type: 'realtime_input',
+      value: { activityEnd: {} },
+    });
+  });
+});

--- a/plugins/google/src/realtime/realtime_api.ts
+++ b/plugins/google/src/realtime/realtime_api.ts
@@ -815,6 +815,33 @@ export class RealtimeSession extends llm.RealtimeSession {
     // TODO(brian): implement push video frames
   }
 
+  /**
+   * Send a text turn to the model as realtime input.
+   *
+   * Unlike {@link generateReply}, this works with models that do not support
+   * mid-session client content updates (e.g. `gemini-3.1` live models): the text is
+   * delivered via the Live API's realtime input (`send_realtime_input({ text })`),
+   * which the model treats as a completed user turn and responds to.
+   *
+   * With manual activity detection the text is wrapped in activity markers so it
+   * forms a complete turn, unless an activity is already open via
+   * {@link startUserActivity}.
+   */
+  sendText(text: string): void {
+    if (this.shouldBlockRealtimeInputForPendingTools()) {
+      return;
+    }
+
+    const wrapActivity = this.manualActivityDetection && !this.inUserActivity;
+    if (wrapActivity) {
+      this.sendClientEvent({ type: 'realtime_input', value: { activityStart: {} } });
+    }
+    this.sendClientEvent({ type: 'realtime_input', value: { text } });
+    if (wrapActivity) {
+      this.sendClientEvent({ type: 'realtime_input', value: { activityEnd: {} } });
+    }
+  }
+
   private sendClientEvent(event: api_proto.ClientEvents) {
     this.messageChannel.put(event);
   }


### PR DESCRIPTION
## Description

Adds a public `sendText(text)` method to the Google plugin's realtime `RealtimeSession`, so callers can inject a text turn into a live Gemini session.

This fills a gap on `gemini-3.1` live models: `generateReply()` throws on them because they don't support mid-session client content updates (`midSessionChatCtxUpdate` is `false`), and `sendClientEvent` is private — so there is currently **no public way** to programmatically send a text turn to a 3.1 live session. `sendText()` delivers the text via the Live API's realtime input (`send_realtime_input({ text })`), which the model treats as a completed user turn and responds to. It works across all live models, not just 3.1.

Motivating use case: server-driven nudges (e.g. "the caller has been silent — check if they're still there") on a `gemini-3.1-flash-live-preview` voice agent, where `generateReply()` is unavailable.

## Changes Made
- `plugins/google/src/realtime/realtime_api.ts`: add `RealtimeSession.sendText(text: string)`. It honors the same pending-tool guard as `pushAudio`, and under manual activity detection wraps the text in `activityStart`/`activityEnd` so it forms a complete turn (unless an activity is already open via `startUserActivity()`).
- `plugins/google/src/realtime/realtime_api.test.ts`: tests for the default single-event path, the pending-blocking-tools no-op, and the manual-activity-detection wrapping.
- `.changeset/`: minor bump for `@livekit/agents-plugin-google`.

## Pre-Review Checklist
- [x] **Build passes**: `turbo run build` (incl. tsc typecheck), plugin `lint`, and vitest pass locally
- [x] **AI-generated code reviewed**: reviewed for quality, minimal surface
- [x] **Changes explained**: see above
- [x] **Scope appropriate**: all changes relate to the new method
- [ ] **Video demo**: n/a (additive API method; covered by unit tests)

## Testing
- [x] Automated tests added/updated
- [x] All tests pass (`vitest run plugins/google/src/realtime/realtime_api.test.ts` → 10 passed)
- [ ] `restaurant_agent.ts` / `realtime_agent.ts` — not exercised (additive method, no change to existing paths)

## Additional Notes

Lint shows 3 pre-existing `@typescript-eslint/no-explicit-any` warnings in `realtime_api.ts` (lines ~1347/1376/1384) that are unrelated to this change. `api:check` also fails on a clean checkout (missing release tags across existing exports), so it's not affected by this PR.

Alternative considered: making `generateReply()` route through realtime input on 3.1. That would fix the standard `AgentSession.generateReply({ userInput })` path, but `instructions` (a model-role steer) doesn't map cleanly onto user-side realtime input, so a dedicated `sendText()` is the smaller, clearer change. Happy to follow up on `generateReply` if preferred.