### PR TITLE
fix(voice/room_io): non-delta transcription final-stream races

### DIFF
--- a/.changeset/fix-non-delta-transcription-final-text.md
+++ b/.changeset/fix-non-delta-transcription-final-text.md
@@ -1,0 +1,20 @@
+---
+'@livekit/agents': patch
+---
+
+Fix `ParticipantTranscriptionOutput` non-delta final-stream publishing two
+races that surfaced with Deepgram-style mid-utterance final bursts.
+
+1. `handleFlush()` previously read `this.latestText` from inside
+   `flushTaskImpl`, so a `captureText()` for the next segment landing
+   before the flush task ran would overwrite the field and cause segment
+   A's `lk.transcription_final: "true"` stream to publish segment B's
+   text. The text to flush is now snapshotted when the task is scheduled
+   and passed in as a parameter.
+
+2. When the first event for a fresh segment was already `is_final`,
+   `handleCaptureText` called `resetState()` after `captureText` had set
+   `latestText`, clearing it back to `""`. The subsequent final stream
+   then published an empty string. `latestText` is now restored from the
+   captured payload immediately after `resetState()` so the same-tick
+   final preserves the captured text.

--- a/agents/src/voice/room_io/_output.test.ts
+++ b/agents/src/voice/room_io/_output.test.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it, vi } from 'vitest';
-import { Future } from '../../utils.js';
-import { ParticipantAudioOutput } from './_output.js';
+import { Future, type Task } from '../../utils.js';
+import { ParticipantAudioOutput, ParticipantTranscriptionOutput } from './_output.js';
 
 type CaptureFrameArg = Parameters<ParticipantAudioOutput['captureFrame']>[0];
 
@@ -218,5 +218,70 @@ describe('ParticipantAudioOutput captureFrame segment accounting', () => {
     expect(output.playbackSegmentsCount).toBe(1);
     expect(output.audioSource.captureFrame).toHaveBeenCalledTimes(1);
     expect(output.pushedDuration).toBeGreaterThan(0);
+  });
+});
+
+describe('ParticipantTranscriptionOutput non-delta final flush', () => {
+  it('snapshots latestText at flush time so a next-segment capture cannot overwrite it', async () => {
+    type FlushTaskImpl = (writer: unknown, text: string, signal: AbortSignal) => Promise<void>;
+    type FlushTarget = ParticipantTranscriptionOutput & {
+      writer: unknown;
+      flushTask: Task<void> | null;
+      latestText: string;
+      flushTaskImpl: FlushTaskImpl;
+      handleFlush: () => void;
+    };
+
+    const output = Object.create(ParticipantTranscriptionOutput.prototype) as FlushTarget;
+    output.writer = null;
+    output.flushTask = null;
+    output.latestText = 'segment-A';
+
+    const flushedTexts: string[] = [];
+    output.flushTaskImpl = vi.fn(async (_writer, text) => {
+      flushedTexts.push(text);
+    });
+
+    output.handleFlush();
+    // Simulate the next segment's first interim landing before the flush task
+    // gets to write — must not corrupt segment A's final text.
+    output.latestText = 'segment-B-interim';
+
+    await output.flushTask!.result;
+
+    expect(flushedTexts).toEqual(['segment-A']);
+  });
+
+  it('preserves latestText through resetState() on a fresh-segment capture (final-only burst)', async () => {
+    type CaptureTarget = ParticipantTranscriptionOutput & {
+      participantIdentity: string | null;
+      capturing: boolean;
+      latestText: string;
+      currentId: string;
+      flushTask: Task<void> | null;
+      writer: unknown;
+      jsonFormat: boolean;
+      room: { isConnected: boolean };
+      logger: { error: () => void };
+      handleCaptureText: (text: string) => Promise<void>;
+      captureText: (text: string) => Promise<void>;
+    };
+
+    const output = Object.create(ParticipantTranscriptionOutput.prototype) as CaptureTarget;
+    output.participantIdentity = 'user-1';
+    output.capturing = false;
+    output.latestText = '';
+    output.currentId = 'SG_initial';
+    output.flushTask = null;
+    output.writer = null;
+    output.jsonFormat = false;
+    output.room = { isConnected: false };
+    output.logger = { error: vi.fn() };
+
+    // First (and only) event for this segment is already a final.
+    await output.captureText('hello world');
+
+    expect(output.capturing).toBe(true);
+    expect(output.latestText).toBe('hello world');
   });
 });

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -219,11 +219,15 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
   protected handleFlush() {
     const currWriter = this.writer;
     this.writer = null;
-    // Snapshot latestText now so a subsequent captureText() for the next
-    // segment doesn't overwrite the text this flush is meant to publish.
+    // Snapshot latestText and currentId now. `setParticipant()` calls
+    // `flush()` then `resetState()` synchronously, so without the snapshot
+    // the in-flight flushTaskImpl would read the next segment's
+    // `this.currentId` when it builds its attributes — publishing the prior
+    // turn's text under the new segment id.
     const textToFlush = this.latestText;
+    const segmentIdToFlush = this.currentId;
     this.flushTask = Task.from((controller) =>
-      this.flushTaskImpl(currWriter, textToFlush, controller.signal),
+      this.flushTaskImpl(currWriter, textToFlush, segmentIdToFlush, controller.signal),
     );
   }
 
@@ -244,7 +248,12 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
         attributes[ATTRIBUTE_TRANSCRIPTION_TRACK_ID] = this.trackId;
       }
     }
-    attributes[ATTRIBUTE_TRANSCRIPTION_SEGMENT_ID] = this.currentId;
+    // Honor a caller-provided SEGMENT_ID — flushTaskImpl snapshots it at
+    // handleFlush time so a racing resetState() can't shift it. Default
+    // (live captures) still reads the current id.
+    if (!attributes[ATTRIBUTE_TRANSCRIPTION_SEGMENT_ID]) {
+      attributes[ATTRIBUTE_TRANSCRIPTION_SEGMENT_ID] = this.currentId;
+    }
 
     return await this.room.localParticipant.streamText({
       topic: TOPIC_TRANSCRIPTION,
@@ -256,10 +265,12 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
   private async flushTaskImpl(
     writer: TextStreamWriter | null,
     text: string,
+    segmentId: string,
     signal: AbortSignal,
   ): Promise<void> {
     const attributes: Record<string, string> = {
       [ATTRIBUTE_TRANSCRIPTION_FINAL]: 'true',
+      [ATTRIBUTE_TRANSCRIPTION_SEGMENT_ID]: segmentId,
     };
     if (this.trackId) {
       attributes[ATTRIBUTE_TRANSCRIPTION_TRACK_ID] = this.trackId;

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -219,20 +219,37 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
   protected handleFlush() {
     const currWriter = this.writer;
     this.writer = null;
-    // Snapshot latestText and currentId now. `setParticipant()` calls
-    // `flush()` then `resetState()` synchronously, so without the snapshot
-    // the in-flight flushTaskImpl would read the next segment's
-    // `this.currentId` when it builds its attributes — publishing the prior
-    // turn's text under the new segment id.
+    // Snapshot everything `flushTaskImpl` / `createTextWriter` will read off
+    // `this` before the queued task runs. `setParticipant()` mutates
+    // `participantIdentity`, `trackId`, then calls `flush()` and
+    // `resetState()` (which rotates `currentId`) — all synchronously, so any
+    // field still read lazily after the task is queued can shift under it.
     const textToFlush = this.latestText;
     const segmentIdToFlush = this.currentId;
+    const trackIdToFlush = this.trackId;
+    const participantIdentityToFlush = this.participantIdentity;
     this.flushTask = Task.from((controller) =>
-      this.flushTaskImpl(currWriter, textToFlush, segmentIdToFlush, controller.signal),
+      this.flushTaskImpl(
+        currWriter,
+        textToFlush,
+        segmentIdToFlush,
+        trackIdToFlush,
+        participantIdentityToFlush,
+        controller.signal,
+      ),
     );
   }
 
-  private async createTextWriter(attributes?: Record<string, string>): Promise<TextStreamWriter> {
-    if (!this.participantIdentity) {
+  private async createTextWriter(
+    attributes?: Record<string, string>,
+    participantIdentityOverride?: string | null,
+  ): Promise<TextStreamWriter> {
+    // flushTaskImpl threads in a snapshotted participantIdentity so a racing
+    // `setParticipant()` between flush queueing and stream open can't publish
+    // the prior turn under the new participant. Live captures (no override)
+    // still read from `this`.
+    const senderIdentity = participantIdentityOverride ?? this.participantIdentity;
+    if (!senderIdentity) {
       throw new Error('participantIdentity not found');
     }
 
@@ -257,7 +274,7 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
 
     return await this.room.localParticipant.streamText({
       topic: TOPIC_TRANSCRIPTION,
-      senderIdentity: this.participantIdentity,
+      senderIdentity,
       attributes,
     });
   }
@@ -266,14 +283,16 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
     writer: TextStreamWriter | null,
     text: string,
     segmentId: string,
+    trackId: string | undefined,
+    participantIdentity: string | null,
     signal: AbortSignal,
   ): Promise<void> {
     const attributes: Record<string, string> = {
       [ATTRIBUTE_TRANSCRIPTION_FINAL]: 'true',
       [ATTRIBUTE_TRANSCRIPTION_SEGMENT_ID]: segmentId,
     };
-    if (this.trackId) {
-      attributes[ATTRIBUTE_TRANSCRIPTION_TRACK_ID] = this.trackId;
+    if (trackId) {
+      attributes[ATTRIBUTE_TRANSCRIPTION_TRACK_ID] = trackId;
     }
 
     const abortPromise = new Promise<void>((resolve) => {
@@ -287,7 +306,10 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
             await Promise.race([writer.close(), abortPromise]);
           }
         } else {
-          const tmpWriter = await Promise.race([this.createTextWriter(attributes), abortPromise]);
+          const tmpWriter = await Promise.race([
+            this.createTextWriter(attributes, participantIdentity),
+            abortPromise,
+          ]);
           if (signal.aborted || !tmpWriter) {
             return;
           }

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -190,6 +190,11 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
     if (!this.capturing) {
       this.resetState();
       this.capturing = true;
+      // resetState() clears latestText, but the caller already set it to the
+      // payload for this capture (captureText, line above). Re-assign so the
+      // subsequent flush republishes the correct text for segments whose first
+      // event is already final (no prior interims).
+      this.latestText = text;
     }
 
     try {
@@ -214,7 +219,12 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
   protected handleFlush() {
     const currWriter = this.writer;
     this.writer = null;
-    this.flushTask = Task.from((controller) => this.flushTaskImpl(currWriter, controller.signal));
+    // Snapshot latestText now so a subsequent captureText() for the next
+    // segment doesn't overwrite the text this flush is meant to publish.
+    const textToFlush = this.latestText;
+    this.flushTask = Task.from((controller) =>
+      this.flushTaskImpl(currWriter, textToFlush, controller.signal),
+    );
   }
 
   private async createTextWriter(attributes?: Record<string, string>): Promise<TextStreamWriter> {
@@ -243,7 +253,11 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
     });
   }
 
-  private async flushTaskImpl(writer: TextStreamWriter | null, signal: AbortSignal): Promise<void> {
+  private async flushTaskImpl(
+    writer: TextStreamWriter | null,
+    text: string,
+    signal: AbortSignal,
+  ): Promise<void> {
     const attributes: Record<string, string> = {
       [ATTRIBUTE_TRANSCRIPTION_FINAL]: 'true',
     };
@@ -266,7 +280,7 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
           if (signal.aborted || !tmpWriter) {
             return;
           }
-          await Promise.race([tmpWriter.write(this.latestText), abortPromise]);
+          await Promise.race([tmpWriter.write(text), abortPromise]);
           if (signal.aborted) {
             return;
           }


### PR DESCRIPTION
## Summary

`ParticipantTranscriptionOutput` (non-delta path, default user-transcription forwarding) had two race conditions that surfaced with Deepgram-style mid-utterance final bursts where multiple `is_final` chunks arrive back-to-back.

### Bug 1 — next-segment capture overwrites the in-flight flush text

`handleFlush()` schedules `flushTaskImpl`, which reads `this.latestText` when it later writes the `lk.transcription_final: \"true\"` stream. When the next segment's first `captureText()` lands before that task runs, it overwrites `latestText`, so segment A's final stream publishes segment B's text.

Observed in the issue: the learner said *\"So, you made a big purchase with, a service. You tell me what exactly it was?\"* — segment A's final stream arrived carrying just *\"service.\"* (the next chunk's fragment), and the client — keyed one entry per `lk.segment_id`, last write wins — replaced the full sentence.

**Fix:** snapshot `latestText` when the flush task is scheduled and pass it as a parameter to `flushTaskImpl`.

```diff
 protected handleFlush() {
   const currWriter = this.writer;
   this.writer = null;
-  this.flushTask = Task.from((controller) => this.flushTaskImpl(currWriter, controller.signal));
+  const textToFlush = this.latestText;
+  this.flushTask = Task.from((controller) =>
+    this.flushTaskImpl(currWriter, textToFlush, controller.signal),
+  );
 }
```

### Bug 2 — `resetState()` wipes the captured text on a final-only first event

`captureText()` sets `this.latestText = payload`, then `handleCaptureText()` runs `resetState()` (which sets `latestText = ''`) when a new segment starts. For any segment whose first event is already `is_final` — common with multi-final bursts — the final stream publishes an empty string. An empty write produces no chunk, so subscribers keyed on the segment never receive the final text.

**Fix:** restore `latestText` from the captured payload immediately after the `resetState()` call in `handleCaptureText`. The legacy class (`ParticipantLegacyTranscriptionOutput`) is unaffected — it tracks `pushedText` separately and resets that explicitly.

```diff
 if (!this.capturing) {
   this.resetState();
   this.capturing = true;
+  this.latestText = text;
 }
```

## Test plan

- [x] Two new regression tests in [agents/src/voice/room_io/_output.test.ts](agents/src/voice/room_io/_output.test.ts) — both fail on `main`, both pass after the fix
- [x] `pnpm vitest run agents/src/voice/room_io/_output.test.ts` — 5/5 pass (3 existing + 2 new)
- [x] `pnpm build:agents` — clean
- [x] `pnpm lint` — no new warnings on touched files
- [x] `pnpm format:check` — clean
- [x] Changeset added (patch)
- [x] Legacy `ParticipantLegacyTranscriptionOutput` semantics untouched

Closes #1759