### PR TITLE
Fix 1.5.0 voice-pipeline regressions vs main

### DIFF
--- a/.changeset/emit-interrupted-tool-executions.md
+++ b/.changeset/emit-interrupted-tool-executions.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Emit `function_tools_executed` for tool calls that finished before a speech interruption. Both the realtime and pipeline tool-execution paths `return` on `speechHandle.interrupted` ahead of their normal emit site, so a tool whose output landed just before a self-interrupt (e.g. Phonic's self-interrupting multi-step cascade) had its result dropped from observability even though it executed. The event is now emitted from the interrupted branches as well — before the in-flight tool execution is cancelled, so only genuinely-completed outputs are reported. This is observability-only and does not change conversation flow: interrupted turns still skip the tool reply, chat-context update, and agent handoff.

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -16,13 +16,20 @@
  */
 import { Heap } from 'heap-js';
 import { describe, expect, it, vi } from 'vitest';
-import { AgentConfigUpdate, ChatContext } from '../llm/chat_context.js';
+import {
+  AgentConfigUpdate,
+  ChatContext,
+  FunctionCall,
+  FunctionCallOutput,
+} from '../llm/chat_context.js';
 import { LLM, type LLMStream } from '../llm/llm.js';
 import { type Tool, ToolContext, ToolFlag, Toolset, tool } from '../llm/tool_context.js';
 import { Future, Task } from '../utils.js';
 import { _getActivityTaskInfo } from './agent.js';
 import { AgentActivity } from './agent_activity.js';
 import type { PreemptiveGenerationInfo } from './audio_recognition.js';
+import { AgentSessionEventTypes } from './events.js';
+import { ToolExecutionOutput, type ToolOutput } from './generation.js';
 import { SpeechHandle } from './speech_handle.js';
 
 const agentMocks = vi.hoisted(() => ({
@@ -795,5 +802,65 @@ describe('AgentActivity - waitForIdle close abort', () => {
     // close() aborts the shared signal; the wait must unblock.
     closeAbort.abort();
     expect(await raceTimeout(pending, 1000)).toBe('resolved');
+  });
+});
+
+/**
+ * Regression test: a realtime (or pipeline) tool whose output landed before a self-interrupt
+ * must still surface `function_tools_executed` for observability. Both interrupted-branches
+ * `return` ahead of their normal emit, so without `emitInterruptedToolExecutions` the completed
+ * tool's event is dropped (the symptom seen with Phonic's self-interrupting multi-step cascade).
+ */
+describe('AgentActivity - emitInterruptedToolExecutions', () => {
+  function build() {
+    const emit = vi.fn();
+    const fakeActivity = {
+      agentSession: { emit },
+      logger: { info() {}, debug() {}, warn() {}, error() {} },
+    };
+    Object.setPrototypeOf(fakeActivity, AgentActivity.prototype);
+    const emitInterrupted = (
+      AgentActivity.prototype as unknown as {
+        emitInterruptedToolExecutions: (this: unknown, toolOutput: ToolOutput, sh: unknown) => void;
+      }
+    ).emitInterruptedToolExecutions.bind(fakeActivity);
+    return { emit, emitInterrupted };
+  }
+
+  const makeOutput = (name: string, output: string): ToolOutput => {
+    const toolCall = FunctionCall.create({ callId: `call_${name}`, name, args: '{}' });
+    const toolCallOutput = FunctionCallOutput.create({
+      callId: `call_${name}`,
+      name,
+      output,
+      isError: false,
+    });
+    return {
+      output: [ToolExecutionOutput.create({ toolCall, toolCallOutput, rawOutput: output })],
+      firstToolStartedFuture: new Future(),
+    };
+  };
+
+  it('emits function_tools_executed for a tool that finished before the interruption', () => {
+    const { emit, emitInterrupted } = build();
+
+    emitInterrupted(makeOutput('get_weather', 'sunny'), { id: 'speech_1' });
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    const [eventType, payload] = emit.mock.calls[0] as [
+      string,
+      { functionCalls: FunctionCall[]; functionCallOutputs: FunctionCallOutput[] },
+    ];
+    expect(eventType).toBe(AgentSessionEventTypes.FunctionToolsExecuted);
+    expect(payload.functionCalls.map((c) => c.name)).toEqual(['get_weather']);
+    expect(payload.functionCallOutputs.map((o) => o.output)).toEqual(['sunny']);
+  });
+
+  it('does not emit when no tool finished before the interruption', () => {
+    const { emit, emitInterrupted } = build();
+
+    emitInterrupted({ output: [], firstToolStartedFuture: new Future() }, { id: 'speech_1' });
+
+    expect(emit).not.toHaveBeenCalled();
   });
 });

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -3113,6 +3113,8 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (speechHandle.interrupted) {
+      // Emit before cancelling so already-finished tool outputs aren't dropped on interruption.
+      this.emitInterruptedToolExecutions(toolOutput, speechHandle);
       await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
       return;
     }
@@ -3645,6 +3647,8 @@ export class AgentActivity implements RecognitionHooks {
         }
       }
       speechHandle._markGenerationDone();
+      // Emit before cancelling so already-finished tool outputs aren't dropped on interruption.
+      this.emitInterruptedToolExecutions(toolOutput, speechHandle);
       await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
 
       // TODO(brian): close tees
@@ -3859,6 +3863,30 @@ export class AgentActivity implements RecognitionHooks {
       newAgentTask,
       ignoreTaskSwitch,
     };
+  }
+
+  /**
+   * Emit `function_tools_executed` for tools that already finished, even when the speech was
+   * interrupted before reaching the normal (non-interrupted) emit site.
+   *
+   * Both the realtime and pipeline interrupted-branches `return` ahead of their emit, so a tool
+   * whose output landed before a self-interrupt (e.g. Phonic's multi-step cascade interrupting its
+   * own previous generation) would otherwise be dropped from observability even though it ran. This
+   * is observability-only: it does not generate a tool reply, update the chat context, or switch
+   * agents — those side effects stay gated on the non-interrupted path. Call this BEFORE cancelling
+   * the tool execution task so only genuinely-completed outputs are reported (mid-flight tools are
+   * aborted afterwards and never enter `toolOutput.output`).
+   */
+  private emitInterruptedToolExecutions(toolOutput: ToolOutput, speechHandle: SpeechHandle): void {
+    if (toolOutput.output.length === 0) return;
+    const { functionToolsExecutedEvent } = this.summarizeToolExecutionOutput(
+      toolOutput,
+      speechHandle,
+    );
+    this.agentSession.emit(
+      AgentSessionEventTypes.FunctionToolsExecuted,
+      functionToolsExecutedEvent,
+    );
   }
 
   private async realtimeReplyTask({


### PR DESCRIPTION
## Summary

Autonomous regression hunt across the 1.5.0 voice / realtime / tool-call / interruption pipeline vs `main` (`git diff main...1.5.0`, with `merge-base(main, 1.5.0) == main` tip, so the diff cleanly isolates 1.5.0's changes). One behavioral fix is applied; the rest of the prioritized diffs were classified as intentional 1.5.0 changes, enhancements, or bug fixes — not regressions.

## The fix: `function_tools_executed` dropped on interruption

**Symptom (seed):** a realtime tool call's `function_tools_executed` event is dropped when the generation is interrupted (Phonic self-interrupting multi-step cascade).

**What I found:** the emit gating is *identical* across `main`, `1.5.0`, **and** the Python oracle. In all three, both the realtime (`_realtimeGenerationTaskImpl`) and pipeline tool paths `return` on `speechHandle.interrupted` **before** the `emit(FunctionToolsExecuted, …)`:
- JS `main` realtime: interrupt-return at `agent_activity.ts:3534`, emit at `:3607`.
- JS `1.5.0` realtime: interrupt-return at `agent_activity.ts:3620`, emit at `:3693`.
- Python realtime: interrupt-return at `agent_activity.py:3654`, emit at `:3708`.

So this is **not** a `main`→`1.5.0` code divergence (the seed's "on main the emit is unconditional" does not match `git show main:agents/src/voice/agent_activity.ts`). It's a long-standing behavior in all implementations: a tool that finishes *just before* a self-interrupt has its `function_tools_executed` event dropped.

**The change (implements the requested behavior as a safe, additive hardening):** emit `function_tools_executed` for already-completed tools from the interrupted branches too — emitted **before** the in-flight tool execution is cancelled, so only genuinely-completed outputs are reported. It is observability-only: interrupted turns still skip the tool reply, chat-context update, and agent handoff (those stay gated on the non-interrupted path). Applied symmetrically to the realtime and pipeline paths via a small `emitInterruptedToolExecutions` helper.

> Note: this is a deliberate divergence from Python parity (Python currently drops the event on interrupt). It is additive and flow-neutral. If parity is preferred over this hardening, revert is a one-block change.

## Test plan

- [x] New deterministic unit tests in `agent_activity.test.ts` (`emitInterruptedToolExecutions`): emits for a tool completed before interruption; no emit when no tool finished.
- [x] `pnpm build:agents` passes.
- [x] Full `agent_activity.test.ts` suite passes (18/18).
- [x] Prettier formatting passes on edited files.
- Pre-existing/environmental (NOT introduced here): `amd.test.ts` fails 11/11 on the clean 1.5.0 base too; fresh-worktree `eslint` hits the duplicate `@typescript-eslint` plugin env error; `api:check` fails pre-existingly (`export * as`).

## Regressions NOT found

The other prioritized diffs were reviewed and classified as intentional, not regressions: ToolContext→class migration (phonic, chat_context, fallback_adapter), the new `ToolExecutor`/async-toolset feature (`tool_executor.ts`, `speech_handle.ts` circular-wait guard, `agent_session.ts` session tools), `maxToolSteps`+1 final-response enhancement, `audio_recognition.ts` metrics refactor + out-of-order guard, `agent_session.emit` record-only-when-recording memory fix, and `transcription/synchronizer.ts` (a transcript-drop *fix* in 1.5.0). The tool-output capture on abort (`generation.ts` `waitUntilAborted` → `toolCompleted`) is unchanged from main.