### PR TITLE
fix(agents): per-iteration abort promise in readStream prevents chunk retention

### DIFF
--- a/.changeset/readstream-abort-promise-retention.md
+++ b/.changeset/readstream-abort-promise-retention.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Fix `readStream()` retaining every chunk until its abort signal fires: racing `reader.read()` against a single long-lived `waitForAbort` promise accumulated one promise reaction (holding that iteration's chunk) per read, pinning every inbound AudioFrame for the lifetime of STT pipelines (#2046).

--- a/agents/src/utils.test.ts
+++ b/agents/src/utils.test.ts
@@ -13,6 +13,7 @@ import {
   dedent,
   delay,
   isPending,
+  readStream,
   resampleStream,
   toStream,
 } from '../src/utils.js';
@@ -933,4 +934,92 @@ world
       expect(outputFrames).toEqual([]);
     });
   });
+});
+
+describe('readStream abort-promise retention (issue #2046)', () => {
+  // Regression: the old implementation hoisted `waitForAbort(signal)` outside the
+  // read loop, so every `ThrowsPromise.race([reader.read(), abortPromise])` attached
+  // a new reaction to that single long-lived promise. The reactions - and the read
+  // results (stream chunks) they transitively held - accumulated until the signal
+  // aborted, pinning every AudioFrame ever read on audio streams.
+  it('delivers all chunks and keeps at most one abort listener', async () => {
+    const controller = new AbortController();
+    let enqueueCtl!: ReadableStreamDefaultController<number>;
+    const stream = new ReadableStream<number>({
+      start(c) {
+        enqueueCtl = c;
+      },
+    });
+    const iterator = readStream(stream, controller.signal)[Symbol.asyncIterator]();
+
+    const CHUNKS = 50;
+    const received: number[] = [];
+    for (let i = 0; i < CHUNKS; i++) {
+      enqueueCtl.enqueue(i);
+      const { value } = await iterator.next();
+      received.push(value as number);
+    }
+    expect(received).toEqual(Array.from({ length: CHUNKS }, (_, i) => i));
+
+    // The signal should never accumulate listeners as chunks flow.
+    const listenerCount = (controller.signal as unknown as NodeJS.EventEmitter).listenerCount?.(
+      'abort',
+    );
+    if (listenerCount !== undefined) {
+      expect(listenerCount).toBeLessThanOrEqual(1);
+    }
+
+    controller.abort();
+    const end = await iterator.next();
+    expect(end.done).toBe(true);
+  });
+
+  it('abort interrupts a pending read', async () => {
+    const controller = new AbortController();
+    const stream = new ReadableStream<number>({ start() {} }); // never produces
+    const received: number[] = [];
+    const consume = (async () => {
+      for await (const v of readStream(stream, controller.signal)) {
+        received.push(v);
+      }
+    })();
+    await delay(10);
+    controller.abort();
+    await consume; // returns instead of hanging
+    expect(received).toEqual([]);
+  });
+
+  // Only meaningful under `node --expose-gc`; the listener-count check above cannot
+  // catch the reaction leak (the old code also held a single listener - the retention
+  // lived in the promise reaction chain, not the listener list).
+  it.skipIf(typeof globalThis.gc !== 'function')(
+    'consumed chunks become collectable while the stream stays open',
+    async () => {
+      const controller = new AbortController();
+      let enqueueCtl!: ReadableStreamDefaultController<{ payload: Uint8Array }>;
+      const stream = new ReadableStream<{ payload: Uint8Array }>({
+        start(c) {
+          enqueueCtl = c;
+        },
+      });
+      const iterator = readStream(stream, controller.signal)[Symbol.asyncIterator]();
+
+      const refs: WeakRef<object>[] = [];
+      for (let i = 0; i < 20; i++) {
+        const chunk = { payload: new Uint8Array(1024) };
+        refs.push(new WeakRef(chunk));
+        enqueueCtl.enqueue(chunk);
+        await iterator.next();
+      }
+
+      globalThis.gc!();
+      await delay(0);
+      globalThis.gc!();
+      const alive = refs.filter((r) => r.deref() !== undefined).length;
+      // With the hoisted abort promise every chunk stayed reachable (alive === 20).
+      expect(alive).toBeLessThanOrEqual(1);
+
+      controller.abort();
+    },
+  );
 });

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -1387,9 +1387,32 @@ export async function* readStream<T>(
   const reader = stream.getReader();
   try {
     if (signal) {
-      const abortPromise = waitForAbort(signal);
       while (true) {
+        // Create a fresh per-iteration abort promise with explicit cleanup.
+        //
+        // A single `waitForAbort(signal)` hoisted outside the loop leaks: every
+        // `ThrowsPromise.race([reader.read(), abortPromise])` registers a new
+        // reaction on the long-lived promise, and because that promise only
+        // settles when the signal aborts (normally at stream teardown), each
+        // reaction - and the settled read result it transitively holds - stays
+        // reachable for the lifetime of the stream. On audio streams this pins
+        // every AudioFrame ever read (#2046; same mechanism as #1950).
+        //
+        // A per-iteration promise + `removeEventListener` after each race means
+        // the signal holds at most one listener at a time and no reaction
+        // outlives its iteration.
+        let abortCleanup: (() => void) | undefined;
+        const abortPromise = new Promise<undefined>((resolve) => {
+          if (signal.aborted) {
+            resolve(undefined);
+            return;
+          }
+          const handler = () => resolve(undefined);
+          signal.addEventListener('abort', handler, { once: true });
+          abortCleanup = () => signal.removeEventListener('abort', handler);
+        });
         const result = await ThrowsPromise.race([reader.read(), abortPromise]);
+        abortCleanup?.();
         if (!result) {
           break;
         }


### PR DESCRIPTION
Fixes #2046.

### What

`readStream()` hoisted a single `waitForAbort(signal)` promise outside its read loop and raced it against every `reader.read()`. Each `ThrowsPromise.race` registers a new reaction on that long-lived promise; since it only settles when the signal aborts (normally stream teardown), every reaction — and the settled read result it transitively holds — stays reachable for the stream's entire lifetime. `AudioRecognition` pumps `sttInputStream` through `readStream()`, so pipeline `AgentSession`s retained **every inbound AudioFrame** (~100/s), ~5.8 MB/min measured in production (details, heap-snapshot retainer chains, and prod before/after numbers in #2046).

Same mechanism as #1950 (the Deepgram plugin's private pump, fixed by #1957); this is the core-utils instance. The fix mirrors #1957's idiom exactly: a per-iteration abort promise with `removeEventListener` cleanup after each race, so the signal holds at most one listener at a time and no reaction outlives its iteration. Abort semantics are unchanged (pending `read()` still interrupted; `if (!result) break` path identical).

### Tests

Three cases in `utils.test.ts`:

1. **Delivery + listener hygiene** — 50 chunks through one signal; all delivered; `listenerCount('abort') ≤ 1`.
2. **Abort interrupts a pending read** — generator returns instead of hanging on a silent stream.
3. **Retention regression** (`it.skipIf` without `--expose-gc`) — 20 consumed chunks tracked via `WeakRef`; after GC, at most 1 remains reachable while the stream and signal stay live. On the old code all 20 stay pinned, so this is the test that actually catches the bug — worth noting that a listener-count assertion alone cannot (the old code also held exactly one listener; the retention lives in the promise **reaction chain**, not the listener list — this also applies to the regression test in #1957).

Verified locally: the retention test **fails on `main`** (20/20 chunks alive) and passes with the fix.

### Production verification

Shipped as a patch on `@livekit/agents@1.4.5` in a production voice agent: per-turn `heapUsed` went from 72→158 MB climbing over 26 turns (no plateau, forced GC reclaimed nothing) to 72→85 MB flat over 23 turns; job-process RSS high-water 275 MB vs ~360 MB.

### Note for maintainers

The hoisted-`waitForAbort`-raced-in-a-loop shape also appears in several plugin pumps (e.g. `cartesia/src/stt.ts`, `assemblyai/src/stt.ts`, `inworld/src/stt.ts`, `sarvam/src/stt.ts`, `soniox/src/stt.ts`, `xai/src/stt.ts`, `baseten/src/tts.ts`). Not all are per-frame loops, but they're the same class as #1950 and may deserve an audit; this PR deliberately stays scoped to the core `readStream()`.
