### PR TITLE
fix(deepgram): recover Flux STT WebSocket closes

### DIFF
--- a/.changeset/deepgram-flux-retryable-close.md
+++ b/.changeset/deepgram-flux-retryable-close.md
@@ -2,4 +2,4 @@
 '@livekit/agents-plugin-deepgram': patch
 ---
 
-Recover Deepgram Flux streaming STT after unexpected WebSocket closes by surfacing them as retryable connection errors.
+Recover Deepgram Flux streaming STT after unexpected WebSocket closes by surfacing them as retryable connection errors, and preserve the transcript timebase across the reconnect so timestamps stay monotonic.

--- a/.changeset/deepgram-flux-retryable-close.md
+++ b/.changeset/deepgram-flux-retryable-close.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-deepgram': patch
+---
+
+Recover Deepgram Flux streaming STT after unexpected WebSocket closes by surfacing them as retryable connection errors.

--- a/agents/src/stt/stt.ts
+++ b/agents/src/stt/stt.ts
@@ -269,6 +269,7 @@ export abstract class SpeechStream implements AsyncIterableIterator<SpeechEvent>
   private logger = log();
   private _connOptions: APIConnectOptions;
   private _startTimeOffset: number = 0;
+  #numRetries = 0;
 
   protected abortController = new AbortController();
 
@@ -288,19 +289,26 @@ export abstract class SpeechStream implements AsyncIterableIterator<SpeechEvent>
     // is run **after** the constructor has finished. Otherwise we get
     // runtime error when trying to access class variables in the
     // `run` method.
-    startSoon(() => this.mainTask().finally(() => this.queue.close()));
+    startSoon(async () => {
+      try {
+        await this.mainTask();
+      } catch {
+        // already surfaced via emitError; swallow to avoid unhandled rejection.
+      } finally {
+        this.queue.close();
+      }
+    });
   }
 
   /**
-   * Runs the STT with retry logic. Errors are emitted via {@link STT} error events
-   * and then re-thrown to trigger `.finally()` cleanup.
+   * Runs the STT with retry logic. Errors are emitted via {@link STT} error events.
    *
-   * @throws {APIError} When the STT request fails with a non-retryable error
-   * @throws {APIConnectionError} When all retry attempts are exhausted
-   * @internal Not annotated with Throws<> because this is fire-and-forget via startSoon()
+   * @throws APIError when the STT request fails with a non-retryable error.
+   * @throws APIConnectionError when all retry attempts are exhausted.
+   * @internal Not annotated with Throws because this is fire-and-forget via startSoon.
    */
   private async mainTask(): Promise<void> {
-    for (let i = 0; i < this._connOptions.maxRetry + 1; i++) {
+    while (true) {
       try {
         return await this.run();
       } catch (error) {
@@ -313,12 +321,13 @@ export abstract class SpeechStream implements AsyncIterableIterator<SpeechEvent>
         }
 
         if (error instanceof APIError) {
-          const retryInterval = intervalForRetry(this._connOptions, i);
+          const retryCount = this.#numRetries;
+          const retryInterval = intervalForRetry(this._connOptions, retryCount);
 
           if (this._connOptions.maxRetry === 0 || !error.retryable) {
             this.emitError({ error, recoverable: false });
             throw error;
-          } else if (i === this._connOptions.maxRetry) {
+          } else if (retryCount === this._connOptions.maxRetry) {
             this.emitError({ error, recoverable: false });
             throw new APIConnectionError({
               message: `failed to recognize speech after ${this._connOptions.maxRetry + 1} attempts`,
@@ -328,7 +337,7 @@ export abstract class SpeechStream implements AsyncIterableIterator<SpeechEvent>
             // Don't emit error event for recoverable errors during retry loop
             // to avoid ERR_UNHANDLED_ERROR or premature session termination
             this.logger.warn(
-              { stt: this.#stt.label, attempt: i + 1, error },
+              { stt: this.#stt.label, attempt: retryCount + 1, error },
               `failed to recognize speech, retrying in ${retryInterval}ms`,
             );
           }
@@ -336,12 +345,17 @@ export abstract class SpeechStream implements AsyncIterableIterator<SpeechEvent>
           if (retryInterval > 0) {
             await delay(retryInterval);
           }
+          this.#numRetries += 1;
         } else {
           this.emitError({ error: toError(error), recoverable: false });
           throw error;
         }
       }
     }
+  }
+
+  protected resetRetryBudget(): void {
+    this.#numRetries = 0;
   }
 
   private emitError({ error, recoverable }: { error: Error; recoverable: boolean }) {

--- a/plugins/deepgram/src/stt_v2.test.ts
+++ b/plugins/deepgram/src/stt_v2.test.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { stt } from '@livekit/agents';
+import { stt } from '@livekit/agents';
+import { AudioFrame } from '@livekit/rtc-node';
 import { describe, expect, it } from 'vitest';
 import { type WebSocket, WebSocketServer } from 'ws';
 import { STTv2, type STTv2Options } from './stt_v2.js';
@@ -189,6 +190,86 @@ describe('Deepgram STTv2 WebSocket recovery', () => {
       );
     } finally {
       stream.close();
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('keeps transcript timestamps monotonic across an unexpected reconnect', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    let firstConnAudioBytes = 0;
+    const stream = createStream(endpointUrl);
+
+    wss.on('connection', (ws) => {
+      const index = connections.push(ws);
+      if (index === 1) {
+        ws.on('message', (data, isBinary) => {
+          if (isBinary) firstConnAudioBytes += (data as Buffer).length;
+        });
+      }
+    });
+
+    const startOfTurn = JSON.stringify({ type: 'TurnInfo', event: 'StartOfTurn', transcript: '' });
+    const endOfTurn = (audioWindowEnd: number) =>
+      JSON.stringify({
+        type: 'TurnInfo',
+        event: 'EndOfTurn',
+        transcript: 'hello',
+        audio_window_start: Math.max(0, audioWindowEnd - 0.5),
+        audio_window_end: audioWindowEnd,
+        words: [
+          {
+            word: 'hello',
+            start: Math.max(0, audioWindowEnd - 0.5),
+            end: audioWindowEnd,
+            confidence: 0.9,
+          },
+        ],
+      });
+
+    const finalEndTimes: number[] = [];
+    const consume = (async () => {
+      for await (const event of stream) {
+        if (event.type === stt.SpeechEventType.FINAL_TRANSCRIPT && event.alternatives?.[0]) {
+          finalEndTimes.push(event.alternatives[0].endTime);
+        }
+      }
+    })();
+
+    try {
+      await waitFor(() => connections.length === 1, 'expected initial WebSocket connection');
+
+      // Stream ~2s of 16 kHz mono audio so the first connection advances the timeline.
+      const oneSecond = () => new AudioFrame(new Int16Array(16_000), 16_000, 1, 16_000);
+      stream.pushFrame(oneSecond());
+      stream.pushFrame(oneSecond());
+      // 16 kHz * 2 bytes/sample * 1.5s = 48_000 bytes => at least 1.5s reached the socket.
+      await waitFor(
+        () => firstConnAudioBytes >= 48_000,
+        `expected ~2s of audio at the first connection, saw ${firstConnAudioBytes} bytes`,
+      );
+
+      // First turn ends 1.0s into the first connection's audio window.
+      connections[0]!.send(startOfTurn);
+      connections[0]!.send(endOfTurn(1.0));
+      await waitFor(() => finalEndTimes.length === 1, 'expected first final transcript');
+
+      // Unexpected close -> base-class retry reconnects.
+      connections[0]!.close(1011, 'unexpected close');
+      await waitFor(() => connections.length === 2, 'expected reconnect after unexpected close');
+
+      // The fresh Deepgram socket restarts audio_window near 0; this turn ends at
+      // 0.5 within the NEW connection's window.
+      connections[1]!.send(startOfTurn);
+      connections[1]!.send(endOfTurn(0.5));
+      await waitFor(() => finalEndTimes.length === 2, 'expected second final transcript');
+
+      // Without timebase preservation the second final lands at ~0.5s — earlier than
+      // the first — and downstream "before answer audio" logic would drop it.
+      expect(finalEndTimes[1]!).toBeGreaterThan(finalEndTimes[0]!);
+    } finally {
+      stream.close();
+      await consume.catch(() => {});
       await closeWebSocketServer(wss);
     }
   });

--- a/plugins/deepgram/src/stt_v2.test.ts
+++ b/plugins/deepgram/src/stt_v2.test.ts
@@ -274,11 +274,248 @@ describe('Deepgram STTv2 WebSocket recovery', () => {
     }
   });
 
-  it('emits start of speech after reconnecting during an active turn', async () => {
+  it('recovers repeated runtime closes within the stream retry budget', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const receivedBinaryMessages: number[] = [];
+    const sttInstance = new STTv2({ apiKey: 'test-api-key', endpointUrl });
+    const errors: unknown[] = [];
+    sttInstance.on('error', (event) => errors.push(event.error));
+    const stream = sttInstance.stream({
+      connOptions: { ...TEST_CONN_OPTIONS, maxRetry: 2 },
+    });
+    const events: Array<{
+      type: stt.SpeechEventType;
+      text?: string;
+      start?: number;
+      end?: number;
+    }> = [];
+
+    wss.on('connection', (ws) => {
+      const connectionIndex = connections.push(ws) - 1;
+      receivedBinaryMessages[connectionIndex] = 0;
+
+      ws.on('message', (_data, isBinary) => {
+        if (!isBinary) return;
+
+        const receivedCount = (receivedBinaryMessages[connectionIndex] ?? 0) + 1;
+        receivedBinaryMessages[connectionIndex] = receivedCount;
+        if (receivedCount !== 1) return;
+
+        if (connectionIndex < 2) {
+          ws.close(1011, 'progress close');
+          return;
+        }
+
+        ws.send(
+          JSON.stringify({
+            type: 'TurnInfo',
+            event: 'Update',
+            transcript: 'after two closes',
+            audio_window_start: 0.1,
+            audio_window_end: 0.4,
+            words: [
+              { word: 'after', start: 0.1, end: 0.2, confidence: 0.9 },
+              { word: 'two', start: 0.2, end: 0.3, confidence: 0.9 },
+              { word: 'closes', start: 0.3, end: 0.4, confidence: 0.9 },
+            ],
+          }),
+        );
+      });
+    });
+
+    const consume = (async () => {
+      for await (const event of stream) {
+        events.push({
+          type: event.type,
+          text: event.alternatives?.[0]?.text,
+          start: event.alternatives?.[0]?.startTime,
+          end: event.alternatives?.[0]?.endTime,
+        });
+      }
+    })();
+
+    const feedAudio = setInterval(() => {
+      stream.pushFrame(new AudioFrame(new Int16Array(1600), 16_000, 1, 1600));
+    }, 10);
+
+    try {
+      stream.pushFrame(new AudioFrame(new Int16Array(1600), 16_000, 1, 1600));
+
+      await waitFor(
+        () => events.some((event) => event.text === 'after two closes'),
+        'expected transcript after repeated runtime closes',
+      );
+
+      expect(connections).toHaveLength(3);
+      expect(receivedBinaryMessages[0]).toBeGreaterThan(0);
+      expect(receivedBinaryMessages[1]).toBeGreaterThan(0);
+      expect(receivedBinaryMessages[2]).toBeGreaterThan(0);
+      expect(
+        events.find((event) => event.text === 'after two closes')?.start,
+      ).toBeGreaterThanOrEqual(0.3);
+      expect(errors).toEqual([]);
+    } finally {
+      clearInterval(feedAudio);
+      stream.close();
+      await consume.catch(() => {});
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('uses the stream retry budget for repeated runtime closes with audio progress', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const receivedBinaryMessages: number[] = [];
+    const sttInstance = new STTv2({ apiKey: 'test-api-key', endpointUrl });
+    const errors: unknown[] = [];
+    sttInstance.on('error', (event) => errors.push(event.error));
+    const stream = sttInstance.stream({
+      connOptions: { ...TEST_CONN_OPTIONS, maxRetry: 1 },
+    });
+
+    wss.on('connection', (ws) => {
+      const connectionIndex = connections.push(ws) - 1;
+      receivedBinaryMessages[connectionIndex] = 0;
+
+      ws.on('message', (_data, isBinary) => {
+        if (!isBinary) return;
+
+        const receivedCount = (receivedBinaryMessages[connectionIndex] ?? 0) + 1;
+        receivedBinaryMessages[connectionIndex] = receivedCount;
+        if (receivedCount === 1) {
+          ws.close(1011, 'progress close');
+        }
+      });
+    });
+
+    const consume = (async () => {
+      for await (const _event of stream) {
+        // Drain until the stream reports the final retry-budget error.
+      }
+    })().catch((error: unknown) => error);
+
+    const feedAudio = setInterval(() => {
+      stream.pushFrame(new AudioFrame(new Int16Array(1600), 16_000, 1, 1600));
+    }, 10);
+
+    try {
+      stream.pushFrame(new AudioFrame(new Int16Array(1600), 16_000, 1, 1600));
+
+      await waitFor(
+        () => errors.length > 0 || connections.length > 2,
+        'expected repeated progress closes to consume the retry budget',
+      );
+
+      expect(connections).toHaveLength(2);
+      expect(receivedBinaryMessages[0]).toBeGreaterThan(0);
+      expect(receivedBinaryMessages[1]).toBeGreaterThan(0);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(Error);
+    } finally {
+      clearInterval(feedAudio);
+      stream.close();
+      await consume;
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('resets the stream retry budget after a final transcript', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const receivedBinaryMessages: number[] = [];
+    const sttInstance = new STTv2({ apiKey: 'test-api-key', endpointUrl });
+    const errors: unknown[] = [];
+    sttInstance.on('error', (event) => errors.push(event.error));
+    const stream = sttInstance.stream({
+      connOptions: { ...TEST_CONN_OPTIONS, maxRetry: 1 },
+    });
+    const events: Array<{ type: stt.SpeechEventType; text?: string }> = [];
+
+    wss.on('connection', (ws) => {
+      const connectionIndex = connections.push(ws) - 1;
+      receivedBinaryMessages[connectionIndex] = 0;
+
+      ws.on('message', (_data, isBinary) => {
+        if (!isBinary) return;
+        receivedBinaryMessages[connectionIndex] =
+          (receivedBinaryMessages[connectionIndex] ?? 0) + 1;
+      });
+    });
+
+    const consume = (async () => {
+      for await (const event of stream) {
+        events.push({
+          type: event.type,
+          text: event.alternatives?.[0]?.text,
+        });
+      }
+    })();
+
+    const startOfTurn = JSON.stringify({
+      type: 'TurnInfo',
+      event: 'StartOfTurn',
+      transcript: '',
+    });
+    const endOfTurn = JSON.stringify({
+      type: 'TurnInfo',
+      event: 'EndOfTurn',
+      transcript: 'retry budget reset',
+      audio_window_start: 0.1,
+      audio_window_end: 0.5,
+      words: [
+        { word: 'retry', start: 0.1, end: 0.2, confidence: 0.9 },
+        { word: 'budget', start: 0.2, end: 0.35, confidence: 0.9 },
+        { word: 'reset', start: 0.35, end: 0.5, confidence: 0.9 },
+      ],
+    });
+
+    const feedAudio = setInterval(() => {
+      stream.pushFrame(new AudioFrame(new Int16Array(1600), 16_000, 1, 1600));
+    }, 10);
+
+    try {
+      stream.pushFrame(new AudioFrame(new Int16Array(1600), 16_000, 1, 1600));
+
+      await waitFor(
+        () => (receivedBinaryMessages[0] ?? 0) > 0,
+        'expected audio on first WebSocket connection',
+      );
+      connections[0]!.close(1011, 'close before final');
+      await waitFor(() => connections.length === 2, 'expected first reconnect');
+
+      await waitFor(
+        () => (receivedBinaryMessages[1] ?? 0) > 0,
+        'expected audio on second WebSocket connection',
+      );
+      connections[1]!.send(startOfTurn);
+      connections[1]!.send(endOfTurn);
+      await waitFor(
+        () => events.some((event) => event.text === 'retry budget reset'),
+        'expected final transcript to reset retry budget',
+      );
+
+      connections[1]!.close(1011, 'close after final');
+      await waitFor(
+        () => connections.length === 3 || errors.length > 0,
+        'expected reconnect after final transcript reset',
+      );
+
+      expect(connections).toHaveLength(3);
+      expect(errors).toEqual([]);
+    } finally {
+      clearInterval(feedAudio);
+      stream.close();
+      await consume.catch(() => {});
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('does not emit duplicate start of speech after reconnecting during an active turn', async () => {
     const { wss, endpointUrl } = await startWebSocketServer();
     const connections: WebSocket[] = [];
     const stream = createStream(endpointUrl);
-    const eventTypes: stt.SpeechEventType[] = [];
+    const events: Array<{ type: stt.SpeechEventType; text?: string }> = [];
 
     wss.on('connection', (ws) => {
       connections.push(ws);
@@ -286,32 +523,42 @@ describe('Deepgram STTv2 WebSocket recovery', () => {
 
     const consume = (async () => {
       for await (const event of stream) {
-        eventTypes.push(event.type);
+        events.push({
+          type: event.type,
+          text: event.alternatives?.[0]?.text,
+        });
       }
     })();
 
-    const startOfTurn = JSON.stringify({ type: 'TurnInfo', event: 'StartOfTurn', transcript: '' });
+    const startOfTurn = (transcript = '') =>
+      JSON.stringify({
+        type: 'TurnInfo',
+        event: 'StartOfTurn',
+        transcript,
+        audio_window_start: 0.1,
+        audio_window_end: 0.2,
+        words: transcript ? [{ word: transcript, start: 0.1, end: 0.2, confidence: 0.9 }] : [],
+      });
 
     try {
       await waitFor(() => connections.length === 1, 'expected initial WebSocket connection');
 
-      connections[0]!.send(startOfTurn);
+      connections[0]!.send(startOfTurn());
       await waitFor(
         () =>
-          eventTypes.filter((eventType) => eventType === stt.SpeechEventType.START_OF_SPEECH)
-            .length === 1,
+          events.filter((event) => event.type === stt.SpeechEventType.START_OF_SPEECH).length === 1,
         'expected first start of speech',
       );
 
       connections[0]!.close(1011, 'unexpected close during speech');
       await waitFor(() => connections.length === 2, 'expected reconnect after unexpected close');
 
-      connections[1]!.send(startOfTurn);
+      connections[1]!.send(startOfTurn('still'));
       await waitFor(
         () =>
-          eventTypes.filter((eventType) => eventType === stt.SpeechEventType.START_OF_SPEECH)
-            .length === 2,
-        'expected second start of speech after reconnect',
+          events.filter((event) => event.type === stt.SpeechEventType.START_OF_SPEECH).length ===
+            1 && events.some((event) => event.text === 'still'),
+        'expected duplicate StartOfTurn transcript without duplicate start of speech',
       );
     } finally {
       stream.close();
@@ -320,7 +567,7 @@ describe('Deepgram STTv2 WebSocket recovery', () => {
     }
   });
 
-  it('starts speech from a non-empty update after reconnecting when StartOfTurn is absent', async () => {
+  it('keeps an active turn open across reconnect when StartOfTurn is absent', async () => {
     const { wss, endpointUrl } = await startWebSocketServer();
     const connections: WebSocket[] = [];
     const stream = createStream(endpointUrl);
@@ -369,12 +616,120 @@ describe('Deepgram STTv2 WebSocket recovery', () => {
       await waitFor(
         () =>
           events.filter((event) => event.type === stt.SpeechEventType.START_OF_SPEECH).length ===
-            2 && events.some((event) => event.text === 'after reconnect'),
-        'expected synthesized start of speech and update transcript after reconnect',
+            1 && events.some((event) => event.text === 'after reconnect'),
+        'expected update transcript without duplicate start of speech after reconnect',
       );
     } finally {
       stream.close();
       await consume.catch(() => {});
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('does not open a turn from trailing transcript after EndOfTurn without reconnect', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const stream = createStream(endpointUrl);
+    const events: Array<{ type: stt.SpeechEventType; text?: string }> = [];
+
+    wss.on('connection', (ws) => {
+      connections.push(ws);
+    });
+
+    const consume = (async () => {
+      for await (const event of stream) {
+        events.push({
+          type: event.type,
+          text: event.alternatives?.[0]?.text,
+        });
+      }
+    })();
+
+    const startOfTurn = JSON.stringify({
+      type: 'TurnInfo',
+      event: 'StartOfTurn',
+      transcript: 'hello',
+      audio_window_start: 0.1,
+      audio_window_end: 0.2,
+      words: [{ word: 'hello', start: 0.1, end: 0.2, confidence: 0.9 }],
+    });
+    const endOfTurn = JSON.stringify({
+      type: 'TurnInfo',
+      event: 'EndOfTurn',
+      transcript: 'hello there',
+      audio_window_start: 0.1,
+      audio_window_end: 1.0,
+      words: [
+        { word: 'hello', start: 0.1, end: 0.5, confidence: 0.9 },
+        { word: 'there', start: 0.5, end: 1.0, confidence: 0.9 },
+      ],
+    });
+    const trailingUpdate = JSON.stringify({
+      type: 'TurnInfo',
+      event: 'Update',
+      transcript: 'and one more thing',
+      audio_window_start: 1.0,
+      audio_window_end: 2.0,
+      words: [
+        { word: 'and', start: 1.0, end: 1.2, confidence: 0.9 },
+        { word: 'one', start: 1.2, end: 1.4, confidence: 0.9 },
+        { word: 'more', start: 1.4, end: 1.7, confidence: 0.9 },
+        { word: 'thing', start: 1.7, end: 2.0, confidence: 0.9 },
+      ],
+    });
+    const startOfSpeechCount = () =>
+      events.filter((event) => event.type === stt.SpeechEventType.START_OF_SPEECH).length;
+
+    try {
+      await waitFor(() => connections.length === 1, 'expected initial WebSocket connection');
+
+      connections[0]!.send(startOfTurn);
+      await waitFor(() => startOfSpeechCount() === 1, 'expected first start of speech');
+
+      connections[0]!.send(endOfTurn);
+      await waitFor(
+        () => events.some((event) => event.type === stt.SpeechEventType.END_OF_SPEECH),
+        'expected end of speech',
+      );
+
+      connections[0]!.send(trailingUpdate);
+      await sleep(50);
+
+      expect(startOfSpeechCount()).toBe(1);
+      expect(events.some((event) => event.text === 'and one more thing')).toBe(false);
+    } finally {
+      stream.close();
+      await consume.catch(() => {});
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('uses the base retry budget for runtime closes that make no audio progress', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const errors: unknown[] = [];
+    const sttInstance = new STTv2({ apiKey: 'test-api-key', endpointUrl });
+    sttInstance.on('error', (event) => errors.push(event.error));
+    const stream = sttInstance.stream({
+      connOptions: { ...TEST_CONN_OPTIONS, maxRetry: 1 },
+    });
+
+    wss.on('connection', (ws) => {
+      connections.push(ws);
+      if (connections.length === 1) {
+        ws.close(1011, 'no progress');
+      }
+    });
+
+    try {
+      await waitFor(
+        () => connections.length === 2,
+        `expected base retry to open a second WebSocket, saw ${connections.length}`,
+      );
+      expect(connections).toHaveLength(2);
+      expect(errors).toEqual([]);
+    } finally {
+      stream.close();
       await closeWebSocketServer(wss);
     }
   });

--- a/plugins/deepgram/src/stt_v2.test.ts
+++ b/plugins/deepgram/src/stt_v2.test.ts
@@ -1,16 +1,165 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { VAD } from '@livekit/agents-plugin-silero';
-import { stt } from '@livekit/agents-plugins-test';
-import { describe, it } from 'vitest';
-import { STTv2 } from './stt_v2.js';
+import type { stt } from '@livekit/agents';
+import { describe, expect, it } from 'vitest';
+import { type WebSocket, WebSocketServer } from 'ws';
+import { STTv2, type STTv2Options } from './stt_v2.js';
+
+const TEST_CONN_OPTIONS = { maxRetry: 1, retryIntervalMs: 1, timeoutMs: 1000 };
+
+async function startWebSocketServer(): Promise<{
+  wss: WebSocketServer;
+  endpointUrl: string;
+}> {
+  const wss = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  await new Promise<void>((resolve) => wss.once('listening', resolve));
+
+  const address = wss.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('failed to bind test WebSocket server');
+  }
+
+  return {
+    wss,
+    endpointUrl: `ws://127.0.0.1:${address.port}/v2/listen`,
+  };
+}
+
+async function closeWebSocketServer(wss: WebSocketServer): Promise<void> {
+  for (const client of wss.clients) {
+    client.terminate();
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    wss.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(condition: () => boolean, message: string): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < 1000) {
+    if (condition()) return;
+    await sleep(5);
+  }
+
+  throw new Error(message);
+}
+
+function createStream(endpointUrl: string, maxRetry = 1) {
+  return new STTv2({ apiKey: 'test-api-key', endpointUrl }).stream({
+    connOptions: { ...TEST_CONN_OPTIONS, maxRetry },
+  });
+}
+
+describe('Deepgram STTv2 WebSocket recovery', () => {
+  it('reconnects when Deepgram closes the WebSocket unexpectedly', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const stream = createStream(endpointUrl);
+
+    wss.on('connection', (ws) => {
+      connections.push(ws);
+
+      if (connections.length === 1) {
+        setTimeout(() => ws.close(1011, 'unexpected close'), 10);
+      }
+    });
+
+    try {
+      await waitFor(
+        () => connections.length === 2,
+        `expected retry to open a second WebSocket, saw ${connections.length}`,
+      );
+    } finally {
+      stream.close();
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('does not reconnect after normal input end closes the WebSocket', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const messages: Array<Record<string, unknown>> = [];
+    const stream = createStream(endpointUrl);
+
+    wss.on('connection', (ws) => {
+      connections.push(ws);
+
+      ws.on('message', (data) => {
+        messages.push(JSON.parse(data.toString()) as Record<string, unknown>);
+        ws.close(1000, 'stream complete');
+      });
+    });
+
+    try {
+      await waitFor(() => connections.length === 1, 'expected initial WebSocket connection');
+
+      stream.endInput();
+
+      await waitFor(
+        () => messages.some((message) => message.type === 'CloseStream'),
+        'expected client to send CloseStream',
+      );
+      await sleep(50);
+
+      expect(connections).toHaveLength(1);
+    } finally {
+      stream.close();
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('treats option-update reconnects as intentional WebSocket closes', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const stream = createStream(endpointUrl, 0) as stt.SpeechStream & {
+      updateOptions(opts: Partial<STTv2Options>): void;
+    };
+
+    wss.on('connection', (ws) => {
+      connections.push(ws);
+    });
+
+    try {
+      await waitFor(() => connections.length === 1, 'expected initial WebSocket connection');
+
+      stream.updateOptions({ keyterms: ['updated'] });
+
+      await waitFor(
+        () => connections.length === 2,
+        `expected option update to reconnect once, saw ${connections.length}`,
+      );
+    } finally {
+      stream.close();
+      await closeWebSocketServer(wss);
+    }
+  });
+});
 
 const hasDeepgramApiKey = Boolean(process.env.DEEPGRAM_API_KEY);
 
 if (hasDeepgramApiKey) {
   describe('Deepgram STTv2 (Flux)', async () => {
-    await stt(new STTv2(), await VAD.load(), { nonStreaming: false });
+    const sileroPackage = '@livekit/agents-plugin-silero';
+    const pluginsTestPackage = '@livekit/agents-plugins-test';
+    const [{ VAD }, { stt: runSttTests }] = await Promise.all([
+      import(/* @vite-ignore */ sileroPackage),
+      import(/* @vite-ignore */ pluginsTestPackage),
+    ]);
+
+    await runSttTests(new STTv2(), await VAD.load(), { nonStreaming: false });
   });
 } else {
   describe('Deepgram STTv2 (Flux)', () => {

--- a/plugins/deepgram/src/stt_v2.test.ts
+++ b/plugins/deepgram/src/stt_v2.test.ts
@@ -273,6 +273,111 @@ describe('Deepgram STTv2 WebSocket recovery', () => {
       await closeWebSocketServer(wss);
     }
   });
+
+  it('emits start of speech after reconnecting during an active turn', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const stream = createStream(endpointUrl);
+    const eventTypes: stt.SpeechEventType[] = [];
+
+    wss.on('connection', (ws) => {
+      connections.push(ws);
+    });
+
+    const consume = (async () => {
+      for await (const event of stream) {
+        eventTypes.push(event.type);
+      }
+    })();
+
+    const startOfTurn = JSON.stringify({ type: 'TurnInfo', event: 'StartOfTurn', transcript: '' });
+
+    try {
+      await waitFor(() => connections.length === 1, 'expected initial WebSocket connection');
+
+      connections[0]!.send(startOfTurn);
+      await waitFor(
+        () =>
+          eventTypes.filter((eventType) => eventType === stt.SpeechEventType.START_OF_SPEECH)
+            .length === 1,
+        'expected first start of speech',
+      );
+
+      connections[0]!.close(1011, 'unexpected close during speech');
+      await waitFor(() => connections.length === 2, 'expected reconnect after unexpected close');
+
+      connections[1]!.send(startOfTurn);
+      await waitFor(
+        () =>
+          eventTypes.filter((eventType) => eventType === stt.SpeechEventType.START_OF_SPEECH)
+            .length === 2,
+        'expected second start of speech after reconnect',
+      );
+    } finally {
+      stream.close();
+      await consume.catch(() => {});
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('starts speech from a non-empty update after reconnecting when StartOfTurn is absent', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const stream = createStream(endpointUrl);
+    const events: Array<{ type: stt.SpeechEventType; text?: string }> = [];
+
+    wss.on('connection', (ws) => {
+      connections.push(ws);
+    });
+
+    const consume = (async () => {
+      for await (const event of stream) {
+        events.push({
+          type: event.type,
+          text: event.alternatives?.[0]?.text,
+        });
+      }
+    })();
+
+    const startOfTurn = JSON.stringify({ type: 'TurnInfo', event: 'StartOfTurn', transcript: '' });
+    const update = JSON.stringify({
+      type: 'TurnInfo',
+      event: 'Update',
+      transcript: 'after reconnect',
+      audio_window_start: 0,
+      audio_window_end: 0.5,
+      words: [
+        { word: 'after', start: 0, end: 0.25, confidence: 0.9 },
+        { word: 'reconnect', start: 0.25, end: 0.5, confidence: 0.9 },
+      ],
+    });
+
+    try {
+      await waitFor(() => connections.length === 1, 'expected initial WebSocket connection');
+
+      connections[0]!.send(startOfTurn);
+      await waitFor(
+        () =>
+          events.filter((event) => event.type === stt.SpeechEventType.START_OF_SPEECH).length === 1,
+        'expected first start of speech',
+      );
+
+      connections[0]!.close(1011, 'unexpected close during speech');
+      await waitFor(() => connections.length === 2, 'expected reconnect after unexpected close');
+
+      connections[1]!.send(update);
+      await waitFor(
+        () =>
+          events.filter((event) => event.type === stt.SpeechEventType.START_OF_SPEECH).length ===
+            2 && events.some((event) => event.text === 'after reconnect'),
+        'expected synthesized start of speech and update transcript after reconnect',
+      );
+    } finally {
+      stream.close();
+      await consume.catch(() => {});
+      await closeWebSocketServer(wss);
+    }
+  });
 });
 
 const hasDeepgramApiKey = Boolean(process.env.DEEPGRAM_API_KEY);

--- a/plugins/deepgram/src/stt_v2.test.ts
+++ b/plugins/deepgram/src/stt_v2.test.ts
@@ -123,7 +123,7 @@ describe('Deepgram STTv2 WebSocket recovery', () => {
     }
   });
 
-  it('does not reconnect after flush sends CloseStream', async () => {
+  it('does not reconnect or close after flush before normal input end', async () => {
     const { wss, endpointUrl } = await startWebSocketServer();
     const connections: WebSocket[] = [];
     const messages: Array<Record<string, unknown>> = [];
@@ -147,6 +147,12 @@ describe('Deepgram STTv2 WebSocket recovery', () => {
       await waitFor(() => connections.length === 1, 'expected initial WebSocket connection');
 
       stream.flush();
+
+      await sleep(50);
+      expect(messages.some((message) => message.type === 'CloseStream')).toBe(false);
+      expect(connections).toHaveLength(1);
+
+      stream.endInput();
 
       await waitFor(
         () => messages.some((message) => message.type === 'CloseStream'),

--- a/plugins/deepgram/src/stt_v2.test.ts
+++ b/plugins/deepgram/src/stt_v2.test.ts
@@ -97,7 +97,9 @@ describe('Deepgram STTv2 WebSocket recovery', () => {
     wss.on('connection', (ws) => {
       connections.push(ws);
 
-      ws.on('message', (data) => {
+      ws.on('message', (data, isBinary) => {
+        if (isBinary) return;
+
         messages.push(JSON.parse(data.toString()) as Record<string, unknown>);
         ws.close(1000, 'stream complete');
       });
@@ -107,6 +109,44 @@ describe('Deepgram STTv2 WebSocket recovery', () => {
       await waitFor(() => connections.length === 1, 'expected initial WebSocket connection');
 
       stream.endInput();
+
+      await waitFor(
+        () => messages.some((message) => message.type === 'CloseStream'),
+        'expected client to send CloseStream',
+      );
+      await sleep(50);
+
+      expect(connections).toHaveLength(1);
+    } finally {
+      stream.close();
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('does not reconnect after flush sends CloseStream', async () => {
+    const { wss, endpointUrl } = await startWebSocketServer();
+    const connections: WebSocket[] = [];
+    const messages: Array<Record<string, unknown>> = [];
+    const stream = createStream(endpointUrl);
+
+    wss.on('connection', (ws) => {
+      connections.push(ws);
+
+      ws.on('message', (data, isBinary) => {
+        if (isBinary) return;
+
+        const message = JSON.parse(data.toString()) as Record<string, unknown>;
+        messages.push(message);
+        if (message.type === 'CloseStream') {
+          ws.close(1000, 'stream complete');
+        }
+      });
+    });
+
+    try {
+      await waitFor(() => connections.length === 1, 'expected initial WebSocket connection');
+
+      stream.flush();
 
       await waitFor(
         () => messages.some((message) => message.type === 'CloseStream'),

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -369,20 +369,19 @@ class SpeechStreamv2 extends stt.SpeechStream {
           if (ws.readyState === WebSocket.OPEN) {
             ws.send(frame.data);
           }
-
-          if (hasEnded) {
-            this.#audioDurationCollector.flush();
-            hasEnded = false;
-          }
         }
       }
 
-      if (hasEnded) break;
+      if (hasEnded) {
+        this.#audioDurationCollector.flush();
+        break;
+      }
     }
 
     // Only send CloseStream if we are exiting normally (not reconnecting)
     if (!this.#reconnectEvent.isSet && !wsClosedEvent.isSet && ws.readyState === WebSocket.OPEN) {
       this.#logger.debug('Sending CloseStream message to Deepgram');
+      this.#expectWsClose(ws);
       ws.send(_CLOSE_MSG);
     }
   }

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -324,10 +324,17 @@ class SpeechStreamv2 extends stt.SpeechStream {
     const samples50ms = Math.floor(this.#opts.sampleRate / 20);
     const audioBstream = new AudioByteStream(this.#opts.sampleRate, 1, samples50ms);
 
-    let hasEnded = false;
-
     // Manual Iterator to allow racing against Reconnect Signal
     const iterator = this.input[Symbol.asyncIterator]();
+    const sendFrames = (frames: AudioFrame[]) => {
+      for (const frame of frames) {
+        this.#audioDurationCollector.push(calculateAudioDurationSeconds(frame));
+
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(frame.data);
+        }
+      }
+    };
 
     while (true) {
       const nextPromise = iterator.next();
@@ -340,42 +347,18 @@ class SpeechStreamv2 extends stt.SpeechStream {
 
       // Check if we need to abort (Reconnect) or if stream is done
       if ('abort' in result || result.done) {
-        if (!('abort' in result) && result.done) {
-          // Normal stream end
-          hasEnded = true;
-        } else {
-          // Reconnect triggered - break loop immediately
-          break;
-        }
-      }
-
-      // If we broke above, we don't process data. If not, 'result' is IteratorResult
-      if (hasEnded && result.value === undefined) {
-        // Process flush below
-      } else if ('value' in result) {
-        const data = result.value;
-        const frames: AudioFrame[] = [];
-
-        if (data === SpeechStreamv2.FLUSH_SENTINEL) {
-          frames.push(...audioBstream.flush());
-          hasEnded = true;
-        } else {
-          frames.push(...audioBstream.write((data as AudioFrame).data.buffer as ArrayBuffer));
-        }
-
-        for (const frame of frames) {
-          this.#audioDurationCollector.push(calculateAudioDurationSeconds(frame));
-
-          if (ws.readyState === WebSocket.OPEN) {
-            ws.send(frame.data);
-          }
-        }
-      }
-
-      if (hasEnded) {
-        this.#audioDurationCollector.flush();
         break;
       }
+
+      const data = result.value;
+
+      if (data === SpeechStreamv2.FLUSH_SENTINEL) {
+        sendFrames(audioBstream.flush());
+        this.#audioDurationCollector.flush();
+        continue;
+      }
+
+      sendFrames(audioBstream.write((data as AudioFrame).data.buffer as ArrayBuffer));
     }
 
     // Only send CloseStream if we are exiting normally (not reconnecting)

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -223,15 +223,15 @@ class SpeechStreamv2 extends stt.SpeechStream {
 
   // Monotonic timestamp base across reconnects. Deepgram's audio_window restarts
   // at 0 on every new socket, so each connection's window times are offset by the
-  // audio already streamed to prior connections (#sentAudioSec snapshotted at
-  // connect into #connectionTimeBaseSec). Without this, transcripts after a
+  // audio already streamed to prior connections (#sentAudioInS snapshotted at
+  // connect into #connectionTimeBaseInS). Without this, transcripts after a
   // reconnect would be timestamped near the start of the session.
   //
   // The SDK sets startTimeOffset once at stream creation (voice/agent.ts sttNode)
   // and relies on the plugin to keep audio_window continuous across its own
   // reconnects ("linear timestamps across reconnections") — this preserves that.
-  #sentAudioSec = 0;
-  #connectionTimeBaseSec = 0;
+  #sentAudioInS = 0;
+  #connectionTimeBaseInS = 0;
 
   // Parity: _reconnect_event - using existing Event class from @livekit/agents
   #reconnectEvent = new Event();
@@ -296,7 +296,7 @@ class SpeechStreamv2 extends stt.SpeechStream {
 
         // Snapshot the timeline base for this connection: the fresh socket's
         // audio_window starts at 0, so offset it by the audio already streamed.
-        this.#connectionTimeBaseSec = this.#sentAudioSec;
+        this.#connectionTimeBaseInS = this.#sentAudioInS;
         // Provider turn state is scoped to one WebSocket. A reconnect during an
         // active turn must not make the next connection suppress StartOfTurn.
         this.#speaking = false;
@@ -347,10 +347,10 @@ class SpeechStreamv2 extends stt.SpeechStream {
     const iterator = this.input[Symbol.asyncIterator]();
     const sendFrames = (frames: AudioFrame[]) => {
       for (const frame of frames) {
-        const durationSec = calculateAudioDurationSeconds(frame);
-        this.#audioDurationCollector.push(durationSec);
+        const durationInS = calculateAudioDurationSeconds(frame);
+        this.#audioDurationCollector.push(durationInS);
         // Track total audio consumed so reconnects can preserve the timeline.
-        this.#sentAudioSec += durationSec;
+        this.#sentAudioInS += durationInS;
 
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(frame.data);
@@ -497,7 +497,7 @@ class SpeechStreamv2 extends stt.SpeechStream {
     const alts = parseTranscription(
       this.#opts.language || 'en',
       data,
-      this.startTimeOffset + this.#connectionTimeBaseSec,
+      this.startTimeOffset + this.#connectionTimeBaseInS,
     );
 
     if (alts.length > 0) {

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -226,6 +226,10 @@ class SpeechStreamv2 extends stt.SpeechStream {
   // audio already streamed to prior connections (#sentAudioSec snapshotted at
   // connect into #connectionTimeBaseSec). Without this, transcripts after a
   // reconnect would be timestamped near the start of the session.
+  //
+  // The SDK sets startTimeOffset once at stream creation (voice/agent.ts sttNode)
+  // and relies on the plugin to keep audio_window continuous across its own
+  // reconnects ("linear timestamps across reconnections") — this preserves that.
   #sentAudioSec = 0;
   #connectionTimeBaseSec = 0;
 

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -20,6 +20,10 @@ import type { V2Models } from './models.js';
 
 const _CLOSE_MSG = JSON.stringify({ type: 'CloseStream' });
 
+type ReceiveTaskResult =
+  | { status: 'expected-close' }
+  | { status: 'unexpected-close'; message: string };
+
 // --- Configuration ---
 
 /**
@@ -233,6 +237,13 @@ class SpeechStreamv2 extends stt.SpeechStream {
   #sentAudioInS = 0;
   #connectionTimeBaseInS = 0;
 
+  // Set only when a runtime close reconnects the socket mid-stream. While true,
+  // the next transcript-bearing event may re-open speech to recover a turn
+  // whose StartOfTurn was delivered on the previous connection. Cleared at
+  // clean turn boundaries so steady-state trailing transcripts after EndOfTurn
+  // do not open spurious turns.
+  #reconnectRecoveryPending = false;
+
   // Parity: _reconnect_event - using existing Event class from @livekit/agents
   #reconnectEvent = new Event();
 
@@ -297,9 +308,6 @@ class SpeechStreamv2 extends stt.SpeechStream {
         // Snapshot the timeline base for this connection: the fresh socket's
         // audio_window starts at 0, so offset it by the audio already streamed.
         this.#connectionTimeBaseInS = this.#sentAudioInS;
-        // Provider turn state is scoped to one WebSocket. A reconnect during an
-        // active turn must not make the next connection suppress StartOfTurn.
-        this.#speaking = false;
 
         // 2. Run Concurrent Tasks (Send & Receive)
         const ws = this.#ws;
@@ -311,9 +319,12 @@ class SpeechStreamv2 extends stt.SpeechStream {
         const reconnectWait = this.#reconnectEvent.wait();
 
         // 3. Race: Normal Completion vs Reconnect Signal
+        const streamTasks = Promise.all([sendPromise, recvPromise]) as Promise<
+          [void, ReceiveTaskResult]
+        >;
         const result = await Promise.race([
-          Promise.all([sendPromise, recvPromise]),
-          reconnectWait.then(() => 'RECONNECT'),
+          streamTasks,
+          reconnectWait.then(() => 'RECONNECT' as const),
         ]);
 
         if (result === 'RECONNECT') {
@@ -322,6 +333,12 @@ class SpeechStreamv2 extends stt.SpeechStream {
           this.#expectWsClose(this.#ws);
           this.#ws.close();
         } else {
+          const [, receiveResult] = result;
+          if (receiveResult.status === 'unexpected-close') {
+            this.#reconnectRecoveryPending = this.#sentAudioInS > this.#connectionTimeBaseInS;
+            throw new APIConnectionError({ message: receiveResult.message });
+          }
+
           // Normal finish (Stream ended or Error thrown)
           break;
         }
@@ -391,8 +408,8 @@ class SpeechStreamv2 extends stt.SpeechStream {
     }
   }
 
-  async #recvTask(ws: WebSocket, wsClosedEvent: Event) {
-    return new Promise<void>((resolve, reject) => {
+  async #recvTask(ws: WebSocket, wsClosedEvent: Event): Promise<ReceiveTaskResult> {
+    return new Promise<ReceiveTaskResult>((resolve) => {
       let wsError: Error | undefined;
 
       ws.on('message', (data: Buffer, isBinary: boolean) => {
@@ -413,7 +430,7 @@ class SpeechStreamv2 extends stt.SpeechStream {
         this.#logger.debug(`Deepgram WebSocket closed: ${code} ${reason}`);
 
         if (this.#closingWs.has(ws) || this.closed || this.input.closed) {
-          resolve();
+          resolve({ status: 'expected-close' });
           return;
         }
 
@@ -421,11 +438,10 @@ class SpeechStreamv2 extends stt.SpeechStream {
         const message = reasonText
           ? `Deepgram WebSocket closed unexpectedly: ${code} ${reasonText}`
           : `Deepgram WebSocket closed unexpectedly: ${code}`;
-        reject(
-          new APIConnectionError({
-            message: wsError ? `${message}: ${wsError.message}` : message,
-          }),
-        );
+        resolve({
+          status: 'unexpected-close',
+          message: wsError ? `${message}: ${wsError.message}` : message,
+        });
       });
 
       ws.on('error', (error) => {
@@ -443,9 +459,8 @@ class SpeechStreamv2 extends stt.SpeechStream {
       const eventType = data.event;
 
       if (eventType === 'StartOfTurn') {
-        if (this.#speaking) return;
-
-        this.#startSpeech();
+        this.#reconnectRecoveryPending = false;
+        if (!this.#speaking) this.#startSpeech();
 
         this.#sendTranscriptEvent(stt.SpeechEventType.INTERIM_TRANSCRIPT, data);
       } else if (eventType === 'Update') {
@@ -461,7 +476,9 @@ class SpeechStreamv2 extends stt.SpeechStream {
         if (!this.#speaking && !this.#startSpeechFromTranscript(data)) return;
 
         this.#speaking = false;
+        this.#reconnectRecoveryPending = false;
         this.#sendTranscriptEvent(stt.SpeechEventType.FINAL_TRANSCRIPT, data);
+        this.resetRetryBudget();
 
         this.queue.put({
           type: stt.SpeechEventType.END_OF_SPEECH,
@@ -476,6 +493,8 @@ class SpeechStreamv2 extends stt.SpeechStream {
   }
 
   #startSpeech() {
+    if (this.#speaking) return;
+
     this.#speaking = true;
     this.queue.put({
       type: stt.SpeechEventType.START_OF_SPEECH,
@@ -484,6 +503,8 @@ class SpeechStreamv2 extends stt.SpeechStream {
   }
 
   #startSpeechFromTranscript(data: Record<string, unknown>) {
+    if (!this.#reconnectRecoveryPending) return false;
+
     const transcript = data.transcript;
     if (typeof transcript !== 'string' || transcript.trim().length === 0) {
       return false;

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -221,6 +221,14 @@ class SpeechStreamv2 extends stt.SpeechStream {
   #requestId = '';
   #speaking = false;
 
+  // Monotonic timestamp base across reconnects. Deepgram's audio_window restarts
+  // at 0 on every new socket, so each connection's window times are offset by the
+  // audio already streamed to prior connections (#sentAudioSec snapshotted at
+  // connect into #connectionTimeBaseSec). Without this, transcripts after a
+  // reconnect would be timestamped near the start of the session.
+  #sentAudioSec = 0;
+  #connectionTimeBaseSec = 0;
+
   // Parity: _reconnect_event - using existing Event class from @livekit/agents
   #reconnectEvent = new Event();
 
@@ -282,6 +290,10 @@ class SpeechStreamv2 extends stt.SpeechStream {
           this.#ws.once('error', onError);
         });
 
+        // Snapshot the timeline base for this connection: the fresh socket's
+        // audio_window starts at 0, so offset it by the audio already streamed.
+        this.#connectionTimeBaseSec = this.#sentAudioSec;
+
         // 2. Run Concurrent Tasks (Send & Receive)
         const ws = this.#ws;
         if (!ws) throw new Error('WebSocket not initialized');
@@ -328,7 +340,10 @@ class SpeechStreamv2 extends stt.SpeechStream {
     const iterator = this.input[Symbol.asyncIterator]();
     const sendFrames = (frames: AudioFrame[]) => {
       for (const frame of frames) {
-        this.#audioDurationCollector.push(calculateAudioDurationSeconds(frame));
+        const durationSec = calculateAudioDurationSeconds(frame);
+        this.#audioDurationCollector.push(durationSec);
+        // Track total audio consumed so reconnects can preserve the timeline.
+        this.#sentAudioSec += durationSec;
 
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(frame.data);
@@ -457,7 +472,11 @@ class SpeechStreamv2 extends stt.SpeechStream {
   }
 
   #sendTranscriptEvent(eventType: stt.SpeechEventType, data: Record<string, unknown>) {
-    const alts = parseTranscription(this.#opts.language || 'en', data, this.startTimeOffset);
+    const alts = parseTranscription(
+      this.#opts.language || 'en',
+      data,
+      this.startTimeOffset + this.#connectionTimeBaseSec,
+    );
 
     if (alts.length > 0) {
       this.queue.put({

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
   type APIConnectOptions,
+  APIConnectionError,
   AudioByteStream,
   Event,
   calculateAudioDurationSeconds,
@@ -214,6 +215,7 @@ class SpeechStreamv2 extends stt.SpeechStream {
   #opts: STTv2Options & { apiKey: string };
   #logger = log();
   #ws: WebSocket | null = null;
+  #closingWs = new WeakSet<WebSocket>();
 
   #audioDurationCollector: PeriodicCollector<number>;
   #requestId = '';
@@ -281,8 +283,12 @@ class SpeechStreamv2 extends stt.SpeechStream {
         });
 
         // 2. Run Concurrent Tasks (Send & Receive)
-        const sendPromise = this.#sendTask();
-        const recvPromise = this.#recvTask();
+        const ws = this.#ws;
+        if (!ws) throw new Error('WebSocket not initialized');
+
+        const wsClosedEvent = new Event();
+        const sendPromise = this.#sendTask(ws, wsClosedEvent);
+        const recvPromise = this.#recvTask(ws, wsClosedEvent);
         const reconnectWait = this.#reconnectEvent.wait();
 
         // 3. Race: Normal Completion vs Reconnect Signal
@@ -294,6 +300,7 @@ class SpeechStreamv2 extends stt.SpeechStream {
         if (result === 'RECONNECT') {
           this.#logger.debug('Reconnecting stream due to option update...');
           // Close current socket; loop will restart and open a new one
+          this.#expectWsClose(this.#ws);
           this.#ws.close();
         } else {
           // Normal finish (Stream ended or Error thrown)
@@ -304,6 +311,7 @@ class SpeechStreamv2 extends stt.SpeechStream {
         throw error; // Let Base Class handle retry logic
       } finally {
         if (this.#ws?.readyState === WebSocket.OPEN) {
+          this.#expectWsClose(this.#ws);
           this.#ws.close();
         }
       }
@@ -311,9 +319,7 @@ class SpeechStreamv2 extends stt.SpeechStream {
     this.close();
   }
 
-  async #sendTask() {
-    if (!this.#ws) return;
-
+  async #sendTask(ws: WebSocket, wsClosedEvent: Event) {
     // Buffer audio into 50ms chunks (Parity)
     const samples50ms = Math.floor(this.#opts.sampleRate / 20);
     const audioBstream = new AudioByteStream(this.#opts.sampleRate, 1, samples50ms);
@@ -325,8 +331,10 @@ class SpeechStreamv2 extends stt.SpeechStream {
 
     while (true) {
       const nextPromise = iterator.next();
-      // If reconnect signal fires, abort the wait
-      const abortPromise = this.#reconnectEvent.wait().then(() => ({ abort: true }) as const);
+      // If reconnect or WebSocket close fires, abort the wait
+      const abortPromise = Promise.race([this.#reconnectEvent.wait(), wsClosedEvent.wait()]).then(
+        () => ({ abort: true }) as const,
+      );
 
       const result = await Promise.race([nextPromise, abortPromise]);
 
@@ -358,8 +366,8 @@ class SpeechStreamv2 extends stt.SpeechStream {
         for (const frame of frames) {
           this.#audioDurationCollector.push(calculateAudioDurationSeconds(frame));
 
-          if (this.#ws!.readyState === WebSocket.OPEN) {
-            this.#ws!.send(frame.data);
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(frame.data);
           }
 
           if (hasEnded) {
@@ -373,19 +381,17 @@ class SpeechStreamv2 extends stt.SpeechStream {
     }
 
     // Only send CloseStream if we are exiting normally (not reconnecting)
-    if (!this.#reconnectEvent.isSet && this.#ws!.readyState === WebSocket.OPEN) {
+    if (!this.#reconnectEvent.isSet && !wsClosedEvent.isSet && ws.readyState === WebSocket.OPEN) {
       this.#logger.debug('Sending CloseStream message to Deepgram');
-      this.#ws!.send(_CLOSE_MSG);
+      ws.send(_CLOSE_MSG);
     }
   }
 
-  async #recvTask() {
-    if (!this.#ws) return;
+  async #recvTask(ws: WebSocket, wsClosedEvent: Event) {
+    return new Promise<void>((resolve, reject) => {
+      let wsError: Error | undefined;
 
-    return new Promise<void>((resolve) => {
-      if (!this.#ws) return resolve();
-
-      this.#ws.on('message', (data: Buffer, isBinary: boolean) => {
+      ws.on('message', (data: Buffer, isBinary: boolean) => {
         if (isBinary) {
           this.#logger.warn('Received unexpected binary message from Deepgram');
           return;
@@ -398,13 +404,29 @@ class SpeechStreamv2 extends stt.SpeechStream {
         }
       });
 
-      this.#ws.on('close', (code, reason) => {
+      ws.on('close', (code, reason) => {
+        wsClosedEvent.set();
         this.#logger.debug(`Deepgram WebSocket closed: ${code} ${reason}`);
-        resolve();
+
+        if (this.#closingWs.has(ws) || this.closed || this.input.closed) {
+          resolve();
+          return;
+        }
+
+        const reasonText = reason.toString();
+        const message = reasonText
+          ? `Deepgram WebSocket closed unexpectedly: ${code} ${reasonText}`
+          : `Deepgram WebSocket closed unexpectedly: ${code}`;
+        reject(
+          new APIConnectionError({
+            message: wsError ? `${message}: ${wsError.message}` : message,
+          }),
+        );
       });
 
-      // Errors are caught by run() listener, resolve here to clean up task
-      this.#ws.on('error', () => resolve());
+      ws.on('error', (error) => {
+        wsError = error;
+      });
     });
   }
 
@@ -502,7 +524,14 @@ class SpeechStreamv2 extends stt.SpeechStream {
     return `${baseUrl}?${qs}`;
   }
 
+  #expectWsClose(ws: WebSocket | null) {
+    if (ws) {
+      this.#closingWs.add(ws);
+    }
+  }
+
   override close() {
+    this.#expectWsClose(this.#ws);
     super.close();
     this.#ws?.close();
   }

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -297,6 +297,9 @@ class SpeechStreamv2 extends stt.SpeechStream {
         // Snapshot the timeline base for this connection: the fresh socket's
         // audio_window starts at 0, so offset it by the audio already streamed.
         this.#connectionTimeBaseSec = this.#sentAudioSec;
+        // Provider turn state is scoped to one WebSocket. A reconnect during an
+        // active turn must not make the next connection suppress StartOfTurn.
+        this.#speaking = false;
 
         // 2. Run Concurrent Tasks (Send & Receive)
         const ws = this.#ws;
@@ -442,23 +445,20 @@ class SpeechStreamv2 extends stt.SpeechStream {
       if (eventType === 'StartOfTurn') {
         if (this.#speaking) return;
 
-        this.#speaking = true;
-        this.queue.put({
-          type: stt.SpeechEventType.START_OF_SPEECH,
-          requestId: this.#requestId,
-        });
+        this.#startSpeech();
 
         this.#sendTranscriptEvent(stt.SpeechEventType.INTERIM_TRANSCRIPT, data);
       } else if (eventType === 'Update') {
-        if (!this.#speaking) return;
+        if (!this.#speaking && !this.#startSpeechFromTranscript(data)) return;
         this.#sendTranscriptEvent(stt.SpeechEventType.INTERIM_TRANSCRIPT, data);
       } else if (eventType === 'EagerEndOfTurn') {
-        if (!this.#speaking) return;
+        if (!this.#speaking && !this.#startSpeechFromTranscript(data)) return;
         this.#sendTranscriptEvent(stt.SpeechEventType.PREFLIGHT_TRANSCRIPT, data);
       } else if (eventType === 'TurnResumed') {
+        if (!this.#speaking) this.#startSpeechFromTranscript(data);
         this.#sendTranscriptEvent(stt.SpeechEventType.INTERIM_TRANSCRIPT, data);
       } else if (eventType === 'EndOfTurn') {
-        if (!this.#speaking) return;
+        if (!this.#speaking && !this.#startSpeechFromTranscript(data)) return;
 
         this.#speaking = false;
         this.#sendTranscriptEvent(stt.SpeechEventType.FINAL_TRANSCRIPT, data);
@@ -473,6 +473,24 @@ class SpeechStreamv2 extends stt.SpeechStream {
       const desc = (data.description as string) || 'unknown error from deepgram';
       throw new Error(`Deepgram API Error: ${desc}`);
     }
+  }
+
+  #startSpeech() {
+    this.#speaking = true;
+    this.queue.put({
+      type: stt.SpeechEventType.START_OF_SPEECH,
+      requestId: this.#requestId,
+    });
+  }
+
+  #startSpeechFromTranscript(data: Record<string, unknown>) {
+    const transcript = data.transcript;
+    if (typeof transcript !== 'string' || transcript.trim().length === 0) {
+      return false;
+    }
+
+    this.#startSpeech();
+    return true;
   }
 
   #sendTranscriptEvent(eventType: stt.SpeechEventType, data: Record<string, unknown>) {


### PR DESCRIPTION
## Summary

Deepgram Flux streaming STT now recovers from unexpected WebSocket closes instead of permanently ending the speech stream. Previously `SpeechStreamv2.#recvTask()` resolved every WebSocket `close` event, so a provider-side close such as code `1005` looked like normal stream completion: `run()` broke out, no retryable error escaped, and the base `SpeechStream.mainTask` never reconnected.

This matches the Python Flux implementation in `livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py`, which treats local/session shutdown as expected and raises on unexpected Deepgram closes so the base retry path reconnects.

## What Changed

- Track intentional WebSocket closes per socket for stream shutdown, input end, cleanup, and option-update reconnects.
- Reject unexpected Flux WebSocket closes with a retryable `APIConnectionError`, letting `SpeechStream.mainTask` reconnect according to existing `connOptions`.
- Bind send/recv tasks to their current WebSocket and wake the send loop when that socket closes, so a retried connection does not inherit stale send work from the previous connection.
- Added local WebSocket tests for unexpected close retry, normal input-end close, and option-update reconnect with `maxRetry: 0`.
- Kept Flux keepalive behavior unchanged. The Python Flux implementation intentionally leaves keepalive disabled; JS V1 STT has its own keepalive/reconnect loop, but that is the non-Flux path.

## Retry Semantics Caveat

This uses the existing base stream retry policy. `maxRetry` defaults to 3 and the counter is lifetime-scoped for a stream, not reset after a healthy connection. For very long sessions with multiple provider-side closes, maintainers may want to decide whether to keep the Python-like base retry behavior, reset retry count after a healthy interval, or expose a dedicated configuration.

## Testing

- `pnpm test plugins/deepgram/src/stt_v2.test.ts` passed (3 local tests, 1 live Deepgram test skipped without `DEEPGRAM_API_KEY`).
- `pnpm --filter @livekit/agents-plugin-deepgram lint` passed with existing warnings.
- `pnpm --filter @livekit/agents-plugin-deepgram... build` passed.
- `pnpm lint` passed with existing warnings.
- `pnpm build` passed.
- `pnpm test agents/src/utils.test.ts` passed.
- `pnpm test` currently fails outside this change due provider/API-key-dependent tests (`CEREBRAS_API_KEY`, Google API key, OpenAI drive-thru examples), a HuggingFace download timeout in `plugins/livekit/src/hf_utils.test.ts`, and existing FakeLLM unhandled errors in `examples/src/testing/survey_agent.test.ts`.

## Post-Deploy Monitoring & Validation

- Search logs for `Deepgram WebSocket closed unexpectedly`, `failed to recognize speech, retrying`, `deepgram.SpeechStreamv2`, `stt_error`, and `agent response timed out`.
- Healthy signal: an unexpected Deepgram close is followed by a retry warning and subsequent STT/turn events from the same session.
- Failure signal: retry exhaustion such as `failed to recognize speech after 4 attempts`, recurring unrecoverable `stt_error`, or continued turn-detection stalls after a Deepgram close.
- Suggested validation window: first release day for sessions using `STTv2` with `turnDetection: 'stt'`.
