### PR TITLE
inference(stt): remove cartesia/ink-2-latest from Cartesia STT type hints

### DIFF
--- a/.changeset/remove-cartesia-ink-2-latest-stt-alias.md
+++ b/.changeset/remove-cartesia-ink-2-latest-stt-alias.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Remove the `cartesia/ink-2-latest` alias from the Cartesia inference STT model type hints. The alias still works at runtime; dated and `-latest` Cartesia snapshot aliases are no longer surfaced in the SDK types.

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -41,7 +41,7 @@ export type DeepgramFluxModels =
   | 'deepgram/flux-general-en'
   | 'deepgram/flux-general-multi';
 
-export type CartesiaModels = 'cartesia/ink-whisper' | 'cartesia/ink-2' | 'cartesia/ink-2-latest';
+export type CartesiaModels = 'cartesia/ink-whisper' | 'cartesia/ink-2';
 
 export type AssemblyaiModels =
   | 'assemblyai/universal-streaming'


### PR DESCRIPTION
## What

Removes `cartesia/ink-2-latest` from the `CartesiaModels` STT type in `agents/src/inference/stt.ts`, plus a changeset. `cartesia/ink-whisper` and `cartesia/ink-2` remain.

(`cartesia/ink-2-2026-04-15` was never present in the Node.js type hints, so there is nothing to remove for it here.)

## Why

The Cartesia team wants to move away from dated / `-latest` STT snapshot aliases. The alias still works at runtime — we just stop surfacing it in the SDK type hints.

## Related

- livekit/cloud-config — removes the aliases from the inference catalog (docs/pricing source of truth): https://github.com/livekit/cloud-config/pull/13726
- livekit/agents — same change for the Python types: https://github.com/livekit/agents/pull/6117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
