### PR TITLE
feat(phonic): handle user text input for Phonic plugin

### DIFF
--- a/.changeset/busy-vans-draw.md
+++ b/.changeset/busy-vans-draw.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-phonic': patch
+---
+
+Add text input support to phonic plugin

--- a/examples/src/phonic_realtime_agent.ts
+++ b/examples/src/phonic_realtime_agent.ts
@@ -62,4 +62,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url), agentName: 'my-agent-q5' }));

--- a/examples/src/phonic_realtime_agent.ts
+++ b/examples/src/phonic_realtime_agent.ts
@@ -62,4 +62,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url), agentName: 'my-agent-q5' }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -265,6 +265,7 @@ export class RealtimeSession extends llm.RealtimeSession {
   private pendingGenerateReplyFut?: Future<llm.GenerationCreatedEvent>;
   private generateReplyRequestId = 0;
   private systemPromptPostfix = '';
+  private pendingUserText?: string;
 
   constructor(realtimeModel: RealtimeModel) {
     super(realtimeModel);
@@ -323,6 +324,8 @@ export class RealtimeSession extends llm.RealtimeSession {
     let sentToolCallOutput = false;
     let sentAddSystemMessage = false;
 
+    let sentUserMessage = false;
+
     for (const [, itemId] of diffOps.toCreate) {
       const item = chatCtx.getById(itemId);
       if (item?.type === 'function_call_output' && this.pendingToolCallIds.has(item.callId)) {
@@ -344,12 +347,17 @@ export class RealtimeSession extends llm.RealtimeSession {
           });
           sentAddSystemMessage = true;
         }
+        if (item.role === 'user' && item.textContent) {
+          this.#logger.info(`Received user text input: ${item.textContent}`);
+          this.pendingUserText = item.textContent;
+          sentUserMessage = true;
+        }
       }
     }
 
     this._chatCtx = chatCtx.copy();
 
-    if (!sentToolCallOutput && !sentAddSystemMessage) {
+    if (!sentToolCallOutput && !sentAddSystemMessage && !sentUserMessage) {
       this.#logger.warn(
         'updateChatCtx called but no new tool call outputs to send. Phonic does not support general chat context updates.',
       );
@@ -534,7 +542,17 @@ export class RealtimeSession extends llm.RealtimeSession {
       this.pendingGenerateReplyFut = undefined;
       return;
     }
-    this.socket.sendGenerateReply({ type: 'generate_reply', system_message: instructions });
+
+    let systemMessage = instructions;
+    if (this.pendingUserText) {
+      const userTextInstruction = `The user sent the following text message: "${this.pendingUserText}". Please respond to their message.`;
+      systemMessage = systemMessage
+        ? `${systemMessage}\n\n${userTextInstruction}`
+        : userTextInstruction;
+      this.pendingUserText = undefined;
+    }
+
+    this.socket.sendGenerateReply({ type: 'generate_reply', system_message: systemMessage });
   }
 
   async commitAudio(): Promise<void> {

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -369,7 +369,7 @@ export class RealtimeSession extends llm.RealtimeSession {
         }
         // Only treat a user message as text input when it's appended at the tail of the context.
         if (item.role === 'user' && item.textContent && itemId === lastItemId) {
-          this.#logger.info(`Received user text input: ${item.textContent}`);
+          this.#logger.debug(`Received user text input: ${item.textContent}`);
           this.pendingUserText = item.textContent;
           bufferedUserText = true;
         }

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -323,8 +323,8 @@ export class RealtimeSession extends llm.RealtimeSession {
     const diffOps = llm.computeChatCtxDiff(this._chatCtx, chatCtx);
     let sentToolCallOutput = false;
     let sentAddSystemMessage = false;
-
-    let sentUserMessage = false;
+    let bufferedUserText = false;
+    const lastItemId = chatCtx.items.at(-1)?.id;
 
     for (const [, itemId] of diffOps.toCreate) {
       const item = chatCtx.getById(itemId);
@@ -347,17 +347,18 @@ export class RealtimeSession extends llm.RealtimeSession {
           });
           sentAddSystemMessage = true;
         }
-        if (item.role === 'user' && item.textContent) {
+        // Only treat a user message as text input when it's appended at the tail of the context.
+        if (item.role === 'user' && item.textContent && itemId === lastItemId) {
           this.#logger.info(`Received user text input: ${item.textContent}`);
           this.pendingUserText = item.textContent;
-          sentUserMessage = true;
+          bufferedUserText = true;
         }
       }
     }
 
     this._chatCtx = chatCtx.copy();
 
-    if (!sentToolCallOutput && !sentAddSystemMessage && !sentUserMessage) {
+    if (!sentToolCallOutput && !sentAddSystemMessage && !bufferedUserText) {
       this.#logger.warn(
         'updateChatCtx called but no new tool call outputs to send. Phonic does not support general chat context updates.',
       );
@@ -510,6 +511,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       }
       this.pendingGenerateReplyFut = undefined;
       this.generateReplyRequestId += 1;
+      this.pendingUserText = undefined;
       if (!fut.done) {
         fut.reject(new Error('generateReply aborted'));
       }


### PR DESCRIPTION
When a user sends text (e.g. typing in a chat), the framework calls updateChatCtx with the user message followed by generateReply. Previously the Phonic plugin ignored user messages in updateChatCtx, so text input was silently dropped.

This change:
- Detects new user messages in updateChatCtx and stores the text
- Includes the user text in the generate_reply system_message sent to the Phonic downstream service, so the LLM can see and respond to typed user input

Demo video:
https://screen.studio/share/TViyimYO

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [x] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.