### PR TITLE
fix(ci): pass GITHUB_TOKEN to snapshot pre-release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,8 @@ jobs:
           pnpm changeset version --snapshot next
           pnpm build
           pnpm publish -r --tag next --no-git-checks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build docs
         if: steps.changesets.outputs.published == 'true'
         run: pnpm doc


### PR DESCRIPTION
## Summary

The snapshot release path (`workflow_dispatch` with `snapshot=true`) fails during `pnpm changeset version --snapshot next`:

```
error Please create a GitHub personal access token ... and add it as the GITHUB_TOKEN environment variable
  at @changesets/get-github-info ...
```

`changeset version` runs the configured `@livekit/changesets-changelog-github` changelog generator, which calls the GitHub API (via `@changesets/get-github-info`) to resolve PR/author info and therefore requires `GITHUB_TOKEN`. The production "Create Release Pull Request or Publish to npm" step already sets this env (it's provided by `changesets/action`), but the "Publish pre-release" step runs `changeset version` directly via `run:` with no `env`, so the token is missing.

## Fix

Add the same `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` env to the "Publish pre-release" step.

## Notes

- Snapshot safety is unchanged: still published under the `next` dist-tag as `0.0.0-next-<timestamp>`, so `latest` and normal semver ranges are unaffected.

## Test plan

- [ ] Re-run the Release workflow via `workflow_dispatch` with `snapshot=true` and confirm `changeset version --snapshot next` succeeds and publishes under the `next` tag.