### PR TITLE
fix(voice): capture activity to local before awaits in closeImplInner

### DIFF
--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -1526,25 +1526,26 @@ export class AgentSession<
     this._onAecWarmupExpired();
     this.off(AgentSessionEventTypes.UserInputTranscribed, this._onUserInputTranscribed);
 
-    if (this.activity) {
+    const activity = this.activity;
+    if (activity) {
       if (!drain) {
         try {
-          await this.activity.interrupt({ force: true }).await;
+          await activity.interrupt({ force: true }).await;
         } catch (error) {
           this.logger.warn({ error }, 'Error interrupting activity');
         }
       }
 
-      await this.activity.drain();
+      await activity.drain();
       // wait any uninterruptible speech to finish
-      await this.activity.currentSpeech?.waitForPlayout();
+      await activity.currentSpeech?.waitForPlayout();
 
       if (reason !== CloseReason.ERROR) {
-        this.activity.commitUserTurn({ audioDetached: true, throwIfNotReady: false });
+        activity.commitUserTurn({ audioDetached: true, throwIfNotReady: false });
       }
 
       try {
-        this.activity.detachAudioInput();
+        activity.detachAudioInput();
       } catch (error) {
         // Ignore detach errors during cleanup - source may not have been set
       }


### PR DESCRIPTION
Fixes #1871

`closeImplInner` reads `this.activity` across multiple `await` boundaries without first capturing a local reference. When `close()` races an activity transition that sets `this.activity = undefined` between the initial `if (this.activity)` guard and the subsequent awaited calls, accesses like `this.activity.currentSpeech?.waitForPlayout()` throw a `TypeError`:

```
TypeError: Cannot read properties of undefined (reading 'currentSpeech')
    at AgentSession.closeImplInner (voice/agent_session.js:968)
```

Because the throw happens before `this.emit(Close, ...)`, the `Close` event is never emitted — so any application code that depends on the session close event silently never runs for those sessions.

The fix captures `this.activity` into a local `const activity` at the top of the block. All reads within the `if (activity)` branch then operate on the captured reference, which remains stable regardless of concurrent mutations to `this.activity`.