### PR TITLE
fix(voice): flush final agent speech in RecorderIO on session teardown

### DIFF
--- a/.changeset/recorder-io-final-speech-flush.md
+++ b/.changeset/recorder-io-final-speech-flush.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(voice): stop RecorderIO from dropping the final agent speech at session teardown. A force-interrupted shutdown marks the current speech done before playout settles, so the recorder could close and fence out the in-flight playbackFinished flush, silently losing the last agent turn and trailing mic audio from the recording. RecorderIO.close() now waits (bounded) for the pending playback event — which carries the authoritative playback position — before fencing, flushes any input captured since the last write, and warns if unflushed agent audio had to be dropped.

--- a/agents/src/voice/recorder_io/recorder_io.test.ts
+++ b/agents/src/voice/recorder_io/recorder_io.test.ts
@@ -1,8 +1,125 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { describe, expect, it } from 'vitest';
+import { AudioFrame } from '@livekit/rtc-node';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initializeLogger } from '../../log.js';
+import { type StreamChannel, createStreamChannel } from '../../stream/stream_channel.js';
 import { isWritableStreamClosedError } from '../../utils.js';
+import type { AgentSession } from '../agent_session.js';
+import { AudioInput, AudioOutput } from '../io.js';
+import { RecorderIO } from './recorder_io.js';
+
+class FakeAudioInput extends AudioInput {
+  private chan: StreamChannel<AudioFrame> = createStreamChannel<AudioFrame>();
+
+  constructor() {
+    super();
+    this.multiStream.addInputStream(this.chan.stream());
+  }
+
+  push(frame: AudioFrame): Promise<void> {
+    return this.chan.write(frame);
+  }
+}
+
+class FakeAudioOutput extends AudioOutput {
+  constructor() {
+    super(48000);
+  }
+
+  clearBuffer(): void {}
+}
+
+function makeFrame(durationMs: number, sampleRate = 48000, channels = 1): AudioFrame {
+  const samplesPerChannel = Math.floor((durationMs / 1000) * sampleRate);
+  return new AudioFrame(
+    new Int16Array(samplesPerChannel * channels),
+    sampleRate,
+    channels,
+    samplesPerChannel,
+  );
+}
+
+function makeRecorder() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'recorder-io-test-'));
+  const outputPath = path.join(dir, 'audio.ogg');
+  const recorder = new RecorderIO({ agentSession: {} as AgentSession });
+  const input = new FakeAudioInput();
+  const inWrapped = recorder.recordInput(input);
+  const outWrapped = recorder.recordOutput(new FakeAudioOutput());
+  return { recorder, input, inWrapped, outWrapped, outputPath };
+}
+
+describe('RecorderIO close', () => {
+  beforeAll(() => {
+    initializeLogger({ pretty: false });
+  });
+
+  it('flushes the final agent speech when playbackFinished lands during close', async () => {
+    const { recorder, outWrapped, outputPath } = makeRecorder();
+    await recorder.start(outputPath);
+
+    await outWrapped.captureFrame(makeFrame(1000));
+    outWrapped.flush();
+
+    // Let wall-clock catch up with the pushed duration so the playback
+    // position clamp doesn't trim the segment.
+    await new Promise((resolve) => setTimeout(resolve, 1050));
+
+    // Mimic the force-interrupt teardown race: close() starts while the
+    // playbackFinished event is still in flight.
+    const closePromise = recorder.close();
+    setTimeout(() => {
+      outWrapped.onPlaybackFinished({ playbackPosition: 1.0, interrupted: true });
+    }, 100);
+    await closePromise;
+
+    expect(fs.existsSync(outputPath)).toBe(true);
+    expect(fs.statSync(outputPath).size).toBeGreaterThan(0);
+  }, 15000);
+
+  it('close() completes after the flush timeout when playbackFinished never arrives', async () => {
+    const { recorder, outWrapped, outputPath } = makeRecorder();
+    (recorder as unknown as { closePlayoutFlushTimeoutMs: number }).closePlayoutFlushTimeoutMs =
+      150;
+    await recorder.start(outputPath);
+
+    await outWrapped.captureFrame(makeFrame(200));
+    outWrapped.flush();
+
+    const start = Date.now();
+    await recorder.close();
+
+    expect(Date.now() - start).toBeGreaterThanOrEqual(140);
+    // Nothing reached the encoder, so no file was produced.
+    expect(fs.existsSync(outputPath)).toBe(false);
+  }, 15000);
+
+  it('flushes trailing input audio on close', async () => {
+    const { recorder, input, inWrapped, outputPath } = makeRecorder();
+    await recorder.start(outputPath);
+
+    // Frames only accumulate while flowing through the intercepting stream,
+    // so consume them like the session does.
+    const reader = inWrapped.stream.getReader();
+    for (let i = 0; i < 5; i++) {
+      await input.push(makeFrame(100));
+      await reader.read();
+    }
+    reader.releaseLock();
+
+    // Close before the 2.5s forward tick: without the final input flush this
+    // audio would be dropped.
+    await recorder.close();
+
+    expect(fs.existsSync(outputPath)).toBe(true);
+    expect(fs.statSync(outputPath).size).toBeGreaterThan(0);
+  }, 15000);
+});
 
 describe('RecorderIO writable stream error detection', () => {
   it('detects ERR_INVALID_STATE stream closure errors', () => {

--- a/agents/src/voice/recorder_io/recorder_io.ts
+++ b/agents/src/voice/recorder_io/recorder_io.ts
@@ -29,6 +29,7 @@ configureFfmpeg();
 
 const WRITE_INTERVAL_MS = 2500;
 const DEFAULT_SAMPLE_RATE = 48000;
+const CLOSE_PLAYOUT_FLUSH_TIMEOUT_MS = 2000;
 
 export interface RecorderOptions {
   agentSession: AgentSession;
@@ -59,6 +60,7 @@ export class RecorderIO {
   private lock: Mutex = new Mutex();
   private started: boolean = false;
   private closing: boolean = false;
+  private closePlayoutFlushTimeoutMs: number = CLOSE_PLAYOUT_FLUSH_TIMEOUT_MS;
 
   // FFmpeg streaming state
   private pcmStream?: PassThrough;
@@ -111,6 +113,26 @@ export class RecorderIO {
     try {
       if (!this.started) return;
 
+      // On a force-interrupted shutdown, the session marks the speech done
+      // before playout settles, so the playout finished event may still be in flight.
+      // Give it a bounded window to land before fencing writers out.
+      if (this.outRecord?.hasPendingData) {
+        const timeoutController = new AbortController();
+        await Promise.race([
+          this.outRecord.waitForPlayout(),
+          delay(this.closePlayoutFlushTimeoutMs, { signal: timeoutController.signal }).catch(
+            () => {},
+          ),
+        ]);
+        timeoutController.abort();
+
+        if (this.outRecord.hasPendingData) {
+          this.logger.warn(
+            'RecorderIO closed before the last playback finished; dropping unflushed agent audio',
+          );
+        }
+      }
+
       // Establish shutdown fence before any async operations, so no writer can proceed.
       this.closing = true;
       this.started = false;
@@ -118,6 +140,19 @@ export class RecorderIO {
       if (this.forwardTask) {
         await cancelAndWait([this.forwardTask]);
         this.forwardTask = undefined;
+      }
+
+      // Flush input captured since the last write so the recording tail isn't dropped.
+      const inputBuf = this.inRecord?.takeBuf(this.outRecord?._lastSpeechEndTime) ?? [];
+      if (inputBuf.length > 0) {
+        try {
+          await this.inChan.write(inputBuf);
+          await this.outChan.write([]);
+        } catch (err) {
+          if (!isWritableStreamClosedError(err)) {
+            this.logger.error({ err }, 'Error writing final RecorderIO input buffer');
+          }
+        }
       }
 
       await this.inChan.close();


### PR DESCRIPTION
Fixes [AGT-3135](https://linear.app/livekit/issue/AGT-3135/recorderio-drops-final-agent-speech-on-force-interrupted-session)

**Bug:** session recordings silently lose the final agent turn when teardown interrupts mid-speech: force-interrupt (#1100) marks speech done instantly, so `RecorderIO.close()` fences writers before the in-flight `playbackFinished` flush lands (a production session lost its final 9.6s turn this way).

**Fix:** `close()` now waits (2s cap) for the real playback event, whose position is authoritative, instead of estimating one from wall clock; warns if audio is still dropped; and flushes mic input captured since the last forward tick. Python already waits for real speech completion, so it is unaffected.

**Tests** reproduce the close race against real ffmpeg; all three fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)