### PR TITLE
Don't retain recorded events when recording is disabled

### DIFF
--- a/.changeset/honest-swans-drum.md
+++ b/.changeset/honest-swans-drum.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Don't retain recorded events when recording is disabled

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -480,8 +480,15 @@ export class AgentSession<
     event: K,
     ...args: Parameters<AgentSessionCallbacks[K]>
   ): boolean {
-    const eventData = args[0] as AgentEvent;
-    this._recordedEvents.push(eventData);
+    // Only retain events when recording is actually enabled. Otherwise this
+    // array grows unbounded for the entire (potentially hours-long) session,
+    // pinning every event's graph (SpeechHandle, OTel spans/contexts, streams)
+    // and leaking memory even though the events are never reported. The buffer
+    // is only consumed by makeSessionReport() when recording is enabled.
+    if (this._enableRecording) {
+      const eventData = args[0] as AgentEvent;
+      this._recordedEvents.push(eventData);
+    }
     return super.emit(event, ...args);
   }
 


### PR DESCRIPTION
## Problem

`AgentSession.emit()` pushed **every** emitted event into `_recordedEvents` unconditionally:

```ts
const eventData = args[0] as AgentEvent;
this._recordedEvents.push(eventData);
```

`emit` fires for every agent event for the whole session (state changes, transcripts, `conversation_item_added`, usage, etc.), and each `AgentEvent` pins a large object graph (`SpeechHandle`, OTel spans/contexts, streams, chat items). The buffer is only cleared at `_onSessionEnd`, so over a long-running session it grows unbounded and leaks memory — even when recording is disabled (the common default).

## Fix

Only push when `_enableRecording` is true. `_recordedEvents` is consumed solely by `makeSessionReport()`, and that report is only uploaded when recording is enabled, so this changes no observable behavior:
- recording **on**: unchanged.
- recording **off**: the buffer stays empty (it was never used anyway), eliminating the leak.

## Notes

Targeted at `1.5.0`. Minimal, behavior-preserving change; no changeset added since this is a release-branch patch (happy to add one if required).