### PR TITLE
fix(core): honor AsyncToolset setup/aclose and close nested session toolsets

### DIFF
--- a/.changeset/fix-async-toolset-lifecycle.md
+++ b/.changeset/fix-async-toolset-lifecycle.md
@@ -1,0 +1,8 @@
+---
+'@livekit/agents': patch
+---
+
+Fix two toolset lifecycle bugs:
+
+- `AsyncToolset.create()` now honors the `setup`/`aclose` hooks it inherits from `ToolsetCreateOptions`. Previously the constructor discarded them, so a custom `setup`/`aclose` on an `AsyncToolset` was silently ignored. The provided `aclose` now runs in addition to the executor drain/close.
+- `AgentSession` close now tears down the flattened set of session toolsets (including nested toolsets) to mirror `AgentActivity.setupToolsets()`. Previously only top-level session toolsets were closed, leaking resources/listeners held by nested toolsets.

--- a/agents/src/llm/async_toolset.test.ts
+++ b/agents/src/llm/async_toolset.test.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { AsyncToolset } from './async_toolset.js';
-import { tool } from './tool_context.js';
+import { type ToolsetContext, tool } from './tool_context.js';
 
 describe('AsyncToolset', () => {
   const lookup = tool({
@@ -18,5 +18,30 @@ describe('AsyncToolset', () => {
     expect(toolset.id).toBe('booking');
     expect(toolset.tools).toEqual([lookup]);
     expect(toolset._executor).toBeDefined();
+  });
+
+  it('invokes the provided setup on activation', async () => {
+    const setup = vi.fn(async (_ctx: ToolsetContext) => {});
+    const toolset = AsyncToolset.create({ id: 'booking', tools: [lookup], setup });
+
+    const ctx: ToolsetContext = { updateTools: vi.fn() };
+    await toolset.setup(ctx);
+
+    expect(setup).toHaveBeenCalledTimes(1);
+    expect(setup).toHaveBeenCalledWith(ctx);
+  });
+
+  it('invokes the provided aclose on teardown and still drains its executor', async () => {
+    const aclose = vi.fn(async () => {});
+    const toolset = AsyncToolset.create({ id: 'booking', tools: [lookup], aclose });
+
+    const drainSpy = vi.spyOn(toolset._executor, 'drain');
+    const executorCloseSpy = vi.spyOn(toolset._executor, 'aclose');
+
+    await toolset.aclose();
+
+    expect(aclose).toHaveBeenCalledTimes(1);
+    expect(drainSpy).toHaveBeenCalledTimes(1);
+    expect(executorCloseSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/agents/src/llm/async_toolset.ts
+++ b/agents/src/llm/async_toolset.ts
@@ -4,7 +4,7 @@
 import type { AgentActivity } from '../voice/agent_activity.js';
 import type { AgentSession } from '../voice/agent_session.js';
 import { ToolExecutor, type ToolHandlingOptions } from '../voice/tool_executor.js';
-import { Toolset, type ToolsetCreateOptions } from './tool_context.js';
+import { Toolset, type ToolsetContext, type ToolsetCreateOptions } from './tool_context.js';
 
 export interface AsyncToolsetCreateOptions extends ToolsetCreateOptions {
   toolHandling?: ToolHandlingOptions;
@@ -13,10 +13,14 @@ export interface AsyncToolsetCreateOptions extends ToolsetCreateOptions {
 export class AsyncToolset extends Toolset {
   readonly _executor = new ToolExecutor({ owningActivity: null });
   private readonly asyncToolOptionsOverride?: ToolHandlingOptions['asyncOptions'];
+  private readonly setupFn?: (ctx: ToolsetContext) => Promise<void>;
+  private readonly acloseFn?: () => Promise<void>;
 
-  private constructor({ id, tools, toolHandling }: AsyncToolsetCreateOptions) {
+  private constructor({ id, tools, toolHandling, setup, aclose }: AsyncToolsetCreateOptions) {
     super({ id, tools });
     this.asyncToolOptionsOverride = toolHandling?.asyncOptions;
+    this.setupFn = setup;
+    this.acloseFn = aclose;
   }
 
   static override create(options: AsyncToolsetCreateOptions): AsyncToolset {
@@ -48,8 +52,13 @@ export class AsyncToolset extends Toolset {
     }
   }
 
+  override async setup(ctx: ToolsetContext): Promise<void> {
+    if (this.setupFn) await this.setupFn(ctx);
+  }
+
   override async aclose(): Promise<void> {
     await super.aclose();
+    if (this.acloseFn) await this.acloseFn();
     await this._executor.drain();
     await this._executor.aclose();
   }

--- a/agents/src/voice/agent_session.test.ts
+++ b/agents/src/voice/agent_session.test.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it, vi } from 'vitest';
+import { Toolset, tool } from '../llm/tool_context.js';
 import { AgentSession, resolveRecordingOptions } from './agent_session.js';
 import { SpeechHandle } from './speech_handle.js';
 
@@ -62,6 +63,31 @@ describe('resolveRecordingOptions', () => {
     const opts = resolveRecordingOptions(true);
     opts.audio = false;
     expect(resolveRecordingOptions(true).audio).toBe(true);
+  });
+});
+
+describe('AgentSession close - session toolset teardown', () => {
+  const noopTool = tool({
+    name: 'noop',
+    description: 'noop',
+    execute: async () => 'ok',
+  });
+
+  // Close must mirror setup, which flattens session tools via `new ToolContext(...).toolsets`
+  // (nested toolsets included). A nested toolset's `aclose()` must therefore run on close.
+  it('closes nested session toolsets, not just top-level ones', async () => {
+    const innerAclose = vi.fn(async () => {});
+    const outerAclose = vi.fn(async () => {});
+    const inner = Toolset.create({ id: 'inner', tools: [noopTool], aclose: innerAclose });
+    const outer = Toolset.create({ id: 'outer', tools: [inner], aclose: outerAclose });
+
+    const session = new AgentSession({ tools: [outer] });
+    (session as unknown as { started: boolean }).started = true;
+
+    await session.close();
+
+    expect(outerAclose).toHaveBeenCalledTimes(1);
+    expect(innerAclose).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -41,7 +41,7 @@ import type {
   ToolContextEntry,
   ToolContextInit,
 } from '../llm/index.js';
-import { normalizeToolContextInit } from '../llm/index.js';
+import { ToolContext, normalizeToolContextInit } from '../llm/index.js';
 import type { LLMError } from '../llm/llm.js';
 import { log } from '../log.js';
 import { type ModelUsage, ModelUsageCollector, filterZeroValues } from '../metrics/model_usage.js';
@@ -1662,10 +1662,11 @@ export class AgentSession<
     await this.activity?.close();
     this.activity = undefined;
 
-    const sessionToolsets = this._tools.filter(
-      (tool): tool is ToolContextEntry<UserData> & { aclose: () => Promise<void> } =>
-        typeof (tool as { aclose?: unknown }).aclose === 'function',
-    );
+    // Mirror setup, which flattens session tools via `new ToolContext(...).toolsets` (see
+    // AgentActivity.setupToolsets) — that includes NESTED toolsets. Closing only the top-level
+    // entries would leak resources/listeners held by nested toolsets. Agent-level toolsets are
+    // torn down separately by AgentActivity.close(), so this path covers session-level tools only.
+    const sessionToolsets = new ToolContext(this._tools).toolsets;
     await Promise.allSettled(sessionToolsets.map((toolset) => toolset.aclose()));
 
     if (this.sessionSpan) {


### PR DESCRIPTION
## Summary

Two toolset lifecycle fixes (Codex review findings), both confirmed present on `1.5.0`:

- **`AsyncToolset` drops `setup`/`aclose`.** `AsyncToolsetCreateOptions extends ToolsetCreateOptions`, so callers can pass `setup`/`aclose`, but the private constructor only destructured `{ id, tools, toolHandling }` and called `super({ id, tools })` — the base `Toolset.setup()`/`aclose()` are no-ops, so the hooks were silently discarded. Now `AsyncToolset` stores and invokes them, mirroring the private `ToolsetFactory`. The provided `aclose` runs **in addition to** the existing executor drain/close.

- **Session close skips flattened/nested toolsets.** `AgentActivity.setupToolsets()` flattens session tools via `new ToolContext(this.agentSession.tools).toolsets`, which includes nested toolsets, and sets all of them up. Close only filtered the top-level `this._tools` array by duck-typing `aclose`, so nested toolsets never got `aclose()` — a resource/listener leak asymmetric with setup. Close now tears down the same flattened set (`new ToolContext(this._tools).toolsets`), keeping `Promise.allSettled`. Agent-level toolsets remain handled by `AgentActivity.close()`, so there's no double-close.

### Before / after

`agents/src/llm/async_toolset.ts`:
```diff
-  private constructor({ id, tools, toolHandling }: AsyncToolsetCreateOptions) {
+  private constructor({ id, tools, toolHandling, setup, aclose }: AsyncToolsetCreateOptions) {
     super({ id, tools });
     this.asyncToolOptionsOverride = toolHandling?.asyncOptions;
+    this.setupFn = setup;
+    this.acloseFn = aclose;
   }
+  override async setup(ctx: ToolsetContext): Promise<void> {
+    if (this.setupFn) await this.setupFn(ctx);
+  }
   override async aclose(): Promise<void> {
     await super.aclose();
+    if (this.acloseFn) await this.acloseFn();
     await this._executor.drain();
     await this._executor.aclose();
   }
```

`agents/src/voice/agent_session.ts` (close path):
```diff
-    const sessionToolsets = this._tools.filter(
-      (tool): tool is ToolContextEntry<UserData> & { aclose: () => Promise<void> } =>
-        typeof (tool as { aclose?: unknown }).aclose === 'function',
-    );
+    const sessionToolsets = new ToolContext(this._tools).toolsets;
     await Promise.allSettled(sessionToolsets.map((toolset) => toolset.aclose()));
```

> Note on the `isToolset` guard: `ToolContext.toolsets` is already typed `readonly Toolset[]`, so iterating it directly is the type-safe replacement for the old `typeof aclose === 'function'` duck-type — a `.filter(isToolset)` would be a redundant no-op.

## Test plan

Added focused unit tests (TDD, RED → GREEN):

- `agents/src/llm/async_toolset.test.ts`: `AsyncToolset.create({ id, tools, setup, aclose })` invokes the provided `setup` on activation, and invokes the provided `aclose` on teardown **and still drains/closes its executor**.
- `agents/src/voice/agent_session.test.ts`: a session configured with a `Toolset` containing a nested `Toolset` closes **both** (`aclose` called on the inner toolset) on session close. RED reproduced the bug exactly (outer top-level closed, nested inner did not).

Validation:
- `pnpm build:agents` — success.
- `pnpm test` on `agents/src/llm` (347 passed, 2 skipped), `agent_session.test.ts`, `agent_activity.test.ts` (16 passed) — all green.
- ESLint + Prettier on changed files — clean (one pre-existing `no-explicit-any` warning at `agent_session.ts:348`, unrelated to this change).

## Caveats

- Nested session toolsets are a supported pattern: `ToolContext.updateTools` already flattens nested toolsets recursively, and setup already operates on the flattened set — this change just makes teardown symmetric.
- Double-close avoidance: this path only closes session-level tools; agent-level toolsets are torn down by `AgentActivity.close()`.
- `api:check` is unaffected (no public export changes); the repo has a known pre-existing `export * as beta` api-extractor failure unrelated to this PR.

Made with [Cursor](https://cursor.com)