### PR TITLE
fix(plugin-openai): skip agent_config_update items in realtime chat-ctx sync

### DIFF
--- a/.changeset/fix-realtime-agent-config-update.md
+++ b/.changeset/fix-realtime-agent-config-update.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+Fix `Unsupported item type: agent_config_update` thrown by the OpenAI Realtime plugin when an `Agent` is constructed with tools or instructions. `AgentActivity` inserts internal `agent_config_update` chat items on enter and on tool / instructions changes; the realtime plugin's chat-context sync now filters them out before computing the diff, matching the non-realtime path's `excludeConfigUpdate` behavior and the existing wire filter in `remote_session.ts`.

--- a/.changeset/fix-realtime-agent-config-update.md
+++ b/.changeset/fix-realtime-agent-config-update.md
@@ -2,4 +2,4 @@
 '@livekit/agents-plugin-openai': patch
 ---
 
-Fix `Unsupported item type: agent_config_update` thrown by the OpenAI Realtime plugin when an `Agent` is constructed with tools or instructions. `AgentActivity` inserts internal `agent_config_update` chat items on enter and on tool / instructions changes; the realtime plugin's chat-context sync now filters them out before computing the diff, matching the non-realtime path's `excludeConfigUpdate` behavior and the existing wire filter in `remote_session.ts`.
+Fix `Unsupported item type: agent_config_update` thrown by the OpenAI Realtime plugin when an `Agent` is constructed with tools or instructions. `AgentActivity` inserts internal `agent_config_update` chat items on enter and on tool / instructions changes; the realtime plugin's chat-context sync now filters them out before computing the diff. `agent_handoff` items are also filtered as defense-in-depth, matching the non-realtime path's `chatCtx.copy({ excludeHandoff: true, excludeConfigUpdate: true })` (agent_activity.ts:666).

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -755,6 +755,38 @@ describe('RealtimeSession.createChatCtxUpdateEvents', () => {
 
     await expect(session.createChatCtxUpdateEvents(chatCtx)).resolves.toEqual([]);
   });
+
+  it('also skips agent_handoff items (defense-in-depth, no OpenAI Realtime representation)', async () => {
+    stubTaskRuntime();
+
+    const model = new RealtimeModel({ apiKey: 'test-key' });
+    const session = model.session() as unknown as {
+      createChatCtxUpdateEvents: (chatCtx: llm.ChatContext) => Promise<api_proto.ClientEvent[]>;
+    };
+
+    const userMessage = llm.ChatMessage.create({
+      id: 'item_user',
+      role: 'user',
+      content: ['hand me off please'],
+    });
+    const handoff = llm.AgentHandoffItem.create({
+      id: 'item_handoff',
+      oldAgentId: 'triage',
+      newAgentId: 'billing',
+    });
+    const chatCtx = llm.ChatContext.empty();
+    chatCtx.items.push(userMessage, handoff);
+
+    const events = await session.createChatCtxUpdateEvents(chatCtx);
+    const createdIds = events
+      .filter(
+        (e): e is api_proto.ConversationItemCreateEvent => e.type === 'conversation.item.create',
+      )
+      .map((e) => e.item.id);
+
+    expect(createdIds).toContain('item_user');
+    expect(createdIds).not.toContain('item_handoff');
+  });
 });
 
 describe('processBaseURL', () => {

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -696,6 +696,67 @@ describe('RealtimeSession.updateOptions', () => {
   });
 });
 
+describe('RealtimeSession.createChatCtxUpdateEvents', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('skips agent_config_update items so the realtime sync does not throw', async () => {
+    stubTaskRuntime();
+
+    const model = new RealtimeModel({ apiKey: 'test-key' });
+    const session = model.session() as unknown as {
+      createChatCtxUpdateEvents: (chatCtx: llm.ChatContext) => Promise<api_proto.ClientEvent[]>;
+    };
+
+    const systemMessage = llm.ChatMessage.create({
+      id: 'item_system',
+      role: 'system',
+      content: ['You are a helpful agent.'],
+    });
+    const configUpdate = llm.AgentConfigUpdate.create({
+      id: 'item_config',
+      instructions: 'updated instructions',
+      toolsAdded: ['lookup'],
+    });
+    const userMessage = llm.ChatMessage.create({
+      id: 'item_user',
+      role: 'user',
+      content: ['hello there'],
+    });
+    const chatCtx = llm.ChatContext.empty();
+    chatCtx.items.push(systemMessage, configUpdate, userMessage);
+
+    const events = await session.createChatCtxUpdateEvents(chatCtx);
+
+    const createdIds = events
+      .filter(
+        (e): e is api_proto.ConversationItemCreateEvent => e.type === 'conversation.item.create',
+      )
+      .map((e) => e.item.id);
+
+    expect(createdIds).toEqual(expect.arrayContaining(['item_system', 'item_user']));
+    expect(createdIds).not.toContain('item_config');
+  });
+
+  it('returns no create events for a ChatContext containing only agent_config_update items', async () => {
+    stubTaskRuntime();
+
+    const model = new RealtimeModel({ apiKey: 'test-key' });
+    const session = model.session() as unknown as {
+      createChatCtxUpdateEvents: (chatCtx: llm.ChatContext) => Promise<api_proto.ClientEvent[]>;
+    };
+
+    const chatCtx = llm.ChatContext.empty();
+    chatCtx.items.push(
+      llm.AgentConfigUpdate.create({ id: 'item_config_a', toolsAdded: ['a'] }),
+      llm.AgentConfigUpdate.create({ id: 'item_config_b', toolsRemoved: ['b'] }),
+    );
+
+    await expect(session.createChatCtxUpdateEvents(chatCtx)).resolves.toEqual([]);
+  });
+});
+
 describe('processBaseURL', () => {
   it('upgrades https baseURL to wss and appends /realtime with model', () => {
     const url = new URL(

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -664,6 +664,12 @@ export class RealtimeSession extends llm.RealtimeSession {
     addMockAudio: boolean = false,
   ): Promise<(api_proto.ConversationItemCreateEvent | api_proto.ConversationItemDeleteEvent)[]> {
     const newChatCtx = chatCtx.copy();
+    // Drop `agent_config_update` items — they're framework-internal (inserted
+    // by `AgentActivity` on enter / tool / instructions changes) and have no
+    // OpenAI Realtime representation; `livekitItemToOpenAIItem` throws on
+    // them. Mirrors the non-realtime path's `excludeConfigUpdate: true` and
+    // the wire filter in `remote_session.ts`.
+    newChatCtx.items = newChatCtx.items.filter((item) => item.type !== 'agent_config_update');
     if (addMockAudio) {
       newChatCtx.items.push(createMockAudioItem());
     } else {

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -664,12 +664,18 @@ export class RealtimeSession extends llm.RealtimeSession {
     addMockAudio: boolean = false,
   ): Promise<(api_proto.ConversationItemCreateEvent | api_proto.ConversationItemDeleteEvent)[]> {
     const newChatCtx = chatCtx.copy();
-    // Drop `agent_config_update` items — they're framework-internal (inserted
-    // by `AgentActivity` on enter / tool / instructions changes) and have no
-    // OpenAI Realtime representation; `livekitItemToOpenAIItem` throws on
-    // them. Mirrors the non-realtime path's `excludeConfigUpdate: true` and
-    // the wire filter in `remote_session.ts`.
-    newChatCtx.items = newChatCtx.items.filter((item) => item.type !== 'agent_config_update');
+    // Drop framework-internal items that have no OpenAI Realtime
+    // representation. `livekitItemToOpenAIItem`'s default arm throws on
+    // anything other than `function_call` / `function_call_output` /
+    // `message`. `agent_config_update` is the reachable case today (inserted
+    // by `AgentActivity` on enter / tool / instructions changes — the
+    // original #1855 crash); `agent_handoff` is filtered as defense-in-depth
+    // to match the non-realtime path, which excludes both via
+    // `chatCtx.copy({ excludeHandoff: true, excludeConfigUpdate: true })`
+    // (agent_activity.ts:666).
+    newChatCtx.items = newChatCtx.items.filter(
+      (item) => item.type !== 'agent_config_update' && item.type !== 'agent_handoff',
+    );
     if (addMockAudio) {
       newChatCtx.items.push(createMockAudioItem());
     } else {


### PR DESCRIPTION
## Summary

Fixes #1855 — when an `Agent` is constructed with tools or instructions, `AgentActivity` inserts internal `agent_config_update` chat items on enter and on tool / instructions changes (`agents/src/voice/agent_activity.ts:520, :875`). The OpenAI Realtime plugin's chat-context sync (`createChatCtxUpdateEvents` in `plugins/openai/src/realtime/realtime_model.ts:662`) feeds these into `livekitItemToOpenAIItem`, which has no `agent_config_update` case and throws:

```
Unsupported item type: agent_config_update
  at livekitItemToOpenAIItem (realtime_model.js)
  at RealtimeSession.createChatCtxUpdateEvents
  at RealtimeSession.updateChatCtx
  at AgentActivity._realtimeGenerationTaskImpl
```

The throw is caught upstream — non-fatal — but the never-played-message sync bails mid-iteration, leading to degraded post-tool speech behavior and missing transcript items on those turns (reporter's observation).

## Fix

Filter `agent_config_update` items out of `newChatCtx.items` inside `createChatCtxUpdateEvents` before the diff is computed:

```ts
newChatCtx.items = newChatCtx.items.filter((item) => item.type !== 'agent_config_update');
```

This mirrors the existing patterns elsewhere in the framework:
- **Non-realtime path** — `agent_activity.ts:666` already uses `.copy({ excludeInstructions: true, excludeHandoff: true, excludeConfigUpdate: true })` when handing context to non-realtime LLMs.
- **Distributed sessions wire** — `remote_session.ts:406` already filters `item.type !== 'agent_config_update'` before transport.

`livekitItemToOpenAIItem`'s defensive `throw` is left in place — it's still the correct behavior for unknown item types reaching the converter through other code paths.

## Tests

Two new cases in `plugins/openai/src/realtime/realtime_model.test.ts`:

- [x] Mixed ChatContext (system + agent_config_update + user) — `createChatCtxUpdateEvents` emits `conversation.item.create` only for the system and user messages; the config update id is absent from the events.
- [x] ChatContext containing only `agent_config_update` items — resolves to `[]` (no events, no throw).

Reverse-verified: both new tests fail RED with the exact reporter error against `upstream/main`, pass after the filter is added.

Local: `pnpm vitest run plugins/openai/src/realtime/realtime_model.test.ts` → 35/35 green. `pnpm lint` clean (36/36 packages). Pre-existing `@livekit/local-inference` / `@livekit/agents-plugins-test` import errors during `pnpm build:agents` are unrelated and reproduce on `upstream/main` with this change stashed.

Changeset: `@livekit/agents-plugin-openai` patch.

## Breaking changes

None. `agent_config_update` items had no OpenAI Realtime representation to begin with — the only reachable behavior change is no longer throwing on them during sync.