### PR TITLE
Allow local image files to be passed to LemonSlice API

### DIFF
--- a/.changeset/chubby-months-stop.md
+++ b/.changeset/chubby-months-stop.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-lemonslice': patch
+---
+
+Add the ability for users to provide a local image to the LemonSlice transport to be used as the avatar image.

--- a/plugins/lemonslice/README.md
+++ b/plugins/lemonslice/README.md
@@ -50,8 +50,9 @@ Set `LEMONSLICE_API_KEY` and `LEMONSLICE_IMAGE_URL` to get up and running.
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `agentId` | `string` | The LemonSlice agent ID to use. Either `agentId` or `agentImageUrl` must be provided. |
-| `agentImageUrl` | `AvatarImage` | A publicly accessible url to your avatar image. Either `agentId` or `agentImageUrl` must be provided. |
+| `agentId` | `string` | The LemonSlice agent ID to use. Exactly one of `agentId`, `agentImageUrl`, or `agentImage` must be provided. |
+| `agentImageUrl` | `string` | A publicly accessible url to your avatar image. Exactly one of `agentId`, `agentImageUrl`, or `agentImage` must be provided. |
+| `agentImage` | `string \| Buffer` | A local image file path or Buffer to upload as the agent's avatar. Exactly one of `agentId`, `agentImageUrl`, or `agentImage` must be provided. |
 | `extraPayload` | `Record<string, unknown>` | Additional LemonSlice session payload fields to forward to LemonSlice. |
 | `apiUrl` | `string` | The LemonSlice API URL. Defaults to `LEMONSLICE_API_URL` env var or the default LemonSlice API endpoint. |
 | `apiKey` | `string` | The LemonSlice API key. Defaults to `LEMONSLICE_API_KEY` env var. |

--- a/plugins/lemonslice/README.md
+++ b/plugins/lemonslice/README.md
@@ -53,6 +53,7 @@ Set `LEMONSLICE_API_KEY` and `LEMONSLICE_IMAGE_URL` to get up and running.
 | `agentId` | `string` | The LemonSlice agent ID to use. Exactly one of `agentId`, `agentImageUrl`, or `agentImage` must be provided. |
 | `agentImageUrl` | `string` | A publicly accessible url to your avatar image. Exactly one of `agentId`, `agentImageUrl`, or `agentImage` must be provided. |
 | `agentImage` | `string \| Buffer` | A local image file path or Buffer to upload as the agent's avatar. Exactly one of `agentId`, `agentImageUrl`, or `agentImage` must be provided. |
+| `agentImageMimeType` | `string` | MIME type for `agentImage` when provided as a Buffer (e.g. `'image/jpeg'`). Ignored for file paths. Defaults to `'image/png'`. |
 | `extraPayload` | `Record<string, unknown>` | Additional LemonSlice session payload fields to forward to LemonSlice. |
 | `apiUrl` | `string` | The LemonSlice API URL. Defaults to `LEMONSLICE_API_URL` env var or the default LemonSlice API endpoint. |
 | `apiKey` | `string` | The LemonSlice API key. Defaults to `LEMONSLICE_API_KEY` env var. |

--- a/plugins/lemonslice/src/avatar.ts
+++ b/plugins/lemonslice/src/avatar.ts
@@ -14,6 +14,8 @@ import type { Room } from '@livekit/rtc-node';
 import { TrackKind } from '@livekit/rtc-node';
 import type { VideoGrant } from 'livekit-server-sdk';
 import { AccessToken } from 'livekit-server-sdk';
+import { readFileSync } from 'node:fs';
+import { extname } from 'node:path';
 import { log } from './log.js';
 
 const ATTRIBUTE_PUBLISH_ON_BEHALF = 'lk.publish_on_behalf';
@@ -38,14 +40,19 @@ export class LemonSliceException extends Error {
 export interface AvatarSessionOptions {
   /**
    * The ID of the LemonSlice agent to add to the session.
-   * Either agentId or agentImageUrl must be provided.
+   * Exactly one of agentId, agentImageUrl, or agentImage must be provided.
    */
   agentId?: string | null;
   /**
    * The URL of the image to use as the agent's avatar.
-   * Either agentId or agentImageUrl must be provided.
+   * Exactly one of agentId, agentImageUrl, or agentImage must be provided.
    */
   agentImageUrl?: string | null;
+  /**
+   * A local image file path or Buffer to upload as the agent's avatar.
+   * Exactly one of agentId, agentImageUrl, or agentImage must be provided.
+   */
+  agentImage?: string | Buffer | null;
   /**
    * A prompt that subtly influences the avatar's movements and expressions.
    */
@@ -125,6 +132,8 @@ export interface StartOptions {
 export class AvatarSession extends voice.AvatarSession {
   private agentId: string | null;
   private agentImageUrl: string | null;
+  private agentImageBytes: Buffer | null;
+  private agentImageMimeType: string;
   private agentPrompt: string | null;
   private idleTimeout: number | null;
   private extraPayload: Record<string, unknown> | null;
@@ -146,12 +155,29 @@ export class AvatarSession extends voice.AvatarSession {
     super();
     this.agentId = options.agentId ?? null;
     this.agentImageUrl = options.agentImageUrl ?? null;
+    this.agentImageMimeType = 'image/png';
 
-    if (!this.agentId && !this.agentImageUrl) {
-      throw new LemonSliceException('Missing agentId or agentImageUrl');
+    if (options.agentImage) {
+      if (typeof options.agentImage === 'string') {
+        this.agentImageBytes = readFileSync(options.agentImage);
+        this.agentImageMimeType = mimeTypeFromExtension(extname(options.agentImage));
+      } else {
+        this.agentImageBytes = options.agentImage;
+      }
+    } else {
+      this.agentImageBytes = null;
     }
-    if (this.agentId && this.agentImageUrl) {
-      throw new LemonSliceException('Only one of agentId or agentImageUrl can be provided');
+
+    const sourceCount = [this.agentId, this.agentImageUrl, this.agentImageBytes].filter(
+      Boolean,
+    ).length;
+    if (sourceCount === 0) {
+      throw new LemonSliceException('Missing one of agentId, agentImageUrl, or agentImage');
+    }
+    if (sourceCount > 1) {
+      throw new LemonSliceException(
+        'Only one of agentId, agentImageUrl, or agentImage can be provided',
+      );
     }
 
     this.agentPrompt = options.agentPrompt ?? null;
@@ -294,13 +320,29 @@ export class AvatarSession extends voice.AvatarSession {
           Object.assign(payload, this.extraPayload);
         }
 
+        const headers: Record<string, string> = {
+          'X-API-Key': this.apiKey,
+        };
+        let body: BodyInit;
+
+        if (this.agentImageBytes) {
+          const formData = new FormData();
+          formData.append('payload', JSON.stringify(payload));
+          formData.append(
+            'image',
+            new Blob([new Uint8Array(this.agentImageBytes)], { type: this.agentImageMimeType }),
+            'image.png',
+          );
+          body = formData;
+        } else {
+          headers['Content-Type'] = 'application/json';
+          body = JSON.stringify(payload);
+        }
+
         const response = await fetch(this.apiUrl, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-API-Key': this.apiKey,
-          },
-          body: JSON.stringify(payload),
+          headers,
+          body,
           signal: AbortSignal.timeout(this.connOptions.timeoutMs),
         });
 
@@ -335,4 +377,16 @@ export class AvatarSession extends voice.AvatarSession {
       message: 'Failed to start LemonSlice Avatar Session after all retries',
     });
   }
+}
+
+const MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+function mimeTypeFromExtension(ext: string): string {
+  return MIME_TYPES[ext.toLowerCase()] ?? 'image/png';
 }

--- a/plugins/lemonslice/src/avatar.ts
+++ b/plugins/lemonslice/src/avatar.ts
@@ -54,6 +54,11 @@ export interface AvatarSessionOptions {
    */
   agentImage?: string | Buffer | null;
   /**
+   * MIME type for the agentImage when provided as a Buffer (e.g. 'image/png').
+   * Defaults to 'image/png'.
+   */
+  agentImageMimeType?: string;
+  /**
    * A prompt that subtly influences the avatar's movements and expressions.
    */
   agentPrompt?: string | null;
@@ -155,20 +160,8 @@ export class AvatarSession extends voice.AvatarSession {
     super();
     this.agentId = options.agentId ?? null;
     this.agentImageUrl = options.agentImageUrl ?? null;
-    this.agentImageMimeType = 'image/png';
 
-    if (options.agentImage) {
-      if (typeof options.agentImage === 'string') {
-        this.agentImageBytes = readFileSync(options.agentImage);
-        this.agentImageMimeType = mimeTypeFromExtension(extname(options.agentImage));
-      } else {
-        this.agentImageBytes = options.agentImage;
-      }
-    } else {
-      this.agentImageBytes = null;
-    }
-
-    const sourceCount = [this.agentId, this.agentImageUrl, this.agentImageBytes].filter(
+    const sourceCount = [this.agentId, this.agentImageUrl, options.agentImage].filter(
       Boolean,
     ).length;
     if (sourceCount === 0) {
@@ -178,6 +171,20 @@ export class AvatarSession extends voice.AvatarSession {
       throw new LemonSliceException(
         'Only one of agentId, agentImageUrl, or agentImage can be provided',
       );
+    }
+
+    this.agentImageMimeType = 'image/png';
+    if (options.agentImage) {
+      if (typeof options.agentImage === 'string') {
+        this.agentImageMimeType = mimeTypeFromExtension(extname(options.agentImage));
+        this.agentImageBytes = readFileSync(options.agentImage);
+      } else {
+        this.agentImageMimeType = options.agentImageMimeType ?? 'image/png';
+        validateMimeType(this.agentImageMimeType);
+        this.agentImageBytes = options.agentImage;
+      }
+    } else {
+      this.agentImageBytes = null;
     }
 
     this.agentPrompt = options.agentPrompt ?? null;
@@ -331,7 +338,7 @@ export class AvatarSession extends voice.AvatarSession {
           formData.append(
             'image',
             new Blob([new Uint8Array(this.agentImageBytes)], { type: this.agentImageMimeType }),
-            'image.png',
+            `image${extensionFromMimeType(this.agentImageMimeType)}`,
           );
           body = formData;
         } else {
@@ -383,10 +390,32 @@ const MIME_TYPES: Record<string, string> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
   '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif',
   '.webp': 'image/webp',
 };
 
+const SUPPORTED_MIME_TYPES = new Set(Object.values(MIME_TYPES));
+
 function mimeTypeFromExtension(ext: string): string {
-  return MIME_TYPES[ext.toLowerCase()] ?? 'image/png';
+  const mime = MIME_TYPES[ext.toLowerCase()];
+  if (!mime) {
+    throw new LemonSliceException(
+      `Unsupported image extension '${ext}'. Supported: ${Object.keys(MIME_TYPES).join(', ')}`,
+    );
+  }
+  return mime;
+}
+
+function validateMimeType(mime: string): void {
+  if (!SUPPORTED_MIME_TYPES.has(mime)) {
+    throw new LemonSliceException(
+      `Unsupported MIME type '${mime}'. Supported: ${[...SUPPORTED_MIME_TYPES].join(', ')}`,
+    );
+  }
+}
+
+function extensionFromMimeType(mime: string): string {
+  for (const [ext, type] of Object.entries(MIME_TYPES)) {
+    if (type === mime) return ext;
+  }
+  return '.png';
 }


### PR DESCRIPTION
## Description
Adds the ability for users to provide a local image filepath or bytes to the LemonSlice plugin to be used as the avatar image.
Video demo: https://www.loom.com/share/7b4aab1be9b84f17864b5132e71c77f8 

## Changes Made
- LemonSlice Avatar session now allows the optional args: `agentImage` and `agentImageMimeType`

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [x] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [x] Automated tests added/updated (if applicable)
- [x] All tests pass
- [x] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.