### PR TITLE
feat(assemblyai): add streaming inactivity timeout option

### DIFF
--- a/.changeset/assemblyai-inactivity-timeout.md
+++ b/.changeset/assemblyai-inactivity-timeout.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-assemblyai': patch
+---
+
+Add AssemblyAI streaming `inactivityTimeout` support.

--- a/plugins/assemblyai/src/stt.test.ts
+++ b/plugins/assemblyai/src/stt.test.ts
@@ -3,8 +3,32 @@
 // SPDX-License-Identifier: Apache-2.0
 import { VAD } from '@livekit/agents-plugin-silero';
 import { stt } from '@livekit/agents-plugins-test';
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
 import { describe, expect, it } from 'vitest';
+import { WebSocketServer } from 'ws';
 import { STT } from './stt.js';
+
+async function startWebSocketServer() {
+  const wss = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  await once(wss, 'listening');
+  const address = wss.address() as AddressInfo;
+  return { wss, baseUrl: `ws://127.0.0.1:${address.port}` };
+}
+
+async function closeWebSocketServer(wss: WebSocketServer): Promise<void> {
+  for (const client of wss.clients) client.close();
+  await new Promise<void>((resolve) => wss.close(() => resolve()));
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for condition');
+}
 
 describe('AssemblyAI options', () => {
   it('accepts u3-rt-pro-beta-1', () => {
@@ -46,6 +70,32 @@ describe('AssemblyAI options', () => {
           previousContextNTurns: 5,
         }),
     ).toThrow(/previousContextNTurns/);
+  });
+
+  it('forwards inactivity timeout to the streaming query', async () => {
+    const { wss, baseUrl } = await startWebSocketServer();
+    let requestUrl = '';
+
+    wss.on('connection', (_ws, req) => {
+      requestUrl = req.url ?? '';
+    });
+
+    try {
+      const stream = new STT({
+        apiKey: 'test-key',
+        baseUrl,
+        inactivityTimeout: 45,
+      }).stream();
+
+      await waitUntil(() => requestUrl !== '');
+      stream.close();
+
+      const url = new URL(`ws://127.0.0.1${requestUrl}`);
+      expect(url.pathname).toBe('/v3/ws');
+      expect(url.searchParams.get('inactivity_timeout')).toBe('45');
+    } finally {
+      await closeWebSocketServer(wss);
+    }
   });
 });
 

--- a/plugins/assemblyai/src/stt.ts
+++ b/plugins/assemblyai/src/stt.ts
@@ -65,6 +65,11 @@ export interface STTOptions {
   encoding: STTEncoding;
   speechModel: STTModels;
   languageDetection?: boolean;
+  /**
+   * Session inactivity timeout in seconds. AssemblyAI accepts integer values
+   * from 5 to 3600; when unset, no inactivity timeout is applied.
+   */
+  inactivityTimeout?: number;
   endOfTurnConfidenceThreshold?: number;
   /** Minimum silence (ms) before a confident end-of-turn is finalized. */
   minTurnSilence?: number;
@@ -322,6 +327,7 @@ export class SpeechStream extends stt.SpeechStream {
           ? JSON.stringify(this.#opts.keytermsPrompt)
           : undefined,
       language_detection: languageDetection,
+      inactivity_timeout: this.#opts.inactivityTimeout,
       prompt: this.#opts.prompt,
       agent_context: this.#opts.agentContext,
       previous_context_n_turns: this.#opts.previousContextNTurns,


### PR DESCRIPTION
## Summary

- Add `inactivityTimeout` to AssemblyAI `STTOptions`.
- Forward it to the AssemblyAI Universal Streaming WebSocket query as `inactivity_timeout`.
- Add a local WebSocket unit test that verifies the query parameter is emitted.

## Why

AssemblyAI's streaming API supports an inactivity timeout for closing idle sessions. The JS plugin already exposes other connection-time Universal Streaming parameters in `STTOptions`, but this timeout was not available, forcing applications to carry a patch or accept the provider default.

This option is useful for voice agents that need explicit idle-session behavior in production, especially when calls can pause or when deployments need predictable cleanup of provider-side streaming sessions.

The option is documented as seconds to match the AssemblyAI API field semantics and to avoid mixing it with the framework's millisecond turn-timing options (`minTurnSilence`, `maxTurnSilence`, etc.).

## Validation

- `pnpm exec vitest run plugins/assemblyai/src/stt.test.ts`
- `pnpm --filter @livekit/agents-plugin-assemblyai lint`
- `pnpm exec prettier --check plugins/assemblyai/src/stt.ts plugins/assemblyai/src/stt.test.ts .changeset/assemblyai-inactivity-timeout.md`
- `pnpm --filter @livekit/agents-plugin-assemblyai build`

I also ran `pnpm --filter @livekit/agents-plugin-assemblyai api:check`; it reached API Extractor but exited nonzero on the existing missing API report/release-tag/unresolved-link warnings for this plugin rather than a new type error.
