### PR TITLE
fix(avatar): normalise snake_case lk.playback_finished payload to avoid audio_end_ms=null

### DIFF
--- a/.changeset/fix-anam-avatar-truncate-null.md
+++ b/.changeset/fix-anam-avatar-truncate-null.md
@@ -1,0 +1,22 @@
+---
+'@livekit/agents': patch
+'@livekit/agents-plugin-openai': patch
+---
+
+Fix DataStream avatars (Anam, Bey, D-ID, LemonSlice, Runway, Tavus, Trugen) stalling the
+conversation on user interruption when paired with the OpenAI Realtime API.
+
+`DataStreamAudioOutput` parsed the `lk.playback_finished` RPC payload with a compile-time-only
+`as PlaybackFinishedEvent` cast. The LiveKit avatar protocol serializes that payload with
+snake_case keys (`playback_position`, `synchronized_transcript`) — confirmed against Anam's
+live engine, which emits `{"playback_position": 2.0, "interrupted": true, "synchronized_transcript": null}`
+— so the camelCase `playbackPosition` read back `undefined`. That became
+`Math.floor(undefined * 1000) === NaN`, which `JSON.stringify` serializes as `null` in
+`conversation.item.truncate`; the OpenAI Realtime API then rejected the truncate with an
+`invalid_type` error and the interrupted turn could not recover.
+
+`DataStreamAudioOutput` now normalizes the wire payload (snake_case primary, camelCase
+fallback), which also restores the previously-dropped `synchronizedTranscript` on interrupted
+turns. As defense-in-depth, the realtime truncate path now clamps a non-finite `audioEndMs` to
+a valid non-negative integer in both `AgentActivity` and the OpenAI plugin so a malformed or
+absent playback position can never again serialize as `null`.

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -3333,9 +3333,16 @@ export class AgentActivity implements RecognitionHooks {
         }
 
         if (interrupted && realtimeModel.capabilities.messageTruncation) {
+          // Defense-in-depth: playbackPositionInS can be non-finite when the avatar
+          // transport reports no (or an unparseable) playback position. Clamp it so we
+          // never serialize NaN -> JSON null into conversation.item.truncate, which the
+          // OpenAI Realtime API rejects as `invalid_type`, stalling the interrupted turn.
+          const playbackPositionInS = Number.isFinite(output.playbackPositionInS)
+            ? output.playbackPositionInS
+            : 0;
           void realtimeSession.truncate({
             messageId: output.message.messageId,
-            audioEndMs: Math.floor(output.playbackPositionInS * 1000),
+            audioEndMs: Math.max(0, Math.floor(playbackPositionInS * 1000)),
             modalities: output.modalities,
             audioTranscript: forwardedText,
           });

--- a/agents/src/voice/avatar/datastream_io.ts
+++ b/agents/src/voice/avatar/datastream_io.ts
@@ -18,7 +18,8 @@ import {
   waitForParticipant,
   waitForTrackPublication,
 } from '../../utils.js';
-import { AudioOutput, type PlaybackFinishedEvent } from '../io.js';
+import { AudioOutput } from '../io.js';
+import { parsePlaybackFinishedPayload } from './playback_payload.js';
 
 const RPC_CLEAR_BUFFER = 'lk.clear_buffer';
 const RPC_PLAYBACK_FINISHED = 'lk.playback_finished';
@@ -237,8 +238,10 @@ export class DataStreamAudioOutput extends AudioOutput {
       'playback finished event received',
     );
 
-    const playbackFinishedEvent = JSON.parse(data.payload) as PlaybackFinishedEvent;
-    this.onPlaybackFinished(playbackFinishedEvent);
+    // The wire payload uses the protocol-canonical snake_case keys
+    // (`playback_position`, `synchronized_transcript`); parsePlaybackFinishedPayload
+    // normalizes them into the camelCase PlaybackFinishedEvent shape.
+    this.onPlaybackFinished(parsePlaybackFinishedPayload(data.payload));
     return 'ok';
   }
 

--- a/agents/src/voice/avatar/playback_payload.test.ts
+++ b/agents/src/voice/avatar/playback_payload.test.ts
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { parsePlaybackFinishedPayload } from './playback_payload.js';
+
+describe('parsePlaybackFinishedPayload', () => {
+  it('parses the protocol-canonical snake_case payload (as emitted by Anam)', () => {
+    // Captured verbatim from a live Anam avatar engine on interruption.
+    const payload =
+      '{"playback_position": 2.000000000000001, "interrupted": true, "synchronized_transcript": null}';
+    const ev = parsePlaybackFinishedPayload(payload);
+    expect(ev.playbackPosition).toBeCloseTo(2.0);
+    expect(ev.interrupted).toBe(true);
+    expect(ev.synchronizedTranscript).toBeUndefined();
+
+    // The whole point of the fix: this must not become NaN -> JSON null.
+    const audioEndMs = Math.floor(ev.playbackPosition * 1000);
+    expect(Number.isFinite(audioEndMs)).toBe(true);
+    expect(JSON.stringify({ audio_end_ms: audioEndMs })).toBe('{"audio_end_ms":2000}');
+  });
+
+  it('preserves a snake_case synchronized_transcript string', () => {
+    const ev = parsePlaybackFinishedPayload(
+      '{"playback_position": 1.5, "interrupted": false, "synchronized_transcript": "hello there"}',
+    );
+    expect(ev.playbackPosition).toBe(1.5);
+    expect(ev.interrupted).toBe(false);
+    expect(ev.synchronizedTranscript).toBe('hello there');
+  });
+
+  it('tolerates camelCase keys as a fallback for JS-side producers', () => {
+    const ev = parsePlaybackFinishedPayload(
+      '{"playbackPosition": 3.25, "interrupted": true, "synchronizedTranscript": "hi"}',
+    );
+    expect(ev.playbackPosition).toBe(3.25);
+    expect(ev.interrupted).toBe(true);
+    expect(ev.synchronizedTranscript).toBe('hi');
+  });
+
+  it('coerces a missing playback position to 0 (never NaN)', () => {
+    const ev = parsePlaybackFinishedPayload('{"interrupted": true}');
+    expect(ev.playbackPosition).toBe(0);
+    expect(ev.interrupted).toBe(true);
+    expect(ev.synchronizedTranscript).toBeUndefined();
+    expect(Number.isFinite(Math.floor(ev.playbackPosition * 1000))).toBe(true);
+  });
+
+  it('coerces a null / non-numeric playback position to 0', () => {
+    expect(parsePlaybackFinishedPayload('{"playback_position": null}').playbackPosition).toBe(0);
+    expect(parsePlaybackFinishedPayload('{"playback_position": "1.5"}').playbackPosition).toBe(0);
+  });
+
+  it('keeps a legitimate zero position as 0', () => {
+    const ev = parsePlaybackFinishedPayload('{"playback_position": 0, "interrupted": true}');
+    expect(ev.playbackPosition).toBe(0);
+  });
+
+  it('defaults interrupted to false when absent', () => {
+    expect(parsePlaybackFinishedPayload('{"playback_position": 1}').interrupted).toBe(false);
+  });
+
+  it('returns a safe default for a malformed / non-object payload (never throws or hangs)', () => {
+    // "null" and "" would throw with a bare JSON.parse + property access; the others parse
+    // to a non-object. All must yield the safe default so onPlaybackFinished still fires and
+    // waitForPlayout() cannot hang the interrupted turn.
+    for (const payload of ['null', '', '123', '"a string"', '[]', 'not json{']) {
+      const ev = parsePlaybackFinishedPayload(payload);
+      expect(ev.playbackPosition).toBe(0);
+      expect(ev.interrupted).toBe(false);
+      expect(ev.synchronizedTranscript).toBeUndefined();
+    }
+  });
+
+  it('only treats a real boolean interrupted as authoritative (not a truthy "false" string)', () => {
+    expect(
+      parsePlaybackFinishedPayload('{"playback_position": 2, "interrupted": "false"}').interrupted,
+    ).toBe(false);
+    expect(
+      parsePlaybackFinishedPayload('{"playback_position": 2, "interrupted": true}').interrupted,
+    ).toBe(true);
+  });
+});

--- a/agents/src/voice/avatar/playback_payload.ts
+++ b/agents/src/voice/avatar/playback_payload.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { PlaybackFinishedEvent } from '../io.js';
+
+/**
+ * Parse a raw `lk.playback_finished` RPC payload into a {@link PlaybackFinishedEvent}.
+ *
+ * The LiveKit avatar DataStream protocol serializes this payload with **snake_case**
+ * keys (`playback_position`, `synchronized_transcript`) — matching the canonical Python
+ * `AvatarRunner`, which sends `json.dumps(asdict(PlaybackFinishedEvent(...)))` over a
+ * dataclass whose fields are `playback_position` / `interrupted` / `synchronized_transcript`.
+ * This was confirmed empirically against Anam's live avatar engine, which emits e.g.
+ * `{"playback_position": 2.0, "interrupted": true, "synchronized_transcript": null}`.
+ *
+ * A bare `JSON.parse(payload) as PlaybackFinishedEvent` cast does no runtime key
+ * remapping, so the camelCase `playbackPosition` field read back `undefined`. Downstream
+ * that became `Math.floor(undefined * 1000) === NaN`, which `JSON.stringify` serializes as
+ * `null` inside `conversation.item.truncate`; the OpenAI Realtime API then rejects the
+ * truncate with an `invalid_type` error, leaving the interrupted turn desynced and the
+ * conversation stalled.
+ *
+ * We accept snake_case as the primary (protocol-canonical) form and tolerate camelCase as
+ * a fallback for any JS-side producer. A missing/`null`/non-finite position is coerced to
+ * `0`, and a malformed or non-object payload yields a safe default event (position `0`, not
+ * interrupted) rather than throwing — so a bad payload can neither propagate a non-finite
+ * position nor escape the RPC handler and hang the unguarded `waitForPlayout()`.
+ */
+export function parsePlaybackFinishedPayload(payload: string): PlaybackFinishedEvent {
+  // Never throw out of the RPC handler: a throw would skip onPlaybackFinished and hang the
+  // unguarded waitForPlayout() on the interrupted turn. Coerce anything that is not a JSON
+  // object into an empty object and fall through to the field defaults below.
+  let raw: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = JSON.parse(payload);
+    if (typeof parsed === 'object' && parsed !== null) {
+      raw = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // malformed JSON; keep the empty default
+  }
+
+  const rawPosition = raw.playback_position ?? raw.playbackPosition;
+  const playbackPosition =
+    typeof rawPosition === 'number' && Number.isFinite(rawPosition) ? rawPosition : 0;
+
+  const rawTranscript = raw.synchronized_transcript ?? raw.synchronizedTranscript;
+  const synchronizedTranscript = typeof rawTranscript === 'string' ? rawTranscript : undefined;
+
+  // Only a real JSON boolean is authoritative; never coerce a truthy string like "false".
+  const interrupted = typeof raw.interrupted === 'boolean' ? raw.interrupted : false;
+
+  return {
+    playbackPosition,
+    interrupted,
+    synchronizedTranscript,
+  };
+}

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -896,11 +896,18 @@ export class RealtimeSession extends llm.RealtimeSession {
     const hasServerSideAudio = this.audioCapableItemIds.has(_options.messageId);
 
     if (hasAudioModality && hasServerSideAudio) {
+      // Guard against a non-finite audioEndMs (e.g. NaN from an unreported avatar
+      // playback position): JSON.stringify would serialize it as `null`, which the
+      // Realtime API rejects with an `invalid_type` error. Clamp to a valid
+      // non-negative integer (ms).
+      const audioEndMs = Number.isFinite(_options.audioEndMs)
+        ? Math.max(0, Math.floor(_options.audioEndMs))
+        : 0;
       this.sendEvent({
         type: 'conversation.item.truncate',
         content_index: 0,
         item_id: _options.messageId,
-        audio_end_ms: _options.audioEndMs,
+        audio_end_ms: audioEndMs,
       } as api_proto.ConversationItemTruncateEvent);
     } else if (_options.audioTranscript !== undefined) {
       // sync it to the remote chat context


### PR DESCRIPTION
## Summary

`DataStreamAudioOutput` decoded the `lk.playback_finished` RPC payload with a compile-time-only `as PlaybackFinishedEvent` cast. The LiveKit avatar DataStream protocol serialises that payload with **snake_case** keys (`playback_position`, `synchronized_transcript`), so the camelCase `playbackPosition` field read back `undefined`. On a user interruption that became `Math.floor(undefined * 1000) === NaN`, which `JSON.stringify` serialises as `null` inside `conversation.item.truncate`. The OpenAI Realtime API then rejected the truncate with an `invalid_type` error and the interrupted turn stalled.

This affects **every** avatar that uses `DataStreamAudioOutput` (Anam, Bey, D-ID, LemonSlice, Runway, Tavus, Trugen). `liveavatar` is unaffected because it tracks the playback position locally and never crosses the snake_case wire boundary.

## Root cause

1. The avatar worker invokes `lk.playback_finished`; the receiver casts the payload without remapping keys — `agents/src/voice/avatar/datastream_io.ts` (`JSON.parse(data.payload) as PlaybackFinishedEvent`).
2. The TS `PlaybackFinishedEvent` interface is camelCase — `agents/src/voice/io.ts` — so `playbackPosition` and `synchronizedTranscript` read `undefined` for a snake_case payload.
3. The interrupted realtime path reads the undefined field and overwrites the valid `0` default — `agents/src/voice/agent_activity.ts`.
4. `Math.floor(undefined * 1000)` is `NaN`, and the OpenAI plugin forwards it unguarded — `plugins/openai/src/realtime/realtime_model.ts` — where `JSON.stringify` turns `NaN` into `null`.

## Fix

- **Primary** — `DataStreamAudioOutput.handlePlaybackFinished` now normalises the wire payload through a new `parsePlaybackFinishedPayload` helper (snake_case primary, camelCase fallback, missing/`null`/non-finite position coerced to `0`). This also restores the previously-dropped `synchronizedTranscript` on interrupted turns.
- **Defence-in-depth** — a non-finite `audioEndMs` is now clamped to a valid non-negative integer in both `AgentActivity` and the OpenAI plugin's `truncate()`, so a malformed or absent playback position can never again serialise as `null`.

## Verification

Confirmed end-to-end against Anam's live avatar engine:

- The raw `lk.playback_finished` payload Anam emits on interruption is `{"playback_position": 2.0, "interrupted": true, "synchronized_transcript": null}` (snake_case), reproducing the original bug.
- Driving the **fixed** `DataStreamAudioOutput` through a real Anam session: `waitForPlayout().playbackPosition` is now `1.52` (finite), the computed `audio_end_ms` is `1520`, and the serialised event is `{"type":"conversation.item.truncate","audio_end_ms":1520}` — no longer `null`.

## Test plan

- [x] New unit test `playback_payload.test.ts` covers snake_case (incl. the exact captured Anam payload), camelCase fallback, missing/`null`/non-numeric position, and a legitimate zero.
- [x] `pnpm build` (full, Turborepo) passes.
- [x] Avatar and OpenAI realtime test suites pass.
- [x] ESLint and Prettier clean on changed files.
