### PR TITLE
Promote TaskGroup workflow out of beta

### DIFF
--- a/.changeset/promote-task-group-stable.md
+++ b/.changeset/promote-task-group-stable.md
@@ -2,4 +2,4 @@
 '@livekit/agents': minor
 ---
 
-Promote the `TaskGroup` workflow out of beta. It now lives in the stable `workflows` namespace — import it as `workflows.TaskGroup` (with `workflows.TaskCompletedEvent`, `workflows.TaskGroupOptions`, and `workflows.TaskGroupResult`) instead of `beta.TaskGroup`. The `beta` namespace continues to re-export these symbols as deprecated aliases for backward compatibility; they will be removed in a future release.
+Promote the `TaskGroup` workflow out of beta. It now lives in the stable `workflows` namespace — import it as `workflows.TaskGroup` (with `workflows.TaskCompletedEvent`, `workflows.TaskGroupOptions`, and `workflows.TaskGroupResult`) instead of `beta.TaskGroup`. The `beta` namespace continues to re-export these symbols as deprecated aliases for backward compatibility; they will be removed in a future release. This is an intentional Node.js-only change; in Python `TaskGroup` remains under `beta.workflows`.

--- a/.changeset/promote-task-group-stable.md
+++ b/.changeset/promote-task-group-stable.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': minor
+---
+
+Promote the `TaskGroup` workflow out of beta. It now lives in the stable `workflows` namespace — import it as `workflows.TaskGroup` (with `workflows.TaskCompletedEvent`, `workflows.TaskGroupOptions`, and `workflows.TaskGroupResult`) instead of `beta.TaskGroup`. The `beta` namespace continues to re-export these symbols as deprecated aliases for backward compatibility; they will be removed in a future release.

--- a/agents/src/beta/index.ts
+++ b/agents/src/beta/index.ts
@@ -1,12 +1,18 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-export {
-  TaskGroup,
-  type TaskCompletedEvent,
-  type TaskGroupOptions,
-  type TaskGroupResult,
-} from './workflows/index.js';
+/**
+ * @deprecated `TaskGroup` has moved to the stable `workflows` namespace.
+ * Import it as `workflows.TaskGroup`. This `beta` re-export is a temporary
+ * compatibility alias and will be removed in a future release.
+ */
+export { TaskGroup } from './workflows/index.js';
+/**
+ * @deprecated Import from the stable `workflows` namespace instead (e.g.
+ * `workflows.TaskGroupResult`). These `beta` re-exports are temporary
+ * compatibility aliases and will be removed in a future release.
+ */
+export type { TaskCompletedEvent, TaskGroupOptions, TaskGroupResult } from './workflows/index.js';
 /**
  * @deprecated `WarmTransferTask` has moved to the stable `workflows` namespace.
  * Import it as `workflows.WarmTransferTask`. This `beta` re-export is a temporary

--- a/agents/src/beta/workflows/index.ts
+++ b/agents/src/beta/workflows/index.ts
@@ -1,12 +1,22 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-export {
-  TaskGroup,
-  type TaskCompletedEvent,
-  type TaskGroupOptions,
-  type TaskGroupResult,
-} from './task_group.js';
+/**
+ * @deprecated `TaskGroup` has moved to the stable `workflows` namespace.
+ * Import it as `workflows.TaskGroup`. This `beta` re-export is a temporary
+ * compatibility alias and will be removed in a future release.
+ */
+export { TaskGroup } from '../../workflows/index.js';
+/**
+ * @deprecated Import from the stable `workflows` namespace instead (e.g.
+ * `workflows.TaskGroupResult`). These `beta` re-exports are temporary
+ * compatibility aliases and will be removed in a future release.
+ */
+export type {
+  TaskCompletedEvent,
+  TaskGroupOptions,
+  TaskGroupResult,
+} from '../../workflows/index.js';
 
 /**
  * @deprecated `WarmTransferTask` has moved to the stable `workflows` namespace.

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -29,7 +29,7 @@ const agentMocks = vi.hoisted(() => ({
   getActivityTaskInfo: vi.fn(() => null),
 }));
 
-// Break circular dependency: agent_activity.ts → agent.js → beta/workflows/task_group.ts
+// Break circular dependency: agent_activity.ts → agent.js → workflows/task_group.ts
 vi.mock('./agent.js', () => {
   class Agent {}
   class AgentTask extends Agent {}

--- a/agents/src/workflows/index.ts
+++ b/agents/src/workflows/index.ts
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 export {
+  TaskGroup,
+  type TaskCompletedEvent,
+  type TaskGroupOptions,
+  type TaskGroupResult,
+} from './task_group.js';
+export {
   WarmTransferTask,
   type WarmTransferResult,
   type WarmTransferTaskOptions,

--- a/agents/src/workflows/task_group.ts
+++ b/agents/src/workflows/task_group.ts
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { z } from 'zod';
-import type { ChatContext } from '../../llm/chat_context.js';
-import { LLM, ToolError, ToolFlag, tool } from '../../llm/index.js';
-import { asError } from '../../utils.js';
-import { AgentTask } from '../../voice/agent.js';
+import type { ChatContext } from '../llm/chat_context.js';
+import { LLM, ToolError, ToolFlag, tool } from '../llm/index.js';
+import { asError } from '../utils.js';
+import { AgentTask } from '../voice/agent.js';
 
 interface FactoryInfo {
   taskFactory: () => AgentTask;

--- a/examples/src/basic_task_group.ts
+++ b/examples/src/basic_task_group.ts
@@ -4,12 +4,12 @@
 import {
   type JobContext,
   ServerOptions,
-  beta,
   cli,
   defineAgent,
   inference,
   llm,
   voice,
+  workflows,
 } from '@livekit/agents';
 import * as openai from '@livekit/agents-plugin-openai';
 import { fileURLToPath } from 'node:url';
@@ -88,7 +88,7 @@ class TaskGroupDemoAgent extends voice.Agent {
           description: 'Start a two-step onboarding flow (name then email).',
           parameters: z.object({}),
           execute: async () => {
-            const tg = new beta.TaskGroup({
+            const tg = new workflows.TaskGroup({
               summarizeChatCtx: true,
               onTaskCompleted: async ({ taskId }) => {
                 await this.session.say(`Completed task with id ${taskId}`);

--- a/examples/src/survey_agent.ts
+++ b/examples/src/survey_agent.ts
@@ -4,11 +4,11 @@
 import {
   type JobContext,
   ServerOptions,
-  beta,
   cli,
   defineAgent,
   llm,
   voice,
+  workflows,
 } from '@livekit/agents';
 // import * as phonic from '@livekit/agents-plugin-phonic';
 import { open } from 'node:fs/promises';
@@ -319,7 +319,7 @@ export class SurveyAgent extends voice.Agent<SurveyUserData> {
   }
 
   async onEnter() {
-    const group = new beta.TaskGroup({
+    const group = new workflows.TaskGroup({
       summarizeChatCtx: false,
     });
 

--- a/examples/src/testing/basic_task_group.test.ts
+++ b/examples/src/testing/basic_task_group.test.ts
@@ -26,13 +26,13 @@
  *   - onEnter() signals readiness instead of awaiting generateReply()
  *   - Tasks tested in isolation and as a group
  */
-import { Future, asError, beta, initializeLogger, llm, voice } from '@livekit/agents';
+import { Future, asError, initializeLogger, llm, voice, workflows } from '@livekit/agents';
 import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-const { TaskGroup } = beta;
-type TaskGroupResult = beta.TaskGroupResult;
-type TaskCompletedEvent = beta.TaskCompletedEvent;
+const { TaskGroup } = workflows;
+type TaskGroupResult = workflows.TaskGroupResult;
+type TaskCompletedEvent = workflows.TaskCompletedEvent;
 
 initializeLogger({ pretty: true, level: 'warn' });
 

--- a/examples/src/testing/survey_agent.test.ts
+++ b/examples/src/testing/survey_agent.test.ts
@@ -17,7 +17,7 @@
  * - Tasks tested in isolation and as a group.
  * - Regression test for disqualify (analogous to out_of_scope).
  */
-import { Future, asError, beta, initializeLogger, voice } from '@livekit/agents';
+import { Future, asError, initializeLogger, voice, workflows } from '@livekit/agents';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   BehavioralTask,
@@ -28,9 +28,9 @@ import {
   type SurveyUserData,
 } from '../survey_agent.js';
 
-const { TaskGroup } = beta;
-type TaskGroupResult = beta.TaskGroupResult;
-type TaskCompletedEvent = beta.TaskCompletedEvent;
+const { TaskGroup } = workflows;
+type TaskGroupResult = workflows.TaskGroupResult;
+type TaskCompletedEvent = workflows.TaskCompletedEvent;
 
 initializeLogger({ pretty: true, level: 'warn' });
 

--- a/examples/src/testing/task_group.test.ts
+++ b/examples/src/testing/task_group.test.ts
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { Future, asError, beta, initializeLogger, llm, voice } from '@livekit/agents';
+import { Future, asError, initializeLogger, llm, voice, workflows } from '@livekit/agents';
 import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-const { TaskGroup } = beta;
-type TaskGroupResult = beta.TaskGroupResult;
-type TaskCompletedEvent = beta.TaskCompletedEvent;
+const { TaskGroup } = workflows;
+type TaskGroupResult = workflows.TaskGroupResult;
+type TaskCompletedEvent = workflows.TaskCompletedEvent;
 
 initializeLogger({ pretty: true, level: 'warn' });
 


### PR DESCRIPTION
## Summary

Promotes the `TaskGroup` workflow out of the experimental `beta` namespace into the stable `workflows` namespace, mirroring exactly how `WarmTransferTask` was promoted in #1850.

- Moved `agents/src/beta/workflows/task_group.ts` → `agents/src/workflows/task_group.ts` (via `git mv`, depth-fixed relative imports).
- Added `TaskGroup`, `TaskCompletedEvent`, `TaskGroupOptions`, `TaskGroupResult` to `agents/src/workflows/index.ts` (alongside the existing `WarmTransferTask` exports).
- Converted the `beta` barrels (`agents/src/beta/index.ts`, `agents/src/beta/workflows/index.ts`) to `@deprecated` re-export aliases pointing at the stable `workflows` namespace.
- Updated in-repo example/test references from `beta.TaskGroup*` → `workflows.TaskGroup*`.
- Added a `@livekit/agents` minor changeset.

## Before / after

```ts
// before
import { beta } from '@livekit/agents';
const tg = new beta.TaskGroup({ ... });

// after
import { workflows } from '@livekit/agents';
const tg = new workflows.TaskGroup({ ... });
```

## Backward compatibility

The `beta` namespace keeps `@deprecated` re-export aliases (`beta.TaskGroup`, `beta.TaskCompletedEvent`, `beta.TaskGroupOptions`, `beta.TaskGroupResult`) that point at the stable `workflows` namespace, so existing `beta.TaskGroup` imports keep compiling. They'll be removed in a future release. This matches the alias pattern introduced for `WarmTransferTask` in #1850.

## Intentional divergence from Python

This intentionally diverges from the Python `livekit-agents`, which keeps `TaskGroup` under `beta.workflows`. The JS surface promotes it to the stable `workflows` namespace.

## Validation

- `pnpm build` — passes (all 36 tasks, incl. examples `tsc`).
- `pnpm format:check` — passes.
- `pnpm lint` — changed files lint clean (verified with `--resolve-plugins-relative-to .`). The repo-wide `pnpm lint` hits the known fresh-worktree "ESLint couldn't determine the plugin @typescript-eslint uniquely" env error (duplicate plugin install across the nested worktree + parent `node_modules`); unrelated to this change.
- TaskGroup unit tests pass: `task_group.test.ts` (6), `basic_task_group.test.ts` + `survey_agent.test.ts` (19 total). The 2 post-test "errors" in `survey_agent.test.ts` are pre-existing `FakeLLM` teardown noise ("No input text found"), unrelated to this namespace alias swap.

## Notes

- Pre-existing/known noise not caused by this PR: `api:check` failure on `export * as`, `amd.test.ts` failures, and the fresh-worktree eslint env error above.

Made with [Cursor](https://cursor.com)