### PR TITLE
(phonic): Use stream_ahead_of_real_time mode for Phonic WebSocket and sample rate 24000

### DIFF
--- a/.changeset/phonic-stream-ahead.md
+++ b/.changeset/phonic-stream-ahead.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-phonic': patch
+---
+
+Enable stream_ahead_of_real_time mode for phonic

--- a/plugins/phonic/package.json
+++ b/plugins/phonic/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "phonic": "^0.31.10"
+    "phonic": "^0.32.5"
   },
   "peerDependencies": {
     "@livekit/agents": "workspace:*",

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -6,13 +6,13 @@ import {
   AudioByteStream,
   DEFAULT_API_CONNECT_OPTIONS,
   Future,
+  type TimedString,
   asError,
   createTimedString,
   llm,
   log,
   shortuuid,
   stream,
-  type TimedString,
 } from '@livekit/agents';
 import { AudioFrame, AudioResampler } from '@livekit/rtc-node';
 import type { Phonic } from 'phonic';
@@ -661,22 +661,6 @@ export class RealtimeSession extends llm.RealtimeSession {
         systemPrompt: this.options.instructions + this.systemPromptPostfix,
         toolsPayload: [...(this.options.phonicTools ?? []), ...this.toolDefinitions],
       }),
-      ...(this.options.additionalLanguages !== undefined && {
-        additional_languages: this.options.additionalLanguages,
-      }),
-      ...(this.options.multilingualMode !== undefined && {
-        multilingual_mode: this.options.multilingualMode,
-      }),
-      audio_speed: this.options.audioSpeed,
-      tools: [...(this.options.phonicTools ?? []), ...this.toolDefinitions],
-      boosted_keywords: this.options.boostedKeywords,
-      ...(this.options.minWordsToInterrupt !== undefined && {
-        min_words_to_interrupt: this.options.minWordsToInterrupt,
-      }),
-      generate_no_input_poke_text: this.options.generateNoInputPokeText,
-      no_input_poke_sec: this.options.noInputPokeSec,
-      no_input_poke_text: this.options.noInputPokeText,
-      no_input_end_conversation_sec: this.options.noInputEndConversationSec,
     });
   }
 
@@ -963,9 +947,9 @@ export class RealtimeSession extends llm.RealtimeSession {
       audio_speed: this.options.audioSpeed,
       tools: toolsPayload,
       boosted_keywords: this.options.boostedKeywords,
-      // ...(this.options.minWordsToInterrupt !== undefined && {
-      //   min_words_to_interrupt: this.options.minWordsToInterrupt,
-      // }),
+      ...(this.options.minWordsToInterrupt !== undefined && {
+        min_words_to_interrupt: this.options.minWordsToInterrupt,
+      }),
       generate_no_input_poke_text: this.options.generateNoInputPokeText,
       no_input_poke_sec: this.options.noInputPokeSec,
       no_input_poke_text: this.options.noInputPokeText,

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -7,18 +7,20 @@ import {
   DEFAULT_API_CONNECT_OPTIONS,
   Future,
   asError,
+  createTimedString,
   llm,
   log,
   shortuuid,
   stream,
+  type TimedString,
 } from '@livekit/agents';
 import { AudioFrame, AudioResampler } from '@livekit/rtc-node';
 import type { Phonic } from 'phonic';
 import { PhonicClient } from 'phonic';
 import type { ServerEvent, Voice } from './api_proto.js';
 
-const PHONIC_INPUT_SAMPLE_RATE = 44100;
-const PHONIC_OUTPUT_SAMPLE_RATE = 44100;
+const PHONIC_INPUT_SAMPLE_RATE = 24000;
+const PHONIC_OUTPUT_SAMPLE_RATE = 24000;
 const PHONIC_NUM_CHANNELS = 1;
 const PHONIC_INPUT_FRAME_MS = 20;
 const DEFAULT_MODEL = 'merritt';
@@ -183,7 +185,7 @@ export class RealtimeModel extends llm.RealtimeModel {
       midSessionInstructionsUpdate: true,
       midSessionToolsUpdate: true,
       perResponseToolChoice: false,
-      nativeTranscriptSync: true,
+      nativeTranscriptSync: false,
     });
 
     const apiKey = options.apiKey || process.env.PHONIC_API_KEY;
@@ -245,9 +247,10 @@ interface GenerationState {
   responseId: string;
   messageChannel: stream.StreamChannel<llm.MessageGeneration>;
   functionChannel: stream.StreamChannel<llm.FunctionCall>;
-  textChannel: stream.StreamChannel<string>;
+  textChannel: stream.StreamChannel<string | TimedString>;
   audioChannel: stream.StreamChannel<AudioFrame>;
   outputText: string;
+  audioCursorSec: number;
 }
 
 /**
@@ -274,7 +277,7 @@ export class RealtimeSession extends llm.RealtimeSession {
   private toolsReady = new Future<void>();
   private closedFuture = new Future<void, never>();
   private connectTask: Promise<void>;
-  private toolDefinitions: Record<string, unknown>[] = [];
+  private toolDefinitions: Phonic.InlineWebSocketTool[] = [];
   private forbidSpeechAfterToolCall = new Set<string>();
   private pendingToolCallIds = new Set<string>();
   private readyToStart = new Future<void>();
@@ -407,7 +410,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     this.toolsReady.resolve();
   }
 
-  private buildToolDefinitions(tools: llm.ToolContext): Record<string, unknown>[] {
+  private buildToolDefinitions(tools: llm.ToolContext): Phonic.InlineWebSocketTool[] {
     this.forbidSpeechAfterToolCall = new Set(this.options.forbidSpeechAfterToolCall ?? []);
     return Object.entries(tools)
       .filter(([, tool]) => llm.isFunctionTool(tool))
@@ -418,7 +421,7 @@ export class RealtimeSession extends llm.RealtimeSession {
           function: {
             name,
             description: tool.description,
-            parameters: llm.toJsonSchema(tool.parameters),
+            parameters: llm.toJsonSchema(tool.parameters) as Phonic.OpenAiFunctionParameters,
             strict: true,
           },
         },
@@ -466,7 +469,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     this.closeCurrentGeneration({ interrupted: true });
     this.pendingUserText = undefined;
 
-    const toolsPayload: Phonic.ConfigOptions.Tools.Item[] = [
+    const toolsPayload: Phonic.ToolDefinition[] = [
       ...(this.options.phonicTools ?? []),
       ...this.toolDefinitions,
     ];
@@ -749,10 +752,8 @@ export class RealtimeSession extends llm.RealtimeSession {
     const gen = this.currentGeneration;
     if (gen === undefined) return;
 
-    if (message.text) {
-      gen.outputText += message.text;
-      gen.textChannel.write(message.text);
-    }
+    let audioFrame: AudioFrame | undefined;
+    let audioDurationSec = 0;
 
     if (message.audio) {
       const bytes = Buffer.from(message.audio, 'base64');
@@ -764,14 +765,30 @@ export class RealtimeSession extends llm.RealtimeSession {
             bytes.byteOffset + sampleCount * Int16Array.BYTES_PER_ELEMENT,
           ),
         );
-        const frame = new AudioFrame(
+        audioFrame = new AudioFrame(
           pcm,
           PHONIC_OUTPUT_SAMPLE_RATE,
           PHONIC_NUM_CHANNELS,
           sampleCount / PHONIC_NUM_CHANNELS,
         );
-        gen.audioChannel.write(frame);
+        audioDurationSec = audioFrame.samplesPerChannel / PHONIC_OUTPUT_SAMPLE_RATE;
       }
+    }
+
+    if (message.text) {
+      gen.outputText += message.text;
+      gen.textChannel.write(
+        createTimedString({
+          text: message.text,
+          startTime: gen.audioCursorSec,
+          endTime: gen.audioCursorSec + audioDurationSec,
+        }),
+      );
+    }
+
+    if (audioFrame) {
+      gen.audioChannel.write(audioFrame);
+      gen.audioCursorSec += audioDurationSec;
     }
   }
 
@@ -838,7 +855,7 @@ export class RealtimeSession extends llm.RealtimeSession {
 
     const responseId = shortuuid('PS_');
 
-    const textChannel = stream.createStreamChannel<string>();
+    const textChannel = stream.createStreamChannel<string | TimedString>();
     const audioChannel = stream.createStreamChannel<AudioFrame>();
     const functionChannel = stream.createStreamChannel<llm.FunctionCall>();
     const messageChannel = stream.createStreamChannel<llm.MessageGeneration>();
@@ -857,6 +874,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       textChannel,
       audioChannel,
       outputText: '',
+      audioCursorSec: 0,
     };
 
     const generationEvent: llm.GenerationCreatedEvent = {
@@ -922,7 +940,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     toolsPayload,
   }: {
     systemPrompt: string;
-    toolsPayload: Phonic.ConfigOptions.Tools.Item[];
+    toolsPayload: Phonic.ToolDefinition[];
   }): Phonic.ConfigOptions {
     return {
       agent: this.options.phonicAgent,
@@ -931,8 +949,8 @@ export class RealtimeSession extends llm.RealtimeSession {
       generate_welcome_message: this.options.generateWelcomeMessage,
       system_prompt: systemPrompt,
       voice_id: this.options.voice,
-      input_format: 'pcm_44100',
-      output_format: 'pcm_44100',
+      input_format: 'pcm_24000',
+      output_format: 'pcm_24000',
       ...(this.options.defaultLanguage !== undefined && {
         default_language: this.options.defaultLanguage,
       }),
@@ -952,6 +970,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       no_input_poke_sec: this.options.noInputPokeSec,
       no_input_poke_text: this.options.noInputPokeText,
       no_input_end_conversation_sec: this.options.noInputEndConversationSec,
+      stream_ahead_of_real_time: true,
     };
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1100,8 +1100,8 @@ importers:
   plugins/phonic:
     dependencies:
       phonic:
-        specifier: ^0.31.10
-        version: 0.31.12
+        specifier: ^0.32.5
+        version: 0.32.5
     devDependencies:
       '@livekit/agents':
         specifier: workspace:*
@@ -4556,8 +4556,8 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  phonic@0.31.12:
-    resolution: {integrity: sha512-y4WKcivisgCYAfsahYs3n18W+uB9PrHDUaooAT8gCGn5MjO+nBMljnBhamqURn8vit2ZFh47ZOED54KY15Ln3w==}
+  phonic@0.32.5:
+    resolution: {integrity: sha512-Zyd7ZCuT9ozjGzAxaPYCNRRZUzlYYckQNoQi2QH5xCqEGiBcj9uWKLMkilPHZ3yZ2Uy7IA6ZeX0Mqrkv5sa+Fg==}
     engines: {node: '>=18.0.0'}
 
   picocolors@1.1.1:
@@ -8613,7 +8613,7 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  phonic@0.31.12:
+  phonic@0.32.5:
     dependencies:
       ws: 8.20.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Description
- Bump phonic to 0.32.5 and enable `stream_ahead_of_real_time` so assistant audio is sent to Livekit agents as soon as it is generated.
- Switch the input and output formats to pcm_24000

## Pre-Review Checklist
- [ ] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [ ] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.