### PR TITLE
chore(deps): replace @ffmpeg-installer/ffmpeg with @livekit/av

### DIFF
--- a/.changeset/av-npm-ffmpeg.md
+++ b/.changeset/av-npm-ffmpeg.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Replace @ffmpeg-installer/ffmpeg with @livekit/av, LiveKit's own minimal LGPL FFmpeg build shipped as platform-specific npm packages.

--- a/agents/package.json
+++ b/agents/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.10.0",
-    "@ffmpeg-installer/ffmpeg": "^1.1.0",
+    "@livekit/av": "^7.1.500",
     "@livekit/local-inference": "^0.2.6",
     "@livekit/mutex": "^1.1.1",
     "@livekit/protocol": "^1.48.0",

--- a/agents/src/audio.ts
+++ b/agents/src/audio.ts
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import ffmpegInstaller from '@ffmpeg-installer/ffmpeg';
 import { AudioFrame } from '@livekit/rtc-node';
 import ffmpeg from 'fluent-ffmpeg';
 import type { ReadableStream } from 'node:stream/web';
+import { configureFfmpeg } from './ffmpeg.js';
 import { log } from './log.js';
 import { createStreamChannel } from './stream/stream_channel.js';
 import { type AudioBuffer, isFfmpegTeardownError } from './utils.js';
 
-ffmpeg.setFfmpegPath(ffmpegInstaller.path);
+configureFfmpeg();
 
 export interface AudioDecodeOptions {
   sampleRate?: number;

--- a/agents/src/ffmpeg.test.ts
+++ b/agents/src/ffmpeg.test.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import * as fs from 'node:fs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { FFMPEG_PATH_ENV, resolveFfmpegPath } from './ffmpeg.js';
+
+describe('ffmpeg path resolution', () => {
+  afterEach(() => {
+    delete process.env[FFMPEG_PATH_ENV];
+  });
+
+  it('prefers the LIVEKIT_FFMPEG_PATH override over the bundled binary', () => {
+    process.env[FFMPEG_PATH_ENV] = '/custom/ffmpeg';
+    expect(resolveFfmpegPath()).toBe('/custom/ffmpeg');
+  });
+
+  it('resolves the @livekit/av bundled binary on supported platforms', () => {
+    const resolved = resolveFfmpegPath();
+    // Supported dev/CI platforms always have the platform package installed.
+    expect(resolved).toBeDefined();
+    expect(fs.existsSync(resolved!)).toBe(true);
+  });
+});

--- a/agents/src/ffmpeg.ts
+++ b/agents/src/ffmpeg.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { getFfmpegPath } from '@livekit/av';
+import ffmpeg from 'fluent-ffmpeg';
+import { log, loggerOptions } from './log.js';
+
+/** Env var allowing users to point at their own ffmpeg binary, bypassing the bundled one. */
+export const FFMPEG_PATH_ENV = 'LIVEKIT_FFMPEG_PATH';
+
+/**
+ * Resolve the ffmpeg binary path:
+ * 1. `LIVEKIT_FFMPEG_PATH` env override, if set
+ * 2. the bundled LGPL binary from the platform-specific `@livekit/av-*` package
+ * 3. `undefined` (caller may fall back to `ffmpeg` on PATH)
+ */
+export const resolveFfmpegPath = (): string | undefined =>
+  process.env[FFMPEG_PATH_ENV] || getFfmpegPath();
+
+/**
+ * Register the resolved ffmpeg binary with fluent-ffmpeg. Call before invoking
+ * `ffmpeg(...)`. Memoized — resolution runs once per process.
+ */
+let configured = false;
+export const configureFfmpeg = (): void => {
+  if (configured) {
+    return;
+  }
+  configured = true;
+  const resolved = resolveFfmpegPath();
+  if (resolved) {
+    ffmpeg.setFfmpegPath(resolved);
+    return;
+  }
+  // No prebuilt binary for this platform (e.g. musl libc) or optional deps were skipped;
+  // leave fluent-ffmpeg's default (`ffmpeg` on PATH). This runs at module-import time,
+  // possibly before initializeLogger() — fall back to console in that case.
+  const message =
+    `no bundled ffmpeg binary for ${process.platform}-${process.arch}; ` +
+    `using \`ffmpeg\` from PATH; set ${FFMPEG_PATH_ENV} to use a specific binary`;
+  if (loggerOptions()) {
+    log().warn(message);
+  } else {
+    console.warn(`[livekit-agents] ${message}`);
+  }
+};

--- a/agents/src/voice/recorder_io/recorder_io.ts
+++ b/agents/src/voice/recorder_io/recorder_io.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import ffmpegInstaller from '@ffmpeg-installer/ffmpeg';
 import { Mutex } from '@livekit/mutex';
 import { AudioFrame, AudioResampler } from '@livekit/rtc-node';
 import ffmpeg from 'fluent-ffmpeg';
@@ -10,6 +9,7 @@ import path from 'node:path';
 import { PassThrough } from 'node:stream';
 import type { ReadableStream } from 'node:stream/web';
 import { TransformStream } from 'node:stream/web';
+import { configureFfmpeg } from '../../ffmpeg.js';
 import { log } from '../../log.js';
 import { isStreamReaderReleaseError } from '../../stream/deferred_stream.js';
 import { type StreamChannel, createStreamChannel } from '../../stream/stream_channel.js';
@@ -25,7 +25,7 @@ import type { AgentSession } from '../agent_session.js';
 import { AudioInput, AudioOutput, type PlaybackFinishedEvent } from '../io.js';
 import { createSilenceFrame } from '../utils.js';
 
-ffmpeg.setFfmpegPath(ffmpegInstaller.path);
+configureFfmpeg();
 
 const WRITE_INTERVAL_MS = 2500;
 const DEFAULT_SAMPLE_RATE = 48000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,9 +109,9 @@ importers:
       '@bufbuild/protobuf':
         specifier: ^1.10.0
         version: 1.10.1
-      '@ffmpeg-installer/ffmpeg':
-        specifier: ^1.1.0
-        version: 1.1.0
+      '@livekit/av':
+        specifier: ^7.1.500
+        version: 7.1.501
       '@livekit/local-inference':
         specifier: ^0.2.6
         version: 0.2.6
@@ -1911,49 +1911,6 @@ packages:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@ffmpeg-installer/darwin-arm64@4.1.5':
-    resolution: {integrity: sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@ffmpeg-installer/darwin-x64@4.1.0':
-    resolution: {integrity: sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@ffmpeg-installer/ffmpeg@1.1.0':
-    resolution: {integrity: sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==}
-
-  '@ffmpeg-installer/linux-arm64@4.1.4':
-    resolution: {integrity: sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@ffmpeg-installer/linux-arm@4.1.3':
-    resolution: {integrity: sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@ffmpeg-installer/linux-ia32@4.1.0':
-    resolution: {integrity: sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==}
-    cpu: [ia32]
-    os: [linux]
-
-  '@ffmpeg-installer/linux-x64@4.1.0':
-    resolution: {integrity: sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==}
-    cpu: [x64]
-    os: [linux]
-
-  '@ffmpeg-installer/win32-ia32@4.1.0':
-    resolution: {integrity: sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@ffmpeg-installer/win32-x64@4.1.0':
-    resolution: {integrity: sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==}
-    cpu: [x64]
-    os: [win32]
-
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
     engines: {node: '>=20.0.0'}
@@ -2161,6 +2118,35 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@livekit/av-darwin-arm64@7.1.501':
+    resolution: {integrity: sha512-vUL1KJvoCicXewhRzeRCcJkqNynsLBhHKL8aJ63OShHnx8e6UGMkzmR70zUO23rZztxQpBxSG8Awah8Z/6Q4sg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@livekit/av-darwin-x64@7.1.501':
+    resolution: {integrity: sha512-y5vd5kSZ6c/Yw4nN+st7NQ6ThIKE0k2n8Z6iYdFf+xLCIxOWyT3av/7wmuVt0QJOJTf9YUv3kQRGssepyvVYNQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@livekit/av-linux-arm64@7.1.501':
+    resolution: {integrity: sha512-tSmB4MEsR8nDysD7p+lWedvabkoLPD6fV5xj3QHRgklwFXkk4yoiUyYbNZb2uIZOvrpMltxnm7kbAYGk34fdXg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@livekit/av-linux-x64@7.1.501':
+    resolution: {integrity: sha512-jpCAtd4kUfLEMIwQW9PxjfrABXK4f91TZ5qx56b6pkkRBMrtFn4e2b1A08+WMeG0jI4X5Yd8XEnjlW5dUzEZaA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@livekit/av-win32-x64@7.1.501':
+    resolution: {integrity: sha512-u3klXmY8oMBbbLDKIOGUnEBhZQk3v9wrzj/ta6lIlhB4bLBKn1Aq/75BK8D7xOxalKjt/RZPGKn94K9ohvxIuA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@livekit/av@7.1.501':
+    resolution: {integrity: sha512-o/T5WvmyMADwIKHx/XHdQ/gfGBikBRU7FZcJ0//COD24ev6YrCE9+L9jLp9HYR3X6Unosh4mlv8UcqFsivDVTw==}
+    engines: {node: '>=18.0.0'}
 
   '@livekit/changesets-changelog-github@0.2.0':
     resolution: {integrity: sha512-HWgR0biITeIaLeBRIUpqYJ0Wacmx7JJjlqhiJtqYrGItqw0kRUe6tTB6vN0fU7tK1oh08hlgr3iYdGLNLNbrNQ==}
@@ -5694,41 +5680,6 @@ snapshots:
 
   '@eslint/js@8.57.0': {}
 
-  '@ffmpeg-installer/darwin-arm64@4.1.5':
-    optional: true
-
-  '@ffmpeg-installer/darwin-x64@4.1.0':
-    optional: true
-
-  '@ffmpeg-installer/ffmpeg@1.1.0':
-    optionalDependencies:
-      '@ffmpeg-installer/darwin-arm64': 4.1.5
-      '@ffmpeg-installer/darwin-x64': 4.1.0
-      '@ffmpeg-installer/linux-arm': 4.1.3
-      '@ffmpeg-installer/linux-arm64': 4.1.4
-      '@ffmpeg-installer/linux-ia32': 4.1.0
-      '@ffmpeg-installer/linux-x64': 4.1.0
-      '@ffmpeg-installer/win32-ia32': 4.1.0
-      '@ffmpeg-installer/win32-x64': 4.1.0
-
-  '@ffmpeg-installer/linux-arm64@4.1.4':
-    optional: true
-
-  '@ffmpeg-installer/linux-arm@4.1.3':
-    optional: true
-
-  '@ffmpeg-installer/linux-ia32@4.1.0':
-    optional: true
-
-  '@ffmpeg-installer/linux-x64@4.1.0':
-    optional: true
-
-  '@ffmpeg-installer/win32-ia32@4.1.0':
-    optional: true
-
-  '@ffmpeg-installer/win32-x64@4.1.0':
-    optional: true
-
   '@google/genai@1.52.0':
     dependencies:
       google-auth-library: 10.6.2
@@ -5898,6 +5849,29 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@livekit/av-darwin-arm64@7.1.501':
+    optional: true
+
+  '@livekit/av-darwin-x64@7.1.501':
+    optional: true
+
+  '@livekit/av-linux-arm64@7.1.501':
+    optional: true
+
+  '@livekit/av-linux-x64@7.1.501':
+    optional: true
+
+  '@livekit/av-win32-x64@7.1.501':
+    optional: true
+
+  '@livekit/av@7.1.501':
+    optionalDependencies:
+      '@livekit/av-darwin-arm64': 7.1.501
+      '@livekit/av-darwin-x64': 7.1.501
+      '@livekit/av-linux-arm64': 7.1.501
+      '@livekit/av-linux-x64': 7.1.501
+      '@livekit/av-win32-x64': 7.1.501
 
   '@livekit/changesets-changelog-github@0.2.0':
     dependencies:


### PR DESCRIPTION
## Description

Swaps the third-party `@ffmpeg-installer/ffmpeg` for `@livekit/av`, our own minimal LGPL FFmpeg 7.1.5 build published as platform-specific npm packages from agents-private. No download step: npm's `os`/`cpu` filters install exactly one platform binary.

## Changes Made
- Add `agents/src/ffmpeg.ts`: resolution order `LIVEKIT_FFMPEG_PATH` env → `@livekit/av` binary → `ffmpeg` on PATH (with warning)
- Register via `configureFfmpeg()` in `audio.ts` / `recorder_io.ts` (same module-level pattern as before)
- Swap dependency; add changeset

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: N/A

## Testing
- [x] Automated tests added/updated: new `ffmpeg.test.ts` (env override precedence, binary resolution)
- [x] All tests pass — decode paths exercised against the real CI-built binary (`ffmpeg -version` → 7.1.5, `--enable-libopus`, no `--enable-gpl`)
- [ ] restaurant_agent.ts / realtime_agent.ts: N/A (no pipeline behavior change)

## Additional Notes
Depends on livekit/agents-private#162: `pnpm-lock.yaml` will be committed once `@livekit/av@7.1.500` is published to npm — CI stays red on install until then.