### PR TITLE
Fix voice handoff drain and playback stalls

### DIFF
--- a/.changeset/clamp-stt-last-speaking-time.md
+++ b/.changeset/clamp-stt-last-speaking-time.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Clamp the STT-derived `lastSpeakingTime` to the current wall-clock time. When the STT stream's clock diverged from the activity's input epoch (e.g. a reused STT pipeline after an agent handoff), the transcript `endTime` could map to a timestamp minutes in the future, causing the end-of-turn bounce task to sleep that long before committing the user turn — the agent appeared to go silent mid-call even though LLM preemptive generation kept running.

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -18,10 +18,15 @@ import { Heap } from 'heap-js';
 import { describe, expect, it, vi } from 'vitest';
 import { ChatContext } from '../llm/chat_context.js';
 import { LLM, type LLMStream } from '../llm/llm.js';
-import { Future } from '../utils.js';
+import { Future, Task } from '../utils.js';
+import { _getActivityTaskInfo } from './agent.js';
 import { AgentActivity } from './agent_activity.js';
 import type { PreemptiveGenerationInfo } from './audio_recognition.js';
 import { SpeechHandle } from './speech_handle.js';
+
+const agentMocks = vi.hoisted(() => ({
+  getActivityTaskInfo: vi.fn(() => null),
+}));
 
 // Break circular dependency: agent_activity.ts → agent.js → beta/workflows/task_group.ts
 vi.mock('./agent.js', () => {
@@ -32,7 +37,7 @@ vi.mock('./agent.js', () => {
     Agent,
     AgentTask,
     StopResponse,
-    _getActivityTaskInfo: () => null,
+    _getActivityTaskInfo: agentMocks.getActivityTaskInfo,
     _setActivityTaskInfo: () => {},
     functionCallStorage: {
       getStore: () => undefined,
@@ -69,14 +74,17 @@ function buildMainTaskRunner() {
   const q_updated = new Future<void>();
   type HeapItem = [number, number, SpeechHandle];
   const speechQueue = new Heap<HeapItem>((a: HeapItem, b: HeapItem) => b[0] - a[0] || a[1] - b[1]);
+  const speechTasks = new Set<Task<void>>();
 
   const fakeActivity = {
     q_updated,
     speechQueue,
+    speechTasks,
     _currentSpeech: undefined as SpeechHandle | undefined,
     _schedulingPaused: false,
     _authorizationPaused: false,
-    getDrainPendingSpeechTasks: () => [],
+    _drainBlockedTasks: [] as Task<void>[],
+    _mainTask: undefined as { result: Promise<void> } | undefined,
     logger: {
       info: () => {},
       debug: () => {},
@@ -85,14 +93,23 @@ function buildMainTaskRunner() {
     },
   };
 
-  const mainTask = (AgentActivity.prototype as Record<string, unknown>).mainTask as (
-    signal: AbortSignal,
+  const proto = AgentActivity.prototype as Record<string, unknown>;
+  fakeActivity.getDrainPendingSpeechTasks = (
+    proto.getDrainPendingSpeechTasks as () => Task<void>[]
+  ).bind(fakeActivity);
+  fakeActivity.wakeupMainTask = (proto.wakeupMainTask as () => void).bind(fakeActivity);
+
+  const mainTask = proto.mainTask as (signal: AbortSignal) => Promise<void>;
+  const pauseSchedulingTask = proto._pauseSchedulingTask as (
+    blockedTasks: Task<void>[],
   ) => Promise<void>;
 
   return {
     fakeActivity,
     mainTask: mainTask.bind(fakeActivity),
+    pauseSchedulingTask: pauseSchedulingTask.bind(fakeActivity),
     speechQueue,
+    speechTasks,
     q_updated,
   };
 }
@@ -227,6 +244,78 @@ describe('AgentActivity - mainTask', () => {
 
     const result = await raceTimeout(mainTaskPromise, 2000);
     expect(result).toBe('resolved');
+  });
+
+  it('does not deadlock when a drain runs from inside its own speech task', async () => {
+    const { fakeActivity, mainTask, pauseSchedulingTask, speechTasks } = buildMainTaskRunner();
+
+    const ac = new AbortController();
+    const mainTaskPromise = mainTask(ac.signal);
+    fakeActivity._mainTask = {
+      result: mainTaskPromise,
+    };
+
+    // Let mainTask park on q_updated before the drain wakes it.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const drain = Task.from(
+      async () => {
+        const current = Task.current() as Task<void>;
+        speechTasks.add(current);
+        await pauseSchedulingTask([]);
+      },
+      undefined,
+      'reentrant-drain',
+    );
+
+    try {
+      const result = await raceTimeout(drain.result, 2000);
+      expect(result).toBe('resolved');
+    } finally {
+      speechTasks.clear();
+      fakeActivity._schedulingPaused = true;
+      fakeActivity.q_updated = new Future();
+      fakeActivity.q_updated.resolve();
+      ac.abort();
+      await raceTimeout(mainTaskPromise, 2000);
+    }
+  });
+
+  it('does not deadlock when drain is held only by interrupted speech tasks', async () => {
+    const { fakeActivity, mainTask, pauseSchedulingTask, speechTasks } = buildMainTaskRunner();
+
+    const interruptedHandle = { interrupted: true } as SpeechHandle;
+    const zombieTask = Task.from(
+      () => new Promise<void>(() => {}),
+      undefined,
+      'zombie-speech-task',
+    );
+    speechTasks.add(zombieTask);
+    vi.mocked(_getActivityTaskInfo).mockImplementation((task: Task<unknown>) =>
+      task === zombieTask ? ({ speechHandle: interruptedHandle } as never) : null,
+    );
+
+    const ac = new AbortController();
+    const mainTaskPromise = mainTask(ac.signal);
+    fakeActivity._mainTask = {
+      result: mainTaskPromise,
+    };
+
+    // Let mainTask park on q_updated before the drain wakes it.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    try {
+      const result = await raceTimeout(pauseSchedulingTask([]), 2000);
+      expect(result).toBe('resolved');
+    } finally {
+      vi.mocked(_getActivityTaskInfo).mockReturnValue(null);
+      speechTasks.clear();
+      fakeActivity._schedulingPaused = true;
+      fakeActivity.q_updated = new Future();
+      fakeActivity.q_updated.resolve();
+      ac.abort();
+      await raceTimeout(mainTaskPromise, 2000);
+    }
   });
 });
 

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -76,7 +76,24 @@ function buildMainTaskRunner() {
   const speechQueue = new Heap<HeapItem>((a: HeapItem, b: HeapItem) => b[0] - a[0] || a[1] - b[1]);
   const speechTasks = new Set<Task<void>>();
 
-  const fakeActivity = {
+  const fakeActivity: {
+    q_updated: Future<void>;
+    speechQueue: Heap<HeapItem>;
+    speechTasks: Set<Task<void>>;
+    _currentSpeech: SpeechHandle | undefined;
+    _schedulingPaused: boolean;
+    _authorizationPaused: boolean;
+    _drainBlockedTasks: Task<void>[];
+    _mainTask: { result: Promise<void> } | undefined;
+    logger: {
+      info: () => void;
+      debug: () => void;
+      warn: () => void;
+      error: () => void;
+    };
+    getDrainPendingSpeechTasks?: () => Task<void>[];
+    wakeupMainTask?: () => void;
+  } = {
     q_updated,
     speechQueue,
     speechTasks,
@@ -93,7 +110,7 @@ function buildMainTaskRunner() {
     },
   };
 
-  const proto = AgentActivity.prototype as Record<string, unknown>;
+  const proto = AgentActivity.prototype as unknown as Record<string, unknown>;
   fakeActivity.getDrainPendingSpeechTasks = (
     proto.getDrainPendingSpeechTasks as () => Task<void>[]
   ).bind(fakeActivity);
@@ -292,7 +309,7 @@ describe('AgentActivity - mainTask', () => {
     );
     speechTasks.add(zombieTask);
     vi.mocked(_getActivityTaskInfo).mockImplementation((task: Task<unknown>) =>
-      task === zombieTask ? ({ speechHandle: interruptedHandle } as never) : null,
+      task === zombieTask ? ({ speechHandle: interruptedHandle } as never) : undefined,
     );
 
     const ac = new AbortController();
@@ -308,7 +325,7 @@ describe('AgentActivity - mainTask', () => {
       const result = await raceTimeout(pauseSchedulingTask([]), 2000);
       expect(result).toBe('resolved');
     } finally {
-      vi.mocked(_getActivityTaskInfo).mockReturnValue(null);
+      vi.mocked(_getActivityTaskInfo).mockReturnValue(undefined);
       speechTasks.clear();
       fakeActivity._schedulingPaused = true;
       fakeActivity.q_updated = new Future();
@@ -316,6 +333,48 @@ describe('AgentActivity - mainTask', () => {
       ac.abort();
       await raceTimeout(mainTaskPromise, 2000);
     }
+  });
+
+  it('does not deadlock cancelling a paused speech whose generation never finishes', async () => {
+    const handle = SpeechHandle.create({ allowInterruptions: true });
+    handle._authorizeGeneration();
+
+    const fakeActivity = {
+      cancelSpeechPauseTask: undefined,
+      falseInterruptionTimer: undefined,
+      pausedSpeech: {
+        handle,
+        agentState: 'speaking',
+        timeout: 1000,
+      },
+      logger: {
+        debug: vi.fn(),
+      },
+      agentSession: {
+        sessionOptions: {
+          turnHandling: {
+            interruption: {
+              resumeFalseInterruption: false,
+            },
+          },
+        },
+        output: {
+          audio: undefined,
+        },
+      },
+    };
+
+    const cancelSpeechPause = (
+      AgentActivity.prototype as unknown as {
+        cancelSpeechPause: (options?: { interrupt?: boolean }) => Promise<void>;
+      }
+    ).cancelSpeechPause.bind(fakeActivity);
+
+    const result = await raceTimeout(cancelSpeechPause(), 2000);
+
+    expect(result).toBe('resolved');
+    expect(handle.interrupted).toBe(true);
+    expect(fakeActivity.pausedSpeech).toBeUndefined();
   });
 });
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -540,6 +540,10 @@ export class AgentActivity implements RecognitionHooks {
 
     if (reuseResources?.sttPipeline) {
       this.logger.debug('reusing STT pipeline from previous activity');
+      // carry the input epoch along with the reused pipeline: its stream clock
+      // is cumulative, so re-stamping inputStartedAt here would push STT-derived
+      // timestamps into the future and stall end-of-turn after every handoff
+      // (1.4.5 silence regression from #1603; see agent_task_handoff_eou.test.ts)
       await this.audioRecognition.start({
         sttPipeline: reuseResources.sttPipeline,
         inputStartedAt: reuseResources.sttInputStartedAt,
@@ -4072,7 +4076,9 @@ export class AgentActivity implements RecognitionHooks {
     ) {
       this.pausedSpeech.handle.interrupt();
       // ensure the generation is done — but only if a generation
-      // was actually started
+      // was actually started. Must be raced against interrupt: an interrupted
+      // paused speech may never mark its generation done, and an un-raced
+      // await here wedges every subsequent user turn (silence loop, #1124)
       if (this.pausedSpeech.handle._hasGenerations) {
         await this.pausedSpeech.handle.waitIfNotInterrupted([
           this.pausedSpeech.handle._waitForGeneration(),

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -4074,7 +4074,9 @@ export class AgentActivity implements RecognitionHooks {
       // ensure the generation is done — but only if a generation
       // was actually started
       if (this.pausedSpeech.handle._hasGenerations) {
-        await this.pausedSpeech.handle._waitForGeneration();
+        await this.pausedSpeech.handle.waitIfNotInterrupted([
+          this.pausedSpeech.handle._waitForGeneration(),
+        ]);
       }
     }
     this.pausedSpeech = undefined;

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -127,6 +127,7 @@ interface OnEnterData {
 
 export interface ReusableResources {
   sttPipeline?: STTPipeline;
+  sttInputStartedAt?: number;
   rtSession?: RealtimeSession;
 }
 
@@ -539,8 +540,12 @@ export class AgentActivity implements RecognitionHooks {
 
     if (reuseResources?.sttPipeline) {
       this.logger.debug('reusing STT pipeline from previous activity');
-      await this.audioRecognition.start({ sttPipeline: reuseResources.sttPipeline });
+      await this.audioRecognition.start({
+        sttPipeline: reuseResources.sttPipeline,
+        inputStartedAt: reuseResources.sttInputStartedAt,
+      });
       reuseResources.sttPipeline = undefined; // ownership transferred
+      reuseResources.sttInputStartedAt = undefined;
     } else {
       await this.audioRecognition.start();
     }
@@ -580,6 +585,7 @@ export class AgentActivity implements RecognitionHooks {
         Object.getPrototypeOf(newActivity.agent).sttNode === Agent.prototype.sttNode
       ) {
         resources.sttPipeline = await this.audioRecognition.detachSttPipeline();
+        resources.sttInputStartedAt = this.audioRecognition.inputStartedAt;
       }
 
       // rt session
@@ -3748,6 +3754,31 @@ export class AgentActivity implements RecognitionHooks {
     this.wakeupMainTask();
 
     if (this._mainTask) {
+      // Drain deadlock guard. A resume-triggered drain can run from inside one of
+      // this activity's own speech tasks; awaiting _mainTask.result there is a
+      // self-await because mainTask cannot exit until that same speech task
+      // de-registers from speechTasks. A barge-in cascade can also leave mainTask
+      // held only by already-done or interrupted "zombie" speech tasks. In both
+      // cases, skip the await; close()/cancelAndWait still reaps mainTask.
+      const currentTask = Task.current();
+      const reentrant = !!currentTask && this.speechTasks.has(currentTask as Task<void>);
+      const pending = this.getDrainPendingSpeechTasks();
+      const allZombie =
+        pending.length > 0 &&
+        pending.every((task) => {
+          if (task.done) return true;
+          const info = _getActivityTaskInfo(task);
+          return !!info?.speechHandle?.interrupted;
+        });
+
+      if (reentrant || allZombie) {
+        this.logger.debug(
+          { reentrant, allZombie, pending: pending.map((task) => task.name) },
+          'skipping mainTask self-await during drain to avoid a deadlock',
+        );
+        return;
+      }
+
       // When pausing/draining, we ensure that all speech_tasks complete fully.
       // This means that even if the SpeechHandle themselves have finished,
       // we still wait for the entire execution (e.g function_tools)

--- a/agents/src/voice/agent_activity_handoff.test.ts
+++ b/agents/src/voice/agent_activity_handoff.test.ts
@@ -21,19 +21,22 @@ initializeLogger({ pretty: false, level: 'silent' });
 
 type FakeActivity = {
   agent: Agent;
-  audioRecognition: { detachSttPipeline: ReturnType<typeof vi.fn> } | undefined;
+  audioRecognition:
+    | { detachSttPipeline: ReturnType<typeof vi.fn>; inputStartedAt?: number }
+    | undefined;
   stt: unknown;
   llm: unknown;
   tools: unknown;
   realtimeSession: unknown;
 };
 
-function createFakeActivity(agent: Agent, stt: unknown) {
+function createFakeActivity(agent: Agent, stt: unknown, inputStartedAt?: number) {
   const detachedPipeline = { id: Symbol('pipeline') };
   const activity = {
     agent,
     audioRecognition: {
       detachSttPipeline: vi.fn(async () => detachedPipeline),
+      inputStartedAt,
     },
     stt,
     llm: undefined,
@@ -67,6 +70,22 @@ describe('AgentActivity STT handoff reuse eligibility', () => {
 
     expect(resources.sttPipeline).toBe(oldActivity.detachedPipeline);
     expect(oldActivity.activity.audioRecognition?.detachSttPipeline).toHaveBeenCalledTimes(1);
+  });
+
+  it('carries the original input start time with a reused STT pipeline', async () => {
+    const sharedStt = { id: 'shared-stt' };
+    const oldInputStartedAt = Date.now() - 60_000;
+    const oldActivity = createFakeActivity(
+      new Agent({ instructions: 'a' }),
+      sharedStt,
+      oldInputStartedAt,
+    );
+    const newActivity = createFakeActivity(new Agent({ instructions: 'b' }), sharedStt);
+
+    const resources = await detachResources(oldActivity.activity, newActivity.activity);
+
+    expect(resources.sttPipeline).toBe(oldActivity.detachedPipeline);
+    expect(resources.sttInputStartedAt).toBe(oldInputStartedAt);
   });
 
   it('does not reuse when the STT instances differ', async () => {

--- a/agents/src/voice/agent_task_handoff_eou.test.ts
+++ b/agents/src/voice/agent_task_handoff_eou.test.ts
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression test for the end-of-turn stall after AgentTask handoffs
+// (1.4.4 -> 1.4.5 regression; reported in production as multi-minute agent
+// silences, minimal repro contributed by the affected customer).
+//
+// Mechanism: across a task handoff the STT pipeline is reused, so provider
+// transcript timestamps (`SpeechData.endTime`) stay cumulative from the STREAM
+// start, while the new activity re-stamps `_inputStartedAt` at handoff time.
+// If VAD misses the user's speech, `lastSpeakingTime` falls back to
+// `endTime * 1000 + _inputStartedAt`, which lands in the future by the stream's
+// age at the handoff, and the end-of-turn timer waits out the difference. The
+// path is only armed under adaptive interruption, the sole stamper of
+// `_inputStartedAt`.
+//
+// Guarded fixes: `inputStartedAt` carried across handoffs (agent_activity) and
+// `lastSpeakingTime` clamped to wall clock (audio_recognition). Without both,
+// the three steps below stall by ~2s/~3s/~8s instead of committing within the
+// endpointing window.
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream, type ReadableStreamDefaultController } from 'node:stream/web';
+import { describe, expect, it, vi } from 'vitest';
+import { asLanguageCode } from '../language.js';
+import { tool } from '../llm/tool_context.js';
+import { initializeLogger } from '../log.js';
+import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
+import type { FakeRecognizeStream } from '../stt/testing/fake_stt.js';
+import { FakeSTT } from '../stt/testing/fake_stt.js';
+import { VAD, VADStream } from '../vad.js';
+import { Agent, AgentTask } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AudioInput } from './io.js';
+import { FakeLLM } from './testing/fake_llm.js';
+
+// Mock `ws` so adaptive interruption connects to an in-memory socket instead of
+// the real LiveKit inference gateway. It opens cleanly and never returns any
+// inference events (so no interruption is ever detected), but the audio
+// forwarding loop still runs — which is all we need, since that loop is what
+// stamps `_inputStartedAt`. This keeps the test hermetic and avoids the noisy
+// unhandled rejections a dead network address would produce.
+vi.mock('ws', async () => {
+  const { EventEmitter } = await import('node:events');
+  class AutoOpenWebSocket extends EventEmitter {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    readyState = AutoOpenWebSocket.CONNECTING;
+    constructor(_url: string, _opts?: unknown) {
+      super();
+      // Open on the next tick, after connectWebSocket has attached its listeners.
+      setTimeout(() => {
+        this.readyState = AutoOpenWebSocket.OPEN;
+        this.emit('open');
+      }, 0);
+    }
+    send(_data: unknown, cb?: (err?: Error) => void) {
+      cb?.();
+    }
+    ping() {}
+    close() {
+      this.readyState = AutoOpenWebSocket.CLOSED;
+      this.emit('close', 1000, Buffer.alloc(0));
+    }
+    terminate() {
+      this.readyState = AutoOpenWebSocket.CLOSED;
+      this.emit('close', 1006, Buffer.alloc(0));
+    }
+  }
+  return { default: AutoOpenWebSocket, WebSocket: AutoOpenWebSocket };
+});
+
+const STEP_GAP_MS = 2_000; // silence between turns; grows the stream-age offset
+const ENDPOINTING_MS = 500; // expected healthy commit delay
+const STEP_INPUTS = ['step one done', 'step two done', 'step three done'] as const;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(check: () => boolean, timeoutMs: number, label: string): Promise<void> {
+  const startedAt = Date.now();
+  while (!check()) {
+    if (Date.now() - startedAt > timeoutMs) throw new Error(`timed out waiting for ${label}`);
+    await sleep(20);
+  }
+}
+
+function silenceFrame(durationMs: number, sampleRate = 16_000): AudioFrame {
+  const samples = Math.floor((sampleRate * durationMs) / 1000);
+  return new AudioFrame(new Int16Array(samples), sampleRate, 1, samples);
+}
+
+/**
+ * A VAD that consumes audio but never detects speech (a missed quiet
+ * utterance), forcing `lastSpeakingTime` to fall back to STT timestamps.
+ * Subclasses the real VAD/VADStream so `instanceof` checks in AgentActivity hold
+ * and the audio tee stays drained (otherwise backpressure would stall the
+ * pipeline). It never writes to the output, so `lastSpeakingTime` is never set
+ * from VAD — which is exactly the precondition for the buggy STT fallback.
+ */
+class DeafVADStream extends VADStream {
+  constructor(vad: VAD) {
+    super(vad);
+    void this.#drain();
+  }
+
+  // Drain the (tee'd) input so the shared audio pipeline doesn't block, but
+  // never emit a VAD event.
+  async #drain(): Promise<void> {
+    try {
+      while (!this.closed) {
+        const { done } = await this.inputReader.read();
+        if (done) break;
+      }
+    } catch {
+      /* stream detached/closed */
+    }
+  }
+}
+
+class DeafVAD extends VAD {
+  label = 'deaf-vad';
+
+  constructor() {
+    super({ updateInterval: 1 });
+  }
+
+  stream(): VADStream {
+    return new DeafVADStream(this);
+  }
+}
+
+/** Audio input that lets the test push frames into the session, like a SIP line. */
+class ScriptedAudioInput extends AudioInput {
+  #controller!: ReadableStreamDefaultController<AudioFrame>;
+
+  constructor() {
+    super();
+    const source = new ReadableStream<AudioFrame>({
+      start: (controller) => {
+        this.#controller = controller;
+      },
+    });
+    this.multiStream.addInputStream(source);
+  }
+
+  push(frame: AudioFrame): void {
+    this.#controller.enqueue(frame);
+  }
+}
+
+/** `SpeechStream.queue` is protected; we inject scripted FINAL_TRANSCRIPTs with a
+ * provider-cumulative `endTime` (which `sendFakeTranscript` hard-codes to 0). */
+type QueueAccess = { queue: { put(ev: SpeechEvent): void } };
+
+describe('AgentTask handoff end-of-turn timing', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('commits end-of-turn promptly after each task handoff when VAD misses the user speech', async () => {
+    // Adaptive interruption needs LiveKit credentials to construct (else the
+    // detector is silently disabled and `_inputStartedAt` is never stamped).
+    // The `ws` mock above means the URL is never actually dialed.
+    const savedEnv = {
+      LIVEKIT_API_KEY: process.env.LIVEKIT_API_KEY,
+      LIVEKIT_API_SECRET: process.env.LIVEKIT_API_SECRET,
+      LIVEKIT_INFERENCE_URL: process.env.LIVEKIT_INFERENCE_URL,
+    };
+    process.env.LIVEKIT_API_KEY = 'test-api-key';
+    process.env.LIVEKIT_API_SECRET = 'test-api-secret';
+    process.env.LIVEKIT_INFERENCE_URL = 'ws://127.0.0.1:1';
+
+    // Streaming STT with aligned transcripts — required for adaptive
+    // interruption (which is what stamps `_inputStartedAt`). We inject
+    // transcript events with provider-cumulative timestamps directly.
+    const stt = new FakeSTT({
+      label: 'scripted-stt',
+      capabilities: { streaming: true, interimResults: true, alignedTranscript: 'word' },
+    });
+
+    const sttStreams: Array<{ stream: FakeRecognizeStream; openedAt: number }> = [];
+    void (async () => {
+      for await (const stream of stt.streamCh) {
+        sttStreams.push({ stream, openedAt: Date.now() });
+      }
+    })();
+
+    const injectFinalTranscript = (text: string) => {
+      const opened = sttStreams[0]!;
+      const endS = (Date.now() - opened.openedAt) / 1000; // cumulative provider timestamp
+      (opened.stream as unknown as QueueAccess).queue.put({
+        type: SpeechEventType.FINAL_TRANSCRIPT,
+        alternatives: [
+          {
+            text,
+            language: asLanguageCode('en'),
+            startTime: Math.max(0, endS - 0.8),
+            endTime: endS,
+            confidence: 0.95,
+          },
+        ],
+      });
+    };
+
+    // Each user input maps to the current task's completion tool call.
+    const fakeLlm = new FakeLLM(
+      STEP_INPUTS.map((input) => ({ input, toolCalls: [{ name: 'completeStep', args: {} }] })),
+    );
+
+    // ---- Parent agent chaining three AgentTasks (mirrors the production shape) ----
+    const toolExecutedAt: Record<number, number> = {};
+
+    const makeStepTask = (step: number): AgentTask<{ step: number }> => {
+      const task: AgentTask<{ step: number }> = new AgentTask<{ step: number }>({
+        instructions: `You are handling step ${step}. Wait for the caller to finish it.`,
+        tools: {
+          completeStep: tool({
+            description: `Record that step ${step} is complete.`,
+            execute: async () => {
+              toolExecutedAt[step] = Date.now();
+              task.complete({ step });
+            },
+          }),
+        },
+      });
+      return task;
+    };
+
+    let allTasksDone = false;
+    const parent = new (class extends Agent {
+      async onEnter(): Promise<void> {
+        for (const step of [1, 2, 3]) {
+          await makeStepTask(step).run(); // task handoff: STT pipeline is reused
+        }
+        allTasksDone = true;
+      }
+    })({ instructions: 'Supervisor: delegate the caller through three steps.' });
+
+    const session = new AgentSession({
+      stt,
+      vad: new DeafVAD(),
+      llm: fakeLlm,
+      turnHandling: {
+        interruption: { mode: 'adaptive' },
+        endpointing: { minDelay: ENDPOINTING_MS, maxDelay: 3_000 },
+      },
+    });
+
+    const audioInput = new ScriptedAudioInput();
+    session.input.audio = audioInput;
+
+    await session.start({ agent: parent });
+
+    // Continuous caller audio, like an open SIP line.
+    const pump = setInterval(() => audioInput.push(silenceFrame(50)), 50);
+
+    const delays: number[] = [];
+    try {
+      await waitFor(() => sttStreams.length >= 1, 5_000, 'STT stream to open');
+
+      for (const [i, input] of STEP_INPUTS.entries()) {
+        const step = i + 1;
+        await sleep(STEP_GAP_MS);
+        const injectedAt = Date.now();
+        injectFinalTranscript(input);
+        await waitFor(() => toolExecutedAt[step] !== undefined, 30_000, `step ${step} tool call`);
+        delays.push(toolExecutedAt[step]! - injectedAt);
+      }
+
+      await waitFor(() => allTasksDone, 5_000, 'parent onEnter to finish');
+    } finally {
+      clearInterval(pump);
+      await session.close().catch(() => {});
+      for (const key of Object.keys(savedEnv) as Array<keyof typeof savedEnv>) {
+        if (savedEnv[key] === undefined) delete process.env[key];
+        else process.env[key] = savedEnv[key];
+      }
+    }
+
+    // The STT pipeline should be reused (a single stream) across all handoffs;
+    // that reuse is what makes `endTime` cumulative while `_inputStartedAt`
+    // resets per activity.
+    expect(sttStreams.length).toBe(1);
+
+    // every step must commit within the endpointing window — no step may
+    // stall by the stream age at its handoff
+    const [step1, step2, step3] = delays;
+    expect(step1!).toBeLessThan(STEP_GAP_MS / 2);
+    expect(step2!).toBeLessThan(STEP_GAP_MS / 2);
+    expect(step3!).toBeLessThan(STEP_GAP_MS / 2);
+  }, 60_000);
+});

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -414,8 +414,8 @@ export class AudioRecognition {
     }
   }
 
-  async start(options?: { sttPipeline?: STTPipeline }) {
-    this.startSttTasks(options?.sttPipeline);
+  async start(options?: { sttPipeline?: STTPipeline; inputStartedAt?: number }) {
+    this.startSttTasks(options?.sttPipeline, options?.inputStartedAt);
 
     this.vadTask = Task.from(({ signal }) => this.createVadTask(this.vad, signal));
     this.vadTask.result.catch((err) => {
@@ -1286,14 +1286,14 @@ export class AudioRecognition {
     );
   }
 
-  private startSttTasks(reusePipeline?: STTPipeline) {
+  private startSttTasks(reusePipeline?: STTPipeline, inputStartedAt?: number) {
     if (!this.stt) return;
 
     this.sttPipeline = reusePipeline ?? new STTPipeline(this.stt);
 
     this.transcriptBuffer = [];
     this.ignoreUserTranscriptUntil = undefined;
-    this._inputStartedAt = undefined;
+    this._inputStartedAt = inputStartedAt;
     this.sttOwnershipTransferred = false;
 
     const pipeline = this.sttPipeline;

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -832,6 +832,7 @@ export class AudioRecognition {
     // clamp to now: a reused STT stream's clock can be far ahead of this
     // activity's input epoch (e.g. after a handoff), and a future
     // lastSpeakingTime would stall the EOU bounce task for that long
+    // (1.4.5 silence regression from #1603; see audio_recognition_eou.test.ts)
     const sttLastSpeakingTime = hasSTTEndTime
       ? Math.min(firstAlternative.endTime * 1000 + inputStartedAt, Date.now())
       : Date.now();

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -829,8 +829,11 @@ export class AudioRecognition {
       firstAlternative !== undefined &&
       firstAlternative.endTime > 0 &&
       inputStartedAt !== undefined;
+    // clamp to now: a reused STT stream's clock can be far ahead of this
+    // activity's input epoch (e.g. after a handoff), and a future
+    // lastSpeakingTime would stall the EOU bounce task for that long
     const sttLastSpeakingTime = hasSTTEndTime
-      ? firstAlternative.endTime * 1000 + inputStartedAt
+      ? Math.min(firstAlternative.endTime * 1000 + inputStartedAt, Date.now())
       : Date.now();
 
     switch (ev.type) {

--- a/agents/src/voice/audio_recognition_eou.test.ts
+++ b/agents/src/voice/audio_recognition_eou.test.ts
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { ParticipantKind } from '@livekit/rtc-node';
+import { ReadableStream, type ReadableStreamDefaultController } from 'node:stream/web';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { initializeLogger } from '../log.js';
+import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
+import { VAD, type VADEvent, type VADStream } from '../vad.js';
+import {
+  AudioRecognition,
+  type RecognitionHooks,
+  type _TurnDetector,
+} from './audio_recognition.js';
+import type { STTNode } from './io.js';
+
+const fastTurnDetector: _TurnDetector = {
+  model: 'test-turn-detector',
+  provider: 'test-provider',
+  supportsLanguage: async () => true,
+  unlikelyThreshold: async () => undefined,
+  predictEndOfTurn: async () => 1.0,
+};
+
+// A VAD that never detects speech — models VAD missing a quiet utterance,
+// which forces AudioRecognition to fall back to STT-derived timestamps.
+class SilentVADStream extends (Object as unknown as { new (): VADStream }) {
+  updateInputStream() {}
+  detachInputStream() {}
+  close() {}
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+  async next(): Promise<IteratorResult<VADEvent>> {
+    return { done: true, value: undefined };
+  }
+}
+
+class SilentVAD extends VAD {
+  label = 'silent-vad';
+  constructor() {
+    super({ updateInterval: 1 });
+  }
+  stream(): any {
+    return new SilentVADStream();
+  }
+}
+
+function createHooks(): RecognitionHooks {
+  return {
+    onInterruption: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onPreemptiveGeneration: vi.fn(),
+    onUserTurnExceeded: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+    onEndOfTurn: vi.fn(async () => true),
+  };
+}
+
+describe('AudioRecognition EOU scheduling with STT timestamps', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function runTurn(opts: { sttEndTimeInS: number }) {
+    vi.useFakeTimers();
+    const hooks = createHooks();
+
+    let sttController!: ReadableStreamDefaultController<SpeechEvent | string>;
+    const sttNode: STTNode = async () =>
+      new ReadableStream<SpeechEvent | string>({
+        start(controller) {
+          sttController = controller;
+        },
+      });
+
+    const ar = new AudioRecognition({
+      recognitionHooks: hooks,
+      stt: sttNode,
+      vad: new SilentVAD(),
+      turnDetector: fastTurnDetector,
+      turnDetectionMode: 'vad',
+      minEndpointingDelay: 0,
+      maxEndpointingDelay: 0,
+      sttModel: 'stt-model',
+      sttProvider: 'stt-provider',
+      getLinkedParticipant: () => ({ sid: 'p1', identity: 'bob', kind: ParticipantKind.AGENT }),
+    });
+
+    // a freshly (re)started activity: input epoch base is "now", while the
+    // (potentially reused) STT stream reports endTime relative to its own,
+    // possibly much older, stream clock
+    await ar.start({ inputStartedAt: Date.now() });
+    await vi.advanceTimersByTimeAsync(0);
+
+    sttController.enqueue({
+      type: SpeechEventType.FINAL_TRANSCRIPT,
+      alternatives: [
+        {
+          language: 'en',
+          text: 'okay',
+          startTime: 0,
+          endTime: opts.sttEndTimeInS,
+          confidence: 0.9,
+        },
+      ],
+    });
+
+    return { ar, hooks };
+  }
+
+  async function closeRecognition(ar: AudioRecognition) {
+    vi.useRealTimers();
+    await ar.close();
+  }
+
+  it('commits the user turn promptly when STT endTime maps to the past', async () => {
+    const { ar, hooks } = await runTurn({ sttEndTimeInS: 0.5 });
+    try {
+      // endpointing delays are 0; the 0.5s stt offset is already in the past
+      // relative to fake-now after 2s, so the turn must have committed
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(hooks.onEndOfTurn).toHaveBeenCalledTimes(1);
+    } finally {
+      await closeRecognition(ar);
+    }
+  });
+
+  it('does not stall the user turn commit when STT endTime maps to the future', async () => {
+    // endTime of 120s on a stream whose epoch base is "now" puts
+    // lastSpeakingTime ~2 minutes in the future (reused STT pipeline after a
+    // handoff, or any stream-clock/input-epoch divergence). VAD missed the
+    // utterance, so the STT timestamp is authoritative.
+    const { ar, hooks } = await runTurn({ sttEndTimeInS: 120 });
+    try {
+      // the user turn must still commit within the endpointing window (0ms)
+      // plus generous scheduling slack — NOT minutes later
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(hooks.onEndOfTurn).toHaveBeenCalledTimes(1);
+    } finally {
+      await closeRecognition(ar);
+    }
+  });
+});

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -859,13 +859,8 @@ async function forwardAudio(
         out.startedForwardingAt = Date.now();
       }
 
-      if (
-        !out.firstFrameFut.done &&
-        audioOutput.sampleRate &&
-        audioOutput.sampleRate !== frame.sampleRate &&
-        !resampler
-      ) {
-        resampler = new AudioResampler(frame.sampleRate, audioOutput.sampleRate, 1);
+      if (audioOutput.sampleRate && audioOutput.sampleRate !== frame.sampleRate && !resampler) {
+        resampler = new AudioResampler(frame.sampleRate, audioOutput.sampleRate, frame.channels);
       }
 
       if (resampler) {

--- a/agents/src/voice/io.ts
+++ b/agents/src/voice/io.ts
@@ -170,6 +170,15 @@ export abstract class AudioOutput extends EventEmitter {
   }
 
   /**
+   * Playback segments captured but not yet finished. Used by chained outputs to detect and
+   * reconcile a segment-count drift against the next output in the chain.
+   * @internal
+   */
+  get pendingPlayoutSegments(): number {
+    return this.playbackSegmentsCount - this.playbackFinishedCount;
+  }
+
+  /**
    * Called when playback actually starts (first frame is sent to output).
    * Developers building audio sinks should call this when the first frame is captured.
    */

--- a/agents/src/voice/room_io/_output.test.ts
+++ b/agents/src/voice/room_io/_output.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { Future } from '../../utils.js';
 import { ParticipantAudioOutput } from './_output.js';
 
+type CaptureFrameArg = Parameters<ParticipantAudioOutput['captureFrame']>[0];
+
 const nextTick = () => new Promise<void>((resolve) => setImmediate(resolve));
 
 describe('ParticipantAudioOutput waitForPlayoutTask', () => {
@@ -150,5 +152,71 @@ describe('ParticipantAudioOutput waitForPlayoutTask', () => {
       interrupted: false,
     });
     expect(output.logger.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('ParticipantAudioOutput captureFrame segment accounting', () => {
+  type TestOutput = ParticipantAudioOutput & {
+    startedFuture: Future<void>;
+    playbackEnabledFuture: Future<void>;
+    interruptedFuture: Future<void>;
+    firstFrameEmitted: boolean;
+    pushedDuration: number;
+    _capturing: boolean;
+    playbackSegmentsCount: number;
+    playbackFinishedCount: number;
+    playbackFinishedFuture: Future<void>;
+    onPlaybackStarted: (createdAt: number) => void;
+    audioSource: {
+      clearQueue: () => void;
+      captureFrame: (frame: CaptureFrameArg) => Promise<void>;
+    };
+  };
+
+  const makeOutput = (opts: { paused: boolean }): TestOutput => {
+    const output = Object.create(ParticipantAudioOutput.prototype) as TestOutput;
+    output.startedFuture = new Future<void>();
+    output.startedFuture.resolve();
+    output.playbackEnabledFuture = new Future<void>();
+    if (!opts.paused) output.playbackEnabledFuture.resolve();
+    output.interruptedFuture = new Future<void>();
+    output.firstFrameEmitted = false;
+    output.pushedDuration = 0;
+    output._capturing = false;
+    output.playbackSegmentsCount = 0;
+    output.playbackFinishedCount = 0;
+    output.playbackFinishedFuture = new Future<void>();
+    output.onPlaybackStarted = vi.fn();
+    output.audioSource = { clearQueue: vi.fn(), captureFrame: vi.fn(async () => {}) };
+    return output;
+  };
+
+  const frame = () => ({ samplesPerChannel: 480, sampleRate: 24000 }) as unknown as CaptureFrameArg;
+
+  it('does not strand the segment counter when a frame is interrupted while paused', async () => {
+    const output = makeOutput({ paused: true });
+
+    const capture = output.captureFrame(frame());
+    output.interruptedFuture.resolve();
+    await capture;
+
+    expect(output.playbackSegmentsCount).toBe(0);
+    expect(output.audioSource.captureFrame).not.toHaveBeenCalled();
+
+    const result = await Promise.race([
+      output.waitForPlayout().then(() => 'resolved' as const),
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 1000)),
+    ]);
+    expect(result).toBe('resolved');
+  });
+
+  it('registers a segment on the normal non-paused path', async () => {
+    const output = makeOutput({ paused: false });
+
+    await output.captureFrame(frame());
+
+    expect(output.playbackSegmentsCount).toBe(1);
+    expect(output.audioSource.captureFrame).toHaveBeenCalledTimes(1);
+    expect(output.pushedDuration).toBeGreaterThan(0);
   });
 });

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -425,8 +425,6 @@ export class ParticipantAudioOutput extends AudioOutput {
   async captureFrame(frame: AudioFrame): Promise<void> {
     await this.startedFuture.await;
 
-    super.captureFrame(frame);
-
     if (!this.playbackEnabledFuture.done) {
       this.audioSource.clearQueue();
       // Race against interruption so a cancel-while-paused can't deadlock an in-flight frame.
@@ -435,6 +433,12 @@ export class ParticipantAudioOutput extends AudioOutput {
         return;
       }
     }
+
+    // Count the playback segment only after the pause/interrupt gate above. super.captureFrame
+    // bumps playbackSegmentsCount; if a frame interrupted-while-paused bailed at the gate after
+    // that bump, the count would strand ahead of playbackFinishedCount and the next
+    // waitForPlayout() would hang forever. See #1662.
+    super.captureFrame(frame);
 
     if (!this.firstFrameEmitted) {
       this.firstFrameEmitted = true;

--- a/agents/src/voice/transcription/synchronizer.test.ts
+++ b/agents/src/voice/transcription/synchronizer.test.ts
@@ -293,3 +293,35 @@ describe('TranscriptionSynchronizer attachment warnings', () => {
     await synchronizer.close();
   });
 });
+
+class DroppingAudioOutput extends AudioOutput {
+  constructor() {
+    super(8000);
+  }
+
+  async captureFrame(_frame: AudioFrame): Promise<void> {
+    // dropped: no super.captureFrame(), no playback-finished event
+  }
+
+  clearBuffer(): void {}
+}
+
+describe('TranscriptionSynchronizer playback-counter drift on a dropped frame', () => {
+  it('does not strand waitForPlayout() when the downstream sink drops a captured frame', async () => {
+    const synchronizer = new TranscriptionSynchronizer(
+      new DroppingAudioOutput(),
+      new MockTextOutput(),
+    );
+    const frame = new AudioFrame(new Int16Array(160), 8000, 1, 160);
+
+    await synchronizer.audioOutput.captureFrame(frame);
+
+    const result = await Promise.race([
+      synchronizer.audioOutput.waitForPlayout().then(() => 'resolved' as const),
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 1000)),
+    ]);
+
+    expect(result).toBe('resolved');
+    await synchronizer.close();
+  });
+});

--- a/agents/src/voice/transcription/synchronizer.test.ts
+++ b/agents/src/voice/transcription/synchronizer.test.ts
@@ -324,4 +324,26 @@ describe('TranscriptionSynchronizer playback-counter drift on a dropped frame', 
     expect(result).toBe('resolved');
     await synchronizer.close();
   });
+
+  it('routes the synthetic finish through the synchronizer like a real playback finish', async () => {
+    const synchronizer = new TranscriptionSynchronizer(
+      new DroppingAudioOutput(),
+      new MockTextOutput(),
+    );
+    const frame = new AudioFrame(new Int16Array(160), 8000, 1, 160);
+    const implBefore = (synchronizer as unknown as { _impl: unknown })._impl;
+
+    await synchronizer.audioOutput.captureFrame(frame);
+    const ev = await synchronizer.audioOutput.waitForPlayout();
+
+    // the reconciled segment was captured through the synchronizer, so its
+    // synthetic finish must also mark the segment finished there: the event
+    // carries a synchronized transcript and the segment is rotated
+    expect(ev.interrupted).toBe(true);
+    expect(typeof ev.synchronizedTranscript).toBe('string');
+    await synchronizer.barrier();
+    expect((synchronizer as unknown as { _impl: unknown })._impl).not.toBe(implBefore);
+
+    await synchronizer.close();
+  });
 });

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -798,7 +798,11 @@ class SyncedAudioOutput extends AudioOutput {
   async waitForPlayout(): Promise<PlaybackFinishedEvent> {
     const drift = this.pendingPlayoutSegments - this.nextInChainAudio.pendingPlayoutSegments;
     for (let i = 0; i < drift; i++) {
-      super.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
+      // route the synthetic finish through our own override (not the base
+      // class) so the synchronizer marks the segment finished, attaches the
+      // synchronized transcript, and rotates — the dropped segment was
+      // captured through the synchronizer like any other
+      this.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
     }
     return super.waitForPlayout();
   }

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -795,6 +795,14 @@ class SyncedAudioOutput extends AudioOutput {
     this.nextInChainAudio.clearBuffer();
   }
 
+  async waitForPlayout(): Promise<PlaybackFinishedEvent> {
+    const drift = this.pendingPlayoutSegments - this.nextInChainAudio.pendingPlayoutSegments;
+    for (let i = 0; i < drift; i++) {
+      super.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
+    }
+    return super.waitForPlayout();
+  }
+
   // this is going to be automatically called by the next_in_chain
   onPlaybackStarted(createdAt: number): void {
     super.onPlaybackStarted(createdAt);


### PR DESCRIPTION
Based on https://github.com/livekit/agents-js/pull/1732

## Description

Fixes several voice-pipeline edge cases that can leave an agent silent or stuck during task handoff, interruption, or reused STT pipelines. The main issue is that activity drain can wait forever on work that can no longer make progress, keeping scheduling/new-turn handling blocked.

## Changes Made

- Prevent `_pauseSchedulingTask()` from self-deadlocking when a drain is triggered from one of the activity's own speech tasks, or when drain is blocked only by done/interrupted speech tasks.
- Preserve the original STT input timestamp base when reusing an `STTPipeline` across handoff, so STT `endTime`-based timing does not drift after activity transfer.
- Fix audio forwarding resampling so sample-rate mismatches are handled after the first frame too, using the actual frame channel count.
- Fix playback segment accounting for interrupted-while-paused audio frames so dropped frames do not strand `waitForPlayout()`.
- Reconcile transcription synchronizer playback-counter drift when a downstream audio sink drops a frame before counting it.
- Add regression coverage for the drain, STT handoff timestamp, audio output segment accounting, and transcription synchronizer drift cases.

## Testing

- `npx vitest run agents/src/voice/agent_activity.test.ts agents/src/voice/agent_activity_handoff.test.ts agents/src/voice/room_io/_output.test.ts agents/src/voice/transcription/synchronizer.test.ts`
  - 4 test files passed
  - 61 tests passed
- `pnpm build:agents`
  - Build passed
  - Type declarations emitted
- `agents-cli` voice interruption smoke against `basic-agent-js`
  - Interruption detected
  - `getWeather` tool executed
  - Fresh assistant reply committed
  - Worker log scan clean: no `InvalidState`, unhandled rejection, scheduling-paused/user-input-drop messages
