### PR TITLE
fix: await realtime chat context updates

### DIFF
--- a/.changeset/await-realtime-chatctx-sync.md
+++ b/.changeset/await-realtime-chatctx-sync.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Await active realtime chat context updates through `Agent.updateChatCtx()` so callers can reliably sequence follow-up model turns after conversation item sync completes.

--- a/agents/src/voice/agent.test.ts
+++ b/agents/src/voice/agent.test.ts
@@ -55,6 +55,19 @@ describe('Agent', () => {
     expect(settled).toBe(true);
   });
 
+  it('should propagate active activity chat context update failures', async () => {
+    const agent = new Agent({ instructions: 'test' });
+    const chatCtx = new ChatContext();
+    const error = new Error('update failed');
+    const updateChatCtx = vi.fn(() => Promise.reject(error));
+    (
+      agent as unknown as { _agentActivity: { updateChatCtx: typeof updateChatCtx } }
+    )._agentActivity = { updateChatCtx };
+
+    await expect(agent.updateChatCtx(chatCtx)).rejects.toBe(error);
+    expect(updateChatCtx).toHaveBeenCalledWith(chatCtx);
+  });
+
   it('should create agent with instructions and tools', () => {
     const instructions = 'You are a helpful assistant with tools';
 
@@ -127,6 +140,23 @@ describe('Agent', () => {
     await update;
 
     expect(settled).toBe(true);
+  });
+
+  it('should propagate realtime session chat context update failures', async () => {
+    const agent = new Agent({ instructions: 'test' });
+    const activity = Object.create(AgentActivity.prototype) as AgentActivity & {
+      agent: Agent;
+      realtimeSession: { updateChatCtx: ReturnType<typeof vi.fn> };
+    };
+    const chatCtx = new ChatContext();
+    const error = new Error('realtime update failed');
+    activity.agent = agent;
+    activity.realtimeSession = {
+      updateChatCtx: vi.fn(() => Promise.reject(error)),
+    };
+
+    await expect(activity.updateChatCtx(chatCtx)).rejects.toBe(error);
+    expect(activity.realtimeSession.updateChatCtx).toHaveBeenCalledOnce();
   });
 
   it('should return a copy of tools, not the original reference', () => {

--- a/agents/src/voice/agent.test.ts
+++ b/agents/src/voice/agent.test.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { ChatContext } from '../llm/chat_context.js';
 import { tool } from '../llm/index.js';
 import { initializeLogger } from '../log.js';
 import { Task } from '../utils.js';
@@ -22,6 +23,36 @@ describe('Agent', () => {
 
     expect(agent).toBeDefined();
     expect(agent.instructions).toBe(instructions);
+  });
+
+  it('should wait for active activity chat context updates', async () => {
+    const agent = new Agent({ instructions: 'test' });
+    const chatCtx = new ChatContext();
+    let resolveUpdate: () => void = () => {
+      throw new Error('update promise was not initialized');
+    };
+    const updatePromise = new Promise<void>((resolve) => {
+      resolveUpdate = resolve;
+    });
+    const updateChatCtx = vi.fn(() => updatePromise);
+    (
+      agent as unknown as { _agentActivity: { updateChatCtx: typeof updateChatCtx } }
+    )._agentActivity = { updateChatCtx };
+
+    let settled = false;
+    const update = agent.updateChatCtx(chatCtx).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+
+    expect(updateChatCtx).toHaveBeenCalledWith(chatCtx);
+    expect(settled).toBe(false);
+
+    resolveUpdate();
+    await update;
+
+    expect(settled).toBe(true);
   });
 
   it('should create agent with instructions and tools', () => {
@@ -62,6 +93,40 @@ describe('Agent', () => {
     // Verify tool properties with proper checks
     expect(agentTools.getTool1?.description).toBe('First test tool');
     expect(agentTools.getTool2?.description).toBe('Second test tool');
+  });
+
+  it('should wait for realtime session chat context updates', async () => {
+    const agent = new Agent({ instructions: 'test' });
+    const activity = Object.create(AgentActivity.prototype) as AgentActivity & {
+      agent: Agent;
+      realtimeSession: { updateChatCtx: ReturnType<typeof vi.fn> };
+    };
+    const chatCtx = new ChatContext();
+    let resolveUpdate: () => void = () => {
+      throw new Error('update promise was not initialized');
+    };
+    const updatePromise = new Promise<void>((resolve) => {
+      resolveUpdate = resolve;
+    });
+    activity.agent = agent;
+    activity.realtimeSession = {
+      updateChatCtx: vi.fn(() => updatePromise),
+    };
+
+    let settled = false;
+    const update = activity.updateChatCtx(chatCtx).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+
+    expect(activity.realtimeSession.updateChatCtx).toHaveBeenCalledOnce();
+    expect(settled).toBe(false);
+
+    resolveUpdate();
+    await update;
+
+    expect(settled).toBe(true);
   });
 
   it('should return a copy of tools, not the original reference', () => {

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -343,7 +343,7 @@ export class Agent<UserData = any> {
       return;
     }
 
-    this._agentActivity.updateChatCtx(chatCtx);
+    await this._agentActivity.updateChatCtx(chatCtx);
   }
 
   // TODO: Add when AgentConfigUpdate is ported to ChatContext.

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -853,7 +853,7 @@ export class AgentActivity implements RecognitionHooks {
 
     if (this.realtimeSession) {
       removeInstructions(chatCtx);
-      this.realtimeSession.updateChatCtx(chatCtx);
+      await this.realtimeSession.updateChatCtx(chatCtx);
     } else {
       updateInstructions({
         chatCtx,


### PR DESCRIPTION
## Summary

- Await `AgentActivity.updateChatCtx()` from `Agent.updateChatCtx()` when an activity is active.
- Await `RealtimeSession.updateChatCtx()` from `AgentActivity.updateChatCtx()` when a realtime session is active.
- Add focused tests covering both async boundaries.
- Add a patch changeset for `@livekit/agents`.

## Why

`Agent.updateChatCtx()` is public async API, but the active realtime path could return before the provider-side chat context sync completed. That allowed an immediately following model turn to race conversation item create/delete acknowledgements and observe stale context.

The realtime session contract already exposes `updateChatCtx()` as a `Promise<void>` and OpenAI Realtime waits for server acknowledgements internally. This change propagates that promise through the voice agent layers so callers can reliably sequence follow-up turns after context sync completes.

This also matches the Python SDK shape, where `Agent.update_chat_ctx()` and `AgentActivity.update_chat_ctx()` await the realtime session update.

## Validation

- `pnpm exec vitest run agents/src/voice/agent.test.ts`
- `pnpm exec vitest run plugins/openai/src/realtime/realtime_model.test.ts`
- `pnpm exec eslint agents/src/voice/agent.ts agents/src/voice/agent_activity.ts agents/src/voice/agent.test.ts` (warnings only, pre-existing `no-explicit-any` warnings)
- `pnpm --filter @livekit/agents build`
- `pnpm --filter @livekit/agents-plugins-test build`
- `pnpm --filter @livekit/agents-plugin-silero build`
- `pnpm --filter @livekit/agents-plugin-openai build`
- Real OpenAI Realtime smoke: update chat context, immediately ask a follow-up turn, verify the model sees the updated context.