### PR TITLE
fix(openai): add receive-side timeout to Responses WebSocket LLM

### DIFF
--- a/.changeset/openai-ws-first-event-timeout.md
+++ b/.changeset/openai-ws-first-event-timeout.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+Add a receive-side (first-event / inactivity) timeout to the OpenAI Responses WebSocket LLM. Previously, if a `response.create` was sent but the server (or an intermediary gateway) left the socket open and silent, the receive loop blocked forever — no watchdog, and retries never engaged because nothing threw. The persistent WS now aborts the turn with a retryable `APIConnectionError` (reconnecting on the next turn) when no event arrives within `responseTimeoutMs` of the request, or when the gap between two consecutive events exceeds it. Configurable via the new `responseTimeoutMs` option (default 15000 ms; set to `0` to disable). Also ports two robustness features from the Python plugin: a parallel-generation guard that resets the stored `previous_response_id` continuation chain when turns overlap, and a retryable error when the receive loop drains without a completed response.

--- a/plugins/openai/src/responses/llm.ts
+++ b/plugins/openai/src/responses/llm.ts
@@ -36,6 +36,20 @@ export interface LLMOptions {
    * @default true
    */
   useWebSocket?: boolean;
+
+  /**
+   * Receive-side deadline in milliseconds for the persistent Responses
+   * WebSocket (only applies when {@link useWebSocket} is `true`). After a
+   * request is sent, the turn is aborted and retried if the server sends no
+   * event within this window, or if the gap between two consecutive events
+   * exceeds it — guarding against the socket staying open but silent, which
+   * would otherwise hang the turn indefinitely. Set to `0` to disable. This is
+   * distinct from the connection-establishment / per-request `connOptions`
+   * timeout used by the HTTP path.
+   *
+   * @defaultValue 15000
+   */
+  responseTimeoutMs?: number;
 }
 
 type HttpLLMOptions = Omit<LLMOptions, 'useWebSocket'>;

--- a/plugins/openai/src/ws/llm.test.ts
+++ b/plugins/openai/src/ws/llm.test.ts
@@ -1,11 +1,15 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { initializeLogger } from '@livekit/agents';
+import { APIConnectionError, llm as core, initializeLogger } from '@livekit/agents';
 import { llm, llmStrict } from '@livekit/agents-plugins-test';
-import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { WebSocket, WebSocketServer } from 'ws';
 import { LLM } from '../responses/llm.js';
-import { buildResponsesWsUrl } from './llm.js';
+import { ResponsesWebSocket, WSLLM, buildResponsesWsUrl } from './llm.js';
+import type { WsResponseCreateEvent } from './types.js';
 
 initializeLogger({ level: 'silent', pretty: false });
 
@@ -52,6 +56,318 @@ describe('buildResponsesWsUrl', () => {
     expect(url.protocol).toBe('ws:');
     expect(url.pathname).toBe('/v1/responses');
     expect(url.searchParams.get('model')).toBe('gpt-4o-mini');
+  });
+});
+
+// ============================================================================
+// Receive-side (first-event / inactivity) timeout
+// ============================================================================
+
+/**
+ * Minimal `ws.WebSocket` stand-in for ResponsesWebSocket. Only implements the
+ * surface the wrapper touches: `readyState`, `on`/`emit`, `send`, and `close`.
+ */
+function createFakeWebSocket() {
+  const emitter = new EventEmitter() as EventEmitter & {
+    readyState: number;
+    sent: string[];
+    send: (data: string) => void;
+    close: () => void;
+    emitServerEvent: (event: unknown) => void;
+  };
+  emitter.readyState = WebSocket.OPEN;
+  emitter.sent = [];
+  emitter.send = (data: string) => {
+    emitter.sent.push(data);
+  };
+  emitter.close = () => {
+    if (emitter.readyState === WebSocket.CLOSED) return;
+    emitter.readyState = WebSocket.CLOSED;
+    emitter.emit('close');
+  };
+  emitter.emitServerEvent = (event: unknown) => {
+    emitter.emit('message', Buffer.from(JSON.stringify(event)));
+  };
+  return emitter;
+}
+
+const basePayload: WsResponseCreateEvent = {
+  type: 'response.create',
+  model: 'gpt-4.1',
+  input: [],
+  tools: [],
+};
+
+async function readResult<T>(promise: Promise<T>): Promise<{ value?: T; error?: unknown }> {
+  try {
+    return { value: await promise };
+  } catch (error) {
+    return { error };
+  }
+}
+
+describe('ResponsesWebSocket receive-side timeout', () => {
+  it('aborts the request with a retryable error when no event arrives in time', async () => {
+    const ws = createFakeWebSocket();
+    const conn = new ResponsesWebSocket(ws as unknown as WebSocket);
+
+    const channel = conn.sendRequest(basePayload, 30);
+    const reader = channel.stream().getReader();
+
+    // The reader must reject (not hang forever) once the deadline elapses.
+    const { error } = await readResult(reader.read());
+
+    expect(error).toBeInstanceOf(APIConnectionError);
+    expect((error as APIConnectionError).retryable).toBe(true);
+    // A silent socket is torn down so the pool reconnects on the next turn.
+    expect(ws.readyState).toBe(WebSocket.CLOSED);
+  });
+
+  it('aborts on an inactivity gap after the first event', async () => {
+    const ws = createFakeWebSocket();
+    const conn = new ResponsesWebSocket(ws as unknown as WebSocket);
+
+    const channel = conn.sendRequest(basePayload, 40);
+    const reader = channel.stream().getReader();
+
+    // First event arrives promptly and resets the idle deadline...
+    ws.emitServerEvent({ type: 'response.created', response: { id: 'resp_1' } });
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    expect(first.value?.type).toBe('response.created');
+
+    // ...but the stream then goes silent, so the next read still times out.
+    const { error } = await readResult(reader.read());
+    expect(error).toBeInstanceOf(APIConnectionError);
+    expect((error as APIConnectionError).retryable).toBe(true);
+    expect(ws.readyState).toBe(WebSocket.CLOSED);
+  });
+
+  it('does not fire when events arrive promptly', async () => {
+    const ws = createFakeWebSocket();
+    const conn = new ResponsesWebSocket(ws as unknown as WebSocket);
+
+    const channel = conn.sendRequest(basePayload, 50);
+    const reader = channel.stream().getReader();
+
+    ws.emitServerEvent({ type: 'response.created', response: { id: 'resp_1' } });
+    ws.emitServerEvent({ type: 'response.completed', response: { id: 'resp_1' } });
+
+    const created = await reader.read();
+    expect(created.value?.type).toBe('response.created');
+    const completed = await reader.read();
+    expect(completed.value?.type).toBe('response.completed');
+
+    // Terminal event closes the channel cleanly; the timer never fires.
+    const end = await reader.read();
+    expect(end.done).toBe(true);
+
+    // Wait past the (cleared) deadline to prove no spurious teardown occurs.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+  });
+
+  it('never arms a timer when the timeout is disabled (0)', async () => {
+    const ws = createFakeWebSocket();
+    const conn = new ResponsesWebSocket(ws as unknown as WebSocket);
+
+    const channel = conn.sendRequest(basePayload, 0);
+    const reader = channel.stream().getReader();
+
+    // Well past what would have been any reasonable deadline.
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+
+    ws.emitServerEvent({ type: 'response.completed', response: { id: 'resp_1' } });
+    const completed = await reader.read();
+    expect(completed.value?.type).toBe('response.completed');
+  });
+});
+
+// ============================================================================
+// Parallel-generation guard (previous_response_id continuation)
+// ============================================================================
+
+interface Deferred<T = void> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * In-process Responses WebSocket server for exercising WSLLM end-to-end without
+ * hitting OpenAI. Records every `response.create` payload it receives and lets
+ * each test script the server's replies per request.
+ */
+class FakeResponsesServer {
+  readonly requests: WsResponseCreateEvent[] = [];
+  #wss: WebSocketServer;
+  #handler: (conn: WebSocket, payload: WsResponseCreateEvent, index: number) => void = () => {};
+  #waiters: Array<{ count: number; d: Deferred }> = [];
+
+  private constructor(wss: WebSocketServer) {
+    this.#wss = wss;
+    wss.on('connection', (conn) => {
+      conn.on('message', (data: Buffer) => {
+        const payload = JSON.parse(data.toString()) as WsResponseCreateEvent;
+        const index = this.requests.push(payload) - 1;
+        this.#handler(conn, payload, index);
+        for (const w of this.#waiters) {
+          if (this.requests.length >= w.count) w.d.resolve();
+        }
+      });
+    });
+  }
+
+  static async start(): Promise<FakeResponsesServer> {
+    const wss = new WebSocketServer({ port: 0 });
+    await new Promise<void>((resolve) => wss.once('listening', resolve));
+    return new FakeResponsesServer(wss);
+  }
+
+  get port(): number {
+    return (this.#wss.address() as AddressInfo).port;
+  }
+
+  onRequest(
+    handler: (conn: WebSocket, payload: WsResponseCreateEvent, index: number) => void,
+  ): void {
+    this.#handler = handler;
+  }
+
+  waitForRequests(count: number): Promise<void> {
+    if (this.requests.length >= count) return Promise.resolve();
+    const d = deferred();
+    this.#waiters.push({ count, d });
+    return d.promise;
+  }
+
+  async close(): Promise<void> {
+    for (const client of this.#wss.clients) client.terminate();
+    await new Promise<void>((resolve) => this.#wss.close(() => resolve()));
+  }
+}
+
+function sendCreated(conn: WebSocket, id: string): void {
+  conn.send(JSON.stringify({ type: 'response.created', response: { id } }));
+}
+function sendDelta(conn: WebSocket, delta: string): void {
+  conn.send(JSON.stringify({ type: 'response.output_text.delta', delta }));
+}
+function sendCompleted(conn: WebSocket, id: string): void {
+  conn.send(JSON.stringify({ type: 'response.completed', response: { id } }));
+}
+
+async function drain(stream: AsyncIterable<unknown>): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _ of stream) {
+    // consume
+  }
+}
+
+function userCtx(items: core.ChatItem[], text: string): core.ChatContext {
+  const ctx = new core.ChatContext([...items]);
+  ctx.addMessage({ role: 'user', content: text });
+  return ctx;
+}
+
+describe('WSLLM parallel-generation guard', () => {
+  let server: FakeResponsesServer;
+  let wsllm: WSLLM;
+
+  afterEach(async () => {
+    await wsllm?.close();
+    await server?.close();
+  });
+
+  it('continues from previous_response_id across serial turns', async () => {
+    server = await FakeResponsesServer.start();
+    // Disable the receive-side deadline so these deterministic tests can't flake.
+    wsllm = new WSLLM({
+      apiKey: 'test',
+      model: 'gpt-4.1',
+      baseURL: `http://localhost:${server.port}`,
+      responseTimeoutMs: 0,
+    });
+
+    let n = 0;
+    server.onRequest((conn) => {
+      const id = `resp_${++n}`;
+      sendCreated(conn, id);
+      sendCompleted(conn, id);
+    });
+
+    const ctx1 = userCtx([], 'hello');
+    await drain(wsllm.chat({ chatCtx: ctx1 }));
+
+    const ctx2 = userCtx(ctx1.items, 'again');
+    await drain(wsllm.chat({ chatCtx: ctx2 }));
+
+    // The second serial turn chains off the first response.
+    expect(server.requests).toHaveLength(2);
+    expect(server.requests[1]!.previous_response_id).toBe('resp_1');
+  });
+
+  it('suppresses continuation during overlap and resets the chain afterwards', async () => {
+    server = await FakeResponsesServer.start();
+    wsllm = new WSLLM({
+      apiKey: 'test',
+      model: 'gpt-4.1',
+      baseURL: `http://localhost:${server.port}`,
+      responseTimeoutMs: 0,
+    });
+
+    const holdFirst = deferred();
+    let n = 0;
+    server.onRequest(async (conn, _payload, index) => {
+      const id = `resp_${++n}`;
+      sendCreated(conn, id);
+      sendDelta(conn, 'x'); // gives the client an observable first chunk
+      if (index === 0) {
+        // Keep the first generation in flight until the test releases it.
+        await holdFirst.promise;
+      }
+      sendCompleted(conn, id);
+    });
+
+    // Turn A: start consuming and wait until its first chunk lands, which proves
+    // response.created was processed (so prev_response_id is now stored) and A
+    // is still active (its completion is being withheld).
+    const firstChunkA = deferred();
+    const ctxA = userCtx([], 'a');
+    const pA = (async () => {
+      for await (const _chunk of wsllm.chat({ chatCtx: ctxA })) {
+        firstChunkA.resolve();
+      }
+    })();
+    await firstChunkA.promise;
+
+    // Turn B starts while A is still active. Even though a stored
+    // previous_response_id exists, the guard must NOT chain off it.
+    const ctxB = userCtx(ctxA.items, 'b');
+    await drain(wsllm.chat({ chatCtx: ctxB }));
+
+    expect(server.requests).toHaveLength(2);
+    expect(server.requests[1]!.previous_response_id).toBeUndefined();
+
+    // Release A and let it finish; overlap must reset the stored chain.
+    holdFirst.resolve();
+    await pA;
+
+    // Turn C is serial again, but because overlap corrupted (and reset) the
+    // chain, it must re-send full context without a previous_response_id.
+    const ctxC = userCtx(ctxB.items, 'c');
+    await drain(wsllm.chat({ chatCtx: ctxC }));
+
+    expect(server.requests).toHaveLength(3);
+    expect(server.requests[2]!.previous_response_id).toBeUndefined();
   });
 });
 

--- a/plugins/openai/src/ws/llm.test.ts
+++ b/plugins/openai/src/ws/llm.test.ts
@@ -369,6 +369,41 @@ describe('WSLLM parallel-generation guard', () => {
     expect(server.requests).toHaveLength(3);
     expect(server.requests[2]!.previous_response_id).toBeUndefined();
   });
+
+  it('reserves synchronously so two chats in the same tick do not both continue', async () => {
+    server = await FakeResponsesServer.start();
+    wsllm = new WSLLM({
+      apiKey: 'test',
+      model: 'gpt-4.1',
+      baseURL: `http://localhost:${server.port}`,
+      responseTimeoutMs: 0,
+    });
+
+    let n = 0;
+    server.onRequest((conn) => {
+      const id = `resp_${++n}`;
+      sendCreated(conn, id);
+      sendCompleted(conn, id);
+    });
+
+    // Establish a stored continuation chain (resp_1).
+    const ctx1 = userCtx([], 'hello');
+    await drain(wsllm.chat({ chatCtx: ctx1 }));
+
+    // Issue two turns in the SAME tick (no await between the chat() calls). The
+    // reservation must be synchronous: the first may chain off resp_1, but the
+    // second must observe the first as in-flight and re-send full context.
+    // (If _onStreamStarted only ran inside the deferred run(), both would read
+    // #activeStreams === 0 and both would continue off resp_1.)
+    const s2a = wsllm.chat({ chatCtx: userCtx(ctx1.items, 'a') });
+    const s2b = wsllm.chat({ chatCtx: userCtx(ctx1.items, 'b') });
+    await Promise.all([drain(s2a), drain(s2b)]);
+
+    const overlapping = [server.requests[1]!, server.requests[2]!];
+    // Exactly one of the two same-tick turns continued off resp_1.
+    expect(overlapping.filter((r) => r.previous_response_id === 'resp_1')).toHaveLength(1);
+    expect(overlapping.filter((r) => !r.previous_response_id)).toHaveLength(1);
+  });
 });
 
 if (hasOpenAIApiKey) {

--- a/plugins/openai/src/ws/llm.test.ts
+++ b/plugins/openai/src/ws/llm.test.ts
@@ -404,6 +404,71 @@ describe('WSLLM parallel-generation guard', () => {
     expect(overlapping.filter((r) => r.previous_response_id === 'resp_1')).toHaveLength(1);
     expect(overlapping.filter((r) => !r.previous_response_id)).toHaveLength(1);
   });
+
+  it('stays reserved across retry attempts, not just the first', async () => {
+    server = await FakeResponsesServer.start();
+    wsllm = new WSLLM({
+      apiKey: 'test',
+      model: 'gpt-4.1',
+      baseURL: `http://localhost:${server.port}`,
+      responseTimeoutMs: 0,
+    });
+
+    // The public LLM wrapper always subscribes to 'error'; mirror that here so
+    // the retryable error below doesn't trip EventEmitter's unhandled-'error'
+    // throw when driving WSLLM directly.
+    wsllm.on('error', () => {});
+
+    const holdRetry = deferred();
+    server.onRequest(async (conn, _payload, index) => {
+      if (index === 0) {
+        // S1 attempt 1: retryable failure -> the base class retries (first retry
+        // is immediate). If the reservation were released in run()'s finally, the
+        // counter would drop to 0 here for the rest of S1's lifetime.
+        conn.send(
+          JSON.stringify({
+            type: 'error',
+            error: { code: 'websocket_connection_limit_reached', message: 'boom' },
+          }),
+        );
+      } else if (index === 1) {
+        // S1 attempt 2 (retry): produce an observable first chunk, then hold the
+        // turn open so S1 is unambiguously still in flight.
+        sendCreated(conn, 'resp_2');
+        sendDelta(conn, 'x');
+        await holdRetry.promise;
+        sendCompleted(conn, 'resp_2');
+      } else {
+        // Concurrent turn S2.
+        sendCreated(conn, `resp_s2_${index}`);
+        sendCompleted(conn, `resp_s2_${index}`);
+      }
+    });
+
+    // Drive S1 with a single retry; resolve once its retried attempt emits a chunk.
+    const s1Retrying = deferred();
+    const ctxS1 = userCtx([], 's1');
+    const pS1 = (async () => {
+      for await (const _chunk of wsllm.chat({
+        chatCtx: ctxS1,
+        connOptions: { maxRetry: 1, retryIntervalMs: 10, timeoutMs: 10_000 },
+      })) {
+        s1Retrying.resolve();
+      }
+    })();
+    await s1Retrying.promise;
+
+    // S1's retried attempt has stored resp_2 and is still active. A concurrent
+    // turn must NOT chain off it (with a per-attempt release it would, because
+    // #activeStreams would have dropped to 0 after S1's first attempt failed).
+    const ctxS2 = userCtx(ctxS1.items, 's2');
+    await drain(wsllm.chat({ chatCtx: ctxS2 }));
+
+    expect(server.requests.at(-1)!.previous_response_id).toBeUndefined();
+
+    holdRetry.resolve();
+    await pS1;
+  });
 });
 
 if (hasOpenAIApiKey) {

--- a/plugins/openai/src/ws/llm.ts
+++ b/plugins/openai/src/ws/llm.ts
@@ -31,6 +31,13 @@ const OPENAI_RESPONSES_WS_URL = 'wss://api.openai.com/v1/responses';
 // OpenAI enforces a 60-minute maximum duration on Responses WebSocket connections.
 const WS_MAX_SESSION_DURATION = 3_600_000;
 
+// Default receive-side deadline: once a `response.create` has been sent, abort the
+// wait if no server event arrives within this window (and, thereafter, if the gap
+// between two consecutive events exceeds it). Healthy first-event latency is ~1s in
+// production, so 15s is comfortably above the happy path while still bounding the
+// pathological "socket stays open, zero events" hang.
+const DEFAULT_WS_RESPONSE_TIMEOUT = 15_000;
+
 /**
  * Build the Responses-API WebSocket URL.
  *
@@ -64,12 +71,27 @@ export function buildResponsesWsUrl(baseURL: string | undefined, model: string):
 // A response is terminated (and its channel closed) when the service sends
 // response.completed, response.failed, or error.
 //
+// Each queue entry may carry a receive-side deadline (see `sendRequest`): if no
+// server event arrives before it fires — the first-event case — or if the gap
+// between two consecutive events exceeds it — the inactivity case — the entry's
+// channel is aborted with a retryable APIConnectionError and the socket is torn
+// down so the next turn reconnects. This guards against the service (or an
+// intermediary gateway) leaving the socket open and silent after a
+// `response.create`, which would otherwise block the reader forever.
+//
 // ============================================================================
+
+interface OutputQueueEntry {
+  channel: stream.StreamChannel<WsServerEvent>;
+  /** Idle/first-event deadline in ms; a non-positive value disables the timer. */
+  timeoutMs?: number;
+  timer?: ReturnType<typeof setTimeout>;
+}
 
 export class ResponsesWebSocket {
   #ws: WebSocket;
   // FIFO queue: the front entry receives validated WsServerEvents for the in-flight response.
-  #outputQueue: stream.StreamChannel<WsServerEvent>[] = [];
+  #outputQueue: OutputQueueEntry[] = [];
 
   constructor(ws: WebSocket) {
     this.#ws = ws;
@@ -91,16 +113,20 @@ export class ResponsesWebSocket {
       if (!parsed.success) return;
 
       const event = parsed.data;
-      void current.write(event);
+      void current.channel.write(event);
 
-      // Close and dequeue on any terminal event.
+      // Close and dequeue on any terminal event; otherwise reset the idle
+      // deadline now that we have proof the connection is still producing.
       if (
         event.type === 'response.completed' ||
         event.type === 'response.failed' ||
         event.type === 'error'
       ) {
-        void current.close();
+        this.#clearTimer(current);
+        void current.channel.close();
         this.#outputQueue.shift();
+      } else {
+        this.#armTimer(current);
       }
     });
 
@@ -108,7 +134,8 @@ export class ResponsesWebSocket {
       // If the WebSocket closes while requests are still in flight, synthesise
       // a typed error event so all readers can handle it cleanly.
       for (const current of this.#outputQueue) {
-        if (!current.closed) {
+        this.#clearTimer(current);
+        if (!current.channel.closed) {
           const closeError: WsServerEvent = {
             type: 'error',
             error: {
@@ -116,7 +143,7 @@ export class ResponsesWebSocket {
               message: 'OpenAI Responses WebSocket closed unexpectedly',
             },
           };
-          void current.write(closeError).finally(() => current.close());
+          void current.channel.write(closeError).finally(() => current.channel.close());
         }
       }
       this.#outputQueue = [];
@@ -126,8 +153,18 @@ export class ResponsesWebSocket {
   /**
    * Send a response.create event.  Returns a typed `StreamChannel<WsServerEvent>`
    * that yields validated server events until the response terminates.
+   *
+   * @param timeoutMs - Receive-side deadline. When set to a positive value, the
+   *   returned channel is aborted with a retryable {@link APIConnectionError} if the
+   *   server sends no event within `timeoutMs` of the request (first-event
+   *   deadline) or between any two consecutive events (inactivity deadline),
+   *   and the underlying socket is closed. This is distinct from the
+   *   connection-establishment timeout used in `connectWs`.
    */
-  sendRequest(payload: WsResponseCreateEvent): stream.StreamChannel<WsServerEvent> {
+  sendRequest(
+    payload: WsResponseCreateEvent,
+    timeoutMs?: number,
+  ): stream.StreamChannel<WsServerEvent> {
     if (this.#ws.readyState !== WebSocket.OPEN) {
       throw new APIConnectionError({
         message: `OpenAI Responses WebSocket is not open (state ${getWebSocketStateLabel(this.#ws.readyState)})`,
@@ -136,17 +173,57 @@ export class ResponsesWebSocket {
     }
 
     const channel = stream.createStreamChannel<WsServerEvent>();
-    this.#outputQueue.push(channel);
+    const entry: OutputQueueEntry = { channel, timeoutMs };
+    this.#outputQueue.push(entry);
+    // Arm the first-event deadline before sending so a completely silent
+    // response is still bounded.
+    this.#armTimer(entry);
     this.#ws.send(JSON.stringify(payload));
     return channel;
   }
 
   close(): void {
     // Drain pending channels before closing the socket.
-    for (const ch of this.#outputQueue) {
-      void ch.close();
+    for (const entry of this.#outputQueue) {
+      this.#clearTimer(entry);
+      void entry.channel.close();
     }
     this.#outputQueue = [];
+    this.#ws.close();
+  }
+
+  #armTimer(entry: OutputQueueEntry): void {
+    if (entry.timeoutMs === undefined || entry.timeoutMs <= 0) return;
+    this.#clearTimer(entry);
+    entry.timer = setTimeout(() => this.#onRequestTimeout(entry), entry.timeoutMs);
+  }
+
+  #clearTimer(entry: OutputQueueEntry): void {
+    if (entry.timer) {
+      clearTimeout(entry.timer);
+      entry.timer = undefined;
+    }
+  }
+
+  #onRequestTimeout(entry: OutputQueueEntry): void {
+    const idx = this.#outputQueue.indexOf(entry);
+    // Already resolved (terminal event or socket close won the race).
+    if (idx === -1) return;
+
+    // Remove the dead entry so a later, healthy turn reusing this connection
+    // (were it not torn down below) can't be misrouted to it.
+    this.#outputQueue.splice(idx, 1);
+    this.#clearTimer(entry);
+
+    void entry.channel.abort(
+      new APIConnectionError({
+        message: `OpenAI Responses WebSocket received no event within ${entry.timeoutMs}ms`,
+        options: { retryable: true },
+      }),
+    );
+
+    // A socket that accepted the request but went silent can't be trusted for
+    // reuse — close it so the pool opens a fresh connection on the next turn.
     this.#ws.close();
   }
 }
@@ -169,12 +246,25 @@ export interface WSLLMOptions {
   serviceTier?: string;
   /** Upper bound for the number of tokens that can be generated for a response. */
   maxOutputTokens?: number;
+  /**
+   * Receive-side deadline in milliseconds for the persistent Responses
+   * WebSocket. After a `response.create` is sent, the turn is aborted (with a
+   * retryable error that triggers reconnect + retry) if the server sends no
+   * event within this window, or if the gap between two consecutive events
+   * exceeds it. Guards against the socket staying open but silent, which would
+   * otherwise hang the turn indefinitely. Set to `0` (or a negative value) to
+   * disable. Distinct from the connection-establishment timeout.
+   *
+   * @defaultValue 15000
+   */
+  responseTimeoutMs?: number;
 }
 
 const defaultLLMOptions: WSLLMOptions = {
   model: 'gpt-4.1',
   apiKey: process.env.OPENAI_API_KEY,
   strictToolSchema: true,
+  responseTimeoutMs: DEFAULT_WS_RESPONSE_TIMEOUT,
 };
 
 // ============================================================================
@@ -187,6 +277,13 @@ export class WSLLM extends llm.LLM {
   #prevResponseId = '';
   #prevChatCtx: llm.ChatContext | null = null;
   #pendingToolCalls = new Set<string>();
+  // Number of in-flight WSLLMStream generations, and whether any two ever
+  // overlapped. The stored previous_response_id / chat-ctx continuation chain
+  // assumes strictly serial turns; concurrent generations can interleave and
+  // corrupt it, so we only take the continuation shortcut when idle and reset
+  // the stored state once all overlapping generations have drained.
+  #activeStreams = 0;
+  #parallelGeneration = false;
 
   /**
    * Create a new instance of the OpenAI Responses API WebSocket LLM.
@@ -251,6 +348,28 @@ export class WSLLM extends llm.LLM {
     this.#pendingToolCalls = callIds;
   }
 
+  /** Called by WSLLMStream when a generation begins. Tracks overlap so the
+   *  continuation chain can be invalidated if turns run concurrently. */
+  _onStreamStarted(): void {
+    if (this.#activeStreams > 0) {
+      this.#parallelGeneration = true;
+    }
+    this.#activeStreams += 1;
+  }
+
+  /** Called by WSLLMStream when a generation ends (success or failure). Once all
+   *  overlapping generations have drained, drop the stored continuation state so
+   *  the next turn re-sends the full context instead of chaining off a
+   *  potentially corrupted previous_response_id. */
+  _onStreamFinished(): void {
+    this.#activeStreams -= 1;
+    if (this.#activeStreams === 0 && this.#parallelGeneration) {
+      this.#prevResponseId = '';
+      this.#prevChatCtx = null;
+      this.#parallelGeneration = false;
+    }
+  }
+
   chat({
     chatCtx,
     toolCtx,
@@ -304,7 +423,14 @@ export class WSLLM extends llm.LLM {
     let prevResponseId: string | undefined;
     const canUseStoredResponse = modelOptions.store !== false;
 
-    if (canUseStoredResponse && this.#prevChatCtx && this.#prevResponseId) {
+    // Only continue from a stored previous_response_id when no other generation
+    // is in flight — a concurrent turn may be mutating the continuation chain.
+    if (
+      canUseStoredResponse &&
+      this.#activeStreams === 0 &&
+      this.#prevChatCtx &&
+      this.#prevResponseId
+    ) {
       const diff = llm.computeChatCtxDiff(this.#prevChatCtx, chatCtx);
       const lastPrevItemId = this.#prevChatCtx.items.at(-1)?.id ?? null;
 
@@ -339,6 +465,7 @@ export class WSLLM extends llm.LLM {
       modelOptions,
       prevResponseId,
       strictToolSchema: this.#opts.strictToolSchema ?? true,
+      responseTimeoutMs: this.#opts.responseTimeoutMs ?? DEFAULT_WS_RESPONSE_TIMEOUT,
     });
   }
 
@@ -368,6 +495,8 @@ export class WSLLMStream extends llm.LLMStream {
   #fullChatCtx: llm.ChatContext;
   #responseId = '';
   #pendingToolCalls = new Set<string>();
+  #responseTimeoutMs: number;
+  #responseCompleted = false;
 
   constructor(
     llm: WSLLM,
@@ -381,6 +510,7 @@ export class WSLLMStream extends llm.LLMStream {
       modelOptions,
       prevResponseId,
       strictToolSchema,
+      responseTimeoutMs,
     }: {
       pool: ConnectionPool<ResponsesWebSocket>;
       model: string | ChatModels;
@@ -391,6 +521,7 @@ export class WSLLMStream extends llm.LLMStream {
       modelOptions: Record<string, unknown>;
       prevResponseId?: string;
       strictToolSchema: boolean;
+      responseTimeoutMs: number;
     },
   ) {
     super(llm, { chatCtx, toolCtx, connOptions });
@@ -401,11 +532,13 @@ export class WSLLMStream extends llm.LLMStream {
     this.#strictToolSchema = strictToolSchema;
     this.#prevResponseId = prevResponseId;
     this.#fullChatCtx = fullChatCtx;
+    this.#responseTimeoutMs = responseTimeoutMs;
   }
 
   protected async run(): Promise<void> {
     let retryable = true;
 
+    this.#llm._onStreamStarted();
     try {
       await this.#pool.withConnection(async (conn: ResponsesWebSocket) => {
         const needsRetry = await this.#runWithConn(conn, this.chatCtx, this.#prevResponseId);
@@ -415,6 +548,19 @@ export class WSLLMStream extends llm.LLMStream {
           // Retry once on the same connection with the full context and no ID.
           retryable = true;
           await this.#runWithConn(conn, this.#fullChatCtx, undefined);
+        }
+
+        // The receive loop drained without a response.completed (e.g. the
+        // channel closed after a non-terminal event). Treat as a transient
+        // failure so the SDK reconnects and retries rather than silently
+        // yielding an empty turn.
+        if (!this.#responseCompleted) {
+          conn.close();
+          this.#pool.invalidate();
+          throw new APIConnectionError({
+            message: 'OpenAI Responses WebSocket stream ended without a completed response',
+            options: { retryable: true },
+          });
         }
       });
     } catch (error) {
@@ -429,6 +575,8 @@ export class WSLLMStream extends llm.LLMStream {
         message: toError(error).message,
         options: { retryable },
       });
+    } finally {
+      this.#llm._onStreamFinished();
     }
   }
 
@@ -483,7 +631,7 @@ export class WSLLMStream extends llm.LLMStream {
 
     let channel: stream.StreamChannel<WsServerEvent>;
     try {
-      channel = conn.sendRequest(payload);
+      channel = conn.sendRequest(payload, this.#responseTimeoutMs);
     } catch (error) {
       if (error instanceof APIConnectionError) {
         conn.close();
@@ -617,6 +765,7 @@ export class WSLLMStream extends llm.LLMStream {
   }
 
   #handleResponseCompleted(event: WsResponseCompletedEvent): llm.ChatChunk | undefined {
+    this.#responseCompleted = true;
     this.#llm._setPendingToolCalls(this.#pendingToolCalls);
 
     if (event.response.usage) {

--- a/plugins/openai/src/ws/llm.ts
+++ b/plugins/openai/src/ws/llm.ts
@@ -497,9 +497,15 @@ export class WSLLMStream extends llm.LLMStream {
   #pendingToolCalls = new Set<string>();
   #responseTimeoutMs: number;
   #responseCompleted = false;
-  // Balances the _onStreamStarted() reservation made in the constructor. run()
-  // may be invoked multiple times (once per retry attempt), so the release must
-  // fire exactly once for the stream's whole lifetime — not per attempt.
+  // Balances the _onStreamStarted() reservation made in the constructor. The
+  // release must fire exactly once, and only after the stream's *whole* lifetime
+  // ends — not per attempt: the base class calls run() once per retry attempt
+  // (up to maxRetry+1 times), so releasing in run()'s finally would drop the
+  // count after the first attempt and leave the stream uncounted during the
+  // retry-delay window, letting a concurrent chat() wrongly reuse the stored
+  // previous_response_id. Instead we release from the monitorMetrics() override,
+  // which the base runs once and which only returns after mainTask has drained
+  // and closed the queue (i.e. after all retries).
   #streamReleased = false;
 
   constructor(
@@ -551,6 +557,20 @@ export class WSLLMStream extends llm.LLMStream {
     this.#llm._onStreamFinished();
   }
 
+  /**
+   * The base class runs this exactly once per stream and it only returns after
+   * `mainTask` has closed the queue — i.e. after every retry attempt has
+   * finished. That makes it the correct place to release the parallel-generation
+   * reservation taken in the constructor (run()'s finally fires per attempt).
+   */
+  protected override async monitorMetrics(): Promise<void> {
+    try {
+      await super.monitorMetrics();
+    } finally {
+      this.#releaseStream();
+    }
+  }
+
   protected async run(): Promise<void> {
     let retryable = true;
 
@@ -590,8 +610,6 @@ export class WSLLMStream extends llm.LLMStream {
         message: toError(error).message,
         options: { retryable },
       });
-    } finally {
-      this.#releaseStream();
     }
   }
 

--- a/plugins/openai/src/ws/llm.ts
+++ b/plugins/openai/src/ws/llm.ts
@@ -497,6 +497,10 @@ export class WSLLMStream extends llm.LLMStream {
   #pendingToolCalls = new Set<string>();
   #responseTimeoutMs: number;
   #responseCompleted = false;
+  // Balances the _onStreamStarted() reservation made in the constructor. run()
+  // may be invoked multiple times (once per retry attempt), so the release must
+  // fire exactly once for the stream's whole lifetime — not per attempt.
+  #streamReleased = false;
 
   constructor(
     llm: WSLLM,
@@ -533,12 +537,23 @@ export class WSLLMStream extends llm.LLMStream {
     this.#prevResponseId = prevResponseId;
     this.#fullChatCtx = fullChatCtx;
     this.#responseTimeoutMs = responseTimeoutMs;
+    // Reserve synchronously here (the constructor runs inside WSLLM.chat(), after
+    // its continuation decision) so a second chat() issued in the same tick
+    // observes this generation as in-flight and can't also take the
+    // previous_response_id shortcut. Doing this in run() would be too late — run
+    // is deferred to a later tick by the LLMStream base constructor.
+    this.#llm._onStreamStarted();
+  }
+
+  #releaseStream(): void {
+    if (this.#streamReleased) return;
+    this.#streamReleased = true;
+    this.#llm._onStreamFinished();
   }
 
   protected async run(): Promise<void> {
     let retryable = true;
 
-    this.#llm._onStreamStarted();
     try {
       await this.#pool.withConnection(async (conn: ResponsesWebSocket) => {
         const needsRetry = await this.#runWithConn(conn, this.chatCtx, this.#prevResponseId);
@@ -576,7 +591,7 @@ export class WSLLMStream extends llm.LLMStream {
         options: { retryable },
       });
     } finally {
-      this.#llm._onStreamFinished();
+      this.#releaseStream();
     }
   }
 


### PR DESCRIPTION
## Description

The OpenAI **Responses** LLM can run over a persistent WebSocket (`plugins/openai/src/ws/llm.ts`, selected via `useWebSocket: true`, the default). That path had **no receive-side timeout**: after a `response.create` is sent, `WSLLMStream` awaits `reader.read()` on the request's `StreamChannel` in an unbounded loop. If the server — or an intermediary OpenAI-compatible gateway (e.g. LiteLLM) — returns **no events** while the socket stays **open and error-free**, the receive loop blocks forever. There is no watchdog, and the SDK's retry/reconnect never engages because nothing throws.

We hit this in production: a voice agent went silent for ~67s after the caller answered, then the caller hung up. On the gateway side, a single Responses WebSocket stayed open and error-free for the whole call (no close, no error frame), so nothing ever broke the wait.

The only timeout in the WS path today is the **connection-establishment** timeout in `connectWs` (a `setTimeout` around the handshake) — nothing guards event *reception*. Note the sibling HTTP branch in `responses/llm.ts` already passes `{ timeout: connOptions.timeoutMs }` to `client.responses.create`; the WS branch dropped that guarantee.

## Changes Made
- **First-event / inactivity deadline on the WS receive path** (`ResponsesWebSocket`). Each queued request may carry a `timeoutMs`. If the server sends no event within that window of the `response.create` (first-event deadline), or the gap between two consecutive events exceeds it (inactivity deadline), the request's channel is aborted with a **retryable `APIConnectionError`**, the timed-out entry is removed from the FIFO queue (so a reused connection can't be misrouted to a dead head entry), and the socket is torn down so the pool reconnects on the next turn. The retryable error engages the base `LLMStream` retry loop (`agents/src/llm/llm.ts`) — the same mechanism the existing `websocket_closed` path relies on.
- **New `responseTimeoutMs` option**, wired `LLM` → `WSLLM` → `WSLLMStream`. Default **15000 ms** (well above the ~1s healthy first-event latency observed in prod, so it won't false-fire); set to `0` to disable. Deliberately **not** reused from the connect `timeoutMs` — they're different concerns.
- **Parallel-generation guard** (ported from the Python plugin). Track in-flight generations (`_onStreamStarted` / `_onStreamFinished`); when turns overlap, reset the stored `previous_response_id` / chat-ctx continuation chain once all overlapping generations drain, and only take the `previous_response_id` continuation shortcut when idle (`#activeStreams === 0`). Previously the TS `WSLLM` used the stored continuation unconditionally.
- **Post-loop retryable** (ported from Python). If the receive loop drains without a `response.completed`, throw a retryable `APIConnectionError` instead of returning `false` silently.
- The existing TS-only `previous_response_not_found` recovery in `#handleError` is preserved.
- Changeset added (`@livekit/agents-plugin-openai`: patch).

## Pre-Review Checklist
- [x] **Build passes**: `pnpm --filter @livekit/agents-plugin-openai build`, ESLint, and Prettier pass locally. (`api:check` fails identically on a clean checkout of `main` due to a pre-existing api-extractor / bundled-TS `export * as` limitation — unrelated to this change.)
- [x] **AI-generated code reviewed**
- [x] **Changes explained**
- [x] **Scope appropriate**

## Testing
- [x] Automated tests added (`plugins/openai/src/ws/llm.test.ts`):
  - first-event deadline fires → retryable `APIConnectionError` (no infinite hang), socket torn down;
  - inactivity deadline fires after the first event;
  - healthy stream (events arrive promptly) is unaffected and the socket is left open;
  - `responseTimeoutMs: 0` disables the timer;
  - parallel-generation guard: serial turns chain via `previous_response_id`, overlapping turns suppress it and reset the continuation chain afterward (driven end-to-end through an in-process WebSocket server).
- [x] All tests pass (`vitest run plugins/openai`: 56 passed).

## Additional Notes
The retryable `APIConnectionError` reuses the same reconnect/retry semantics as the existing `websocket_closed` handling, so behavior on failure matches what reviewers already expect from this file.
