### PR TITLE
fix(openai): default withAzure voice to marin, matching RealtimeModel

### DIFF
--- a/.changeset/azure-realtime-default-voice.md
+++ b/.changeset/azure-realtime-default-voice.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+Change the default voice in `RealtimeModel.withAzure` from `alloy` to `marin`, matching the `RealtimeModel` constructor and the Python plugin.

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -248,7 +248,7 @@ export class RealtimeModel extends llm.RealtimeModel {
    * @param apiKey - Azure OpenAI API key. If undefined, will attempt to read from the environment variable AZURE_OPENAI_API_KEY.
    * @param entraToken - Azure Entra authentication token. Required if not using API key authentication.
    * @param baseURL - Base URL for the API endpoint. If undefined, constructed from the azure_endpoint.
-   * @param voice - Voice setting for audio outputs. Defaults to "alloy".
+   * @param voice - Voice setting for audio outputs. Defaults to "marin".
    * @param inputAudioTranscription - Options for transcribing input audio. Defaults to @see DEFAULT_INPUT_AUDIO_TRANSCRIPTION.
    * @param inputAudioNoiseReduction - Options for noise reduction. Defaults to undefined.
    * @param turnDetection - Options for server-based voice activity detection (VAD). Defaults to @see DEFAULT_SERVER_VAD_OPTIONS.
@@ -266,7 +266,7 @@ export class RealtimeModel extends llm.RealtimeModel {
     apiKey,
     entraToken,
     baseURL,
-    voice = 'alloy',
+    voice = 'marin',
     temperature, // eslint-disable-line @typescript-eslint/no-unused-vars
     inputAudioTranscription = AZURE_DEFAULT_INPUT_AUDIO_TRANSCRIPTION,
     inputAudioNoiseReduction,


### PR DESCRIPTION
## Description
`RealtimeModel.withAzure` defaults `voice` to `alloy`, while the `RealtimeModel` constructor and the Python plugin's `RealtimeModel.with_azure` both default to `marin`. This mismatch was surfaced by MCP docs feedback: the Azure OpenAI realtime docs state the default is `marin`, but the Node.js `withAzure` path didn't match. This aligns the Azure factory default with the rest of the plugin.

## Changes Made
- Change the `voice` default in `RealtimeModel.withAzure` from `'alloy'` to `'marin'`, and update the JSDoc to match.
- Add a patch changeset for `@livekit/agents-plugin-openai`.

## Pre-Review Checklist
- [ ] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [ ] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable)

## Testing
- [ ] Automated tests added/updated (if applicable) — default-value change only; no behavior beyond the default literal.
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
This is a user-visible behavior change for anyone relying on the implicit `alloy` default with Azure, hence the changeset.