### PR TITLE
feat(voice): accept async-iterable input in pipeline nodes

### DIFF
--- a/.changeset/ttsnode-async-iterable-input.md
+++ b/.changeset/ttsnode-async-iterable-input.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-Pipeline nodes (`ttsNode`, `sttNode`, `transcriptionNode`, `realtimeAudioOutputNode`) now accept an async generator/iterable as their stream input, so overrides can pass a generator directly without wrapping it in `toStream()` first.
+Pipeline nodes (`ttsNode`, `sttNode`, `transcriptionNode`, `realtimeAudioOutputNode`) now accept an async generator/iterable as their stream input end-to-end. This includes the static `Agent.default.*` helpers and the `Agent.create()` / `AgentTask.create()` hook overrides, so overrides can pass a generator directly to `voice.Agent.default.<node>(ctx.agent, generator, settings)` without wrapping it in `toStream()` first. Also fixes a `getReader is not a function` crash when an `Agent.create`/`AgentTask.create` stream hook received a plain `AsyncIterable`.

--- a/.changeset/ttsnode-async-iterable-input.md
+++ b/.changeset/ttsnode-async-iterable-input.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Pipeline nodes (`ttsNode`, `sttNode`, `transcriptionNode`, `realtimeAudioOutputNode`) now accept an async generator/iterable as their stream input, so overrides can pass a generator directly without wrapping it in `toStream()` first.

--- a/agents/src/voice/agent.test.ts
+++ b/agents/src/voice/agent.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { ChatContext, ChatMessage, tool } from '../llm/index.js';
 import { initializeLogger } from '../log.js';
+import { SynthesizeStream } from '../tts/index.js';
 import { Task } from '../utils.js';
 import { Agent, AgentTask, _setActivityTaskInfo } from './agent.js';
 import { AgentActivity, agentActivityStorage } from './agent_activity.js';
@@ -337,6 +338,74 @@ describe('Agent', () => {
       const result = await agent.realtimeAudioOutputNode(audio, {});
 
       expect(result).toBe(audio);
+    });
+  });
+
+  describe('AsyncIterable pipeline node inputs', () => {
+    it('accepts a plain AsyncIterable into Agent.create stream hooks without getReader crash', async () => {
+      const outputFrame = 'output-audio' as unknown as AudioFrame;
+      const agent = Agent.create({
+        instructions: 'factory instructions',
+        async *ttsNode(ctx, text) {
+          expect(ctx.agent).toBe(agent);
+          const chunks: string[] = [];
+          for await (const chunk of text) {
+            chunks.push(chunk);
+          }
+          expect(chunks).toEqual(['hello']);
+          yield outputFrame;
+        },
+      });
+
+      async function* textInput() {
+        yield 'hello';
+      }
+
+      // Before the fix the AgentV2 hook adapter called readStream(text).getReader()
+      // unconditionally, crashing with "getReader is not a function" on a plain iterable.
+      const result = await agent.ttsNode(textInput(), {});
+
+      expect(result).not.toBeNull();
+      await expect(collectReadableStream(result!)).resolves.toEqual([outputFrame]);
+    });
+
+    it('accepts a plain AsyncIterable into Agent.default.ttsNode', async () => {
+      const frame = 'frame' as unknown as AudioFrame;
+      const agent = new Agent({ instructions: 'default instructions' });
+
+      let capturedInput: unknown;
+      const ttsStream = {
+        startTimeOffset: 0,
+        updateInputStream(input: unknown) {
+          capturedInput = input;
+        },
+        close() {},
+        async *[Symbol.asyncIterator]() {
+          yield { frame, timedTranscripts: [] };
+          yield SynthesizeStream.END_OF_STREAM;
+        },
+      };
+
+      (agent as any)._agentActivity = {
+        tts: {
+          capabilities: { streaming: true },
+          stream: () => ttsStream,
+          close: async () => {},
+        },
+        agentSession: { connOptions: { ttsConnOptions: {} } },
+      };
+
+      async function* textInput() {
+        yield 'hello';
+      }
+
+      const result = await Agent.default.ttsNode(agent, textInput(), {});
+
+      expect(result).not.toBeNull();
+      // The default must normalize the AsyncIterable into a real ReadableStream before
+      // handing it to the TTS stream (the stream calls .cancel() during cleanup).
+      expect(capturedInput).toBeInstanceOf(ReadableStream);
+      await expect(collectReadableStream(result!)).resolves.toEqual([frame]);
     });
   });
 

--- a/agents/src/voice/agent.test.ts
+++ b/agents/src/voice/agent.test.ts
@@ -369,6 +369,30 @@ describe('Agent', () => {
       await expect(collectReadableStream(result!)).resolves.toEqual([outputFrame]);
     });
 
+    it('forwards transformed output through an Agent.create transcriptionNode hook', async () => {
+      const agent = Agent.create({
+        instructions: 'factory instructions',
+        async *transcriptionNode(ctx, text) {
+          expect(ctx.agent).toBe(agent);
+          for await (const chunk of text) {
+            yield `${chunk}!`;
+          }
+        },
+      });
+
+      async function* textInput() {
+        yield 'hello';
+        yield 'world';
+      }
+
+      // Before transcriptionNode was wired as an Agent.create hook the override didn't exist,
+      // so the base default returned the input unchanged instead of the transformed output.
+      const result = await agent.transcriptionNode(textInput(), {});
+
+      expect(result).not.toBeNull();
+      await expect(collectReadableStream(result!)).resolves.toEqual(['hello!', 'world!']);
+    });
+
     it('accepts a plain AsyncIterable into Agent.default.ttsNode', async () => {
       const frame = 'frame' as unknown as AudioFrame;
       const agent = new Agent({ instructions: 'default instructions' });

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -310,11 +310,7 @@ export class Agent<UserData = any> {
     text: ReadableStream<string | TimedString> | AsyncIterable<string | TimedString>,
     modelSettings: ModelSettings,
   ): Promise<ReadableStream<string | TimedString> | null> {
-    return Agent.default.transcriptionNode(
-      this,
-      text instanceof ReadableStream ? text : toStream(text),
-      modelSettings,
-    );
+    return Agent.default.transcriptionNode(this, text, modelSettings);
   }
 
   async onUserTurnCompleted(_chatCtx: ChatContext, _newMessage: ChatMessage): Promise<void> {}
@@ -335,11 +331,7 @@ export class Agent<UserData = any> {
     audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
     modelSettings: ModelSettings,
   ): Promise<ReadableStream<SpeechEvent | string> | null> {
-    return Agent.default.sttNode(
-      this,
-      audio instanceof ReadableStream ? audio : toStream(audio),
-      modelSettings,
-    );
+    return Agent.default.sttNode(this, audio, modelSettings);
   }
 
   async llmNode(
@@ -354,22 +346,14 @@ export class Agent<UserData = any> {
     text: ReadableStream<string> | AsyncIterable<string>,
     modelSettings: ModelSettings,
   ): Promise<ReadableStream<AudioFrame> | null> {
-    return Agent.default.ttsNode(
-      this,
-      text instanceof ReadableStream ? text : toStream(text),
-      modelSettings,
-    );
+    return Agent.default.ttsNode(this, text, modelSettings);
   }
 
   async realtimeAudioOutputNode(
     audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
     modelSettings: ModelSettings,
   ): Promise<ReadableStream<AudioFrame> | null> {
-    return Agent.default.realtimeAudioOutputNode(
-      this,
-      audio instanceof ReadableStream ? audio : toStream(audio),
-      modelSettings,
-    );
+    return Agent.default.realtimeAudioOutputNode(this, audio, modelSettings);
   }
 
   // realtime_audio_output_node
@@ -414,9 +398,10 @@ export class Agent<UserData = any> {
   static default = {
     async sttNode(
       agent: Agent,
-      audio: ReadableStream<AudioFrame>,
+      audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
       _modelSettings: ModelSettings,
     ): Promise<ReadableStream<SpeechEvent | string> | null> {
+      const input = audio instanceof ReadableStream ? audio : toStream(audio);
       const activity = agent.getActivityOrThrow();
       if (!activity.stt) {
         throw new Error('sttNode called but no STT node is available');
@@ -446,7 +431,7 @@ export class Agent<UserData = any> {
 
       stream.startTimeOffset = (Date.now() - audioInputStartedAt) / 1000;
 
-      stream.updateInputStream(audio);
+      stream.updateInputStream(input);
 
       let cleaned = false;
       const cleanup = () => {
@@ -529,9 +514,10 @@ export class Agent<UserData = any> {
 
     async ttsNode(
       agent: Agent,
-      text: ReadableStream<string>,
+      text: ReadableStream<string> | AsyncIterable<string>,
       _modelSettings: ModelSettings,
     ): Promise<ReadableStream<AudioFrame> | null> {
+      const input = text instanceof ReadableStream ? text : toStream(text);
       const activity = agent.getActivityOrThrow();
       if (!activity.tts) {
         throw new Error('ttsNode called but no TTS node is available');
@@ -545,14 +531,14 @@ export class Agent<UserData = any> {
 
       const connOptions = activity.agentSession.connOptions.ttsConnOptions;
       const stream = wrappedTts.stream({ connOptions });
-      stream.updateInputStream(text);
+      stream.updateInputStream(input);
 
       let cleaned = false;
       const cleanup = async () => {
         if (cleaned) return;
         cleaned = true;
         stream.close();
-        await text.cancel('tts node cleanup').catch(() => {});
+        await input.cancel('tts node cleanup').catch(() => {});
         if (wrappedTts !== activity.tts) {
           await wrappedTts.close();
         }
@@ -584,18 +570,18 @@ export class Agent<UserData = any> {
 
     async transcriptionNode(
       agent: Agent,
-      text: ReadableStream<string | TimedString>,
+      text: ReadableStream<string | TimedString> | AsyncIterable<string | TimedString>,
       _modelSettings: ModelSettings,
     ): Promise<ReadableStream<string | TimedString> | null> {
-      return text;
+      return text instanceof ReadableStream ? text : toStream(text);
     },
 
     async realtimeAudioOutputNode(
       _agent: Agent,
-      audio: ReadableStream<AudioFrame>,
+      audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
       _modelSettings: ModelSettings,
     ): Promise<ReadableStream<AudioFrame> | null> {
-      return audio;
+      return audio instanceof ReadableStream ? audio : toStream(audio);
     },
   };
 }

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -31,7 +31,7 @@ import { SentenceTokenizer as BasicSentenceTokenizer } from '../tokenize/basic/i
 import type { TTS } from '../tts/index.js';
 import { SynthesizeStream, StreamAdapter as TTSStreamAdapter } from '../tts/index.js';
 import { type FlushSentinel, USERDATA_TIMED_TRANSCRIPT } from '../types.js';
-import { Future, Task } from '../utils.js';
+import { Future, Task, toStream } from '../utils.js';
 import type { VAD } from '../vad.js';
 import { type AgentActivity, agentActivityStorage } from './agent_activity.js';
 import type { AgentSession, TurnDetectionMode } from './agent_session.js';
@@ -307,10 +307,14 @@ export class Agent<UserData = any> {
   async onExit(): Promise<void> {}
 
   async transcriptionNode(
-    text: ReadableStream<string | TimedString>,
+    text: ReadableStream<string | TimedString> | AsyncIterable<string | TimedString>,
     modelSettings: ModelSettings,
   ): Promise<ReadableStream<string | TimedString> | null> {
-    return Agent.default.transcriptionNode(this, text, modelSettings);
+    return Agent.default.transcriptionNode(
+      this,
+      text instanceof ReadableStream ? text : toStream(text),
+      modelSettings,
+    );
   }
 
   async onUserTurnCompleted(_chatCtx: ChatContext, _newMessage: ChatMessage): Promise<void> {}
@@ -328,10 +332,14 @@ export class Agent<UserData = any> {
   }
 
   async sttNode(
-    audio: ReadableStream<AudioFrame>,
+    audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
     modelSettings: ModelSettings,
   ): Promise<ReadableStream<SpeechEvent | string> | null> {
-    return Agent.default.sttNode(this, audio, modelSettings);
+    return Agent.default.sttNode(
+      this,
+      audio instanceof ReadableStream ? audio : toStream(audio),
+      modelSettings,
+    );
   }
 
   async llmNode(
@@ -343,17 +351,25 @@ export class Agent<UserData = any> {
   }
 
   async ttsNode(
-    text: ReadableStream<string>,
+    text: ReadableStream<string> | AsyncIterable<string>,
     modelSettings: ModelSettings,
   ): Promise<ReadableStream<AudioFrame> | null> {
-    return Agent.default.ttsNode(this, text, modelSettings);
+    return Agent.default.ttsNode(
+      this,
+      text instanceof ReadableStream ? text : toStream(text),
+      modelSettings,
+    );
   }
 
   async realtimeAudioOutputNode(
-    audio: ReadableStream<AudioFrame>,
+    audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
     modelSettings: ModelSettings,
   ): Promise<ReadableStream<AudioFrame> | null> {
-    return Agent.default.realtimeAudioOutputNode(this, audio, modelSettings);
+    return Agent.default.realtimeAudioOutputNode(
+      this,
+      audio instanceof ReadableStream ? audio : toStream(audio),
+      modelSettings,
+    );
   }
 
   // realtime_audio_output_node

--- a/agents/src/voice/agent_v2.ts
+++ b/agents/src/voice/agent_v2.ts
@@ -19,6 +19,7 @@ import { readStream, toStream } from '../utils.js';
 import type { VAD } from '../vad.js';
 import type { Agent, AgentOptions, AgentTask, AgentTaskOptions, ModelSettings } from './agent.js';
 import type { AgentSession } from './agent_session.js';
+import type { TimedString } from './io.js';
 import type { TurnHandlingOptions } from './turn_config/turn_handling.js';
 
 /** Context passed to hooks created with `Agent.create()`. */
@@ -93,6 +94,12 @@ export interface AgentHooks<
     audio: AsyncIterable<AudioFrame>,
     modelSettings: ModelSettings,
   ) => AgentHookNodeResult<AudioFrame>;
+  /** Transforms the agent's output transcript before it is forwarded. */
+  transcriptionNode?: (
+    ctx: ContextT,
+    text: AsyncIterable<string | TimedString>,
+    modelSettings: ModelSettings,
+  ) => AgentHookNodeResult<string | TimedString>;
 }
 
 export interface AgentCreateOptions<UserData = any>
@@ -134,6 +141,7 @@ export function createAgentV2<UserData>(
       llmNode,
       ttsNode,
       realtimeAudioOutputNode,
+      transcriptionNode,
       ...agentOptions
     }: AgentCreateOptions<UserData>) {
       super({
@@ -150,6 +158,7 @@ export function createAgentV2<UserData>(
           llmNode,
           ttsNode,
           realtimeAudioOutputNode,
+          transcriptionNode,
         },
         new AgentHookContext(this),
       );
@@ -208,6 +217,15 @@ export function createAgentV2<UserData>(
         super.realtimeAudioOutputNode(audio, modelSettings),
       );
     }
+
+    override async transcriptionNode(
+      text: ReadableStream<string | TimedString> | AsyncIterable<string | TimedString>,
+      modelSettings: ModelSettings,
+    ): Promise<ReadableStream<string | TimedString> | null> {
+      return this.hookAdapter.transcriptionNode(text, modelSettings, () =>
+        super.transcriptionNode(text, modelSettings),
+      );
+    }
   }
 
   return new AgentV2(options);
@@ -228,6 +246,7 @@ export function createAgentTaskV2<ResultT, UserData>(
       llmNode,
       ttsNode,
       realtimeAudioOutputNode,
+      transcriptionNode,
       ...taskOptions
     }: AgentTaskCreateOptions<ResultT, UserData>) {
       super({
@@ -244,6 +263,7 @@ export function createAgentTaskV2<ResultT, UserData>(
           llmNode,
           ttsNode,
           realtimeAudioOutputNode,
+          transcriptionNode,
         },
         new AgentTaskHookContext(this),
       );
@@ -300,6 +320,15 @@ export function createAgentTaskV2<ResultT, UserData>(
     ): Promise<ReadableStream<AudioFrame> | null> {
       return this.hookAdapter.realtimeAudioOutputNode(audio, modelSettings, () =>
         super.realtimeAudioOutputNode(audio, modelSettings),
+      );
+    }
+
+    override async transcriptionNode(
+      text: ReadableStream<string | TimedString> | AsyncIterable<string | TimedString>,
+      modelSettings: ModelSettings,
+    ): Promise<ReadableStream<string | TimedString> | null> {
+      return this.hookAdapter.transcriptionNode(text, modelSettings, () =>
+        super.transcriptionNode(text, modelSettings),
       );
     }
   }
@@ -399,6 +428,20 @@ class AgentHookAdapter<UserData, ContextT extends AgentContext<UserData>> {
 
     const input = audio instanceof ReadableStream ? readStream(audio) : audio;
     const result = await this.hooks.realtimeAudioOutputNode(this.context, input, modelSettings);
+    return result === null ? null : toStream(result);
+  }
+
+  async transcriptionNode(
+    text: ReadableStream<string | TimedString> | AsyncIterable<string | TimedString>,
+    modelSettings: ModelSettings,
+    fallback: () => Promise<ReadableStream<string | TimedString> | null>,
+  ): Promise<ReadableStream<string | TimedString> | null> {
+    if (!this.hooks.transcriptionNode) {
+      return fallback();
+    }
+
+    const input = text instanceof ReadableStream ? readStream(text) : text;
+    const result = await this.hooks.transcriptionNode(this.context, input, modelSettings);
     return result === null ? null : toStream(result);
   }
 }

--- a/agents/src/voice/agent_v2.ts
+++ b/agents/src/voice/agent_v2.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { AudioFrame } from '@livekit/rtc-node';
-import type { ReadableStream } from 'node:stream/web';
+import { ReadableStream } from 'node:stream/web';
 import type { Instructions, ReadonlyChatContext } from '../llm/chat_context.js';
 import type {
   ChatChunk,
@@ -173,7 +173,7 @@ export function createAgentV2<UserData>(
     }
 
     override async sttNode(
-      audio: ReadableStream<AudioFrame>,
+      audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
       modelSettings: ModelSettings,
     ): Promise<ReadableStream<SpeechEvent | string> | null> {
       return this.hookAdapter.sttNode(audio, modelSettings, () =>
@@ -192,7 +192,7 @@ export function createAgentV2<UserData>(
     }
 
     override async ttsNode(
-      text: ReadableStream<string>,
+      text: ReadableStream<string> | AsyncIterable<string>,
       modelSettings: ModelSettings,
     ): Promise<ReadableStream<AudioFrame> | null> {
       return this.hookAdapter.ttsNode(text, modelSettings, () =>
@@ -201,7 +201,7 @@ export function createAgentV2<UserData>(
     }
 
     override async realtimeAudioOutputNode(
-      audio: ReadableStream<AudioFrame>,
+      audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
       modelSettings: ModelSettings,
     ): Promise<ReadableStream<AudioFrame> | null> {
       return this.hookAdapter.realtimeAudioOutputNode(audio, modelSettings, () =>
@@ -267,7 +267,7 @@ export function createAgentTaskV2<ResultT, UserData>(
     }
 
     override async sttNode(
-      audio: ReadableStream<AudioFrame>,
+      audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
       modelSettings: ModelSettings,
     ): Promise<ReadableStream<SpeechEvent | string> | null> {
       return this.hookAdapter.sttNode(audio, modelSettings, () =>
@@ -286,7 +286,7 @@ export function createAgentTaskV2<ResultT, UserData>(
     }
 
     override async ttsNode(
-      text: ReadableStream<string>,
+      text: ReadableStream<string> | AsyncIterable<string>,
       modelSettings: ModelSettings,
     ): Promise<ReadableStream<AudioFrame> | null> {
       return this.hookAdapter.ttsNode(text, modelSettings, () =>
@@ -295,7 +295,7 @@ export function createAgentTaskV2<ResultT, UserData>(
     }
 
     override async realtimeAudioOutputNode(
-      audio: ReadableStream<AudioFrame>,
+      audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
       modelSettings: ModelSettings,
     ): Promise<ReadableStream<AudioFrame> | null> {
       return this.hookAdapter.realtimeAudioOutputNode(audio, modelSettings, () =>
@@ -342,7 +342,7 @@ class AgentHookAdapter<UserData, ContextT extends AgentContext<UserData>> {
   }
 
   async sttNode(
-    audio: ReadableStream<AudioFrame>,
+    audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
     modelSettings: ModelSettings,
     fallback: () => Promise<ReadableStream<SpeechEvent | string> | null>,
   ): Promise<ReadableStream<SpeechEvent | string> | null> {
@@ -350,7 +350,8 @@ class AgentHookAdapter<UserData, ContextT extends AgentContext<UserData>> {
       return fallback();
     }
 
-    const result = await this.hooks.sttNode(this.context, readStream(audio), modelSettings);
+    const input = audio instanceof ReadableStream ? readStream(audio) : audio;
+    const result = await this.hooks.sttNode(this.context, input, modelSettings);
     return result === null ? null : toStream(result);
   }
 
@@ -374,7 +375,7 @@ class AgentHookAdapter<UserData, ContextT extends AgentContext<UserData>> {
   }
 
   async ttsNode(
-    text: ReadableStream<string>,
+    text: ReadableStream<string> | AsyncIterable<string>,
     modelSettings: ModelSettings,
     fallback: () => Promise<ReadableStream<AudioFrame> | null>,
   ): Promise<ReadableStream<AudioFrame> | null> {
@@ -382,12 +383,13 @@ class AgentHookAdapter<UserData, ContextT extends AgentContext<UserData>> {
       return fallback();
     }
 
-    const result = await this.hooks.ttsNode(this.context, readStream(text), modelSettings);
+    const input = text instanceof ReadableStream ? readStream(text) : text;
+    const result = await this.hooks.ttsNode(this.context, input, modelSettings);
     return result === null ? null : toStream(result);
   }
 
   async realtimeAudioOutputNode(
-    audio: ReadableStream<AudioFrame>,
+    audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
     modelSettings: ModelSettings,
     fallback: () => Promise<ReadableStream<AudioFrame> | null>,
   ): Promise<ReadableStream<AudioFrame> | null> {
@@ -395,11 +397,8 @@ class AgentHookAdapter<UserData, ContextT extends AgentContext<UserData>> {
       return fallback();
     }
 
-    const result = await this.hooks.realtimeAudioOutputNode(
-      this.context,
-      readStream(audio),
-      modelSettings,
-    );
+    const input = audio instanceof ReadableStream ? readStream(audio) : audio;
+    const result = await this.hooks.realtimeAudioOutputNode(this.context, input, modelSettings);
     return result === null ? null : toStream(result);
   }
 }

--- a/agents/src/voice/io.ts
+++ b/agents/src/voice/io.ts
@@ -15,7 +15,7 @@ import { Future } from '../utils.js';
 import type { ModelSettings } from './agent.js';
 
 export type STTNode = (
-  audio: ReadableStream<AudioFrame>,
+  audio: ReadableStream<AudioFrame> | AsyncIterable<AudioFrame>,
   modelSettings: ModelSettings,
 ) => Promise<ReadableStream<SpeechEvent | string> | null>;
 
@@ -26,7 +26,7 @@ export type LLMNode = (
 ) => Promise<ReadableStream<ChatChunk | string | FlushSentinel> | null>;
 
 export type TTSNode = (
-  text: ReadableStream<string>,
+  text: ReadableStream<string> | AsyncIterable<string>,
   modelSettings: ModelSettings,
 ) => Promise<ReadableStream<AudioFrame> | null>;
 


### PR DESCRIPTION
## Description
Pipeline node overrides can now take an async generator/iterable as their stream input instead of having to `toStream()` it first.

## Changes Made
- Widen `ttsNode`/`sttNode`/`transcriptionNode`/`realtimeAudioOutputNode` inputs to `ReadableStream<T> | AsyncIterable<T>`
- Normalize the input via `toStream` in each `Agent` instance method; `Agent.default.*` impls keep taking a `ReadableStream`
- Changeset (`@livekit/agents` patch)

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
- [ ] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
N/A
