### PR TITLE
refactor(testing): use `using` for withMockTools

### DIFF
--- a/agents/src/voice/testing/run_result.test.ts
+++ b/agents/src/voice/testing/run_result.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { ReadableStream } from 'node:stream/web';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { FunctionCall } from '../../llm/chat_context.js';

--- a/agents/src/voice/testing/run_result.test.ts
+++ b/agents/src/voice/testing/run_result.test.ts
@@ -8,7 +8,7 @@ import { ToolContext, tool } from '../../llm/tool_context.js';
 import { Agent } from '../agent.js';
 import { performToolExecutions } from '../generation.js';
 import { SpeechHandle } from '../speech_handle.js';
-import { mockToolsStorage, withMockTools } from './run_result.js';
+import { activeMockTools, withMockTools } from './run_result.js';
 
 class AgentA extends Agent {
   constructor() {
@@ -23,53 +23,53 @@ class AgentB extends Agent {
 }
 
 describe('withMockTools', () => {
-  it('sets the mock registry for the given agent inside the callback', async () => {
+  it('sets the mock registry for the given agent inside the block', () => {
     const mock = () => 'mocked';
 
-    await withMockTools(AgentA, { tool1: mock })(async () => {
-      const store = mockToolsStorage.getStore();
-      expect(store).toBeDefined();
-      expect(store?.get(AgentA)?.tool1).toBe(mock);
-    });
+    {
+      using _mock = withMockTools(AgentA, { tool1: mock });
+      expect(activeMockTools).toBeDefined();
+      expect(activeMockTools?.get(AgentA)?.tool1).toBe(mock);
+    }
 
-    expect(mockToolsStorage.getStore()).toBeUndefined();
+    expect(activeMockTools).toBeUndefined();
   });
 
-  it('merges mocks across nested calls and isolates per agent', async () => {
+  it('merges mocks across nested blocks and isolates per agent', () => {
     const mockA = () => 'a';
     const mockB = () => 'b';
 
-    await withMockTools(AgentA, { toolA: mockA })(async () => {
-      await withMockTools(AgentB, { toolB: mockB })(async () => {
-        const store = mockToolsStorage.getStore();
-        expect(store?.get(AgentA)?.toolA).toBe(mockA);
-        expect(store?.get(AgentB)?.toolB).toBe(mockB);
-      });
+    {
+      using _mockA = withMockTools(AgentA, { toolA: mockA });
+      {
+        using _mockB = withMockTools(AgentB, { toolB: mockB });
+        expect(activeMockTools?.get(AgentA)?.toolA).toBe(mockA);
+        expect(activeMockTools?.get(AgentB)?.toolB).toBe(mockB);
+      }
 
-      const store = mockToolsStorage.getStore();
-      expect(store?.get(AgentA)?.toolA).toBe(mockA);
-      expect(store?.get(AgentB)).toBeUndefined();
-    });
+      expect(activeMockTools?.get(AgentA)?.toolA).toBe(mockA);
+      expect(activeMockTools?.get(AgentB)).toBeUndefined();
+    }
   });
 
-  it('inner call for same agent overrides outer mocks', async () => {
+  it('inner block for same agent overrides outer mocks', () => {
     const outer = () => 'outer';
     const inner = () => 'inner';
 
-    await withMockTools(AgentA, { tool1: outer })(async () => {
-      await withMockTools(AgentA, { tool1: inner })(async () => {
-        expect(mockToolsStorage.getStore()?.get(AgentA)?.tool1).toBe(inner);
-      });
-      expect(mockToolsStorage.getStore()?.get(AgentA)?.tool1).toBe(outer);
-    });
+    {
+      using _outer = withMockTools(AgentA, { tool1: outer });
+      {
+        using _inner = withMockTools(AgentA, { tool1: inner });
+        expect(activeMockTools?.get(AgentA)?.tool1).toBe(inner);
+      }
+      expect(activeMockTools?.get(AgentA)?.tool1).toBe(outer);
+    }
   });
 
-  it('returns the callback value (including async results)', async () => {
-    const result = await withMockTools(AgentA, { tool1: async () => 42 })(async () => {
-      const mock = mockToolsStorage.getStore()?.get(AgentA)?.tool1;
-      return await mock?.();
-    });
-    expect(result).toBe(42);
+  it('exposes the mock for invocation within the block', async () => {
+    using _mock = withMockTools(AgentA, { tool1: async () => 42 });
+    const mock = activeMockTools?.get(AgentA)?.tool1;
+    expect(await mock?.()).toBe(42);
   });
 
   it('routes performToolExecutions to the mock when set, original otherwise', async () => {
@@ -100,7 +100,8 @@ describe('withMockTools', () => {
       });
 
     // 1) With a mock registered: the mock runs, the real tool does not.
-    await withMockTools(AgentA, { greet: () => 'mocked' })(async () => {
+    {
+      using _mock = withMockTools(AgentA, { greet: () => 'mocked' });
       const controller = new AbortController();
       const call = FunctionCall.create({
         callId: 'call_1',
@@ -117,7 +118,7 @@ describe('withMockTools', () => {
       await task.result;
       expect(realCalled).toBe(false);
       expect(output.output[0]?.rawOutput).toBe('mocked');
-    });
+    }
 
     // 2) Without a mock: the real tool runs.
     const controller = new AbortController();
@@ -149,33 +150,32 @@ describe('withMockTools', () => {
     const speechHandle = SpeechHandle.create({ allowInterruptions: false });
     const session = { currentAgent: new AgentA() } as never;
 
-    await withMockTools(AgentA, {
+    using _mock = withMockTools(AgentA, {
       failing: () => {
         throw new Error('test failure');
       },
-    })(async () => {
-      const controller = new AbortController();
-      const call = FunctionCall.create({
-        callId: 'call_err',
-        name: 'failing',
-        args: '{}',
-      });
-      const stream = new ReadableStream<FunctionCall>({
-        start(c) {
-          c.enqueue(call);
-          c.close();
-        },
-      });
-      const [task, output] = performToolExecutions({
-        session,
-        speechHandle,
-        toolCtx,
-        toolCallStream: stream,
-        controller,
-      });
-      await task.result;
-      expect(output.output[0]?.rawException?.message).toBe('test failure');
-      expect(output.output[0]?.toolCallOutput?.isError).toBe(true);
     });
+    const controller = new AbortController();
+    const call = FunctionCall.create({
+      callId: 'call_err',
+      name: 'failing',
+      args: '{}',
+    });
+    const stream = new ReadableStream<FunctionCall>({
+      start(c) {
+        c.enqueue(call);
+        c.close();
+      },
+    });
+    const [task, output] = performToolExecutions({
+      session,
+      speechHandle,
+      toolCtx,
+      toolCallStream: stream,
+      controller,
+    });
+    await task.result;
+    expect(output.output[0]?.rawException?.message).toBe('test failure');
+    expect(output.output[0]?.toolCallOutput?.isError).toBe(true);
   });
 });

--- a/agents/src/voice/testing/run_result.ts
+++ b/agents/src/voice/testing/run_result.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { AsyncLocalStorage } from 'node:async_hooks';
 import { z } from 'zod';
 import type { AgentHandoffItem, ChatItem, ChatRole } from '../../llm/chat_context.js';
 import { ChatContext } from '../../llm/chat_context.js';
@@ -963,14 +962,13 @@ export type MockToolFn = (...args: any[]) => any;
 export type MockToolsMap = Map<AgentConstructor, Record<string, MockToolFn>>;
 
 /** @internal */
-export const mockToolsStorage = new AsyncLocalStorage<MockToolsMap>();
+export let activeMockTools: MockToolsMap | undefined;
 
 /** @internal */
 export function getMockTool(agent: Agent, toolName: string): MockToolFn | undefined {
-  const store = mockToolsStorage.getStore();
-  if (!store) return undefined;
+  if (!activeMockTools) return undefined;
 
-  for (const [agentConstructor, mocks] of store) {
+  for (const [agentConstructor, mocks] of activeMockTools) {
     if (agent.constructor === agentConstructor) {
       return mocks[toolName];
     }
@@ -980,39 +978,43 @@ export function getMockTool(agent: Agent, toolName: string): MockToolFn | undefi
 
 /**
  * Temporarily assign a set of mock tool callables to a specific Agent type. Returns
- * a runner that takes an async callback. While the callback is running, tool calls
- * for the matching agent type and tool name are routed to the supplied mock instead
- * of the real `execute` implementation.
+ * a {@link Disposable} for use with a `using` declaration. While the binding is in
+ * scope, tool calls for the matching agent type and tool name are routed to the
+ * supplied mock instead of the real `execute` implementation, and are restored when
+ * the enclosing block exits.
  *
- * Mirrors the Python `mock_tools` context manager, adapted to JS via a curried
- * callback form (Python uses `with`, JS uses an async callback).
+ * Mirrors the Python `mock_tools` context manager, adapted to JS via the explicit
+ * resource management `using` syntax (Python uses `with`).
  *
  * @param agent - The Agent constructor whose tools should be mocked.
  * @param mocks - A record mapping tool name to a mock implementation.
  *
  * @example
  * ```typescript
- * await withMockTools(
- *   DriveThruAgent,
- *   {
+ * {
+ *   using _mock = withMockTools(DriveThruAgent, {
  *     orderRegularItem: () => new Error('test failure'),
  *     getWeather: () => 'sunny',
- *   },
- * )(async () => {
+ *   });
+ *
  *   const result = await session.run({ userInput: 'Order a burger' });
  *   result.expect.containsFunctionCall({ name: 'orderRegularItem' });
- * });
+ * }
  * ```
  */
 export function withMockTools(
   agent: AgentConstructor,
   mocks: Record<string, MockToolFn>,
-): <T>(callback: () => Promise<T>) => Promise<T> {
-  return <T>(callback: () => Promise<T>): Promise<T> => {
-    const current = mockToolsStorage.getStore();
-    const updated: MockToolsMap = new Map(current ?? []);
-    updated.set(agent, mocks);
-    return mockToolsStorage.run(updated, callback);
+): Disposable {
+  const previous = activeMockTools;
+  const updated: MockToolsMap = new Map(previous ?? []);
+  updated.set(agent, mocks);
+  activeMockTools = updated;
+
+  return {
+    [Symbol.dispose]() {
+      activeMockTools = previous;
+    },
   };
 }
 

--- a/examples/src/drive-thru/test_agent.test.ts
+++ b/examples/src/drive-thru/test_agent.test.ts
@@ -179,28 +179,28 @@ describe('DriveThru Agent Tests', { timeout: 180_000 }, () => {
 
     it('should recover gracefully when a tool throws', async () => {
       // Simulate a tool error via withMockTools (mirrors Python's mock_tools usage).
-      await voice.testing.withMockTools(DriveThruAgent, {
+      using _mock = voice.testing.withMockTools(DriveThruAgent, {
         orderRegularItem: () => {
           throw new Error('test failure');
         },
-      })(async () => {
-        const result = session.run({ userInput: 'Can I get a large vanilla shake?' });
-        await result.wait();
-
-        result.expect.skipNextEventIf({ type: 'message', role: 'assistant' });
-        result.expect.nextEvent().isFunctionCall({
-          name: 'orderRegularItem',
-          args: { itemId: 'shake_vanilla', size: 'L' },
-        });
-        result.expect.nextEvent().isFunctionCallOutput();
-        await result.expect.nextEvent().isMessage({ role: 'assistant' }).judge(judgeInstance, {
-          intent:
-            "should inform the user that something went wrong, it's ok to ask them to try again",
-        });
-
-        // leaving this commented, some LLMs may occasionally try to retry.
-        // result.expect.noMoreEvents();
       });
+
+      const result = session.run({ userInput: 'Can I get a large vanilla shake?' });
+      await result.wait();
+
+      result.expect.skipNextEventIf({ type: 'message', role: 'assistant' });
+      result.expect.nextEvent().isFunctionCall({
+        name: 'orderRegularItem',
+        args: { itemId: 'shake_vanilla', size: 'L' },
+      });
+      result.expect.nextEvent().isFunctionCallOutput();
+      await result.expect.nextEvent().isMessage({ role: 'assistant' }).judge(judgeInstance, {
+        intent:
+          "should inform the user that something went wrong, it's ok to ask them to try again",
+      });
+
+      // leaving this commented, some LLMs may occasionally try to retry.
+      // result.expect.noMoreEvents();
     });
   });
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->
Switches `withMockTools` from a curried callback runner to a `Disposable` used with a `using` declaration, scoping mocks to a block instead of a callback.

## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- Replace `AsyncLocalStorage` backing with a module-level `activeMockTools` binding; `withMockTools` now returns `{ [Symbol.dispose] }` that restores the prior value on block exit (preserves nesting/override semantics).
- Update unit tests and the drive-thru failure test to use `using` blocks.
- Import `ReadableStream` from `node:stream/web` in the test to fix a type mismatch with `performToolExecutions`.

## Pre-Review Checklist
- [ ] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [ ] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
<!-- Describe how you tested these changes -->
- [x] Automated tests added/updated (if applicable)
- [x] All tests pass

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->
Targets `claude/port-tool-mocking-js-i2Fpr`.
