### PR TITLE
fix(voice): commit interrupted speech without a synchronized transcript

### DIFF
--- a/.changeset/phantom-utterance-interrupted-transcript.md
+++ b/.changeset/phantom-utterance-interrupted-transcript.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents": patch
+---
+
+Fix interrupted assistant speech being dropped from chat history when the audio output provides no playback-aligned transcript. On a mid-playout interruption, `forwardedTextFor` (and the realtime reply path) returned `synchronizedTranscript ?? ''`, so an interrupted-but-heard reply produced no `conversation_item_added` and was missing from `chatCtx` — common with avatar outputs that don't emit a synchronized transcript. The commit now falls back to the forwarded generation text (`textOut.text`), matching the Python SDK's `_ForwardOutput.forwarded_text` behavior.

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2593,7 +2593,7 @@ export class AgentActivity implements RecognitionHooks {
     const forwardedTextFor = (output: SegmentOutput): string => {
       if (output.played === 'skipped') return '';
       if (output.played === 'partial' && output.audioOut) {
-        return output.synchronizedTranscript ?? '';
+        return output.synchronizedTranscript || output.textOut?.text || '';
       }
       return output.textOut?.text ?? '';
     };
@@ -3427,7 +3427,7 @@ export class AgentActivity implements RecognitionHooks {
         const interrupted = output.played === 'partial';
         let forwardedText = output.textOut?.text || '';
         if (interrupted && output.audioOut) {
-          forwardedText = output.synchronizedTranscript ?? '';
+          forwardedText = output.synchronizedTranscript || forwardedText;
         }
 
         if (interrupted && realtimeModel.capabilities.messageTruncation) {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -115,6 +115,7 @@ import {
   type _AudioOut,
   type _TextOut,
   applyInstructionsModality,
+  forwardedTextFor,
   performAudioForwarding,
   performLLMInference,
   performTTSInference,
@@ -200,6 +201,15 @@ interface PausedSpeechInfo {
   handle: SpeechHandle;
   agentState: AgentState;
   timeout: number;
+}
+
+/// Analog to Python's _ForwardOutput
+export interface ForwardOutput {
+  played: 'full' | 'partial' | 'skipped';
+  textOut: _TextOut | null;
+  synchronizedTranscript?: string;
+  audioOut: _AudioOut | null;
+  playbackPositionInS: number;
 }
 
 export class AgentActivity implements RecognitionHooks {
@@ -2582,21 +2592,7 @@ export class AgentActivity implements RecognitionHooks {
       ttsGenData?: _TTSGenerationData;
     }
 
-    interface SegmentOutput {
-      textOut: _TextOut | null;
-      audioOut: _AudioOut | null;
-      played: 'full' | 'partial' | 'skipped';
-      playbackPositionInS: number;
-      synchronizedTranscript?: string;
-    }
-
-    const forwardedTextFor = (output: SegmentOutput): string => {
-      if (output.played === 'skipped') return '';
-      if (output.played === 'partial' && output.audioOut) {
-        return output.synchronizedTranscript || output.textOut?.text || '';
-      }
-      return output.textOut?.text ?? '';
-    };
+    type SegmentOutput = ForwardOutput;
 
     const segmentQueue = new AsyncIterableQueue<SpeechSegment>();
     let synthesizeTask: Task<void> | null = null;
@@ -3239,14 +3235,9 @@ export class AgentActivity implements RecognitionHooks {
       }
     };
 
-    interface MessageOutput {
+    interface MessageOutput extends ForwardOutput {
       message: MessageGeneration;
-      textOut: _TextOut | null;
-      audioOut: _AudioOut | null;
       modalities?: ('text' | 'audio')[];
-      played: 'full' | 'partial' | 'skipped';
-      playbackPositionInS: number;
-      synchronizedTranscript?: string;
     }
 
     const tasks: Array<Task<void>> = [];
@@ -3425,10 +3416,7 @@ export class AgentActivity implements RecognitionHooks {
         if (output.played === 'skipped') continue;
 
         const interrupted = output.played === 'partial';
-        let forwardedText = output.textOut?.text || '';
-        if (interrupted && output.audioOut) {
-          forwardedText = output.synchronizedTranscript || forwardedText;
-        }
+        const forwardedText = forwardedTextFor(output);
 
         if (interrupted && realtimeModel.capabilities.messageTruncation) {
           // Defense-in-depth: playbackPositionInS can be non-finite when the avatar

--- a/agents/src/voice/agent_activity_interrupted_commit.test.ts
+++ b/agents/src/voice/agent_activity_interrupted_commit.test.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream } from 'node:stream/web';
+import { describe, expect, it, vi } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { Agent } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AgentSessionEventTypes, type ConversationItemAddedEvent } from './events.js';
+import { AudioOutput } from './io.js';
+import { FakeLLM } from './testing/fake_llm.js';
+
+function frame(durationMs = 20, sampleRate = 24000): AudioFrame {
+  const samples = Math.floor((sampleRate * durationMs) / 1000);
+  return new AudioFrame(new Int16Array(samples), sampleRate, 1, samples);
+}
+
+// Audio sink that reports the first frame as played, then (on the interruption's
+// clearBuffer) reports a partial playout WITHOUT a synchronized transcript —
+// the case an avatar / non-aligned output produces. Calls `onFirstFrame` once
+// the first frame is captured so the test can interrupt mid-playout.
+class InterruptibleOutput extends AudioOutput {
+  onFirstFrame?: () => void;
+  private started = false;
+  constructor() {
+    super(24000);
+  }
+  async captureFrame(f: AudioFrame): Promise<void> {
+    await super.captureFrame(f);
+    if (!this.started) {
+      this.started = true;
+      this.onPlaybackStarted(Date.now());
+      this.onFirstFrame?.();
+    }
+  }
+  flush(): void {
+    super.flush();
+  }
+  clearBuffer(): void {
+    this.onPlaybackFinished({ playbackPosition: 0.02, interrupted: true });
+  }
+}
+
+// Agent that synthesizes a few real frames for whatever text it receives, so the
+// audio path produces a first frame (no TTS provider needed).
+class FrameAgent extends Agent {
+  constructor() {
+    super({ instructions: 'test' });
+  }
+  async ttsNode(): Promise<ReadableStream<AudioFrame> | null> {
+    return new ReadableStream<AudioFrame>({
+      start(controller) {
+        for (let i = 0; i < 10; i++) controller.enqueue(frame());
+        controller.close();
+      },
+    });
+  }
+}
+
+describe('AgentActivity interrupted-speech commit', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('commits an interrupted reply to chat ctx when no synchronized transcript is available', async () => {
+    const session = new AgentSession({
+      llm: new FakeLLM([{ input: 'hello', content: 'A fairly long spoken reply.' }]),
+    });
+    const audioOut = new InterruptibleOutput();
+    session.output.audio = audioOut;
+    // Interrupt the reply as soon as the first audio frame is played out.
+    audioOut.onFirstFrame = () => session.interrupt({ force: true });
+
+    const assistantMessages: { content: string; interrupted: boolean }[] = [];
+    session.on(AgentSessionEventTypes.ConversationItemAdded, (ev: ConversationItemAddedEvent) => {
+      if (ev.item.type === 'message' && ev.item.role === 'assistant') {
+        assistantMessages.push({
+          content: ev.item.textContent ?? '',
+          interrupted: !!ev.item.interrupted,
+        });
+      }
+    });
+
+    await session.start({ agent: new FrameAgent() });
+    try {
+      const handle = session.generateReply({ userInput: 'hello' });
+      await handle.waitForPlayout();
+      await vi.waitFor(() => expect(assistantMessages.length).toBeGreaterThan(0));
+
+      // The interrupted-but-heard reply must reach chat ctx (pre-fix it was
+      // dropped because the partial branch returned `synchronizedTranscript ?? ''`,
+      // committing an empty string and skipping the message).
+      const msg = assistantMessages[0]!;
+      expect(msg.interrupted).toBe(true);
+      expect(msg.content.length).toBeGreaterThan(0);
+      expect('A fairly long spoken reply.'.startsWith(msg.content)).toBe(true);
+    } finally {
+      await session.close();
+    }
+  });
+});

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -47,6 +47,7 @@ import {
   functionCallStorage,
   isStopResponse,
 } from './agent.js';
+import type { ForwardOutput } from './agent_activity.ts';
 import type { AgentSession } from './agent_session.js';
 import {
   AudioOutput,
@@ -829,6 +830,22 @@ export interface _AudioOut {
    * metric.
    */
   startedForwardingAt?: number;
+}
+
+/**
+ * The text that actually reached the user, accounting for interruptions.
+ *
+ * On a mid-playout interruption (`played === 'partial'`) we prefer the
+ * playback-aligned `synchronizedTranscript`, but fall back to the full generated
+ * text when no synchronized transcript is available (e.g. avatar outputs) so the
+ * heard reply is still committed to chat ctx rather than dropped.
+ */
+export function forwardedTextFor(output: ForwardOutput): string {
+  if (output.played === 'skipped') return '';
+  if (output.played === 'partial' && output.synchronizedTranscript) {
+    return output.synchronizedTranscript;
+  }
+  return output.textOut?.text ?? '';
 }
 
 async function forwardAudio(


### PR DESCRIPTION
On a midplayout interruption, `forwardedTextFor` and the realtime reply path returned `synchronizedTranscript ?? ''`, so an interrupted-but-heard reply with no playback-aligned transcript (common with avatar outputs) produced no `conversation_item_added` and was dropped from `chatCtx`. Fall back to the forwarded generation text, matching the Python SDK's `forwarded_text` behaviour.