### PR TITLE
increase memory warning threshold

### DIFF
--- a/.changeset/crisp-areas-leave.md
+++ b/.changeset/crisp-areas-leave.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+increase memory warning threshold

--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -169,7 +169,7 @@ export class ServerOptions {
     port = undefined,
     logLevel = 'info',
     production = false,
-    jobMemoryWarnMB = 500,
+    jobMemoryWarnMB = 1000,
     jobMemoryLimitMB = 0,
   }: {
     /**


### PR DESCRIPTION
when using in-memory models like VAD and Noise cancellation, it could push an agent process to be over 500MB. further increase the default threshold to avoid triggering false alarms
