### PR TITLE
fix: use err.name check for AbortError instead of instanceof Error

### DIFF
--- a/agents/src/llm/fallback_adapter.ts
+++ b/agents/src/llm/fallback_adapter.ts
@@ -241,7 +241,7 @@ class FallbackLLMStream extends LLMStream {
       }
 
       // Handle timeout errors
-      if (error instanceof Error && error.name === 'AbortError') {
+      if ((error as { name?: string })?.name === 'AbortError') {
         if (checkRecovery) {
           this._log.warn({ llm: llm.label() }, 'recovery timed out');
         } else {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1608,7 +1608,7 @@ export class AgentActivity implements RecognitionHooks {
     const onAbort = () => waitInactiveTask.cancel();
     signal.addEventListener('abort', onAbort, { once: true });
     const waitInactiveResult = waitInactiveTask.result.catch((error) => {
-      if (error instanceof Error && error.name === 'AbortError') {
+      if ((error as { name?: string })?.name === 'AbortError') {
         return;
       }
       throw error;

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -1729,8 +1729,8 @@ export class AudioRecognition {
         this.logger.debug('EOU detection task completed');
       })
       .catch((err: unknown) => {
-        if (err instanceof Error && err.name === 'AbortError') {
-          // ignore aborted errors
+        if ((err as { name?: string })?.name === 'AbortError') {
+          // ignore aborted errors (DOMException from AbortSignal is not instanceof Error)
           return;
         }
         this.logger.error(err, 'Error in EOU detection task:');
@@ -1745,7 +1745,7 @@ export class AudioRecognition {
     try {
       await this.bounceEOUTask.result;
     } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
+      if ((error as { name?: string })?.name === 'AbortError') {
         return;
       }
       throw error;
@@ -2264,7 +2264,7 @@ export class AudioRecognition {
         this.logger.debug('User turn committed');
       })
       .catch((err: unknown) => {
-        if (err instanceof Error && err.name === 'AbortError') {
+        if ((err as { name?: string })?.name === 'AbortError') {
           this.logger.debug('User turn commit task cancelled');
           return;
         }

--- a/plugins/elevenlabs/src/stt.ts
+++ b/plugins/elevenlabs/src/stt.ts
@@ -393,7 +393,7 @@ export class STT extends stt.STT {
       if (error instanceof APIStatusError) {
         throw new APIConnectionError({ message: error.message });
       }
-      if (error instanceof Error && error.name === 'AbortError') {
+      if ((error as { name?: string })?.name === 'AbortError') {
         throw new APITimeoutError({});
       }
       throw new APIConnectionError({});

--- a/plugins/google/src/beta/gemini_tts.ts
+++ b/plugins/google/src/beta/gemini_tts.ts
@@ -267,7 +267,7 @@ export class ChunkedStream extends tts.ChunkedStream {
 
       sendLastFrame(true);
     } catch (error: unknown) {
-      if (error instanceof Error && error.name === 'AbortError') {
+      if ((error as { name?: string })?.name === 'AbortError') {
         return;
       }
       if (isAPIError(error)) throw error;

--- a/plugins/openai/src/tts.ts
+++ b/plugins/openai/src/tts.ts
@@ -147,7 +147,7 @@ export class ChunkedStream extends tts.ChunkedStream {
 
       this.queue.close();
     } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
+      if ((error as { name?: string })?.name === 'AbortError') {
         return;
       }
       throw error;


### PR DESCRIPTION
Fixes #1712

`DOMException`, which is what `AbortSignal`/`AbortController` throws, is not `instanceof Error` in Node.js or Bun. As a result, guards written as:

```ts
if (err instanceof Error && err.name === 'AbortError')
```

never match a real abort. The `instanceof Error` condition is already false for `DOMException`, so the abort falls through to the error-level logger — producing the spurious `DOMException` constant table in logs on every normal turn teardown.

The `.name` property is not exclusive to `Error` subclasses; any thrown value can carry it. Dropping `instanceof Error` and using an optional-chaining cast:

```ts
if ((err as { name?: string })?.name === 'AbortError')
```

matches both `Error` subclasses and `DOMException` uniformly across runtimes, which is the same approach the Web Platform (and Node's own `AbortSignal` docs) recommends.

Six occurrences fixed across the agents package and the Google, ElevenLabs, and OpenAI plugins.