### PR TITLE
fix: align to anam sampling rate

### DIFF
--- a/.changeset/anam-avatar-sample-rate.md
+++ b/.changeset/anam-avatar-sample-rate.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-anam': patch
+---
+
+fix(anam): set avatar audio output sample rate to 24000 Hz to match the Anam worker's expected rate

--- a/plugins/anam/src/avatar.ts
+++ b/plugins/anam/src/avatar.ts
@@ -36,6 +36,7 @@ export async function mintAvatarJoinToken({
 
 const AVATAR_IDENTITY = 'anam-avatar-agent';
 const _AVATAR_NAME = 'anam-avatar-agent';
+const SAMPLE_RATE = 24000;
 
 export class AvatarSession extends voice.AvatarSession {
   private sessionId?: string;
@@ -125,6 +126,7 @@ export class AvatarSession extends voice.AvatarSession {
     agentSession.output.audio = new voice.DataStreamAudioOutput({
       room,
       destinationIdentity: this.avatarIdentity,
+      sampleRate: SAMPLE_RATE,
       waitRemoteTrack: TrackKind.KIND_VIDEO,
     });
   }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->
- Set the Anam avatar plugin's audio output sample rate to 24000 Hz
- without this, the video conversation can sound quite weird

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- Added SAMPLE_RATE = 24000 constant in plugins/anam/src/avatar.ts
- Pass sampleRate: SAMPLE_RATE to DataStreamAudioOutput when wiring agentSession.output.audio

## Pre-Review Checklist
- [ ] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [ ] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.