### PR TITLE
Add scoped filler support to RunContext

### DIFF
--- a/.changeset/funky-mugs-stare.md
+++ b/.changeset/funky-mugs-stare.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Add scoped filler support to RunContext

--- a/.changeset/scoped-filler-run-context.md
+++ b/.changeset/scoped-filler-run-context.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Add scoped filler speech support to RunContext for long-running tools.

--- a/.changeset/scoped-filler-run-context.md
+++ b/.changeset/scoped-filler-run-context.md
@@ -1,5 +1,0 @@
----
-'@livekit/agents': patch
----
-
-Add scoped filler speech support to RunContext for long-running tools.

--- a/agents/src/voice/run_context.test.ts
+++ b/agents/src/voice/run_context.test.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { EventEmitter } from 'node:events';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { FunctionCall, type FunctionCallOutput } from '../llm/chat_context.js';
 import { Future } from '../utils.js';
 import type { AgentSession } from './agent_session.js';
@@ -142,6 +142,58 @@ describe('RunContext filler', () => {
     await expect(ctx.filler('Still searching.', async () => 'lookup result')).resolves.toBe(
       'lookup result',
     );
+  });
+
+  it('removes the abort listener when waitForIdle wins the race', async () => {
+    const { ctx, session } = buildContext();
+    const activeAbortListeners = new Map<AbortSignal, Set<EventListenerOrEventListenerObject>>();
+    const originalAddEventListener = AbortSignal.prototype.addEventListener;
+    const originalRemoveEventListener = AbortSignal.prototype.removeEventListener;
+    const addSpy = vi.spyOn(AbortSignal.prototype, 'addEventListener').mockImplementation(function (
+      this: AbortSignal,
+      type: string,
+      callback: EventListenerOrEventListenerObject | null,
+      options?: AddEventListenerOptions | boolean,
+    ) {
+      if (type === 'abort' && callback) {
+        const listeners = activeAbortListeners.get(this) ?? new Set();
+        listeners.add(callback);
+        activeAbortListeners.set(this, listeners);
+      }
+      return originalAddEventListener.call(this, type, callback, options);
+    });
+    const removeSpy = vi
+      .spyOn(AbortSignal.prototype, 'removeEventListener')
+      .mockImplementation(function (
+        this: AbortSignal,
+        type: string,
+        callback: EventListenerOrEventListenerObject | null,
+        options?: EventListenerOptions | boolean,
+      ) {
+        if (type === 'abort' && callback) {
+          const listeners = activeAbortListeners.get(this);
+          listeners?.delete(callback);
+          if (listeners?.size === 0) {
+            activeAbortListeners.delete(this);
+          }
+        }
+        return originalRemoveEventListener.call(this, type, callback, options);
+      });
+
+    try {
+      await ctx.filler('Listener cleanup.', { delay: 30 }, async () => {
+        await sleep(5);
+        expect([...activeAbortListeners.values()].every((listeners) => listeners.size <= 1)).toBe(
+          true,
+        );
+      });
+
+      expect(session.listenerCount(AgentSessionEventTypes.AgentStateChanged)).toBe(0);
+      expect(session.listenerCount(AgentSessionEventTypes.UserStateChanged)).toBe(0);
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
   });
 
   it('does not create filler when maxSteps is zero', async () => {

--- a/agents/src/voice/run_context.test.ts
+++ b/agents/src/voice/run_context.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { FunctionCall, type FunctionCallOutput } from '../llm/chat_context.js';
 import { Future } from '../utils.js';
 import type { AgentSession } from './agent_session.js';
+import { AgentSessionEventTypes } from './events.js';
 import { RunContext } from './run_context.js';
 import { SpeechHandle } from './speech_handle.js';
 
@@ -121,20 +122,285 @@ describe('RunContext filler', () => {
 
     expect(session.sayTexts).toEqual(['Still working.']);
   });
+
+  it('does not let scheduler shutdown errors replace the callback result', async () => {
+    const functionCall = FunctionCall.create({
+      callId: 'call_123',
+      name: 'slow_lookup',
+      args: '{"query":"flights"}',
+    });
+    const speechHandle = SpeechHandle.create();
+    const session = new FakeFillerSession({
+      waitForIdleError: new Error('AgentSession is closing'),
+    });
+    const ctx = new RunContext(
+      session as unknown as AgentSession<unknown>,
+      speechHandle,
+      functionCall,
+    );
+
+    await expect(ctx.filler('Still searching.', async () => 'lookup result')).resolves.toBe(
+      'lookup result',
+    );
+  });
+
+  it('does not create filler when maxSteps is zero', async () => {
+    const { ctx, session } = buildContext();
+
+    await ctx.filler('Disabled.', { delay: 0, interval: 1, maxSteps: 0 }, async () => {
+      await sleep(20);
+    });
+
+    expect(session.sayTexts).toEqual([]);
+  });
+
+  it('repeats filler on an interval until maxSteps is reached', async () => {
+    const { ctx, session } = buildContext();
+
+    await ctx.filler('Still working.', { delay: 0, interval: 5, maxSteps: 3 }, async () => {
+      await sleep(40);
+    });
+
+    expect(session.sayTexts).toEqual(['Still working.', 'Still working.', 'Still working.']);
+  });
+
+  it('invokes callable sources lazily and only advances step for created speeches', async () => {
+    const { ctx, session } = buildContext();
+    const steps: number[] = [];
+
+    await ctx.filler(
+      (step) => {
+        steps.push(step);
+        return steps.length === 1 ? null : `step ${step}`;
+      },
+      { delay: 0, interval: 5, maxSteps: 1 },
+      async () => {
+        expect(steps).toEqual([]);
+        await sleep(25);
+      },
+    );
+
+    expect(steps).toEqual([0, 0]);
+    expect(session.sayTexts).toEqual(['step 0']);
+  });
+
+  it('accepts SpeechHandle sources without calling session.say', async () => {
+    const { ctx, session } = buildContext();
+    const fillerHandle = SpeechHandle.create();
+    fillerHandle._markDone();
+
+    await ctx.filler(
+      () => fillerHandle,
+      { delay: 0 },
+      async () => {
+        await sleep(10);
+      },
+    );
+
+    expect(session.sayTexts).toEqual([]);
+  });
+
+  it('honors an external abort signal before the dwell completes', async () => {
+    const { ctx, session } = buildContext();
+    const abortController = new AbortController();
+
+    await ctx.filler('Cancelled.', { delay: 30, signal: abortController.signal }, async () => {
+      await sleep(10);
+      abortController.abort();
+      await sleep(30);
+    });
+
+    expect(session.sayTexts).toEqual([]);
+  });
+
+  it('honors an already-aborted external signal', async () => {
+    const { ctx, session } = buildContext();
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await ctx.filler(
+      'Already cancelled.',
+      { delay: 0, signal: abortController.signal },
+      async () => {
+        await sleep(10);
+      },
+    );
+
+    expect(session.sayTexts).toEqual([]);
+  });
+
+  it('exits promptly while still waiting for the session to become idle', async () => {
+    const functionCall = FunctionCall.create({
+      callId: 'call_123',
+      name: 'slow_lookup',
+      args: '{"query":"flights"}',
+    });
+    const speechHandle = SpeechHandle.create();
+    const session = new FakeFillerSession({ waitForIdleNeverResolves: true });
+    const ctx = new RunContext(
+      session as unknown as AgentSession<unknown>,
+      speechHandle,
+      functionCall,
+    );
+
+    await expect(
+      ctx.filler('Still waiting.', { delay: 0 }, async () => {
+        await sleep(5);
+        return 'done';
+      }),
+    ).resolves.toBe('done');
+    expect(session.sayTexts).toEqual([]);
+  });
+
+  it('does not let session.say shutdown errors replace the callback result', async () => {
+    const functionCall = FunctionCall.create({
+      callId: 'call_123',
+      name: 'slow_lookup',
+      args: '{"query":"flights"}',
+    });
+    const speechHandle = SpeechHandle.create();
+    const session = new FakeFillerSession({
+      sayError: new Error('AgentSession is closing, cannot use say()'),
+    });
+    const ctx = new RunContext(
+      session as unknown as AgentSession<unknown>,
+      speechHandle,
+      functionCall,
+    );
+
+    await expect(
+      ctx.filler('Still searching.', { delay: 0 }, async () => {
+        await sleep(10);
+        return 'lookup result';
+      }),
+    ).resolves.toBe('lookup result');
+  });
+
+  it('requires a callback scope', async () => {
+    const { ctx } = buildContext();
+    const filler = ctx.filler as unknown as (source: string) => Promise<unknown>;
+
+    await expect(filler('x')).rejects.toThrow('RunContext.filler requires a callback scope');
+  });
+
+  it('restarts the idle dwell when agent speech or thinking starts', async () => {
+    const { ctx, session } = buildContext();
+
+    await ctx.filler('After agent state.', { delay: 30 }, async () => {
+      await sleep(20);
+      session.emitAgentState('speaking');
+      await sleep(20);
+      expect(session.sayTexts).toEqual([]);
+      session.emitAgentState('thinking');
+      await sleep(20);
+      expect(session.sayTexts).toEqual([]);
+      await sleep(20);
+    });
+
+    expect(session.sayTexts).toEqual(['After agent state.']);
+  });
+
+  it('restarts the idle dwell when the user starts speaking', async () => {
+    const { ctx, session } = buildContext();
+
+    await ctx.filler('After user state.', { delay: 30 }, async () => {
+      await sleep(20);
+      session.emitUserState('speaking');
+      await sleep(20);
+      expect(session.sayTexts).toEqual([]);
+      await sleep(20);
+    });
+
+    expect(session.sayTexts).toEqual(['After user state.']);
+  });
+
+  it('stops repeating filler after the owning speech handle is interrupted', async () => {
+    const functionCall = FunctionCall.create({
+      callId: 'call_123',
+      name: 'slow_lookup',
+      args: '{"query":"flights"}',
+    });
+    const speechHandle = SpeechHandle.create();
+    const session = new FakeFillerSession();
+    const ctx = new RunContext(
+      session as unknown as AgentSession<unknown>,
+      speechHandle,
+      functionCall,
+    );
+
+    await ctx.filler('Repeat.', { delay: 0, interval: 5 }, async () => {
+      await sleep(15);
+      speechHandle.interrupt();
+      const countAtInterrupt = session.sayTexts.length;
+      await sleep(30);
+      expect(session.sayTexts).toHaveLength(countAtInterrupt);
+    });
+  });
+
+  it('validates filler timing options', async () => {
+    const { ctx } = buildContext();
+
+    await expect(ctx.filler('x', { delay: -1 }, async () => undefined)).rejects.toThrow(
+      'delay must be non-negative',
+    );
+    await expect(ctx.filler('x', { interval: -1 }, async () => undefined)).rejects.toThrow(
+      'interval must be non-negative when set',
+    );
+    await expect(ctx.filler('x', { maxSteps: -1 }, async () => undefined)).rejects.toThrow(
+      'maxSteps must be non-negative when set',
+    );
+  });
 });
 
 class FakeFillerSession extends EventEmitter {
   userData = {};
   sayTexts: string[] = [];
 
+  constructor(
+    private readonly options: {
+      waitForIdleError?: Error;
+      waitForIdleNeverResolves?: boolean;
+      sayError?: Error;
+    } = {},
+  ) {
+    super();
+  }
+
   async waitForIdle(): Promise<void> {
+    if (this.options.waitForIdleError) {
+      throw this.options.waitForIdleError;
+    }
+    if (this.options.waitForIdleNeverResolves) {
+      await new Promise(() => undefined);
+    }
     return;
   }
 
   say(text: string): SpeechHandle {
+    if (this.options.sayError) {
+      throw this.options.sayError;
+    }
     this.sayTexts.push(text);
     const handle = SpeechHandle.create();
     handle._markDone();
     return handle;
+  }
+
+  emitAgentState(newState: 'speaking' | 'thinking'): void {
+    this.emit(AgentSessionEventTypes.AgentStateChanged, {
+      type: 'agent_state_changed',
+      oldState: 'idle',
+      newState,
+      createdAt: Date.now(),
+    });
+  }
+
+  emitUserState(newState: 'speaking'): void {
+    this.emit(AgentSessionEventTypes.UserStateChanged, {
+      type: 'user_state_changed',
+      oldState: 'listening',
+      newState,
+      createdAt: Date.now(),
+    });
   }
 }

--- a/agents/src/voice/run_context.test.ts
+++ b/agents/src/voice/run_context.test.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { EventEmitter } from 'node:events';
 import { describe, expect, it } from 'vitest';
-import { FunctionCall, FunctionCallOutput } from '../llm/chat_context.js';
+import { FunctionCall, type FunctionCallOutput } from '../llm/chat_context.js';
 import { Future } from '../utils.js';
 import type { AgentSession } from './agent_session.js';
 import { RunContext } from './run_context.js';
@@ -65,3 +66,75 @@ describe('RunContext async updates', () => {
     expect(ctx.updates[0]![1].output).toContain('standalone');
   });
 });
+
+describe('RunContext filler', () => {
+  function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function buildContext() {
+    const functionCall = FunctionCall.create({
+      callId: 'call_123',
+      name: 'slow_lookup',
+      args: '{"query":"flights"}',
+    });
+    const speechHandle = SpeechHandle.create();
+    const session = new FakeFillerSession();
+    const ctx = new RunContext(
+      session as unknown as AgentSession<unknown>,
+      speechHandle,
+      functionCall,
+    );
+    return { ctx, session };
+  }
+
+  it('speaks filler after the session stays idle for the delay', async () => {
+    const { ctx, session } = buildContext();
+
+    await ctx.filler('Still searching.', { delay: 10 }, async () => {
+      await sleep(30);
+    });
+
+    expect(session.sayTexts).toEqual(['Still searching.']);
+  });
+
+  it('cancels pending filler when the scope exits before the delay', async () => {
+    const { ctx, session } = buildContext();
+
+    await ctx.filler('Too late.', { delay: 50 }, async () => {
+      await sleep(5);
+    });
+
+    expect(session.sayTexts).toEqual([]);
+  });
+
+  it('restarts the idle dwell when update takes the floor', async () => {
+    const { ctx, session } = buildContext();
+
+    await ctx.filler('Still working.', { delay: 30 }, async () => {
+      await sleep(20);
+      await ctx.update('halfway');
+      await sleep(20);
+      expect(session.sayTexts).toEqual([]);
+      await sleep(20);
+    });
+
+    expect(session.sayTexts).toEqual(['Still working.']);
+  });
+});
+
+class FakeFillerSession extends EventEmitter {
+  userData = {};
+  sayTexts: string[] = [];
+
+  async waitForIdle(): Promise<void> {
+    return;
+  }
+
+  say(text: string): SpeechHandle {
+    this.sayTexts.push(text);
+    const handle = SpeechHandle.create();
+    handle._markDone();
+    return handle;
+  }
+}

--- a/agents/src/voice/run_context.ts
+++ b/agents/src/voice/run_context.ts
@@ -5,7 +5,12 @@ import { FunctionCall, FunctionCallOutput } from '../llm/chat_context.js';
 import type { Future } from '../utils.js';
 import type { AgentActivity } from './agent_activity.js';
 import type { AgentSession } from './agent_session.js';
-import type { SpeechHandle } from './speech_handle.js';
+import {
+  AgentSessionEventTypes,
+  type AgentStateChangedEvent,
+  type UserStateChangedEvent,
+} from './events.js';
+import { type SpeechHandle, isSpeechHandle } from './speech_handle.js';
 
 export type UnknownUserData = unknown;
 
@@ -21,6 +26,25 @@ export interface RunContextUpdateOptions {
   template?: PromptTemplate<UpdatePromptArgs>;
 }
 
+export type FillerSource = string | ((step: number) => SpeechHandle | string | null | undefined);
+
+export interface RunContextFillerOptions {
+  /**
+   * Continuous-idle dwell, in milliseconds, before filler speech fires.
+   * Defaults to 0, which fires as soon as the session is next idle.
+   */
+  delay?: number;
+  /**
+   * Cooldown, in milliseconds, before waiting for another idle dwell.
+   * When omitted, filler speech fires at most once.
+   */
+  interval?: number;
+  /** Maximum number of filler speeches to create. */
+  maxSteps?: number;
+  /** Optional external cancellation signal for the filler scheduler. */
+  signal?: AbortSignal;
+}
+
 export interface AttachedToolExecutor {
   toolOptions: {
     updateTemplate: PromptTemplate<UpdatePromptArgs>;
@@ -34,6 +58,7 @@ export class RunContext<UserData = UnknownUserData> {
   private _executor?: AttachedToolExecutor;
   private _firstUpdateFuture?: Future<unknown>;
   private _updates: Array<[FunctionCall, FunctionCallOutput]> = [];
+  private _fillerSchedulers: FillerScheduler[] = [];
   constructor(
     public readonly session: AgentSession<UserData>,
     public readonly speechHandle: SpeechHandle,
@@ -97,6 +122,10 @@ export class RunContext<UserData = UnknownUserData> {
    * @param options - Per-call overrides; see {@link RunContextUpdateOptions}.
    */
   async update(message: unknown, options: RunContextUpdateOptions = {}): Promise<void> {
+    for (const scheduler of this._fillerSchedulers) {
+      scheduler.resetDwell();
+    }
+
     const updateStep = this._updates.length;
     const renderedMessage =
       typeof message === 'string'
@@ -128,6 +157,50 @@ export class RunContext<UserData = UnknownUserData> {
   async foreground<T>(fn: (activity: AgentActivity) => Promise<T> | T): Promise<T> {
     await this._drainPendingReply();
     return this.session.waitForIdleAndHold(fn);
+  }
+
+  /**
+   * Speak filler audio while a long-running tool step is in progress.
+   *
+   * The scheduler waits until the session is continuously idle for
+   * {@link RunContextFillerOptions.delay} milliseconds, then speaks `source`
+   * through {@link AgentSession.say}. When `interval` is set, it waits that
+   * many milliseconds before starting another idle dwell; otherwise it fires at
+   * most once. Agent speech, user speech, and {@link RunContext.update} reset
+   * any pending dwell so filler does not race real conversation turns.
+   *
+   * @example
+   * ```ts
+   * await ctx.filler('Still searching, hang on.', { delay: 5000 }, async () => {
+   *   return await slowLookup();
+   * });
+   * ```
+   */
+  async filler<T>(source: FillerSource, fn: () => Promise<T> | T): Promise<T>;
+  async filler<T>(
+    source: FillerSource,
+    options: RunContextFillerOptions,
+    fn: () => Promise<T> | T,
+  ): Promise<T>;
+  async filler<T>(
+    source: FillerSource,
+    optionsOrFn: RunContextFillerOptions | (() => Promise<T> | T),
+    maybeFn?: () => Promise<T> | T,
+  ): Promise<T> {
+    const options = typeof optionsOrFn === 'function' ? {} : optionsOrFn;
+    const fn = typeof optionsOrFn === 'function' ? optionsOrFn : maybeFn;
+    if (!fn) {
+      throw new Error('RunContext.filler requires a callback scope');
+    }
+
+    const scheduler = new FillerScheduler(this.session, this.speechHandle, source, options);
+    this._fillerSchedulers.push(scheduler);
+    try {
+      return await fn();
+    } finally {
+      await scheduler.close();
+      this._fillerSchedulers = this._fillerSchedulers.filter((s) => s !== scheduler);
+    }
   }
 
   _attachExecutor(executor: AttachedToolExecutor, firstUpdateFuture: Future<unknown>): void {
@@ -196,4 +269,160 @@ function stringifyToolOutput(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+class FillerScheduler {
+  private readonly abortController = new AbortController();
+  private readonly delay: number;
+  private readonly interval?: number;
+  private readonly maxSteps?: number;
+  private readonly task: Promise<void>;
+  private dwellAbortController?: AbortController;
+  private createdSpeeches: SpeechHandle[] = [];
+
+  constructor(
+    private readonly session: AgentSession,
+    private readonly speechHandle: SpeechHandle,
+    private readonly source: FillerSource,
+    options: RunContextFillerOptions,
+  ) {
+    const { delay = 0, interval, maxSteps, signal } = options;
+    if (delay < 0) {
+      throw new Error('delay must be non-negative');
+    }
+    if (interval !== undefined && interval < 0) {
+      throw new Error('interval must be non-negative when set');
+    }
+    if (maxSteps !== undefined && maxSteps < 0) {
+      throw new Error('maxSteps must be non-negative when set');
+    }
+
+    this.delay = delay;
+    this.interval = interval;
+    this.maxSteps = maxSteps;
+
+    if (signal?.aborted) {
+      this.abortController.abort();
+    } else {
+      signal?.addEventListener('abort', () => this.abortController.abort(), { once: true });
+    }
+
+    this.task = this.run();
+  }
+
+  resetDwell(): void {
+    this.dwellAbortController?.abort();
+  }
+
+  async close(): Promise<void> {
+    this.abortController.abort();
+    await this.task;
+  }
+
+  private async run(): Promise<void> {
+    const onAgentStateChanged = (event: AgentStateChangedEvent): void => {
+      if (event.newState === 'speaking' || event.newState === 'thinking') {
+        this.resetDwell();
+      }
+    };
+    const onUserStateChanged = (event: UserStateChangedEvent): void => {
+      if (event.newState === 'speaking') {
+        this.resetDwell();
+      }
+    };
+
+    this.session.on(AgentSessionEventTypes.AgentStateChanged, onAgentStateChanged);
+    this.session.on(AgentSessionEventTypes.UserStateChanged, onUserStateChanged);
+
+    const loop = this.loop();
+    try {
+      await this.speechHandle.waitIfNotInterrupted([loop]);
+    } finally {
+      this.abortController.abort();
+      this.session.off(AgentSessionEventTypes.AgentStateChanged, onAgentStateChanged);
+      this.session.off(AgentSessionEventTypes.UserStateChanged, onUserStateChanged);
+      await loop.catch(() => undefined);
+    }
+  }
+
+  private async loop(): Promise<void> {
+    while (!this.abortController.signal.aborted) {
+      const idleReached = await waitUnlessAborted(
+        this.session.waitForIdle(),
+        this.abortController.signal,
+      );
+      if (!idleReached) return;
+
+      this.dwellAbortController = new AbortController();
+      const dwellCompleted = await sleepUnlessAborted(this.delay, [
+        this.abortController.signal,
+        this.dwellAbortController.signal,
+      ]);
+      this.dwellAbortController = undefined;
+      if (!dwellCompleted) {
+        continue;
+      }
+
+      const handle = this.createSpeech();
+      if (handle) {
+        this.createdSpeeches.push(handle);
+      }
+
+      if (
+        this.interval === undefined ||
+        (this.maxSteps !== undefined && this.createdSpeeches.length >= this.maxSteps)
+      ) {
+        return;
+      }
+
+      const intervalCompleted = await sleepUnlessAborted(this.interval, [
+        this.abortController.signal,
+      ]);
+      if (!intervalCompleted) return;
+    }
+  }
+
+  private createSpeech(): SpeechHandle | undefined {
+    const value =
+      typeof this.source === 'function' ? this.source(this.createdSpeeches.length) : this.source;
+    if (typeof value === 'string') {
+      return this.session.say(value);
+    }
+    if (isSpeechHandle(value)) {
+      return value;
+    }
+    return undefined;
+  }
+}
+
+async function waitUnlessAborted<T>(promise: Promise<T>, signal: AbortSignal): Promise<boolean> {
+  if (signal.aborted) return false;
+  const abortPromise = new Promise<false>((resolve) => {
+    signal.addEventListener('abort', () => resolve(false), { once: true });
+  });
+  const result = await Promise.race([promise.then(() => true), abortPromise]);
+  return result;
+}
+
+async function sleepUnlessAborted(ms: number, signals: AbortSignal[]): Promise<boolean> {
+  if (signals.some((signal) => signal.aborted)) return false;
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve(true);
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      cleanup();
+      resolve(false);
+    };
+    const cleanup = () => {
+      for (const signal of signals) {
+        signal.removeEventListener('abort', onAbort);
+      }
+    };
+    for (const signal of signals) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
 }

--- a/agents/src/voice/run_context.ts
+++ b/agents/src/voice/run_context.ts
@@ -45,20 +45,20 @@ export interface RunContextFillerOptions {
   signal?: AbortSignal;
 }
 
-export interface AttachedToolExecutor {
+export interface AttachedToolExecutor<UserData = UnknownUserData> {
   toolOptions: {
     updateTemplate: PromptTemplate<UpdatePromptArgs>;
   };
-  enqueueReply(ctx: RunContext, items: [FunctionCall, FunctionCallOutput]): Promise<void>;
+  enqueueReply(ctx: RunContext<UserData>, items: [FunctionCall, FunctionCallOutput]): Promise<void>;
   replyTask?: Promise<void>;
 }
 
 export class RunContext<UserData = UnknownUserData> {
   private readonly initialStepIdx: number;
-  private _executor?: AttachedToolExecutor;
+  private _executor?: AttachedToolExecutor<UserData>;
   private _firstUpdateFuture?: Future<unknown>;
   private _updates: Array<[FunctionCall, FunctionCallOutput]> = [];
-  private _fillerSchedulers: FillerScheduler[] = [];
+  private _fillerSchedulers: FillerScheduler<UserData>[] = [];
   constructor(
     public readonly session: AgentSession<UserData>,
     public readonly speechHandle: SpeechHandle,
@@ -203,7 +203,10 @@ export class RunContext<UserData = UnknownUserData> {
     }
   }
 
-  _attachExecutor(executor: AttachedToolExecutor, firstUpdateFuture: Future<unknown>): void {
+  _attachExecutor(
+    executor: AttachedToolExecutor<UserData>,
+    firstUpdateFuture: Future<unknown>,
+  ): void {
     if (this._firstUpdateFuture !== undefined) {
       throw new Error('Executor already attached');
     }
@@ -271,7 +274,7 @@ function stringifyToolOutput(value: unknown): string {
   }
 }
 
-class FillerScheduler {
+class FillerScheduler<UserData = UnknownUserData> {
   private readonly abortController = new AbortController();
   private readonly delay: number;
   private readonly interval?: number;
@@ -281,7 +284,7 @@ class FillerScheduler {
   private createdSpeeches: SpeechHandle[] = [];
 
   constructor(
-    private readonly session: AgentSession,
+    private readonly session: AgentSession<UserData>,
     private readonly speechHandle: SpeechHandle,
     private readonly source: FillerSource,
     options: RunContextFillerOptions,
@@ -308,6 +311,7 @@ class FillerScheduler {
     }
 
     this.task = this.run();
+    void this.task.catch(() => undefined);
   }
 
   resetDwell(): void {
@@ -316,7 +320,7 @@ class FillerScheduler {
 
   async close(): Promise<void> {
     this.abortController.abort();
-    await this.task;
+    await this.task.catch(() => undefined);
   }
 
   private async run(): Promise<void> {
@@ -361,6 +365,10 @@ class FillerScheduler {
       this.dwellAbortController = undefined;
       if (!dwellCompleted) {
         continue;
+      }
+
+      if (this.maxSteps !== undefined && this.createdSpeeches.length >= this.maxSteps) {
+        return;
       }
 
       const handle = this.createSpeech();

--- a/agents/src/voice/run_context.ts
+++ b/agents/src/voice/run_context.ts
@@ -405,11 +405,19 @@ class FillerScheduler<UserData = UnknownUserData> {
 
 async function waitUnlessAborted<T>(promise: Promise<T>, signal: AbortSignal): Promise<boolean> {
   if (signal.aborted) return false;
+  let onAbort: (() => void) | undefined;
   const abortPromise = new Promise<false>((resolve) => {
-    signal.addEventListener('abort', () => resolve(false), { once: true });
+    onAbort = () => resolve(false);
+    signal.addEventListener('abort', onAbort, { once: true });
   });
-  const result = await Promise.race([promise.then(() => true), abortPromise]);
-  return result;
+
+  try {
+    return await Promise.race([promise.then(() => true), abortPromise]);
+  } finally {
+    if (onAbort) {
+      signal.removeEventListener('abort', onAbort);
+    }
+  }
 }
 
 async function sleepUnlessAborted(ms: number, signals: AbortSignal[]): Promise<boolean> {

--- a/examples/src/async_tool_agent.ts
+++ b/examples/src/async_tool_agent.ts
@@ -7,7 +7,7 @@ import {
   AgentTask,
   type ChatContext,
   type JobContext,
-  LLMStream,
+  type LLMStream,
   type RunContext,
   ServerOptions,
   ToolFlag,
@@ -134,7 +134,11 @@ function createTravelAgent() {
         'This will take a couple of minutes.',
     );
 
-    await delay(30_000, { signal });
+    await ctx.filler(
+      'Still searching flight inventory, hang tight.',
+      { delay: 5_000, signal },
+      () => delay(30_000, { signal }),
+    );
 
     const airlines = sample(['United', 'Delta', 'American', 'JetBlue', 'Southwest', 'Alaska'], 3);
     const prices = Object.fromEntries(airlines.map((airline) => [airline, randomInt(180, 650)]));
@@ -164,7 +168,15 @@ function createTravelAgent() {
       logger.info({ email: userEmail }, 'Captured user email address');
     }
 
-    await delay(40_000, { signal });
+    const confirmationFillers = [
+      'Still confirming the booking.',
+      "Almost there, I'm finalizing the reservation.",
+    ];
+    await ctx.filler(
+      (step) => confirmationFillers[step],
+      { delay: 5_000, interval: 10_000, maxSteps: confirmationFillers.length, signal },
+      () => delay(40_000, { signal }),
+    );
 
     const confirmation = `FL-${randomInt(100000, 999999)}`;
     return (


### PR DESCRIPTION
## Summary
- Adds scoped `ctx.filler(...)` support for long-running tools using the Python filler behavior as reference.
- Waits for session idle before playing filler speech and resets the dwell timer on updates or speech activity.
- Adds focused RunContext tests covering scope lifecycle, idle gating, cancellation, and interruption behavior.

## Test plan
- `pnpm test agents/src/voice/run_context.test.ts`
- Pinned ESLint check on edited files
- `pnpm build:agents`

## Notes
- Full package lint is blocked in the nested worktree by ESLint plugin ambiguity.
- `api:check` is blocked by the existing API Extractor `export * as` limitation.
- `agents-cli` smoke was not run because there is no deterministic dispatchable filler probe in the repo yet.