### PR TITLE
feat(phonic): add onConversationCreated callback to realtime model

### DIFF
--- a/.changeset/seven-snails-occur.md
+++ b/.changeset/seven-snails-occur.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-phonic': patch
+---
+
+Add `onConversationCreated` callback to the Phonic realtime model, invoked with the conversation ID once Phonic creates the conversation.

--- a/examples/src/phonic_realtime_agent.ts
+++ b/examples/src/phonic_realtime_agent.ts
@@ -34,6 +34,9 @@ export default defineAgent({
         voice: 'sabrina',
         audioSpeed: 1.2,
         minWordsToInterrupt: 3,
+        onConversationCreated: (conversationId) => {
+          console.log(`Phonic conversation id: ${conversationId}`);
+        },
       }),
     });
 

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -54,6 +54,7 @@ export interface RealtimeModelOptions {
   noInputPokeText?: string;
   noInputEndConversationSec?: number;
   forbidSpeechAfterToolCall?: string[];
+  onConversationCreated?: (conversationId: string) => void;
   /** Set by `updateInstructions` via `voice.Agent` rather than the RealtimeModel constructor */
   instructions?: string;
 }
@@ -168,6 +169,10 @@ export class RealtimeModel extends llm.RealtimeModel {
        */
       forbidSpeechAfterToolCall?: string[];
       /**
+       * Called with the Phonic conversation ID once the conversation is created
+       */
+      onConversationCreated?: (conversationId: string) => void;
+      /**
        * Connection options for the API connection
        */
       connOptions?: APIConnectOptions;
@@ -227,6 +232,7 @@ export class RealtimeModel extends llm.RealtimeModel {
       noInputPokeText: options.noInputPokeText,
       noInputEndConversationSec: options.noInputEndConversationSec,
       forbidSpeechAfterToolCall: options.forbidSpeechAfterToolCall,
+      onConversationCreated: options.onConversationCreated,
       connOptions: options.connOptions ?? DEFAULT_API_CONNECT_OPTIONS,
       model: options.model ?? DEFAULT_MODEL,
       baseUrl: options.baseUrl,
@@ -707,6 +713,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       case 'conversation_created':
         this.conversationId = message.conversation_id;
         this.#logger.info(`Phonic Conversation began with ID: ${this.conversationId}`);
+        this.options.onConversationCreated?.(this.conversationId);
         break;
       case 'tool_call_interrupted':
         this.handleToolCallInterrupted(message);


### PR DESCRIPTION
## Summary

Exposes the Phonic conversation ID to consumers of the realtime model. Today the ID is only logged internally when the `conversation_created` event arrives and is stored on a private `RealtimeSession` field.

This adds an optional `onConversationCreated?: (conversationId: string) => void` callback to the `RealtimeModel` constructor options, invoked once when Phonic creates the conversation.

```ts
const llm = new phonic.realtime.RealtimeModel({
  voice: 'sabrina',
  onConversationCreated: (conversationId) => {
    console.log(`Phonic conversation id: ${conversationId}`);
  },
});
```

## Changes

- `plugins/phonic`: add `onConversationCreated` option and invoke it from the `conversation_created` handler.
- `examples/src/phonic_realtime_agent.ts`: demonstrate the callback.
- changeset (patch).