### PR TITLE
fix(avatar): handle clear-buffer RPC failures

### DIFF
--- a/.changeset/catch-avatar-clear-buffer-rpc.md
+++ b/.changeset/catch-avatar-clear-buffer-rpc.md
@@ -2,4 +2,5 @@
 '@livekit/agents': patch
 ---
 
-Handle rejected avatar clear-buffer RPCs without emitting unhandled promise rejections.
+Prevent rejected avatar clear-buffer RPCs from emitting unhandled rejections or stranding
+playout waiters.

--- a/.changeset/catch-avatar-clear-buffer-rpc.md
+++ b/.changeset/catch-avatar-clear-buffer-rpc.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Handle rejected avatar clear-buffer RPCs without emitting unhandled promise rejections.

--- a/agents/src/voice/avatar/datastream_io.test.ts
+++ b/agents/src/voice/avatar/datastream_io.test.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { Room } from '@livekit/rtc-node';
+import { describe, expect, it, vi } from 'vitest';
+import { DataStreamAudioOutput } from './datastream_io.js';
+
+const { logger } = vi.hoisted(() => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('../../log.js', () => ({
+  log: () => logger,
+}));
+
+function createRoom(performRpc: () => Promise<string>) {
+  const avatar = { identity: 'avatar' };
+
+  return {
+    isConnected: true,
+    localParticipant: {
+      performRpc: vi.fn(performRpc),
+      registerRpcMethod: vi.fn(),
+    },
+    remoteParticipants: new Map([[avatar.identity, avatar]]),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+}
+
+describe('DataStreamAudioOutput.clearBuffer', () => {
+  it('handles a rejected clear-buffer RPC', async () => {
+    const room = createRoom(() => Promise.reject(new Error('Failed to send')));
+    const output = new DataStreamAudioOutput({
+      room: room as unknown as Room,
+      destinationIdentity: 'avatar',
+    });
+
+    await vi.waitFor(() => {
+      output.clearBuffer();
+      expect(room.localParticipant.performRpc).toHaveBeenCalledOnce();
+    });
+    await vi.waitFor(() => expect(logger.warn).toHaveBeenCalledOnce());
+  });
+});

--- a/agents/src/voice/avatar/datastream_io.test.ts
+++ b/agents/src/voice/avatar/datastream_io.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { Room } from '@livekit/rtc-node';
+import { Room } from '@livekit/rtc-node';
 import { describe, expect, it, vi } from 'vitest';
 import { DataStreamAudioOutput } from './datastream_io.js';
 
@@ -16,26 +16,29 @@ vi.mock('../../log.js', () => ({
   log: () => logger,
 }));
 
-function createRoom(performRpc: () => Promise<string>) {
+function createRoom(performRpc: () => Promise<string>): Room {
   const avatar = { identity: 'avatar' };
+  const room = new Room();
 
-  return {
-    isConnected: true,
+  Object.defineProperties(room, {
+    isConnected: { value: true },
     localParticipant: {
-      performRpc: vi.fn(performRpc),
-      registerRpcMethod: vi.fn(),
+      value: {
+        performRpc: vi.fn(performRpc),
+        registerRpcMethod: vi.fn(),
+      },
     },
-    remoteParticipants: new Map([[avatar.identity, avatar]]),
-    on: vi.fn(),
-    off: vi.fn(),
-  };
+    remoteParticipants: { value: new Map([[avatar.identity, avatar]]) },
+  });
+
+  return room;
 }
 
 describe('DataStreamAudioOutput.clearBuffer', () => {
   it('handles a rejected clear-buffer RPC', async () => {
     const room = createRoom(() => Promise.reject(new Error('Failed to send')));
     const output = new DataStreamAudioOutput({
-      room: room as unknown as Room,
+      room,
       destinationIdentity: 'avatar',
     });
 

--- a/agents/src/voice/avatar/datastream_io.test.ts
+++ b/agents/src/voice/avatar/datastream_io.test.ts
@@ -31,7 +31,6 @@ function createRoom(performRpcImpl: () => Promise<string>) {
   const avatar = { identity: 'avatar' };
   const room = new Room();
   const performRpc = vi.fn(performRpcImpl);
-  const streamBytes = vi.fn(async () => createByteStreamWriter());
 
   Object.defineProperties(room, {
     isConnected: { value: true },
@@ -39,7 +38,7 @@ function createRoom(performRpcImpl: () => Promise<string>) {
       value: {
         performRpc,
         registerRpcMethod: vi.fn(),
-        streamBytes,
+        streamBytes: vi.fn(async () => createByteStreamWriter()),
       },
     },
     remoteParticipants: { value: new Map([[avatar.identity, avatar]]) },
@@ -61,8 +60,6 @@ describe('DataStreamAudioOutput.clearBuffer', () => {
     vi.clearAllMocks();
     DataStreamAudioOutput._playbackFinishedRpcRegistered = false;
     DataStreamAudioOutput._playbackFinishedHandlers = {};
-    DataStreamAudioOutput._playbackStartedRpcRegistered = false;
-    DataStreamAudioOutput._playbackStartedHandlers = {};
   });
 
   it('settles pending playout when the clear-buffer RPC rejects', async () => {
@@ -92,7 +89,6 @@ describe('DataStreamAudioOutput.clearBuffer', () => {
       { error, destinationIdentity: 'avatar' },
       'failed to perform clear buffer rpc',
     );
-    expect(output.pendingPlayoutSegments).toBe(0);
   });
 
   it('does not let a late rejection settle a newer segment', async () => {
@@ -105,33 +101,20 @@ describe('DataStreamAudioOutput.clearBuffer', () => {
       room,
       destinationIdentity: 'avatar',
     });
-    const playbackEvents: PlaybackFinishedEvent[] = [];
-    output.on(AudioOutput.EVENT_PLAYBACK_FINISHED, (event) => playbackEvents.push(event));
 
     await output.captureFrame(createFrame());
     output.flush();
-    const firstPlayout = output.waitForPlayout();
     output.clearBuffer();
 
-    const firstEvent = { playbackPosition: 0.01, interrupted: true };
-    output.onPlaybackFinished(firstEvent);
-    await expect(firstPlayout).resolves.toEqual(firstEvent);
+    output.onPlaybackFinished({ playbackPosition: 0.01, interrupted: true });
 
     await nextTick();
     await output.captureFrame(createFrame());
     output.flush();
     const secondPlayout = output.waitForPlayout();
-    let secondSettled = false;
-    void secondPlayout.then(() => {
-      secondSettled = true;
-    });
 
     rejectRpc(new Error('Failed to send'));
     await vi.waitFor(() => expect(logger.warn).toHaveBeenCalledOnce());
-
-    expect(secondSettled).toBe(false);
-    expect(output.pendingPlayoutSegments).toBe(1);
-    expect(playbackEvents).toEqual([firstEvent]);
 
     const secondEvent = { playbackPosition: 0.02, interrupted: false };
     output.onPlaybackFinished(secondEvent);
@@ -161,6 +144,5 @@ describe('DataStreamAudioOutput.clearBuffer', () => {
       { playbackPosition: 0, interrupted: true },
       { playbackPosition: 0, interrupted: true },
     ]);
-    expect(output.pendingPlayoutSegments).toBe(0);
   });
 });

--- a/agents/src/voice/avatar/datastream_io.test.ts
+++ b/agents/src/voice/avatar/datastream_io.test.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { Room } from '@livekit/rtc-node';
-import { describe, expect, it, vi } from 'vitest';
+import { AudioFrame, ByteStreamWriter, Room } from '@livekit/rtc-node';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AudioOutput, type PlaybackFinishedEvent } from '../io.js';
 import { DataStreamAudioOutput } from './datastream_io.js';
 
 const { logger } = vi.hoisted(() => ({
@@ -16,36 +17,150 @@ vi.mock('../../log.js', () => ({
   log: () => logger,
 }));
 
-function createRoom(performRpc: () => Promise<string>): Room {
+function createByteStreamWriter(): ByteStreamWriter {
+  return new ByteStreamWriter(new WritableStream<Uint8Array>(), {
+    streamId: 'test-stream',
+    mimeType: 'application/octet-stream',
+    topic: 'lk.audio_stream',
+    timestamp: 0,
+    name: 'audio',
+  });
+}
+
+function createRoom(performRpcImpl: () => Promise<string>) {
   const avatar = { identity: 'avatar' };
   const room = new Room();
+  const performRpc = vi.fn(performRpcImpl);
+  const streamBytes = vi.fn(async () => createByteStreamWriter());
 
   Object.defineProperties(room, {
     isConnected: { value: true },
     localParticipant: {
       value: {
-        performRpc: vi.fn(performRpc),
+        performRpc,
         registerRpcMethod: vi.fn(),
+        streamBytes,
       },
     },
     remoteParticipants: { value: new Map([[avatar.identity, avatar]]) },
   });
 
-  return room;
+  return { room, performRpc };
+}
+
+function createFrame(): AudioFrame {
+  return new AudioFrame(new Int16Array(160), 8000, 1, 160);
+}
+
+function nextTick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
 }
 
 describe('DataStreamAudioOutput.clearBuffer', () => {
-  it('handles a rejected clear-buffer RPC', async () => {
-    const room = createRoom(() => Promise.reject(new Error('Failed to send')));
+  beforeEach(() => {
+    vi.clearAllMocks();
+    DataStreamAudioOutput._playbackFinishedRpcRegistered = false;
+    DataStreamAudioOutput._playbackFinishedHandlers = {};
+    DataStreamAudioOutput._playbackStartedRpcRegistered = false;
+    DataStreamAudioOutput._playbackStartedHandlers = {};
+  });
+
+  it('settles pending playout when the clear-buffer RPC rejects', async () => {
+    const error = new Error('Failed to send');
+    const { room, performRpc } = createRoom(() => Promise.reject(error));
     const output = new DataStreamAudioOutput({
       room,
       destinationIdentity: 'avatar',
     });
 
-    await vi.waitFor(() => {
-      output.clearBuffer();
-      expect(room.localParticipant.performRpc).toHaveBeenCalledOnce();
+    await output.captureFrame(createFrame());
+    output.flush();
+
+    const playout = output.waitForPlayout();
+    output.clearBuffer();
+
+    await expect(playout).resolves.toEqual({
+      playbackPosition: 0,
+      interrupted: true,
     });
+    expect(performRpc).toHaveBeenCalledExactlyOnceWith({
+      destinationIdentity: 'avatar',
+      method: 'lk.clear_buffer',
+      payload: '',
+    });
+    expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+      { error, destinationIdentity: 'avatar' },
+      'failed to perform clear buffer rpc',
+    );
+    expect(output.pendingPlayoutSegments).toBe(0);
+  });
+
+  it('does not let a late rejection settle a newer segment', async () => {
+    let rejectRpc: (reason?: unknown) => void = () => {};
+    const rpc = new Promise<string>((_resolve, reject) => {
+      rejectRpc = reject;
+    });
+    const { room } = createRoom(() => rpc);
+    const output = new DataStreamAudioOutput({
+      room,
+      destinationIdentity: 'avatar',
+    });
+    const playbackEvents: PlaybackFinishedEvent[] = [];
+    output.on(AudioOutput.EVENT_PLAYBACK_FINISHED, (event) => playbackEvents.push(event));
+
+    await output.captureFrame(createFrame());
+    output.flush();
+    const firstPlayout = output.waitForPlayout();
+    output.clearBuffer();
+
+    const firstEvent = { playbackPosition: 0.01, interrupted: true };
+    output.onPlaybackFinished(firstEvent);
+    await expect(firstPlayout).resolves.toEqual(firstEvent);
+
+    await nextTick();
+    await output.captureFrame(createFrame());
+    output.flush();
+    const secondPlayout = output.waitForPlayout();
+    let secondSettled = false;
+    void secondPlayout.then(() => {
+      secondSettled = true;
+    });
+
+    rejectRpc(new Error('Failed to send'));
     await vi.waitFor(() => expect(logger.warn).toHaveBeenCalledOnce());
+
+    expect(secondSettled).toBe(false);
+    expect(output.pendingPlayoutSegments).toBe(1);
+    expect(playbackEvents).toEqual([firstEvent]);
+
+    const secondEvent = { playbackPosition: 0.02, interrupted: false };
+    output.onPlaybackFinished(secondEvent);
+    await expect(secondPlayout).resolves.toEqual(secondEvent);
+  });
+
+  it('settles every segment pending when clearBuffer was called', async () => {
+    const { room } = createRoom(() => Promise.reject(new Error('Failed to send')));
+    const output = new DataStreamAudioOutput({
+      room,
+      destinationIdentity: 'avatar',
+    });
+    const playbackEvents: PlaybackFinishedEvent[] = [];
+    output.on(AudioOutput.EVENT_PLAYBACK_FINISHED, (event) => playbackEvents.push(event));
+
+    await output.captureFrame(createFrame());
+    output.flush();
+    await nextTick();
+    await output.captureFrame(createFrame());
+    output.flush();
+
+    const playout = output.waitForPlayout();
+    output.clearBuffer();
+    await expect(playout).resolves.toEqual({ playbackPosition: 0, interrupted: true });
+
+    expect(playbackEvents).toEqual([
+      { playbackPosition: 0, interrupted: true },
+      { playbackPosition: 0, interrupted: true },
+    ]);
+    expect(output.pendingPlayoutSegments).toBe(0);
   });
 });

--- a/agents/src/voice/avatar/datastream_io.ts
+++ b/agents/src/voice/avatar/datastream_io.ts
@@ -212,9 +212,7 @@ export class DataStreamAudioOutput extends AudioOutput {
   clearBuffer(): void {
     if (!this.started) return;
 
-    // Capture the current segment high-water mark before starting the RPC. The rejection may
-    // arrive after a real playback-finished event or after a new segment has started, so draining
-    // the live pending count in the catch handler could incorrectly finish newer audio.
+    // A delayed rejection must not finish audio captured after this call.
     const playoutTarget = this.capturedPlayoutSegments;
 
     void this.room
@@ -229,16 +227,11 @@ export class DataStreamAudioOutput extends AudioOutput {
           'failed to perform clear buffer rpc',
         );
 
-        this.settlePlayoutThrough(playoutTarget);
+        const finishedSegments = this.capturedPlayoutSegments - this.pendingPlayoutSegments;
+        for (let segment = finishedSegments; segment < playoutTarget; segment++) {
+          this.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
+        }
       });
-  }
-
-  private settlePlayoutThrough(playoutTarget: number): void {
-    const finishedSegments = this.capturedPlayoutSegments - this.pendingPlayoutSegments;
-
-    for (let segment = finishedSegments; segment < playoutTarget; segment++) {
-      this.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
-    }
   }
 
   private handlePlaybackFinished(data: RpcInvocationData): string {

--- a/agents/src/voice/avatar/datastream_io.ts
+++ b/agents/src/voice/avatar/datastream_io.ts
@@ -212,6 +212,11 @@ export class DataStreamAudioOutput extends AudioOutput {
   clearBuffer(): void {
     if (!this.started) return;
 
+    // Capture the current segment high-water mark before starting the RPC. The rejection may
+    // arrive after a real playback-finished event or after a new segment has started, so draining
+    // the live pending count in the catch handler could incorrectly finish newer audio.
+    const playoutTarget = this.capturedPlayoutSegments;
+
     void this.room
       .localParticipant!.performRpc({
         destinationIdentity: this.destinationIdentity,
@@ -223,7 +228,17 @@ export class DataStreamAudioOutput extends AudioOutput {
           { error, destinationIdentity: this.destinationIdentity },
           'failed to perform clear buffer rpc',
         );
+
+        this.settlePlayoutThrough(playoutTarget);
       });
+  }
+
+  private settlePlayoutThrough(playoutTarget: number): void {
+    const finishedSegments = this.capturedPlayoutSegments - this.pendingPlayoutSegments;
+
+    for (let segment = finishedSegments; segment < playoutTarget; segment++) {
+      this.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
+    }
   }
 
   private handlePlaybackFinished(data: RpcInvocationData): string {

--- a/agents/src/voice/avatar/datastream_io.ts
+++ b/agents/src/voice/avatar/datastream_io.ts
@@ -212,11 +212,18 @@ export class DataStreamAudioOutput extends AudioOutput {
   clearBuffer(): void {
     if (!this.started) return;
 
-    this.room.localParticipant!.performRpc({
-      destinationIdentity: this.destinationIdentity,
-      method: RPC_CLEAR_BUFFER,
-      payload: '',
-    });
+    void this.room
+      .localParticipant!.performRpc({
+        destinationIdentity: this.destinationIdentity,
+        method: RPC_CLEAR_BUFFER,
+        payload: '',
+      })
+      .catch((error) => {
+        this.#logger.warn(
+          { error, destinationIdentity: this.destinationIdentity },
+          'failed to perform clear buffer rpc',
+        );
+      });
   }
 
   private handlePlaybackFinished(data: RpcInvocationData): string {


### PR DESCRIPTION
## Problem

`DataStreamAudioOutput.clearBuffer()` starts `LocalParticipant.performRpc()` and discards the returned promise. If the remote avatar participant disconnects while interruption clean-up is running, the RPC can reject with `Failed to send`, producing a process-level unhandled rejection even though the session can continue.

## Solution

Treat the clear-buffer RPC as intentionally fire-and-forget and attach a rejection handler. Failed calls are reported through the existing logger with the destination identity, whilst the synchronous `clearBuffer(): void` contract remains unchanged.

This keeps interruption clean-up non-blocking and avoids changing callers for an RPC whose recipient may already be unavailable. A focussed regression test covers the rejected RPC path, and a patch changeset records the fix.

## Verification

- `pnpm test -- agents/src/voice/avatar/datastream_io.test.ts`
- `pnpm exec eslint -f unix agents/src/voice/avatar/datastream_io.ts agents/src/voice/avatar/datastream_io.test.ts`
- `pnpm exec prettier --check agents/src/voice/avatar/datastream_io.ts agents/src/voice/avatar/datastream_io.test.ts .changeset/catch-avatar-clear-buffer-rpc.md`
- `pnpm --filter @livekit/agents typecheck`
- `pnpm build:agents`
