### PR TITLE
fix(agents): preserve custom tracer provider with Cloud tracing

### DIFF
--- a/.changeset/preserve-custom-tracer-provider.md
+++ b/.changeset/preserve-custom-tracer-provider.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-Preserve custom OpenTelemetry tracer providers when LiveKit Cloud tracing is enabled.
+Preserve custom OpenTelemetry tracer providers when LiveKit Cloud tracing is enabled, and support sharing an OpenTelemetry 2.x provider with LiveKit Cloud via the `registerSpanProcessor` and `createCloudSpanProcessor` options of `setTracerProvider`.

--- a/.changeset/preserve-custom-tracer-provider.md
+++ b/.changeset/preserve-custom-tracer-provider.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Preserve custom OpenTelemetry tracer providers when LiveKit Cloud tracing is enabled.

--- a/.changeset/preserve-custom-tracer-provider.md
+++ b/.changeset/preserve-custom-tracer-provider.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-Preserve custom OpenTelemetry tracer providers when LiveKit Cloud tracing is enabled, and support sharing an OpenTelemetry 2.x provider with LiveKit Cloud via the `registerSpanProcessor` and `createCloudSpanProcessor` options of `setTracerProvider`.
+Preserve custom OpenTelemetry tracer providers when LiveKit Cloud tracing is enabled, and support sharing an OpenTelemetry 2.x provider with LiveKit Cloud via the `registerSpanProcessor` and `createCloudSpanProcessor` options of `setTracerProvider` together with the new `FanoutSpanProcessor` helper.

--- a/agents/package.json
+++ b/agents/package.json
@@ -46,6 +46,8 @@
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.5.5",
     "@types/ws": "catalog:",
+    "otel-v2-sdk-trace-base": "npm:@opentelemetry/sdk-trace-base@^2.8.0",
+    "otel-v2-sdk-trace-node": "npm:@opentelemetry/sdk-trace-node@^2.8.0",
     "tsup": "^8.4.0",
     "typescript": "^5.0.0",
     "zod": "^3.25.76"

--- a/agents/src/telemetry/index.ts
+++ b/agents/src/telemetry/index.ts
@@ -23,6 +23,7 @@ export {
   setupCloudTracer,
   tracer,
   uploadSessionReport,
+  type SetTracerProviderOptions,
   type StartSpanOptions,
 } from './traces.js';
 export { recordException, recordRealtimeMetrics } from './utils.js';

--- a/agents/src/telemetry/index.ts
+++ b/agents/src/telemetry/index.ts
@@ -23,7 +23,9 @@ export {
   setupCloudTracer,
   tracer,
   uploadSessionReport,
+  type CloudSpanProcessorOptions,
   type SetTracerProviderOptions,
+  type SpanProcessorLike,
   type StartSpanOptions,
 } from './traces.js';
 export { recordException, recordRealtimeMetrics } from './utils.js';

--- a/agents/src/telemetry/index.ts
+++ b/agents/src/telemetry/index.ts
@@ -18,6 +18,7 @@ export {
 } from './pino_otel_transport.js';
 export * as traceTypes from './trace_types.js';
 export {
+  FanoutSpanProcessor,
   flushOtelLogs,
   setTracerProvider,
   setupCloudTracer,

--- a/agents/src/telemetry/traces.otel2.type.test.ts
+++ b/agents/src/telemetry/traces.otel2.type.test.ts
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { context as otelContext, trace } from '@opentelemetry/api';
+// Real OpenTelemetry SDK 2.x packages, installed under aliases so they can coexist with this
+// package's SDK 1.x dependency. Included in `pnpm typecheck`, this file is the compile-time
+// regression test that the telemetry API composes with an SDK 2.x provider without type errors,
+// and the runtime regression test that spans flushed through such a provider actually reach both
+// the user's exporter and the cloud span processor.
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type SpanProcessor,
+} from 'otel-v2-sdk-trace-base';
+import { NodeTracerProvider } from 'otel-v2-sdk-trace-node';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type CloudSpanProcessorOptions,
+  setTracerProvider,
+  setupCloudTracer,
+  tracer,
+} from './traces.js';
+
+/** Span processor that forwards to a list of processors that can grow after construction. */
+class FanoutSpanProcessor implements SpanProcessor {
+  private readonly processors: SpanProcessor[] = [];
+
+  add(processor: SpanProcessor): void {
+    this.processors.push(processor);
+  }
+
+  onStart(...args: Parameters<SpanProcessor['onStart']>): void {
+    for (const processor of this.processors) {
+      processor.onStart(...args);
+    }
+  }
+
+  onEnd(...args: Parameters<SpanProcessor['onEnd']>): void {
+    for (const processor of this.processors) {
+      processor.onEnd(...args);
+    }
+  }
+
+  async forceFlush(): Promise<void> {
+    await Promise.all(this.processors.map((processor) => processor.forceFlush()));
+  }
+
+  async shutdown(): Promise<void> {
+    await Promise.all(this.processors.map((processor) => processor.shutdown()));
+  }
+}
+
+describe('setupCloudTracer with an OpenTelemetry SDK 2.x provider', () => {
+  let userExporter: InMemorySpanExporter;
+  let cloudExporter: InMemorySpanExporter;
+  let fanout: FanoutSpanProcessor;
+  let provider: NodeTracerProvider;
+  let prevKey: string | undefined;
+  let prevSecret: string | undefined;
+
+  beforeEach(() => {
+    prevKey = process.env.LIVEKIT_API_KEY;
+    prevSecret = process.env.LIVEKIT_API_SECRET;
+    process.env.LIVEKIT_API_KEY = 'devkey';
+    process.env.LIVEKIT_API_SECRET = 'secretsecretsecretsecretsecretsecret';
+
+    userExporter = new InMemorySpanExporter();
+    cloudExporter = new InMemorySpanExporter();
+    fanout = new FanoutSpanProcessor();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(userExporter), fanout],
+    });
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    vi.restoreAllMocks();
+    otelContext.disable();
+    trace.disable();
+    // Assigning undefined to process.env.X stores the string "undefined"; delete instead so
+    // env vars that were originally unset stay unset for later tests.
+    if (prevKey === undefined) delete process.env.LIVEKIT_API_KEY;
+    else process.env.LIVEKIT_API_KEY = prevKey;
+    if (prevSecret === undefined) delete process.env.LIVEKIT_API_SECRET;
+    else process.env.LIVEKIT_API_SECRET = prevSecret;
+  });
+
+  it('exports spans to both the user exporter and the cloud span processor', async () => {
+    let cloudOptions: CloudSpanProcessorOptions | undefined;
+    setTracerProvider(provider, {
+      registerSpanProcessor: (processor) => fanout.add(processor),
+      createCloudSpanProcessor: (options) => {
+        cloudOptions = options;
+        return new SimpleSpanProcessor(cloudExporter);
+      },
+    });
+
+    await setupCloudTracer({
+      roomId: 'room1',
+      jobId: 'job1',
+      cloudHostname: 'example.livekit.cloud',
+      enableTraces: true,
+      enableLogs: false,
+    });
+
+    const span = tracer.startSpan({ name: 'otel2-span' });
+    span.end();
+    await provider.forceFlush();
+
+    expect(tracer.getProvider()).toBe(provider);
+    expect(cloudOptions?.url).toBe('https://example.livekit.cloud/observability/traces/otlp/v0');
+    expect(cloudOptions?.headers.Authorization).toMatch(/^Bearer /);
+
+    const cloudSpans = cloudExporter.getFinishedSpans();
+    expect(cloudSpans.map((s) => s.name)).toEqual(['otel2-span']);
+    // room_id/job_id are the attributes LiveKit Cloud correlates traces on; their presence
+    // proves the metadata span processor works against SDK 2.x spans at runtime.
+    expect(cloudSpans[0]!.attributes).toMatchObject({ room_id: 'room1', job_id: 'job1' });
+
+    expect(userExporter.getFinishedSpans().map((s) => s.name)).toEqual(['otel2-span']);
+  });
+
+  it('disables cloud tracing but keeps the user pipeline when no processor factory is supplied', async () => {
+    setTracerProvider(provider, {
+      registerSpanProcessor: (processor) => fanout.add(processor),
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await setupCloudTracer({
+      roomId: 'room1',
+      jobId: 'job1',
+      cloudHostname: 'example.livekit.cloud',
+      enableTraces: true,
+      enableLogs: false,
+    });
+
+    const span = tracer.startSpan({ name: 'otel2-user-only' });
+    span.end();
+    await provider.forceFlush();
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('createCloudSpanProcessor'));
+    expect(cloudExporter.getFinishedSpans()).toHaveLength(0);
+    expect(userExporter.getFinishedSpans().map((s) => s.name)).toEqual(['otel2-user-only']);
+  });
+});

--- a/agents/src/telemetry/traces.otel2.type.test.ts
+++ b/agents/src/telemetry/traces.otel2.type.test.ts
@@ -7,7 +7,11 @@ import { context as otelContext, trace } from '@opentelemetry/api';
 // regression test that the telemetry API composes with an SDK 2.x provider without type errors,
 // and the runtime regression test that spans flushed through such a provider actually reach both
 // the user's exporter and the cloud span processor.
-import { InMemorySpanExporter, SimpleSpanProcessor } from 'otel-v2-sdk-trace-base';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type SpanProcessor,
+} from 'otel-v2-sdk-trace-base';
 import { NodeTracerProvider } from 'otel-v2-sdk-trace-node';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -86,6 +90,41 @@ describe('setupCloudTracer with an OpenTelemetry SDK 2.x provider', () => {
     expect(cloudSpans[0]!.attributes).toMatchObject({ room_id: 'room1', job_id: 'job1' });
 
     expect(userExporter.getFinishedSpans().map((s) => s.name)).toEqual(['otel2-span']);
+  });
+
+  it('forwards the SDK 2.x onEnding hook to dynamically registered processors', async () => {
+    setTracerProvider(provider, {
+      registerSpanProcessor: (processor) => fanout.add(processor),
+      createCloudSpanProcessor: () => new SimpleSpanProcessor(cloudExporter),
+    });
+
+    await setupCloudTracer({
+      roomId: 'room1',
+      jobId: 'job1',
+      cloudHostname: 'example.livekit.cloud',
+      enableTraces: true,
+      enableLogs: false,
+    });
+
+    const onEndingProcessor: SpanProcessor = {
+      forceFlush: async () => undefined,
+      onStart: () => undefined,
+      onEnding: (span) => span.setAttribute('livekit.test.on_ending', true),
+      onEnd: () => undefined,
+      shutdown: async () => undefined,
+    };
+    fanout.add(onEndingProcessor);
+
+    const span = tracer.startSpan({ name: 'otel2-on-ending' });
+    span.end();
+    await provider.forceFlush();
+
+    // onEnding fires while the span is still mutable, before any onEnd export, so the
+    // attribute it sets must be visible to both backends.
+    const [cloudSpan] = cloudExporter.getFinishedSpans();
+    const [userSpan] = userExporter.getFinishedSpans();
+    expect(cloudSpan!.attributes['livekit.test.on_ending']).toBe(true);
+    expect(userSpan!.attributes['livekit.test.on_ending']).toBe(true);
   });
 
   it('disables cloud tracing but keeps the user pipeline when no processor factory is supplied', async () => {

--- a/agents/src/telemetry/traces.otel2.type.test.ts
+++ b/agents/src/telemetry/traces.otel2.type.test.ts
@@ -7,48 +7,16 @@ import { context as otelContext, trace } from '@opentelemetry/api';
 // regression test that the telemetry API composes with an SDK 2.x provider without type errors,
 // and the runtime regression test that spans flushed through such a provider actually reach both
 // the user's exporter and the cloud span processor.
-import {
-  InMemorySpanExporter,
-  SimpleSpanProcessor,
-  type SpanProcessor,
-} from 'otel-v2-sdk-trace-base';
+import { InMemorySpanExporter, SimpleSpanProcessor } from 'otel-v2-sdk-trace-base';
 import { NodeTracerProvider } from 'otel-v2-sdk-trace-node';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type CloudSpanProcessorOptions,
+  FanoutSpanProcessor,
   setTracerProvider,
   setupCloudTracer,
   tracer,
 } from './traces.js';
-
-/** Span processor that forwards to a list of processors that can grow after construction. */
-class FanoutSpanProcessor implements SpanProcessor {
-  private readonly processors: SpanProcessor[] = [];
-
-  add(processor: SpanProcessor): void {
-    this.processors.push(processor);
-  }
-
-  onStart(...args: Parameters<SpanProcessor['onStart']>): void {
-    for (const processor of this.processors) {
-      processor.onStart(...args);
-    }
-  }
-
-  onEnd(...args: Parameters<SpanProcessor['onEnd']>): void {
-    for (const processor of this.processors) {
-      processor.onEnd(...args);
-    }
-  }
-
-  async forceFlush(): Promise<void> {
-    await Promise.all(this.processors.map((processor) => processor.forceFlush()));
-  }
-
-  async shutdown(): Promise<void> {
-    await Promise.all(this.processors.map((processor) => processor.shutdown()));
-  }
-}
 
 describe('setupCloudTracer with an OpenTelemetry SDK 2.x provider', () => {
   let userExporter: InMemorySpanExporter;

--- a/agents/src/telemetry/traces.test.ts
+++ b/agents/src/telemetry/traces.test.ts
@@ -2,14 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { context as otelContext, trace } from '@opentelemetry/api';
-import {
-  InMemorySpanExporter,
-  SimpleSpanProcessor,
-  type SpanProcessor,
-} from '@opentelemetry/sdk-trace-base';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { setTracerProvider, setupCloudTracer, tracer } from './traces.js';
+import { type SpanProcessorLike, setTracerProvider, setupCloudTracer, tracer } from './traces.js';
 
 /** Helper: extract parentSpanId across OTel SDK v1/v2 */
 function parentSpanId(span: unknown): string | undefined {
@@ -179,6 +175,9 @@ describe('setupCloudTracer with a user-configured provider', () => {
   });
 
   it('does not replace the user provider (attaches the cloud exporter to it instead)', async () => {
+    const addSpanProcessor = vi.spyOn(userProvider, 'addSpanProcessor');
+    setTracerProvider(userProvider);
+
     await setupCloudTracer({
       roomId: 'room1',
       jobId: 'job1',
@@ -190,14 +189,19 @@ describe('setupCloudTracer with a user-configured provider', () => {
     // No span is created/ended here so the newly attached cloud BatchSpanProcessor has
     // nothing to flush over the network on shutdown.
     expect(tracer.getProvider()).toBe(userProvider);
+    expect(addSpanProcessor).toHaveBeenCalledTimes(2);
+    expect(addSpanProcessor.mock.calls[1]![0]).toBeInstanceOf(BatchSpanProcessor);
   });
 
-  it('uses an explicit processor registrar when the provider has no addSpanProcessor method', async () => {
-    const registeredProcessors: SpanProcessor[] = [];
+  it('warns and skips cloud tracing when a registrar is supplied without a processor factory', async () => {
+    // Simulates an OTel 2.x-style provider: no addSpanProcessor, so this package's own SDK 1.x
+    // exporter must not be attached and the user has to supply createCloudSpanProcessor.
+    const registeredProcessors: SpanProcessorLike[] = [];
     Object.defineProperty(userProvider, 'addSpanProcessor', { value: undefined });
     setTracerProvider(userProvider, {
       registerSpanProcessor: (processor) => registeredProcessors.push(processor),
     });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     await setupCloudTracer({
       roomId: 'room1',
@@ -208,8 +212,8 @@ describe('setupCloudTracer with a user-configured provider', () => {
     });
 
     expect(tracer.getProvider()).toBe(userProvider);
-    expect(registeredProcessors).toHaveLength(2);
-    expect(registeredProcessors[1]).toBeInstanceOf(BatchSpanProcessor);
+    expect(registeredProcessors).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('createCloudSpanProcessor'));
   });
 
   it('preserves a custom provider when no processor registrar is available', async () => {

--- a/agents/src/telemetry/traces.test.ts
+++ b/agents/src/telemetry/traces.test.ts
@@ -193,6 +193,36 @@ describe('setupCloudTracer with a user-configured provider', () => {
     expect(addSpanProcessor.mock.calls[1]![0]).toBeInstanceOf(BatchSpanProcessor);
   });
 
+  it('prefers a user-supplied cloud processor factory over the built-in exporter', async () => {
+    const addSpanProcessor = vi.spyOn(userProvider, 'addSpanProcessor');
+    const factoryProcessor = new SimpleSpanProcessor(new InMemorySpanExporter());
+    const createCloudSpanProcessor = vi.fn(() => factoryProcessor);
+    setTracerProvider(userProvider, { createCloudSpanProcessor });
+
+    await setupCloudTracer({
+      roomId: 'room1',
+      jobId: 'job1',
+      cloudHostname: 'example.livekit.cloud',
+      enableTraces: true,
+      enableLogs: false,
+    });
+
+    expect(createCloudSpanProcessor).toHaveBeenCalledOnce();
+    expect(addSpanProcessor).toHaveBeenCalledTimes(2);
+    expect(addSpanProcessor.mock.calls[1]![0]).toBe(factoryProcessor);
+  });
+
+  it('warns when a cloud processor factory is supplied without a usable registrar', () => {
+    Object.defineProperty(userProvider, 'addSpanProcessor', { value: undefined });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    setTracerProvider(userProvider, {
+      createCloudSpanProcessor: () => new SimpleSpanProcessor(new InMemorySpanExporter()),
+    });
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Ignoring createCloudSpanProcessor'));
+  });
+
   it('warns and skips cloud tracing when a registrar is supplied without a processor factory', async () => {
     // Simulates an OTel 2.x-style provider: no addSpanProcessor, so this package's own SDK 1.x
     // exporter must not be attached and the user has to supply createCloudSpanProcessor.

--- a/agents/src/telemetry/traces.test.ts
+++ b/agents/src/telemetry/traces.test.ts
@@ -2,9 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { context as otelContext, trace } from '@opentelemetry/api';
-import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setTracerProvider, setupCloudTracer, tracer } from './traces.js';
 
 /** Helper: extract parentSpanId across OTel SDK v1/v2 */
@@ -163,6 +167,7 @@ describe('setupCloudTracer with a user-configured provider', () => {
 
   afterEach(async () => {
     await userProvider.shutdown();
+    vi.restoreAllMocks();
     otelContext.disable();
     trace.disable();
     // Assigning undefined to process.env.X stores the string "undefined"; delete instead so
@@ -185,5 +190,42 @@ describe('setupCloudTracer with a user-configured provider', () => {
     // No span is created/ended here so the newly attached cloud BatchSpanProcessor has
     // nothing to flush over the network on shutdown.
     expect(tracer.getProvider()).toBe(userProvider);
+  });
+
+  it('uses an explicit processor registrar when the provider has no addSpanProcessor method', async () => {
+    const registeredProcessors: SpanProcessor[] = [];
+    Object.defineProperty(userProvider, 'addSpanProcessor', { value: undefined });
+    setTracerProvider(userProvider, {
+      registerSpanProcessor: (processor) => registeredProcessors.push(processor),
+    });
+
+    await setupCloudTracer({
+      roomId: 'room1',
+      jobId: 'job1',
+      cloudHostname: 'example.livekit.cloud',
+      enableTraces: true,
+      enableLogs: false,
+    });
+
+    expect(tracer.getProvider()).toBe(userProvider);
+    expect(registeredProcessors).toHaveLength(2);
+    expect(registeredProcessors[1]).toBeInstanceOf(BatchSpanProcessor);
+  });
+
+  it('preserves a custom provider when no processor registrar is available', async () => {
+    Object.defineProperty(userProvider, 'addSpanProcessor', { value: undefined });
+    setTracerProvider(userProvider);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await setupCloudTracer({
+      roomId: 'room1',
+      jobId: 'job1',
+      cloudHostname: 'example.livekit.cloud',
+      enableTraces: true,
+      enableLogs: false,
+    });
+
+    expect(tracer.getProvider()).toBe(userProvider);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('registerSpanProcessor'));
   });
 });

--- a/agents/src/telemetry/traces.ts
+++ b/agents/src/telemetry/traces.ts
@@ -193,6 +193,12 @@ class MetadataSpanProcessor implements SpanProcessor {
 export interface SpanProcessorLike {
   forceFlush(): Promise<void>;
   onStart(span: unknown, parentContext: unknown): void;
+  /**
+   * Pre-end hook introduced in OpenTelemetry SDK 2.x (experimental there): called synchronously
+   * when a span begins ending, while it is still mutable, before any `onEnd` call. SDK 1.x
+   * never invokes it.
+   */
+  onEnding?(span: unknown): void;
   onEnd(span: unknown): void;
   shutdown(): Promise<void>;
 }
@@ -218,6 +224,12 @@ export class FanoutSpanProcessor implements SpanProcessorLike {
   onStart(span: unknown, parentContext: unknown): void {
     for (const processor of this.processors) {
       processor.onStart(span, parentContext);
+    }
+  }
+
+  onEnding(span: unknown): void {
+    for (const processor of this.processors) {
+      processor.onEnding?.(span);
     }
   }
 
@@ -326,11 +338,11 @@ function resolveSpanProcessorRegistrar(
  *
  * @example OpenTelemetry SDK 1.x
  * ```typescript
+ * import { telemetry } from '@livekit/agents';
  * import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
- * import { setTracerProvider } from '@livekit/agents/telemetry';
  *
  * const provider = new NodeTracerProvider();
- * setTracerProvider(provider, {
+ * telemetry.setTracerProvider(provider, {
  *   metadata: { room_id: 'room123', job_id: 'job456' }
  * });
  * ```
@@ -341,16 +353,16 @@ function resolveSpanProcessorRegistrar(
  * cloud processor must be constructed from the caller's own SDK packages so its version matches
  * the provider's.
  * ```typescript
- * import { FanoutSpanProcessor, setTracerProvider } from '@livekit/agents/telemetry';
+ * import { telemetry } from '@livekit/agents';
  * import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
  * import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
  *
- * const fanout = new FanoutSpanProcessor();
+ * const fanout = new telemetry.FanoutSpanProcessor();
  * const provider = new NodeTracerProvider({
  *   spanProcessors: [new BatchSpanProcessor(myBackendExporter), fanout],
  * });
  * provider.register();
- * setTracerProvider(provider, {
+ * telemetry.setTracerProvider(provider, {
  *   registerSpanProcessor: (processor) => fanout.add(processor),
  *   createCloudSpanProcessor: ({ url, headers }) =>
  *     new BatchSpanProcessor(new OTLPTraceExporter({ url, headers })),

--- a/agents/src/telemetry/traces.ts
+++ b/agents/src/telemetry/traces.ts
@@ -199,6 +199,43 @@ export interface SpanProcessorLike {
 
 type SpanProcessorRegistrar = (spanProcessor: SpanProcessorLike) => void;
 
+/**
+ * Span processor that forwards to a list of processors that can grow after the owning provider
+ * is constructed.
+ *
+ * OpenTelemetry 2.x providers accept span processors only at construction time. Include one of
+ * these in the provider's `spanProcessors` and pass its {@link FanoutSpanProcessor.add | add}
+ * method as `registerSpanProcessor` so LiveKit Cloud tracing can attach its processors later.
+ */
+export class FanoutSpanProcessor implements SpanProcessorLike {
+  private readonly processors: SpanProcessorLike[] = [];
+
+  /** Adds a processor that receives all span events from this point on. */
+  add(processor: SpanProcessorLike): void {
+    this.processors.push(processor);
+  }
+
+  onStart(span: unknown, parentContext: unknown): void {
+    for (const processor of this.processors) {
+      processor.onStart(span, parentContext);
+    }
+  }
+
+  onEnd(span: unknown): void {
+    for (const processor of this.processors) {
+      processor.onEnd(span);
+    }
+  }
+
+  async forceFlush(): Promise<void> {
+    await Promise.all(this.processors.map((processor) => processor.forceFlush()));
+  }
+
+  async shutdown(): Promise<void> {
+    await Promise.all(this.processors.map((processor) => processor.shutdown()));
+  }
+}
+
 /** Connection details for building a span processor that exports to LiveKit Cloud. */
 export interface CloudSpanProcessorOptions {
   /** OTLP/HTTP protobuf endpoint for LiveKit Cloud traces. */
@@ -257,6 +294,10 @@ export interface SetTracerProviderOptions {
    * ```
    *
    * Not needed for SDK 1.x providers, where the built-in cloud exporter is used.
+   *
+   * The returned processor is only checked structurally, so an SDK-version mismatch — e.g. a
+   * processor built from SDK 1.x packages returned for a 2.x provider — compiles but drops spans
+   * at runtime. Always construct it from the same packages that built the provider.
    */
   createCloudSpanProcessor?: (options: CloudSpanProcessorOptions) => SpanProcessorLike;
 }
@@ -296,15 +337,15 @@ function resolveSpanProcessorRegistrar(
  *
  * @example OpenTelemetry SDK 2.x — share one provider between another backend and LiveKit Cloud.
  * SDK 2.x providers accept span processors only at construction time, so the provider must be
- * built around a processor whose targets can grow later (`fanout` below), and the cloud
- * processor must be constructed from the caller's own SDK packages so its version matches the
- * provider's.
+ * built around a processor whose targets can grow later ({@link FanoutSpanProcessor}), and the
+ * cloud processor must be constructed from the caller's own SDK packages so its version matches
+ * the provider's.
  * ```typescript
+ * import { FanoutSpanProcessor, setTracerProvider } from '@livekit/agents/telemetry';
  * import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
  * import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
- * import { setTracerProvider } from '@livekit/agents/telemetry';
  *
- * const fanout = new FanoutSpanProcessor(); // forwards to a mutable list of processors
+ * const fanout = new FanoutSpanProcessor();
  * const provider = new NodeTracerProvider({
  *   spanProcessors: [new BatchSpanProcessor(myBackendExporter), fanout],
  * });
@@ -334,6 +375,14 @@ export function setTracerProvider(
           'Pass registerSpanProcessor to setTracerProvider when using OpenTelemetry 2.x.',
       );
     }
+  }
+
+  if (options?.createCloudSpanProcessor && !registerSpanProcessor) {
+    console.warn(
+      'Ignoring createCloudSpanProcessor because the custom tracer provider has no way to ' +
+        'register span processors. Pass registerSpanProcessor to setTracerProvider when using ' +
+        'OpenTelemetry 2.x.',
+    );
   }
 
   if (registerSpanProcessor) {

--- a/agents/src/telemetry/traces.ts
+++ b/agents/src/telemetry/traces.ts
@@ -183,12 +183,50 @@ class MetadataSpanProcessor implements SpanProcessor {
   }
 }
 
+type SpanProcessorRegistrar = (spanProcessor: SpanProcessor) => void;
+
+const spanProcessorRegistrars = new WeakMap<TracerProvider, SpanProcessorRegistrar>();
+
+interface LegacySpanProcessorProvider extends TracerProvider {
+  addSpanProcessor?: SpanProcessorRegistrar;
+}
+
+/** Options for configuring a custom tracer provider. */
+export interface SetTracerProviderOptions {
+  /** Attributes to add to every span created by the provider. */
+  metadata?: Attributes;
+  /**
+   * Adds a span processor to the provider.
+   *
+   * OpenTelemetry 2.x providers no longer expose `addSpanProcessor`. Supply this callback when
+   * using a provider backed by a mutable or delegating span processor so LiveKit Cloud tracing can
+   * share the same provider as another observability backend.
+   */
+  registerSpanProcessor?: (spanProcessor: SpanProcessor) => void;
+}
+
+function resolveSpanProcessorRegistrar(
+  provider: TracerProvider,
+  registerSpanProcessor?: SpanProcessorRegistrar,
+): SpanProcessorRegistrar | undefined {
+  if (registerSpanProcessor) {
+    return registerSpanProcessor;
+  }
+
+  const legacyProvider = provider as LegacySpanProcessorProvider;
+  if (typeof legacyProvider.addSpanProcessor === 'function') {
+    return legacyProvider.addSpanProcessor.bind(legacyProvider);
+  }
+
+  return undefined;
+}
+
 /**
  * Set the tracer provider for the livekit-agents framework.
  * This should be called before agent session start if using custom tracer providers.
  *
- * @param provider - The tracer provider to use (must be a NodeTracerProvider)
- * @param options - Optional configuration with metadata property to inject into all spans
+ * @param provider - The tracer provider to use
+ * @param options - Optional provider configuration
  *
  * @example
  * ```typescript
@@ -202,11 +240,29 @@ class MetadataSpanProcessor implements SpanProcessor {
  * ```
  */
 export function setTracerProvider(
-  provider: NodeTracerProvider,
-  options?: { metadata?: Attributes },
+  provider: TracerProvider,
+  options?: SetTracerProviderOptions,
 ): void {
+  const registerSpanProcessor = resolveSpanProcessorRegistrar(
+    provider,
+    options?.registerSpanProcessor,
+  );
+
   if (options?.metadata) {
-    provider.addSpanProcessor(new MetadataSpanProcessor(options.metadata));
+    if (registerSpanProcessor) {
+      registerSpanProcessor(new MetadataSpanProcessor(options.metadata));
+    } else {
+      console.warn(
+        'Unable to register LiveKit span metadata on the custom tracer provider. ' +
+          'Pass registerSpanProcessor to setTracerProvider when using OpenTelemetry 2.x.',
+      );
+    }
+  }
+
+  if (registerSpanProcessor) {
+    spanProcessorRegistrars.set(provider, registerSpanProcessor);
+  } else {
+    spanProcessorRegistrars.delete(provider);
   }
 
   tracer.setProvider(provider);
@@ -261,42 +317,51 @@ export async function setupCloudTracer(options: {
     });
 
     if (enableTraces) {
-      // Configure OTLP exporter to send traces to LiveKit Cloud
-      const spanExporter = new OTLPTraceExporter({
-        url: `https://${cloudHostname}/observability/traces/otlp/v0`,
-        headers,
-        compression: CompressionAlgorithm.GZIP,
-      });
-
       // If the user already configured a tracer provider (e.g. setTracerProvider in the job
       // entrypoint), attach the cloud exporter to it rather than replacing it, so spans reach
       // both the user's backend and LiveKit Cloud.
       const currentProvider = tracer.getProvider();
       const existingProvider =
-        currentProvider instanceof ProxyTracerProvider
-          ? undefined
-          : (currentProvider as Partial<NodeTracerProvider>);
+        currentProvider instanceof ProxyTracerProvider ? undefined : currentProvider;
+      const registerSpanProcessor = existingProvider
+        ? spanProcessorRegistrars.get(existingProvider)
+        : undefined;
 
-      if (existingProvider && typeof existingProvider.addSpanProcessor === 'function') {
-        // The user's provider keeps its own Resource (incl. service.name): a provider has one
-        // Resource shared by all exporters, so applying `resource` here would also relabel the
-        // spans going to the user's own backend. room_id/job_id — the keys Cloud correlates on —
-        // still ride along as span attributes via MetadataSpanProcessor.
-        existingProvider.addSpanProcessor(new MetadataSpanProcessor(metadata));
-        existingProvider.addSpanProcessor(new BatchSpanProcessor(spanExporter));
+      if (existingProvider && !registerSpanProcessor) {
+        console.warn(
+          'LiveKit Cloud tracing is disabled because the custom tracer provider cannot register ' +
+            'additional span processors. Pass registerSpanProcessor to setTracerProvider when ' +
+            'using OpenTelemetry 2.x.',
+        );
       } else {
-        const tracerProvider = new NodeTracerProvider({
-          resource,
-          spanProcessors: [
-            new MetadataSpanProcessor(metadata),
-            new BatchSpanProcessor(spanExporter),
-          ],
+        // Configure OTLP exporter to send traces to LiveKit Cloud
+        const spanExporter = new OTLPTraceExporter({
+          url: `https://${cloudHostname}/observability/traces/otlp/v0`,
+          headers,
+          compression: CompressionAlgorithm.GZIP,
         });
-        // register() installs an AsyncLocalStorageContextManager (needed for span nesting)
-        // and sets the global tracer provider. Both use set-once semantics in the OTel API,
-        // so if the user already called NodeSDK.start(), these are safe no-ops.
-        tracerProvider.register();
-        setTracerProvider(tracerProvider);
+
+        if (existingProvider && registerSpanProcessor) {
+          // The user's provider keeps its own Resource (incl. service.name): a provider has one
+          // Resource shared by all exporters, so applying `resource` here would also relabel the
+          // spans going to the user's own backend. room_id/job_id — the keys Cloud correlates on —
+          // still ride along as span attributes via MetadataSpanProcessor.
+          registerSpanProcessor(new MetadataSpanProcessor(metadata));
+          registerSpanProcessor(new BatchSpanProcessor(spanExporter));
+        } else {
+          const tracerProvider = new NodeTracerProvider({
+            resource,
+            spanProcessors: [
+              new MetadataSpanProcessor(metadata),
+              new BatchSpanProcessor(spanExporter),
+            ],
+          });
+          // register() installs an AsyncLocalStorageContextManager (needed for span nesting)
+          // and sets the global tracer provider. Both use set-once semantics in the OTel API,
+          // so if the user already called NodeSDK.start(), these are safe no-ops.
+          tracerProvider.register();
+          setTracerProvider(tracerProvider);
+        }
       }
     }
 

--- a/agents/src/telemetry/traces.ts
+++ b/agents/src/telemetry/traces.ts
@@ -183,12 +183,50 @@ class MetadataSpanProcessor implements SpanProcessor {
   }
 }
 
-type SpanProcessorRegistrar = (spanProcessor: SpanProcessor) => void;
+/**
+ * Structural span-processor contract compatible with both OpenTelemetry SDK 1.x and 2.x.
+ *
+ * The concrete `SpanProcessor` types of the two SDK majors are not mutually assignable (their
+ * span types differ), so cross-version composition is expressed through this shape instead.
+ * Any real `SpanProcessor` instance from either SDK major satisfies it.
+ */
+export interface SpanProcessorLike {
+  forceFlush(): Promise<void>;
+  onStart(span: unknown, parentContext: unknown): void;
+  onEnd(span: unknown): void;
+  shutdown(): Promise<void>;
+}
 
-const spanProcessorRegistrars = new WeakMap<TracerProvider, SpanProcessorRegistrar>();
+type SpanProcessorRegistrar = (spanProcessor: SpanProcessorLike) => void;
+
+/** Connection details for building a span processor that exports to LiveKit Cloud. */
+export interface CloudSpanProcessorOptions {
+  /** OTLP/HTTP protobuf endpoint for LiveKit Cloud traces. */
+  url: string;
+  /** Request headers, including the authorization token, the exporter must send. */
+  headers: Record<string, string>;
+}
+
+interface CustomProviderConfig {
+  registerSpanProcessor: SpanProcessorRegistrar;
+  createCloudSpanProcessor?: (options: CloudSpanProcessorOptions) => SpanProcessorLike;
+}
+
+const customProviderConfigs = new WeakMap<TracerProvider, CustomProviderConfig>();
 
 interface LegacySpanProcessorProvider extends TracerProvider {
-  addSpanProcessor?: SpanProcessorRegistrar;
+  addSpanProcessor?: (spanProcessor: SpanProcessor) => void;
+}
+
+/**
+ * OpenTelemetry SDK 1.x providers expose `addSpanProcessor`; 2.x providers do not. The method's
+ * presence is also how the cloud setup decides whether this package's own SDK 1.x exporter may
+ * be attached to the provider.
+ */
+function isSdk1Provider(provider: TracerProvider): provider is LegacySpanProcessorProvider & {
+  addSpanProcessor: (spanProcessor: SpanProcessor) => void;
+} {
+  return typeof (provider as LegacySpanProcessorProvider).addSpanProcessor === 'function';
 }
 
 /** Options for configuring a custom tracer provider. */
@@ -202,7 +240,25 @@ export interface SetTracerProviderOptions {
    * using a provider backed by a mutable or delegating span processor so LiveKit Cloud tracing can
    * share the same provider as another observability backend.
    */
-  registerSpanProcessor?: (spanProcessor: SpanProcessor) => void;
+  registerSpanProcessor?: SpanProcessorRegistrar;
+  /**
+   * Builds the span processor that exports to LiveKit Cloud, called when cloud tracing starts.
+   *
+   * This package ships OpenTelemetry SDK 1.x, and processors/exporters must match the SDK major
+   * version of the provider they run in. When the provider is built on OpenTelemetry 2.x, supply
+   * this callback and construct the processor from your own SDK packages:
+   *
+   * ```typescript
+   * import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+   * import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-node';
+   *
+   * createCloudSpanProcessor: ({ url, headers }) =>
+   *   new BatchSpanProcessor(new OTLPTraceExporter({ url, headers }))
+   * ```
+   *
+   * Not needed for SDK 1.x providers, where the built-in cloud exporter is used.
+   */
+  createCloudSpanProcessor?: (options: CloudSpanProcessorOptions) => SpanProcessorLike;
 }
 
 function resolveSpanProcessorRegistrar(
@@ -213,9 +269,8 @@ function resolveSpanProcessorRegistrar(
     return registerSpanProcessor;
   }
 
-  const legacyProvider = provider as LegacySpanProcessorProvider;
-  if (typeof legacyProvider.addSpanProcessor === 'function') {
-    return legacyProvider.addSpanProcessor.bind(legacyProvider);
+  if (isSdk1Provider(provider)) {
+    return provider.addSpanProcessor.bind(provider);
   }
 
   return undefined;
@@ -228,7 +283,7 @@ function resolveSpanProcessorRegistrar(
  * @param provider - The tracer provider to use
  * @param options - Optional provider configuration
  *
- * @example
+ * @example OpenTelemetry SDK 1.x
  * ```typescript
  * import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
  * import { setTracerProvider } from '@livekit/agents/telemetry';
@@ -236,6 +291,28 @@ function resolveSpanProcessorRegistrar(
  * const provider = new NodeTracerProvider();
  * setTracerProvider(provider, {
  *   metadata: { room_id: 'room123', job_id: 'job456' }
+ * });
+ * ```
+ *
+ * @example OpenTelemetry SDK 2.x — share one provider between another backend and LiveKit Cloud.
+ * SDK 2.x providers accept span processors only at construction time, so the provider must be
+ * built around a processor whose targets can grow later (`fanout` below), and the cloud
+ * processor must be constructed from the caller's own SDK packages so its version matches the
+ * provider's.
+ * ```typescript
+ * import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+ * import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+ * import { setTracerProvider } from '@livekit/agents/telemetry';
+ *
+ * const fanout = new FanoutSpanProcessor(); // forwards to a mutable list of processors
+ * const provider = new NodeTracerProvider({
+ *   spanProcessors: [new BatchSpanProcessor(myBackendExporter), fanout],
+ * });
+ * provider.register();
+ * setTracerProvider(provider, {
+ *   registerSpanProcessor: (processor) => fanout.add(processor),
+ *   createCloudSpanProcessor: ({ url, headers }) =>
+ *     new BatchSpanProcessor(new OTLPTraceExporter({ url, headers })),
  * });
  * ```
  */
@@ -260,9 +337,12 @@ export function setTracerProvider(
   }
 
   if (registerSpanProcessor) {
-    spanProcessorRegistrars.set(provider, registerSpanProcessor);
+    customProviderConfigs.set(provider, {
+      registerSpanProcessor,
+      createCloudSpanProcessor: options?.createCloudSpanProcessor,
+    });
   } else {
-    spanProcessorRegistrars.delete(provider);
+    customProviderConfigs.delete(provider);
   }
 
   tracer.setProvider(provider);
@@ -317,50 +397,76 @@ export async function setupCloudTracer(options: {
     });
 
     if (enableTraces) {
+      const cloudExporterOptions: CloudSpanProcessorOptions = {
+        url: `https://${cloudHostname}/observability/traces/otlp/v0`,
+        headers,
+      };
+
       // If the user already configured a tracer provider (e.g. setTracerProvider in the job
       // entrypoint), attach the cloud exporter to it rather than replacing it, so spans reach
       // both the user's backend and LiveKit Cloud.
       const currentProvider = tracer.getProvider();
       const existingProvider =
         currentProvider instanceof ProxyTracerProvider ? undefined : currentProvider;
-      const registerSpanProcessor = existingProvider
-        ? spanProcessorRegistrars.get(existingProvider)
-        : undefined;
 
-      if (existingProvider && !registerSpanProcessor) {
-        console.warn(
-          'LiveKit Cloud tracing is disabled because the custom tracer provider cannot register ' +
-            'additional span processors. Pass registerSpanProcessor to setTracerProvider when ' +
-            'using OpenTelemetry 2.x.',
-        );
-      } else {
-        // Configure OTLP exporter to send traces to LiveKit Cloud
-        const spanExporter = new OTLPTraceExporter({
-          url: `https://${cloudHostname}/observability/traces/otlp/v0`,
-          headers,
-          compression: CompressionAlgorithm.GZIP,
+      if (!existingProvider) {
+        const tracerProvider = new NodeTracerProvider({
+          resource,
+          spanProcessors: [
+            new MetadataSpanProcessor(metadata),
+            new BatchSpanProcessor(
+              new OTLPTraceExporter({
+                ...cloudExporterOptions,
+                compression: CompressionAlgorithm.GZIP,
+              }),
+            ),
+          ],
         });
+        // register() installs an AsyncLocalStorageContextManager (needed for span nesting)
+        // and sets the global tracer provider. Both use set-once semantics in the OTel API,
+        // so if the user already called NodeSDK.start(), these are safe no-ops.
+        tracerProvider.register();
+        setTracerProvider(tracerProvider);
+      } else {
+        const config = customProviderConfigs.get(existingProvider);
 
-        if (existingProvider && registerSpanProcessor) {
-          // The user's provider keeps its own Resource (incl. service.name): a provider has one
-          // Resource shared by all exporters, so applying `resource` here would also relabel the
-          // spans going to the user's own backend. room_id/job_id — the keys Cloud correlates on —
-          // still ride along as span attributes via MetadataSpanProcessor.
-          registerSpanProcessor(new MetadataSpanProcessor(metadata));
-          registerSpanProcessor(new BatchSpanProcessor(spanExporter));
+        if (!config) {
+          console.warn(
+            'LiveKit Cloud tracing is disabled because the custom tracer provider cannot register ' +
+              'additional span processors. Pass registerSpanProcessor to setTracerProvider when ' +
+              'using OpenTelemetry 2.x.',
+          );
         } else {
-          const tracerProvider = new NodeTracerProvider({
-            resource,
-            spanProcessors: [
-              new MetadataSpanProcessor(metadata),
-              new BatchSpanProcessor(spanExporter),
-            ],
-          });
-          // register() installs an AsyncLocalStorageContextManager (needed for span nesting)
-          // and sets the global tracer provider. Both use set-once semantics in the OTel API,
-          // so if the user already called NodeSDK.start(), these are safe no-ops.
-          tracerProvider.register();
-          setTracerProvider(tracerProvider);
+          // The cloud span processor must match the provider's OTel SDK major version: this
+          // package's own BatchSpanProcessor/OTLPTraceExporter are SDK 1.x and only work with an
+          // SDK 1.x provider (2.x spans carry instrumentationScope/parentSpanContext, which the
+          // 1.x exporter cannot serialize). For any other provider, the user-supplied factory
+          // builds the processor from the SDK version the provider actually runs on.
+          const cloudSpanProcessor = config.createCloudSpanProcessor
+            ? config.createCloudSpanProcessor(cloudExporterOptions)
+            : isSdk1Provider(existingProvider)
+              ? new BatchSpanProcessor(
+                  new OTLPTraceExporter({
+                    ...cloudExporterOptions,
+                    compression: CompressionAlgorithm.GZIP,
+                  }),
+                )
+              : undefined;
+
+          if (!cloudSpanProcessor) {
+            console.warn(
+              'LiveKit Cloud tracing is disabled because no exporter compatible with the custom ' +
+                'tracer provider is available. Pass createCloudSpanProcessor to setTracerProvider ' +
+                'to build the cloud span processor from your OpenTelemetry SDK version.',
+            );
+          } else {
+            // The user's provider keeps its own Resource (incl. service.name): a provider has one
+            // Resource shared by all exporters, so applying `resource` here would also relabel
+            // the spans going to the user's own backend. room_id/job_id — the keys Cloud
+            // correlates on — still ride along as span attributes via MetadataSpanProcessor.
+            config.registerSpanProcessor(new MetadataSpanProcessor(metadata));
+            config.registerSpanProcessor(cloudSpanProcessor);
+          }
         }
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,12 @@ importers:
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
+      otel-v2-sdk-trace-base:
+        specifier: npm:@opentelemetry/sdk-trace-base@^2.8.0
+        version: '@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0)'
+      otel-v2-sdk-trace-node:
+        specifier: npm:@opentelemetry/sdk-trace-node@^2.8.0
+        version: '@opentelemetry/sdk-trace-node@2.9.0(@opentelemetry/api@1.9.0)'
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(@microsoft/api-extractor@7.43.7(@types/node@22.19.1))(postcss@8.5.17)(tsx@4.21.0)(typescript@5.9.3)
@@ -2354,6 +2360,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/context-async-hooks@2.9.0':
+    resolution: {integrity: sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/core@1.27.0':
     resolution: {integrity: sha512-yQPKnK5e+76XuiqUH/gKyS8wv/7qITd5ln56QkBTf3uggr0VkXOXfcaAuG330UfdYu83wsyoBwqwxigpIG+Jkg==}
     engines: {node: '>=14'}
@@ -2374,6 +2386,12 @@ packages:
 
   '@opentelemetry/core@2.8.0':
     resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.9.0':
+    resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -2468,6 +2486,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
+  '@opentelemetry/resources@2.9.0':
+    resolution: {integrity: sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/sdk-logs@0.208.0':
     resolution: {integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -2510,11 +2534,29 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
+  '@opentelemetry/sdk-trace-base@2.9.0':
+    resolution: {integrity: sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-node@1.30.1':
     resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.9.0':
+    resolution: {integrity: sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.9.0':
+    resolution: {integrity: sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/semantic-conventions@1.27.0':
     resolution: {integrity: sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==}
@@ -6365,6 +6407,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@opentelemetry/context-async-hooks@2.9.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -6381,6 +6427,11 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.38.0
+
+  '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.38.0
@@ -6506,6 +6557,12 @@ snapshots:
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
 
+  '@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
+
   '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -6553,6 +6610,14 @@ snapshots:
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
 
+  '@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
+
   '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -6562,6 +6627,20 @@ snapshots:
       '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
       semver: 7.7.3
+
+  '@opentelemetry/sdk-trace-node@2.9.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.9.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace@2.9.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/semantic-conventions@1.27.0': {}
 


### PR DESCRIPTION
## Description

Preserves a caller-provided OpenTelemetry tracer provider when LiveKit Cloud tracing is enabled, including providers built on OpenTelemetry SDK 2.x.

OpenTelemetry 2.x removed `NodeTracerProvider.addSpanProcessor()`. The previous fallback created a second provider and moved LiveKit's internal tracer to it, splitting application spans and LiveKit spans across different exporters.

Related to #1879.

## Changes Made

- Add an optional `registerSpanProcessor` callback to `setTracerProvider` for providers backed by a mutable or delegating span processor, and export a `FanoutSpanProcessor` helper so 2.x consumers don't have to hand-roll one (2.x providers accept span processors only at construction time).
- Add an optional `createCloudSpanProcessor` callback that receives the Cloud OTLP endpoint and auth headers and returns a span processor the caller constructs from **their own** OTel SDK packages, so the cloud processor/exporter always matches the provider's SDK major version. This package's built-in SDK 1.x `BatchSpanProcessor`/`OTLPTraceExporter` are only attached to providers that expose `addSpanProcessor` (SDK 1.x) or to the provider this package creates itself — they are never injected into a 2.x provider.
- Type the cross-version callbacks with a structural `SpanProcessorLike` contract that real `SpanProcessor` instances from either SDK major satisfy, so 2.x consumers compose without type errors or casts.
- Retain `addSpanProcessor()` as the OpenTelemetry 1.x compatibility path with no API changes required.
- Preserve an incompatible custom provider and emit an actionable warning instead of silently replacing it or exporting broken data.
- Add an OpenTelemetry 2.x compile/runtime regression test (`traces.otel2.type.test.ts`): it is included in `pnpm typecheck` (compile-time check against real `@opentelemetry/sdk-trace-base@2.x` types, installed under npm aliases as devDependencies) and runs under vitest, composing a real 2.x `NodeTracerProvider`, ending a span, flushing, and asserting spans reach both the user exporter and the cloud span processor with `room_id`/`job_id` attributes.
- Add a patch changeset for `@livekit/agents`.

## Pre-Review Checklist

- [x] **Build passes**: Package build, typecheck, lint, formatting, and focused tests pass locally
- [x] **AI-generated code reviewed**: Removed implementation-specific assertions and unnecessary comments
- [x] **Changes explained**: Root cause and compatibility behavior are documented above
- [x] **Scope appropriate**: Only tracer-provider composition, its tests, and release note are changed
- [x] **Video demo**: Not applicable; this is a telemetry-only change with automated regression coverage

## Testing

- [x] `pnpm vitest run agents/src/telemetry/` (15 tests, including the OTel 2.x suite, factory-precedence, and `onEnding` forwarding coverage)
- [x] `pnpm --filter @livekit/agents typecheck` (includes the OTel 2.x compile regression test)
- [x] `pnpm --filter @livekit/agents build`
- [x] Verified the compile regression is real: assigning this package's SDK 1.x `SpanProcessor` to a 2.x `SpanProcessor` parameter fails with TS2345, while the new `SpanProcessorLike` surface compiles cleanly in both directions
- [x] Lint and prettier clean on touched files

## Additional Notes

`pnpm --filter @livekit/agents api:check` remains blocked on `main` by API Extractor's unsupported `export * as` syntax in `dist/index.d.ts`.

---

**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.
