### PR TITLE
chore(deps): update @livekit/rtc-node to 0.13.31

### DIFF
--- a/.changeset/update-rtc-node-0-13-31.md
+++ b/.changeset/update-rtc-node-0-13-31.md
@@ -1,0 +1,7 @@
+---
+'@livekit/agents': patch
+---
+
+chore(deps): update @livekit/rtc-node to 0.13.31
+
+Fixes AudioSource.waitForPlayout resolving early with audio still queued (livekit/node-sdks#693).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@livekit/rtc-node':
-      specifier: ^0.13.30
-      version: 0.13.30
+      specifier: ^0.13.31
+      version: 0.13.31
     '@types/ws':
       specifier: ^8.5.10
       version: 8.18.1
@@ -214,7 +214,7 @@ importers:
     devDependencies:
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@22.19.1)
@@ -331,7 +331,7 @@ importers:
         version: 0.1.9
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -405,7 +405,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -433,7 +433,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -464,7 +464,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -501,7 +501,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@22.19.1)
@@ -529,7 +529,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -566,7 +566,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -600,7 +600,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -634,7 +634,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -659,7 +659,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -693,7 +693,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -727,7 +727,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -773,7 +773,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -795,7 +795,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -822,7 +822,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -850,7 +850,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -875,7 +875,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -903,7 +903,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -962,7 +962,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -987,7 +987,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1015,7 +1015,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1046,7 +1046,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1086,7 +1086,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1117,7 +1117,7 @@ importers:
         version: link:../openai
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1139,7 +1139,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1167,7 +1167,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1201,7 +1201,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1226,7 +1226,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1260,7 +1260,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1288,7 +1288,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1316,7 +1316,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1341,7 +1341,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1369,7 +1369,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@types/node':
         specifier: ^22.5.5
         version: 22.19.1
@@ -1394,7 +1394,7 @@ importers:
         version: link:../../agents
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -1431,7 +1431,7 @@ importers:
         version: link:../test
       '@livekit/rtc-node':
         specifier: 'catalog:'
-        version: 0.13.30
+        version: 0.13.31
       '@microsoft/api-extractor':
         specifier: ^7.35.0
         version: 7.43.7(@types/node@25.6.0)
@@ -2262,8 +2262,8 @@ packages:
     resolution: {integrity: sha512-ZJD2DNoHfR8PzKeyDMH6i1zKpk7S4LlrQDIZvisxj6HPaJnKofzSssNMF8fpGFvVCZ844kbcOFogRPgHFno82w==}
     engines: {node: '>= 18'}
 
-  '@livekit/rtc-node@0.13.30':
-    resolution: {integrity: sha512-chUeAKM2EABTbd0Xtkf+TXPPb+wS8ry7Pze0CSWN/MhC1Lx5QD26qr2LECrzFxnGg4httK0SzlEnpurgboOxiQ==}
+  '@livekit/rtc-node@0.13.31':
+    resolution: {integrity: sha512-uCpyUUOoph+sDsjW6mSmDe6ox1vSfgaWR5VFgP7u4KGf1clyJooX7d6Fe94ZruDjLTsGxxV97IOmVU5+cBiBgg==}
     engines: {node: '>= 18'}
 
   '@livekit/throws-transformer@0.1.8':
@@ -5946,7 +5946,7 @@ snapshots:
 
   '@livekit/noise-cancellation-node@0.1.9':
     dependencies:
-      '@livekit/rtc-node': 0.13.30
+      '@livekit/rtc-node': 0.13.31
       tsx: 4.21.0
     optionalDependencies:
       '@livekit/noise-cancellation-darwin-arm64': 0.1.9
@@ -5987,7 +5987,7 @@ snapshots:
       '@livekit/rtc-ffi-bindings-linux-x64-gnu': 0.12.60
       '@livekit/rtc-ffi-bindings-win32-x64-msvc': 0.12.60
 
-  '@livekit/rtc-node@0.13.30':
+  '@livekit/rtc-node@0.13.31':
     dependencies:
       '@datastructures-js/deque': 1.0.8
       '@livekit/mutex': 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,6 @@ minimumReleaseAgeExclude:
   - "@opentelemetry/core@2.8.0"
 
 catalog:
-  '@livekit/rtc-node': ^0.13.30
+  '@livekit/rtc-node': ^0.13.31
   ws: ^8.18.0
   '@types/ws': ^8.5.10


### PR DESCRIPTION
## Summary

- Bump the workspace catalog `@livekit/rtc-node` peer dependency from `^0.13.30` to `^0.13.31`
- Pick up the `AudioSource.waitForPlayout` fix from [livekit/node-sdks#693](https://github.com/livekit/node-sdks/pull/693), which prevents agent speech tails from being clipped when the internal playout promise was latched by a drain timer, `clearQueue()`, or pause

## Test plan

- [x] `@livekit/rtc-node@0.13.31` published via [livekit/node-sdks#694](https://github.com/livekit/node-sdks/pull/694)
- [x] `pnpm install` lockfile updated
- [ ] CI passes