### PR TITLE
docs(readme): move 1.5.0 migration note above title, drop 1.0 release blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ SPDX-License-Identifier: Apache-2.0
 
 <!--END_BANNER_IMAGE-->
 
-# LiveKit Agents for Node.js
+> [!TIP]
+> See the ✨ new JavaScript-idiomatic agent API ✨ and breaking changes in the [agents-js 1.5.0 migration guide](https://docs.livekit.io/reference/migration-guides/agents-v1.5).
 
-> For details on the new JavaScript-idiomatic agent API and the breaking changes in agents-js 1.5.0, see the [agents-js 1.5.0 migration guide](https://docs.livekit.io/reference/migration-guides/agents-v1.5).
+# LiveKit Agents for Node.js
 
 <!--BEGIN_DESCRIPTION-->
 
@@ -28,10 +29,6 @@ This is a Node.js distribution of the [LiveKit Agents framework](https://livekit
 originally written in Python.
 
 <!--END_DESCRIPTION-->
-
-## ✨ 1.0 Release ✨
-
-This README reflects the 1.0 release. See the [migration guide](https://docs.livekit.io/agents/start/v0-migration/nodejs/) if you're trying to upgrade from `0.x`.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SPDX-License-Identifier: Apache-2.0
 <!--END_BANNER_IMAGE-->
 
 > [!TIP]
-> See the ✨ new JavaScript-idiomatic agent API ✨ and breaking changes in the [agents-js 1.5.0 migration guide](https://docs.livekit.io/reference/migration-guides/agents-v1.5).
+> We just released livekit-agents 1.5.0. Check the release note and [migration guide here](https://docs.livekit.io/reference/migration-guides/agents-v1.5).
 
 # LiveKit Agents for Node.js
 


### PR DESCRIPTION
## Description
Moves the agents-js 1.5.0 migration guide note above the repo title as a `> [!TIP]` alert and removes the outdated ✨ 1.0 Release ✨ blurb.

## Changes Made
- Move the 1.5.0 migration guide blockquote above the `# LiveKit Agents for Node.js` heading
- Add `> [!TIP]` marker so it renders as a GitHub alert
- Remove the ✨ 1.0 Release ✨ section

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: N/A (docs only)

## Testing
- [ ] Automated tests added/updated (if applicable) — N/A, docs only
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes) — N/A

## Additional Notes
README-only change.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.