### PR TITLE
feat(workflows): expose humanAgentRoomName option on WarmTransferTask

### DIFF
--- a/.changeset/warm-transfer-human-agent-room-name.md
+++ b/.changeset/warm-transfer-human-agent-room-name.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-Add an optional `humanAgentRoomName` option to `WarmTransferTask`, allowing the human-agent briefing room to be pre-created with custom configuration (e.g. an egress request to record the transfer leg) before the task dials the human agent.
+Add an optional `roomName` option to `WarmTransferTask`, allowing the human-agent briefing room to be pre-created with custom configuration (e.g. an egress request to record the transfer leg) before the task dials the human agent.

--- a/.changeset/warm-transfer-human-agent-room-name.md
+++ b/.changeset/warm-transfer-human-agent-room-name.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Add an optional `humanAgentRoomName` option to `WarmTransferTask`, allowing the human-agent briefing room to be pre-created with custom configuration (e.g. an egress request to record the transfer leg) before the task dials the human agent.

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -21,12 +21,12 @@ describe('resolveHumanAgentRoomName', () => {
 });
 
 describe('createWarmTransferTask', () => {
-  it('rejects an empty humanAgentRoomName', () => {
+  it('rejects an empty roomName', () => {
     expect(() =>
       createWarmTransferTask({
         sipCallTo: '+15551234567',
         sipTrunkId: 'ST_dummy',
-        humanAgentRoomName: '',
+        roomName: '',
       }),
     ).toThrow(/must not be empty/);
   });

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
-import { resolveHumanAgentRoomName } from './warm_transfer.js';
+import { createWarmTransferTask, resolveHumanAgentRoomName } from './warm_transfer.js';
 
 describe('resolveHumanAgentRoomName', () => {
   it('defaults to `<callerRoom>-human-agent` when no override is given', () => {
@@ -17,5 +17,17 @@ describe('resolveHumanAgentRoomName', () => {
     expect(() => resolveHumanAgentRoomName('call-123', 'call-123')).toThrow(
       /must differ from the caller room name/,
     );
+  });
+});
+
+describe('createWarmTransferTask', () => {
+  it('rejects an empty humanAgentRoomName', () => {
+    expect(() =>
+      createWarmTransferTask({
+        sipCallTo: '+15551234567',
+        sipTrunkId: 'ST_dummy',
+        humanAgentRoomName: '',
+      }),
+    ).toThrow(/must not be empty/);
   });
 });

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { resolveHumanAgentRoomName } from './warm_transfer.js';
+
+describe('resolveHumanAgentRoomName', () => {
+  it('defaults to `<callerRoom>-human-agent` when no override is given', () => {
+    expect(resolveHumanAgentRoomName('call-123')).toBe('call-123-human-agent');
+  });
+
+  it('returns the override when provided', () => {
+    expect(resolveHumanAgentRoomName('call-123', 'consult-abc')).toBe('consult-abc');
+  });
+
+  it('rejects an override equal to the caller room name', () => {
+    expect(() => resolveHumanAgentRoomName('call-123', 'call-123')).toThrow(
+      /must differ from the caller room name/,
+    );
+  });
+});

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -661,6 +661,21 @@ function formatConversationHistory(chatCtx?: ChatContext): string {
   return previousConversation;
 }
 
+/**
+ * Resolve the name of the room used to dial and brief the human agent.
+ *
+ * Exported for testing; not re-exported from the package index.
+ */
+export function resolveHumanAgentRoomName(callerRoomName: string, override?: string): string {
+  if (override === undefined) {
+    return `${callerRoomName}-human-agent`;
+  }
+  if (override === callerRoomName) {
+    throw new Error('`humanAgentRoomName` must differ from the caller room name');
+  }
+  return override;
+}
+
 const CALLER_HANGUP_INSTRUCTION = `The caller has hung up before the transfer could be completed.
 Briefly inform the human agent that the caller has left and that you are ending the call now.`;
 

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -65,7 +65,7 @@ export interface WarmTransferTaskOptions {
   ringingTimeout?: number | null;
   /**
    * Name of the room used to dial and brief the human agent. Defaults to
-   * `` `${callerRoom.name}-human-agent` ``.
+   * `${callerRoom.name}-human-agent`.
    *
    * Set this to control the briefing room's configuration: pre-create a room
    * under this name (e.g. with `RoomServiceClient.createRoom` and an `egress`

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -77,7 +77,7 @@ export interface WarmTransferTaskOptions {
    * (the same lifecycle as the default room), which also ends any egress
    * attached to it. Must differ from the caller room's name.
    */
-  humanAgentRoomName?: string;
+  roomName?: string;
   /** Audio played to the caller while they are on hold during the transfer. */
   holdAudio?: AudioSourceType | AudioConfig | AudioConfig[] | null;
   /**
@@ -128,7 +128,7 @@ export function createWarmTransferTask({
   sipHeaders = {},
   dtmf,
   ringingTimeout,
-  humanAgentRoomName: rawHumanAgentRoomName,
+  roomName: rawRoomName,
   holdAudio = { source: BuiltinAudioClip.HOLD_MUSIC, volume: 0.8 },
   callerHangupInstruction,
   instructions,
@@ -145,8 +145,8 @@ export function createWarmTransferTask({
     throw new Error('`sipCallTo` must be set');
   }
 
-  if (rawHumanAgentRoomName !== undefined && rawHumanAgentRoomName.length === 0) {
-    throw new Error('`humanAgentRoomName` must not be empty');
+  if (rawRoomName !== undefined && rawRoomName.length === 0) {
+    throw new Error('`roomName` must not be empty');
   }
 
   // Resolve the SIP trunk: an explicit id wins, then a custom connection (which
@@ -387,7 +387,7 @@ export function createWarmTransferTask({
     }
 
     const ctx = jobCtx ?? getJobContext();
-    const humanAgentRoomName = resolveHumanAgentRoomName(callerRoom.name, rawHumanAgentRoomName);
+    const humanAgentRoomName = resolveHumanAgentRoomName(callerRoom.name, rawRoomName);
     const room = new Room();
     const transferAgent = new Agent({
       instructions: task.instructions,
@@ -691,7 +691,7 @@ export function resolveHumanAgentRoomName(callerRoomName: string, override?: str
     return `${callerRoomName}-human-agent`;
   }
   if (override === callerRoomName) {
-    throw new Error('`humanAgentRoomName` must differ from the caller room name');
+    throw new Error('`roomName` must differ from the caller room name');
   }
   return override;
 }

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -63,6 +63,21 @@ export interface WarmTransferTaskOptions {
    * nearest second.
    */
   ringingTimeout?: number | null;
+  /**
+   * Name of the room used to dial and brief the human agent. Defaults to
+   * `` `${callerRoom.name}-human-agent` ``.
+   *
+   * Set this to control the briefing room's configuration: pre-create a room
+   * under this name (e.g. with `RoomServiceClient.createRoom` and an `egress`
+   * request to record the transfer leg) before running the task, and the
+   * transfer agent joins the pre-configured room instead of implicitly
+   * creating one with project defaults.
+   *
+   * The room is deleted when the transfer completes, fails, or is cancelled
+   * (the same lifecycle as the default room), which also ends any egress
+   * attached to it. Must differ from the caller room's name.
+   */
+  humanAgentRoomName?: string;
   /** Audio played to the caller while they are on hold during the transfer. */
   holdAudio?: AudioSourceType | AudioConfig | AudioConfig[] | null;
   /**
@@ -113,6 +128,7 @@ export function createWarmTransferTask({
   sipHeaders = {},
   dtmf,
   ringingTimeout,
+  humanAgentRoomName: rawHumanAgentRoomName,
   holdAudio = { source: BuiltinAudioClip.HOLD_MUSIC, volume: 0.8 },
   callerHangupInstruction,
   instructions,
@@ -127,6 +143,10 @@ export function createWarmTransferTask({
 }: WarmTransferTaskOptions = {}): AgentTask<WarmTransferResult> {
   if (!sipCallTo) {
     throw new Error('`sipCallTo` must be set');
+  }
+
+  if (rawHumanAgentRoomName !== undefined && rawHumanAgentRoomName.length === 0) {
+    throw new Error('`humanAgentRoomName` must not be empty');
   }
 
   // Resolve the SIP trunk: an explicit id wins, then a custom connection (which
@@ -367,7 +387,7 @@ export function createWarmTransferTask({
     }
 
     const ctx = jobCtx ?? getJobContext();
-    const humanAgentRoomName = `${callerRoom.name}-human-agent`;
+    const humanAgentRoomName = resolveHumanAgentRoomName(callerRoom.name, rawHumanAgentRoomName);
     const room = new Room();
     const transferAgent = new Agent({
       instructions: task.instructions,


### PR DESCRIPTION
## Motivation

`WarmTransferTask` hardcodes the human-agent briefing room name as `` `${callerRoom.name}-human-agent` `` and relies on implicit room creation when the transfer agent connects. That makes it impossible to configure the briefing room ahead of time — most notably to attach a RoomComposite egress so the agent ↔ human-agent consultation leg of a warm transfer gets recorded (the caller-room leg is already recordable with a normal room egress; the consult room was not).

## Changes

- Add an optional `humanAgentRoomName` option to `WarmTransferTaskOptions` (defaults to the existing `` `${callerRoom.name}-human-agent` ``, so behavior is unchanged when unset).
- Users can now pre-create the briefing room under this name (e.g. `RoomServiceClient.createRoom` with an `egress` request); the transfer agent then joins the pre-configured room instead of implicitly creating one with project defaults.
- Extract name resolution into a `resolveHumanAgentRoomName` helper (module-level export for tests; not added to the package index).
- Validation: empty string rejected eagerly in `createWarmTransferTask`; an override equal to the caller room name rejected at dial time.
- No lifecycle changes: token grant, `room.connect`, `createSipParticipant`, `deleteRoomOnClose`, and all cancellation/teardown paths are untouched. The JSDoc documents that the room is deleted when the transfer completes/fails/cancels (which also ends any attached egress).

## Example

```ts
const consultRoomName = `${ctx.room.name}-consult`;
await roomService.createRoom({
  name: consultRoomName,
  egress: new RoomEgress({
    room: new RoomCompositeEgressRequest({ audioOnly: true, fileOutputs: [...] }),
  }),
});

await new workflows.WarmTransferTask({
  sipCallTo: SUPERVISOR_PHONE_NUMBER,
  sipTrunkId: SIP_TRUNK_ID,
  humanAgentRoomName: consultRoomName,
  chatCtx: ctx.session.history,
}).run();
```

## Testing

- New unit tests in `agents/src/workflows/warm_transfer.test.ts`: default name resolution, override, same-name-as-caller rejection, empty-string rejection (4/4 passing).
- Full `agents/src` suite: 1282 passed / 5 skipped; typecheck, build, and lint on touched files clean.
- Changeset included (`@livekit/agents`: patch).