### PR TITLE
fix(voice): emit the wrapper error on session error events

### DIFF
--- a/.changeset/tidy-eyes-repeat.md
+++ b/.changeset/tidy-eyes-repeat.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(voice): emit the wrapper error (with `recoverable`) on session `error` events instead of the inner error

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1001,16 +1001,16 @@ export class AgentActivity implements RecognitionHooks {
 
   private onError(ev: RealtimeModelError | STTError | TTSError | LLMError): void {
     if (ev.type === 'realtime_model_error') {
-      const errorEvent = createErrorEvent(ev.error, this.llm);
+      const errorEvent = createErrorEvent(ev, this.llm);
       this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
     } else if (ev.type === 'stt_error') {
-      const errorEvent = createErrorEvent(ev.error, this.stt);
+      const errorEvent = createErrorEvent(ev, this.stt);
       this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
     } else if (ev.type === 'tts_error') {
-      const errorEvent = createErrorEvent(ev.error, this.tts);
+      const errorEvent = createErrorEvent(ev, this.tts);
       this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
     } else if (ev.type === 'llm_error') {
-      const errorEvent = createErrorEvent(ev.error, this.llm);
+      const errorEvent = createErrorEvent(ev, this.llm);
       this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
     }
 

--- a/agents/src/voice/events.ts
+++ b/agents/src/voice/events.ts
@@ -282,14 +282,14 @@ export const createUserTurnExceededEvent = ({
 
 export type ErrorEvent = {
   type: 'error';
-  error: RealtimeModelError | STTError | TTSError | LLMError | InterruptionDetectionError | unknown;
-  source: LLM | STT | TTS | RealtimeModel | unknown;
+  error: RealtimeModelError | STTError | TTSError | LLMError | InterruptionDetectionError;
+  source?: LLM | STT | TTS | RealtimeModel;
   createdAt: number;
 };
 
 export const createErrorEvent = (
-  error: RealtimeModelError | STTError | TTSError | LLMError | InterruptionDetectionError | unknown,
-  source: LLM | STT | TTS | RealtimeModel | unknown,
+  error: RealtimeModelError | STTError | TTSError | LLMError | InterruptionDetectionError,
+  source?: LLM | STT | TTS | RealtimeModel,
   createdAt: number = Date.now(),
 ): ErrorEvent => ({
   type: 'error',

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -827,7 +827,7 @@ export class SessionHost {
       {
         case: 'error',
         value: new pb.AgentSessionEvent_Error({
-          message: event.error ? String(event.error) : 'Unknown error',
+          message: event.error ? event.error.label : 'Unknown error',
         }),
       },
       event.createdAt,


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->
The session `error` event handed subscribers the inner provider error instead of the `LLMError`/`STTError`/`TTSError`/`RealtimeModelError` wrapper, so `ev.error.recoverable` was always `undefined` and the documented continue-after-recoverable-error pattern could not work. Matches the Python implementation, which passes the wrapper.

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- Pass the wrapper `ev` (not `ev.error`) to `createErrorEvent` in all four `onError` branches
- Narrow `ErrorEvent` types: drop `| unknown` from `error` (which collapsed the union and let the original bug through unflagged) and make `source` an optional concrete component
- Use `event.error.label` for remote session error messages, since `String()` on the wrapper would yield `[object Object]`

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
<!-- Describe how you tested these changes -->
- [x] All tests pass
- No regression test added: with the narrowed types, reintroducing the bug (`ev.error` at the call sites) is a compile error (`TS2345`), so the type system covers it

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->
The existing changeset only describes the emit fix. The narrowing is technically a breaking type change for anyone constructing `ErrorEvent`s with arbitrary errors — happy to amend the changeset to mention it so it shows up in the release notes.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.