### PR TITLE
fix(ipc): bound native dispose() with a timeout so job children always exit

### DIFF
--- a/.changeset/bound-native-dispose-timeout.md
+++ b/.changeset/bound-native-dispose-timeout.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Bound the native `dispose()` in the process job executor with a timeout so a job child always reaches `process.exit(0)`. Previously, if native FFI disposal hung on a handle that never drained, the child would never exit and would linger indefinitely holding the job's full RSS while still answering supervisor pings (so it was never reclaimed by the orphan reaper).

--- a/agents/src/ipc/job_proc_lazy_main.ts
+++ b/agents/src/ipc/job_proc_lazy_main.ts
@@ -16,6 +16,7 @@ import type { IPCMessage } from './message.js';
 
 const ORPHANED_TIMEOUT = 15 * 1000;
 const SESSION_CLOSE_TIMEOUT = 60 * 1000;
+const DISPOSE_TIMEOUT = 10 * 1000;
 
 const safeSend = (msg: IPCMessage): boolean => {
   try {
@@ -319,7 +320,20 @@ const startJob = (
     // still running, causing: "mutex lock failed: Invalid argument"
     // See: https://github.com/livekit/node-sdks/issues/564
     try {
-      await dispose();
+      // Bound the wait: if native disposal hangs on a handle that never drains,
+      // an unbounded await here leaves the job child alive forever. It never
+      // reaches process.exit() yet keeps answering supervisor pings, so it is
+      // never reclaimed. Fall through to process.exit() on timeout; a crash on
+      // exit is still preferable to a zombie holding the job's full RSS.
+      await Promise.race([
+        dispose(),
+        new Promise<void>((_, reject) =>
+          setTimeout(
+            () => reject(new Error('native resource disposal timed out')),
+            DISPOSE_TIMEOUT,
+          ),
+        ),
+      ]);
       logger.debug('native resources disposed');
     } catch (error) {
       logger.warn({ error }, 'failed to dispose native resources');


### PR DESCRIPTION
Closes #1905.

### Problem

The process job child awaits `dispose()` (native FFI teardown) without a timeout before `process.exit(0)` (`agents/src/ipc/job_proc_lazy_main.ts`). If native disposal hangs on a handle that never drains, the child never exits — it lingers indefinitely holding the job's full RSS while still answering supervisor pings, so neither the orphan reaper nor the no-op `SIGTERM` handler reclaims it. On a long-running fleet these accumulate into a multi-day memory climb and eventual OOM. Full production trace in #1905.

### Fix

Race `dispose()` against a `DISPOSE_TIMEOUT` (10s) and fall through to `process.exit(0)` on expiry. `dispose()` is still attempted first, so the normal path keeps the libc++abi-crash guard (livekit/node-sdks#564) intact; the timeout only changes the pathological case from "hang forever" to "exit anyway". A crash on exit is strictly preferable to an immortal zombie holding the job's full RSS.

### Notes

- Adds a changeset (`@livekit/agents` patch).
- Happy path is unchanged (`dispose()` resolves well under 10s); the timeout only fires when disposal is genuinely wedged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
