### PR TITLE
fix(eot-runner): return gracefully when native binding unavailable instead of throwing

### DIFF
--- a/agents/src/inference/eot/runner.ts
+++ b/agents/src/inference/eot/runner.ts
@@ -36,9 +36,12 @@ export default class EotRunner extends InferenceRunner<EotInferenceInput, EotInf
   async initialize(): Promise<void> {
     this.#mod = _getLocalInferenceModule();
     if (this.#mod === undefined) {
-      throw new Error(
-        'EotRunner: @livekit/local-inference native binding unavailable in the inference process',
-      );
+      // _getLocalInferenceModule() already emits a WARN when the binding
+      // cannot be loaded (e.g. Bun on Windows does not fetch optional native
+      // packages). Returning here — rather than throwing — keeps the inference
+      // process alive so the agent falls back to VAD-only turn detection
+      // instead of crashing with a FATAL (see #1900).
+      return;
     }
     // Eagerly page in the EOT model singleton (~138 MB) so the first
     // request doesn't pay the load on the hot path.
@@ -47,7 +50,10 @@ export default class EotRunner extends InferenceRunner<EotInferenceInput, EotInf
 
   async run(data: EotInferenceInput): Promise<EotInferenceOutput> {
     if (this.#mod === undefined) {
-      throw new Error('EotRunner not initialized');
+      // Native binding unavailable — return a zero probability so callers
+      // treat every frame as "not end-of-turn" and VAD remains the sole
+      // turn-detection mechanism.
+      return { probability: 0, inferenceDurationMs: 0 };
     }
     // base64 → bytes → Int16Array view (PCM is 16 kHz s16le)
     const bytes = Buffer.from(data.pcm, 'base64');


### PR DESCRIPTION
## Summary

Fixes #1900.

When `@livekit/local-inference` cannot be loaded (e.g. Bun on Windows does not fetch optional platform packages), `_getLocalInferenceModule()` already logs a WARN and returns `undefined`. `EotRunner.initialize()` was then **throwing** an `Error`, which propagated through `ThrowsPromise.all()` in `inference_proc_lazy_main.ts` and crashed the inference process with a FATAL, taking the worker down too.

## Root cause

From the issue's log output:
```
[01:33:51.054] DEBUG (18628): initializing inference runner
    runner: "lk_eot_audio"
                    ^
error: EotRunner: @livekit/local-inference native binding unavailable in the inference process
      at initialize (...runner.js:11:17)
      at <anonymous> (...inference_proc_lazy_main.js:43:17)

[01:33:51.531] WARN (18628): @livekit/local-inference native binding not loadable...
[01:33:51.583] FATAL (23772): closing worker due to error.
```

The WARN ("native binding not loadable") was already being emitted by `_getLocalInferenceModule()` → `getNative()`. The crash happened because `initialize()` then threw, propagating up through `ThrowsPromise.all()`.

## Fix

Two changes in `EotRunner`:

1. **`initialize()`**: when `#mod === undefined`, return early instead of throwing. The WARN is already emitted upstream by `_warmup.ts`.

2. **`run()`**: when `#mod === undefined`, return `{ probability: 0, inferenceDurationMs: 0 }` instead of throwing. A zero probability means every frame is treated as "not end-of-turn", so VAD remains the sole turn-detection mechanism — the same outcome as explicitly setting `turnDetection: 'vad'`.

This keeps the inference process alive and lets the agent degrade gracefully to VAD-only mode when the native binding is unavailable, rather than crashing with a FATAL.