### PR TITLE
docs(readme): move migration guide blurb above repo title

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ SPDX-License-Identifier: Apache-2.0
 
 <!--END_BANNER_IMAGE-->
 
+## ✨ 1.0 Release ✨
+
+> [!TIP]
+> This README reflects the 1.0 release. See the [migration guide](https://docs.livekit.io/agents/start/v0-migration/nodejs/) if you're trying to upgrade from `0.x`.
+
 # LiveKit Agents for Node.js
 
 <!--BEGIN_DESCRIPTION-->
@@ -26,10 +31,6 @@ This is a Node.js distribution of the [LiveKit Agents framework](https://livekit
 originally written in Python.
 
 <!--END_DESCRIPTION-->
-
-## ✨ 1.0 Release ✨
-
-This README reflects the 1.0 release. See the [migration guide](https://docs.livekit.io/agents/start/v0-migration/nodejs/) if you're trying to upgrade from `0.x`.
 
 ## Features
 
@@ -118,9 +119,9 @@ import {
   WorkerOptions,
   cli,
   defineAgent,
+  inference,
   llm,
   voice,
-  inference,
 } from '@livekit/agents';
 import * as silero from '@livekit/agents-plugin-silero';
 import { fileURLToPath } from 'node:url';
@@ -155,7 +156,10 @@ export default defineAgent({
       llm: new inference.LLM({ model: 'openai/gpt-4.1-mini' }),
       // Text-to-speech (TTS) is your agent's voice, turning the LLM's text into speech that the user can hear
       // See all available models as well as voice selections at https://docs.livekit.io/agents/models/tts/
-      tts: new inference.TTS({ model: 'cartesia/sonic-3', voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc' }),
+      tts: new inference.TTS({
+        model: 'cartesia/sonic-3',
+        voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc',
+      }),
       // VAD and turn detection are used to determine when the user is speaking and when the agent should respond
       // See more at https://docs.livekit.io/agents/build/turns
       vad: ctx.proc.userData.vad! as silero.VAD,
@@ -254,7 +258,10 @@ export default defineAgent({
       vad: ctx.proc.userData.vad! as silero.VAD,
       stt: new inference.STT({ model: 'deepgram/nova-3', language: 'en' }),
       llm: new inference.LLM({ model: 'openai/gpt-4.1-mini' }),
-      tts: new inference.TTS({ model: 'cartesia/sonic-3', voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc' }),
+      tts: new inference.TTS({
+        model: 'cartesia/sonic-3',
+        voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc',
+      }),
       userData: userdata,
     });
 
@@ -344,6 +351,7 @@ To contribute to this project:
 To test any changes or plugins:
 
 1. Build the project:
+
    ```bash
    pnpm build
    ```
@@ -372,7 +380,9 @@ Refer to [the license](LICENSES/Apache-2.0.txt) for details.
 The LiveKit turn detection models are licensed under the [LiveKit Model License](MODEL_LICENSE).
 
 <!--BEGIN_REPO_NAV-->
+
 <br/><table>
+
 <thead><tr><th colspan="2">LiveKit Ecosystem</th></tr></thead>
 <tbody>
 <tr><td>Agents SDKs</td><td><a href="https://github.com/livekit/agents">Python</a> · <b>Node.js</b></td></tr><tr></tr>


### PR DESCRIPTION
## Description
Moves the 1.0 release / migration guide blurb above the repo title in the README and formats it as a `> [!TIP]` alert.

## Changes Made
- Move ✨ 1.0 Release ✨ section above the `# LiveKit Agents for Node.js` heading
- Wrap the migration guide blurb in a `> [!TIP]` alert

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: N/A (docs only)

## Testing
- [ ] Automated tests added/updated (if applicable) — N/A, docs only
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes) — N/A

## Additional Notes
README-only change; prettier pre-commit hook passed.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.