### PR TITLE
fix(voice): commit in-flight assistant turn when the session closes mid-playout

### DIFF
--- a/.changeset/commit-inflight-turn-on-close.md
+++ b/.changeset/commit-inflight-turn-on-close.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Commit the in-flight assistant turn (interrupted: true, partially-forwarded text) when the session closes mid-playout — previously a room disconnect during playback dropped the turn from chatCtx entirely, with no ConversationItemAdded emitted (#2041)

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Mutex } from '@livekit/mutex';
 import type { AudioFrame } from '@livekit/rtc-node';
-import { ThrowsPromise } from '@livekit/throws-transformer/throws';
+import { type Throws, ThrowsPromise } from '@livekit/throws-transformer/throws';
 import type { Span } from '@opentelemetry/api';
 import { ROOT_CONTEXT, context as otelContext, trace } from '@opentelemetry/api';
 import { Heap } from 'heap-js';
@@ -236,9 +236,12 @@ export interface ForwardOutput {
  * shutdown) — parking there would keep the reply task from committing the
  * in-flight assistant turn.
  */
-async function raceWithAbort<T>(p: Promise<T>, signal: AbortSignal): Promise<T | undefined> {
+async function raceWithAbort<T>(
+  p: Promise<T>,
+  signal: AbortSignal,
+): Promise<Throws<T | undefined, Error>> {
   if (signal.aborted) {
-    return (await isPending(p)) ? undefined : p;
+    return (await isPending(p)) ? undefined : ThrowsPromise.fromPromise<T | undefined, Error>(p);
   }
   return ThrowsPromise.race([
     ThrowsPromise.fromPromise<T | undefined, Error>(p),

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -79,6 +79,7 @@ import {
   delay,
   isDevMode,
   isHosted,
+  isPending,
   waitForAbort,
   waitUntilTimeout,
 } from '../utils.js';
@@ -226,27 +227,23 @@ export interface ForwardOutput {
 }
 
 /**
- * Resolve with `p`, or with `undefined` as soon as `signal` aborts. Used where
- * a promise may never settle once the room is gone (e.g. waitForPlayout during
+ * Resolves with `p`, or with `undefined` once `signal` aborts while `p` is
+ * still pending. An already-settled `p` always wins, even when the signal has
+ * already fired — an {@link AudioOutput} is allowed to report
+ * `playbackFinished` synchronously from `clearBuffer()`, and its synchronized
+ * transcript must not be discarded in that case. Used where a promise may
+ * never settle once the room is gone (e.g. `waitForPlayout()` during
  * shutdown) — parking there would keep the reply task from committing the
- * in-flight assistant turn (#2041).
+ * in-flight assistant turn.
  */
-function raceWithAbort<T>(p: Promise<T>, signal: AbortSignal): Promise<T | undefined> {
-  if (signal.aborted) return Promise.resolve(undefined);
-  return new Promise<T | undefined>((resolve, reject) => {
-    const onAbort = () => resolve(undefined);
-    signal.addEventListener('abort', onAbort, { once: true });
-    p.then(
-      (v) => {
-        signal.removeEventListener('abort', onAbort);
-        resolve(v);
-      },
-      (e) => {
-        signal.removeEventListener('abort', onAbort);
-        reject(e);
-      },
-    );
-  });
+async function raceWithAbort<T>(p: Promise<T>, signal: AbortSignal): Promise<T | undefined> {
+  if (signal.aborted) {
+    return (await isPending(p)) ? undefined : p;
+  }
+  return ThrowsPromise.race([
+    ThrowsPromise.fromPromise<T | undefined, Error>(p),
+    ThrowsPromise.fromPromise<undefined, Error>(waitForAbort(signal).then(() => undefined)),
+  ]);
 }
 
 export class AgentActivity implements RecognitionHooks {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -225,6 +225,30 @@ export interface ForwardOutput {
   playbackPositionInS: number;
 }
 
+/**
+ * Resolve with `p`, or with `undefined` as soon as `signal` aborts. Used where
+ * a promise may never settle once the room is gone (e.g. waitForPlayout during
+ * shutdown) — parking there would keep the reply task from committing the
+ * in-flight assistant turn (#2041).
+ */
+function raceWithAbort<T>(p: Promise<T>, signal: AbortSignal): Promise<T | undefined> {
+  if (signal.aborted) return Promise.resolve(undefined);
+  return new Promise<T | undefined>((resolve, reject) => {
+    const onAbort = () => resolve(undefined);
+    signal.addEventListener('abort', onAbort, { once: true });
+    p.then(
+      (v) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(v);
+      },
+      (e) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(e);
+      },
+    );
+  });
+}
+
 export class AgentActivity implements RecognitionHooks {
   agent: Agent;
   agentSession: AgentSession;
@@ -2924,11 +2948,31 @@ export class AgentActivity implements RecognitionHooks {
           await cancelAndWait(forwardTasks, AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
           if (audioOutput) {
             audioOutput.clearBuffer();
-            const interruptedPlaybackEv = await audioOutput.waitForPlayout();
-            if (output.audioOut?.firstFrameFut.done && !output.audioOut.firstFrameFut.rejected) {
+            // During shutdown (room disconnected / activity closing) the
+            // output may never report playback finished — don't park forever
+            // on a promise that cannot resolve, or the turn is lost (#2041).
+            // The abort signal fires when the reply task is cancelled, so
+            // racing it lets the commit below still happen; we only lose the
+            // final playback position, not the turn.
+            const interruptedPlaybackEv = await raceWithAbort(
+              audioOutput.waitForPlayout(),
+              replyAbortController.signal,
+            );
+            if (
+              interruptedPlaybackEv &&
+              output.audioOut?.firstFrameFut.done &&
+              !output.audioOut.firstFrameFut.rejected
+            ) {
               output.played = 'partial';
               output.playbackPositionInS = interruptedPlaybackEv.playbackPosition;
               output.synchronizedTranscript = interruptedPlaybackEv.synchronizedTranscript;
+            } else if (
+              output.audioOut?.firstFrameFut.done &&
+              !output.audioOut.firstFrameFut.rejected
+            ) {
+              // Playback started but the output went away before reporting a
+              // final position — the visitor heard part of this turn.
+              output.played = 'partial';
             }
           } else if (output.textOut?.text) {
             output.played = 'partial';
@@ -4127,6 +4171,18 @@ export class AgentActivity implements RecognitionHooks {
     const unlock = await this.lock.lock();
     try {
       this.cancelPreemptiveGeneration();
+
+      // Commit the in-flight assistant turn before teardown (#2041): a room
+      // disconnect mid-playout parks the reply task on a playout promise that
+      // will never resolve, and hard-cancelling it there dropped the turn —
+      // no ConversationItemAdded, nothing in chatCtx. Resolving the speech's
+      // interrupt future lets the task exit through its existing interruption
+      // branch, which commits the partially-forwarded text (interrupted: true)
+      // exactly like a user barge-in does. The cancelAndWait below then aborts
+      // any await that cannot complete on a dead room (see raceWithAbort).
+      if (this._currentSpeech && !this._currentSpeech.done()) {
+        this._currentSpeech._cancel();
+      }
 
       await cancelAndWait(Array.from(this.speechTasks), AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
       await this._toolExecutor.drain();

--- a/agents/src/voice/agent_activity_close_commit.test.ts
+++ b/agents/src/voice/agent_activity_close_commit.test.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream } from 'node:stream/web';
+import { describe, expect, it, vi } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { Agent } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AgentSessionEventTypes, type ConversationItemAddedEvent } from './events.js';
+import { AudioOutput } from './io.js';
+import { FakeLLM } from './testing/fake_llm.js';
+
+function frame(durationMs = 20, sampleRate = 24000): AudioFrame {
+  const samples = Math.floor((sampleRate * durationMs) / 1000);
+  return new AudioFrame(new Int16Array(samples), sampleRate, 1, samples);
+}
+
+// Audio sink that starts playback but can never finish it — the shape a room
+// disconnect produces: waitForPlayout() promises stop resolving, clearBuffer()
+// has nobody left to report a final position. Pre-fix, closing the session in
+// this state parked the pipeline reply task forever and the in-flight
+// assistant turn was dropped from chat ctx entirely (#2041).
+class DeadRoomOutput extends AudioOutput {
+  onFirstFrame?: () => void;
+  private started = false;
+  constructor() {
+    super(24000);
+  }
+  async captureFrame(f: AudioFrame): Promise<void> {
+    await super.captureFrame(f);
+    if (!this.started) {
+      this.started = true;
+      this.onPlaybackStarted(Date.now());
+      this.onFirstFrame?.();
+    }
+  }
+  flush(): void {
+    super.flush();
+  }
+  clearBuffer(): void {
+    // Room is gone: playback finished is never reported.
+  }
+}
+
+// Agent that synthesizes a few real frames for whatever text it receives, so
+// the audio path produces a first frame (no TTS provider needed).
+class FrameAgent extends Agent {
+  constructor() {
+    super({ instructions: 'test' });
+  }
+  async ttsNode(): Promise<ReadableStream<AudioFrame> | null> {
+    return new ReadableStream<AudioFrame>({
+      start(controller) {
+        for (let i = 0; i < 10; i++) controller.enqueue(frame());
+        controller.close();
+      },
+    });
+  }
+}
+
+describe('AgentActivity close mid-playout commit', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('commits the in-flight assistant turn when the session closes mid-playout', async () => {
+    const session = new AgentSession({
+      llm: new FakeLLM([{ input: 'hello', content: 'A fairly long spoken reply.' }]),
+    });
+    const audioOut = new DeadRoomOutput();
+    session.output.audio = audioOut;
+
+    const assistantMessages: { content: string; interrupted: boolean }[] = [];
+    session.on(AgentSessionEventTypes.ConversationItemAdded, (ev: ConversationItemAddedEvent) => {
+      if (ev.item.type === 'message' && ev.item.role === 'assistant') {
+        assistantMessages.push({
+          content: ev.item.textContent ?? '',
+          interrupted: !!ev.item.interrupted,
+        });
+      }
+    });
+
+    // Close the session as soon as the first audio frame plays — the
+    // "visitor closed the tab mid-answer" scenario.
+    let closePromise: Promise<void> | undefined;
+    audioOut.onFirstFrame = () => {
+      closePromise = session.close();
+    };
+
+    await session.start({ agent: new FrameAgent() });
+    session.generateReply({ userInput: 'hello' });
+
+    await vi.waitFor(() => expect(closePromise).toBeDefined(), { timeout: 5000 });
+    await closePromise!;
+
+    // The partially played turn must reach chat ctx as an interrupted message
+    // (pre-fix: zero assistant items — the turn vanished).
+    expect(assistantMessages.length).toBeGreaterThan(0);
+    const msg = assistantMessages[0]!;
+    expect(msg.interrupted).toBe(true);
+    expect(msg.content.length).toBeGreaterThan(0);
+    expect('A fairly long spoken reply.'.startsWith(msg.content)).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #2041 — as offered there; happy to rework if you'd prefer a different approach.

## Problem
A room disconnect while the agent is speaking parks the pipeline reply task on a playout promise that can never resolve. `AgentActivity.close()` then hard-cancels the task, so the partially-spoken turn is dropped entirely — no `ConversationItemAdded`, nothing in `chatCtx`. For public-facing agents where visitors bounce mid-answer constantly, the last (often most interesting) turn of every such session vanishes from history.

## Fix (two small changes)
1. `close()` resolves the current speech's interrupt future before cancelling speech tasks, so the reply task exits through its **existing interruption branch** — which already commits the partially-forwarded text with `interrupted: true`. No new commit logic.
2. The interruption branch's post-`clearBuffer()` `waitForPlayout()` is raced against the reply abort signal (`raceWithAbort`) so it can't park on a dead room. On abort, the segment is still marked partially played (the first frame was heard); only the final playback position is lost.

Worst case degrades to the previous behavior (cancel timeout); it can't regress.

## Testing
- New regression test (`agent_activity_close_commit.test.ts`) simulates the disconnect with an `AudioOutput` that starts playback but never reports it finished: **red before the fix** (zero assistant items), green after (item lands as `interrupted` with the spoken prefix).
- Full voice suite passes: 44 files / 416 tests.

Found running LiveKit Agents 1.4.8 in production at asksarfaraz.ai (context in #2041, sibling report #2040).
