### PR TITLE
elevenlabs: deprecate STT modelId in favor of model

### DIFF
--- a/.changeset/elevenlabs-stt-model-param.md
+++ b/.changeset/elevenlabs-stt-model-param.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-elevenlabs': patch
+---
+
+Deprecate the ElevenLabs STT `modelId` option in favor of `model`, matching the TTS plugin. `modelId` still works as a deprecated alias.

--- a/examples/src/elevenlabs_scribe_v2.ts
+++ b/examples/src/elevenlabs_scribe_v2.ts
@@ -22,7 +22,7 @@ export default defineAgent({
         minSpeechDurationMs: 100,
         minSilenceDurationMs: 300,
       },
-      modelId: 'scribe_v2_realtime',
+      model: 'scribe_v2_realtime',
     });
 
     const session = new voice.AgentSession({

--- a/plugins/elevenlabs/src/stt.test.ts
+++ b/plugins/elevenlabs/src/stt.test.ts
@@ -193,7 +193,7 @@ describe('ElevenLabs STT', () => {
         baseURL,
         languageCode: 'en',
         tagAudioEvents: false,
-        modelId: 'scribe_v2',
+        model: 'scribe_v2',
         keyterms: ['LiveKit', 'ElevenLabs'],
       });
 
@@ -262,7 +262,7 @@ describe('ElevenLabs STT', () => {
     });
 
     try {
-      const eleven = new STT({ apiKey: 'test-key', baseURL, modelId: 'scribe_v2_realtime' });
+      const eleven = new STT({ apiKey: 'test-key', baseURL, model: 'scribe_v2_realtime' });
       const stream = eleven.stream();
       stream.startTimeOffset = 1;
 
@@ -341,7 +341,7 @@ describe('ElevenLabs STT', () => {
       const eleven = new STT({
         apiKey: 'test-key',
         baseURL,
-        modelId: 'scribe_v2_realtime',
+        model: 'scribe_v2_realtime',
         languageCode: 'en',
         includeTimestamps: true,
         serverVad: {
@@ -389,7 +389,7 @@ describe('ElevenLabs STT', () => {
     });
 
     try {
-      const eleven = new STT({ apiKey: 'test-key', baseURL, modelId: 'scribe_v2_realtime' });
+      const eleven = new STT({ apiKey: 'test-key', baseURL, model: 'scribe_v2_realtime' });
       const stream = eleven.stream();
 
       await waitUntil(() => urls.length === 1);

--- a/plugins/elevenlabs/src/stt.ts
+++ b/plugins/elevenlabs/src/stt.ts
@@ -57,6 +57,8 @@ export interface STTOptions {
   serverVad?: VADOptions | null;
   includeTimestamps?: boolean;
   httpSession?: STTHTTPSession;
+  model?: ElevenLabsSTTModels | string;
+  /** @deprecated Use `model` instead. */
   modelId?: ElevenLabsSTTModels | string;
   keyterms?: string[];
   noVerbatim?: boolean;
@@ -192,20 +194,30 @@ export class STT extends stt.STT {
   label = 'elevenlabs.STT';
 
   constructor(opts: STTOptions = {}) {
-    let modelId = opts.modelId;
-    if (opts.useRealtime !== undefined) {
-      if (modelId !== undefined) {
+    let model = opts.model;
+    if (opts.modelId !== undefined) {
+      if (model !== undefined) {
         log().warn(
-          'both `useRealtime` and `modelId` parameters are provided. `useRealtime` will be ignored.',
+          'both `model` and `modelId` parameters are provided. `modelId` will be ignored.',
+        );
+      } else {
+        log().warn('`modelId` parameter is deprecated, use `model` instead.');
+        model = opts.modelId;
+      }
+    }
+    if (opts.useRealtime !== undefined) {
+      if (model !== undefined) {
+        log().warn(
+          'both `useRealtime` and `model` parameters are provided. `useRealtime` will be ignored.',
         );
       } else {
         log().warn(
-          '`useRealtime` parameter is deprecated. Specify a realtime modelId to enable streaming. Defaulting modelId to one based on useRealtime parameter.',
+          '`useRealtime` parameter is deprecated. Specify a realtime model to enable streaming. Defaulting model to one based on useRealtime parameter.',
         );
-        modelId = opts.useRealtime ? 'scribe_v2_realtime' : 'scribe_v1';
+        model = opts.useRealtime ? 'scribe_v2_realtime' : 'scribe_v1';
       }
     }
-    modelId = modelId ?? 'scribe_v1';
+    const modelId = model ?? 'scribe_v1';
     const useRealtime = modelId === 'scribe_v2_realtime';
 
     if (!useRealtime && opts.serverVad !== undefined) {


### PR DESCRIPTION
## Description

The ElevenLabs STT plugin takes `modelId` while the ElevenLabs TTS plugin takes `model`, which makes it easy to pass the wrong parameter name when configuring both from the same config shape. Reported via [MCP docs feedback in Slack](https://live-kit.slack.com/archives/C0A8DECQMLP/p1783671220752889). This aligns STT with TTS without breaking existing code. Companion PRs: livekit/agents#6378 (same change for Python), livekit/web#5084 (docs cross-link).

## Changes Made
- Add a `model` option to `STTOptions` as the preferred spelling; `modelId` remains a deprecated alias that logs a deprecation warning (same pattern as the existing `useRealtime` deprecation and the TTS plugin's legacy `modelID`).
- If both are provided, `model` wins and a warning is logged. Behavior is otherwise unchanged, including the `scribe_v1` default.
- Update the scribe example and existing tests to use `model`.
- Add a changeset.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: N/A — no user-visible behavior change

## Testing
- [x] All tests pass (`vitest run plugins/elevenlabs/src/stt.test.ts`: 6 passed, 1 skipped integration test)
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes) — N/A, plugin-scoped option rename

## Additional Notes
The deprecation warning is user-visible log output for anyone currently passing `modelId`; the option keeps working unchanged.