### PR TITLE
fix(rime): send language parameter for TTS

### DIFF
--- a/.changeset/rime-language-param.md
+++ b/.changeset/rime-language-param.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-rime': patch
+---
+
+Send Rime TTS language selection with the documented `language` API parameter while preserving `lang` as a legacy option.

--- a/plugins/rime/src/tts.test.ts
+++ b/plugins/rime/src/tts.test.ts
@@ -4,8 +4,62 @@
 import { initializeLogger } from '@livekit/agents';
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts } from '@livekit/agents-plugins-test';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { TTS } from './tts.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TTS, type TTSOptions } from './tts.js';
+
+const { MockWebSocket } = vi.hoisted(() => {
+  class MockWebSocket {
+    static OPEN = 1;
+    static CLOSED = 3;
+    static instances: MockWebSocket[] = [];
+
+    readyState = 0;
+    readonly sent: unknown[] = [];
+    readonly #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+    constructor(
+      readonly url: string,
+      readonly options: unknown,
+    ) {
+      MockWebSocket.instances.push(this);
+    }
+
+    on(event: string, listener: (...args: unknown[]) => void) {
+      const listeners = this.#listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+      listeners.add(listener);
+      this.#listeners.set(event, listeners);
+      return this;
+    }
+
+    off(event: string, listener: (...args: unknown[]) => void) {
+      this.#listeners.get(event)?.delete(listener);
+      return this;
+    }
+
+    send(data: unknown): void {
+      this.sent.push(data);
+    }
+
+    close(): void {
+      this.readyState = MockWebSocket.CLOSED;
+      this.emit('close', 1000, Buffer.from(''));
+    }
+
+    terminate(): void {
+      this.readyState = MockWebSocket.CLOSED;
+    }
+
+    emit(event: string, ...args: unknown[]): void {
+      for (const listener of this.#listeners.get(event) ?? []) {
+        listener(...args);
+      }
+    }
+  }
+
+  return { MockWebSocket };
+});
+
+vi.mock('ws', () => ({ default: MockWebSocket, WebSocket: MockWebSocket }));
 
 initializeLogger({ pretty: false, level: 'silent' });
 
@@ -29,6 +83,53 @@ async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | 'tim
     if (timer) clearTimeout(timer);
   });
 }
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = performance.now();
+  while (!predicate()) {
+    if (performance.now() - start > timeoutMs) {
+      throw new Error('condition not met within timeout');
+    }
+    await sleep(5);
+  }
+}
+
+async function captureFetchPayload(opts: Partial<TTSOptions>): Promise<Record<string, unknown>> {
+  let payload: Record<string, unknown> | undefined;
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+    payload = JSON.parse(String(init?.body));
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'audio/pcm' },
+      },
+    );
+  });
+
+  const rimeTTS = new TTS({
+    apiKey: 'test-rime-key',
+    baseURL: 'https://rime.test/v1/rime-tts',
+    modelId: 'arcana',
+    speaker: 'luna',
+    ...opts,
+  });
+
+  const result = await withTimeout(rimeTTS.synthesize('Hello from Rime.').next(), 1000);
+  expect(result).not.toBe('timeout');
+  expect(payload).toBeDefined();
+  return payload!;
+}
+
+beforeEach(() => {
+  MockWebSocket.instances.length = 0;
+});
 
 describe('Rime TTS streaming', () => {
   afterEach(() => {
@@ -80,6 +181,53 @@ describe('Rime TTS streaming', () => {
 
     const doneResult = await stream.next();
     expect(doneResult.done).toBe(true);
+  });
+});
+
+describe('Rime TTS language options', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends language instead of lang in one-shot payloads', async () => {
+    const payload = await captureFetchPayload({ language: 'eng', lang: 'spa' });
+
+    expect(payload.language).toBe('eng');
+    expect(payload).not.toHaveProperty('lang');
+  });
+
+  it('maps legacy lang to the Rime language API parameter', async () => {
+    const payload = await captureFetchPayload({ lang: 'spa' });
+
+    expect(payload.language).toBe('spa');
+    expect(payload).not.toHaveProperty('lang');
+  });
+
+  it('sends language instead of lang in WebSocket query parameters', async () => {
+    const rimeTTS = new TTS({
+      apiKey: 'test-rime-key',
+      baseURL: 'wss://rime.test',
+      useWebsocket: true,
+      modelId: 'arcana',
+      speaker: 'luna',
+      language: 'eng',
+      lang: 'spa',
+    });
+    const stream = rimeTTS.stream({
+      connOptions: { maxRetry: 0, retryIntervalMs: 0, timeoutMs: 1000 },
+    });
+
+    try {
+      await waitFor(() => MockWebSocket.instances.length > 0);
+      const socket = MockWebSocket.instances[0]!;
+      const url = new URL(socket.url);
+
+      expect(url.searchParams.get('language')).toBe('eng');
+      expect(url.searchParams.has('lang')).toBe(false);
+    } finally {
+      stream.close();
+      await withTimeout(stream.next(), 1000);
+    }
   });
 });
 

--- a/plugins/rime/src/tts.ts
+++ b/plugins/rime/src/tts.ts
@@ -59,6 +59,9 @@ export interface TTSOptions {
   useWebsocket?: boolean;
   segment?: string;
   tokenizer?: tokenize.SentenceTokenizer;
+  /** Rime TTS language code. Prefer this over the deprecated `lang` option. */
+  language?: DefaultLanguages | string;
+  /** @deprecated Use `language` instead. */
   lang?: DefaultLanguages | string;
   repetition_penalty?: number;
   temperature?: number;
@@ -88,7 +91,8 @@ const defaultTTSOptions: TTSOptions = {
 
 function modelParams(opts: TTSOptions): Record<string, string | number | boolean> {
   const params: Record<string, string | number | boolean> = {};
-  if (opts.lang !== undefined) params.lang = opts.lang;
+  const language = opts.language ?? opts.lang;
+  if (language !== undefined) params.language = language;
 
   if (opts.modelId === 'arcana') {
     if (opts.repetition_penalty !== undefined) params.repetition_penalty = opts.repetition_penalty;
@@ -139,6 +143,7 @@ function fetchPayload(opts: TTSOptions, text: string): Record<string, unknown> {
         'tokenizer',
         'speaker',
         'modelId',
+        'language',
         'lang',
         'repetition_penalty',
         'temperature',


### PR DESCRIPTION
## Summary

- Add `language` as the preferred Rime TTS language option while keeping `lang` as a deprecated compatibility alias.
- Send the documented Rime API parameter as `language` for both HTTP and WebSocket TTS requests.
- Add unit coverage for HTTP payloads, legacy `lang` fallback, and WebSocket query parameters.

## Why

The Rime API expects the language selection under the `language` parameter. The current JS plugin exposes `lang` and forwards `lang` into Rime request parameters, which makes code using the documented Rime parameter shape harder to write and can silently send the wrong query key.

This keeps the existing `lang` option working for users who already depend on it, but prefers `language` when both are provided so new code can use the provider's documented API spelling.

## Validation

- `pnpm exec vitest run plugins/rime/src/tts.test.ts`
- `pnpm --filter @livekit/agents-plugin-rime lint`
- `pnpm exec prettier --check plugins/rime/src/tts.ts plugins/rime/src/tts.test.ts .changeset/rime-language-param.md`
- `pnpm --filter @livekit/agents-plugin-rime build`

I also ran `pnpm --filter @livekit/agents-plugin-rime api:check`; it reached API Extractor but exited nonzero on the existing missing API report/release-tag warnings for this plugin rather than a new type error.
