### PR TITLE
fix(voice): export uncommitted user turn spans on close

### DIFF
--- a/.changeset/close-dangling-user-turn.md
+++ b/.changeset/close-dangling-user-turn.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+End uncommitted `user_turn` spans when audio recognition closes so speech detected without a transcript is still exported to observability.

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -1017,7 +1017,7 @@ export class AudioRecognition {
 
   private async onSTTEvent(ev: SpeechEvent) {
     // Collect provider-known STT ids for this user turn. The actual attribute is
-    // written once when the user_turn span ends (see endCommittedUserTurnSpan), to avoid
+    // written once when the user_turn span ends (see _endUserTurnSpan), to avoid
     // ordering issues with span creation.
     if (ev.requestId && !this.sttRequestIds.includes(ev.requestId)) {
       this.sttRequestIds.push(ev.requestId);
@@ -1639,7 +1639,7 @@ export class AudioRecognition {
         });
 
         if (committed) {
-          this.endCommittedUserTurnSpan({
+          this._endUserTurnSpan({
             transcript: this.audioTranscript,
             confidence: confidenceAvg,
             transcriptionDelay: metrics.transcriptionDelay ?? 0,
@@ -2245,7 +2245,7 @@ export class AudioRecognition {
     this.endUserTurnSpan();
   }
 
-  private endCommittedUserTurnSpan({
+  private _endUserTurnSpan({
     transcript,
     confidence,
     transcriptionDelay,

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -1001,6 +1001,15 @@ export class AudioRecognition {
     return this.userTurnSpan;
   }
 
+  private endUserTurnSpan(): void {
+    if (this.userTurnSpan?.isRecording()) {
+      this.userTurnSpan.end();
+    }
+    this.userTurnSpan = undefined;
+    this.userTurnStart = undefined;
+    this.sttRequestIds = [];
+  }
+
   private userTurnContext(span: Span): Context {
     const base = this.rootSpanContext ?? ROOT_CONTEXT;
     return trace.setSpan(base, span);
@@ -1008,7 +1017,7 @@ export class AudioRecognition {
 
   private async onSTTEvent(ev: SpeechEvent) {
     // Collect provider-known STT ids for this user turn. The actual attribute is
-    // written once when the user_turn span ends (see _endUserTurnSpan), to avoid
+    // written once when the user_turn span ends (see endCommittedUserTurnSpan), to avoid
     // ordering issues with span creation.
     if (ev.requestId && !this.sttRequestIds.includes(ev.requestId)) {
       this.sttRequestIds.push(ev.requestId);
@@ -1630,7 +1639,7 @@ export class AudioRecognition {
         });
 
         if (committed) {
-          this._endUserTurnSpan({
+          this.endCommittedUserTurnSpan({
             transcript: this.audioTranscript,
             confidence: confidenceAvg,
             transcriptionDelay: metrics.transcriptionDelay ?? 0,
@@ -2106,11 +2115,7 @@ export class AudioRecognition {
       this.turnDetectorFlushed = true;
     }
 
-    if (this.userTurnSpan?.isRecording()) {
-      this.userTurnSpan.end();
-    }
-    this.userTurnSpan = undefined;
-    this.sttRequestIds = [];
+    this.endUserTurnSpan();
 
     const restartStt = async () => {
       const unlock = await this.sttLifecycleLock.lock();
@@ -2234,9 +2239,13 @@ export class AudioRecognition {
 
     await this.interruptionStreamChannel?.close();
     this.cancelBackchannelBoundary();
+
+    // A speech segment may never produce a transcript or committed turn. End
+    // its span after all recognition tasks stop so it is still exported.
+    this.endUserTurnSpan();
   }
 
-  private _endUserTurnSpan({
+  private endCommittedUserTurnSpan({
     transcript,
     confidence,
     transcriptionDelay,
@@ -2257,11 +2266,8 @@ export class AudioRecognition {
       if (this.sttRequestIds.length) {
         this.userTurnSpan.setAttribute(traceTypes.ATTR_PROVIDER_REQUEST_IDS, this.sttRequestIds);
       }
-      this.userTurnSpan.end();
-      this.userTurnSpan = undefined;
-      this.userTurnStart = undefined;
     }
-    this.sttRequestIds = [];
+    this.endUserTurnSpan();
   }
 
   private get vadBaseTurnDetection() {

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -1001,15 +1001,6 @@ export class AudioRecognition {
     return this.userTurnSpan;
   }
 
-  private endUserTurnSpan(): void {
-    if (this.userTurnSpan?.isRecording()) {
-      this.userTurnSpan.end();
-    }
-    this.userTurnSpan = undefined;
-    this.userTurnStart = undefined;
-    this.sttRequestIds = [];
-  }
-
   private userTurnContext(span: Span): Context {
     const base = this.rootSpanContext ?? ROOT_CONTEXT;
     return trace.setSpan(base, span);
@@ -2115,7 +2106,7 @@ export class AudioRecognition {
       this.turnDetectorFlushed = true;
     }
 
-    this.endUserTurnSpan();
+    this._endUserTurnSpan();
 
     const restartStt = async () => {
       const unlock = await this.sttLifecycleLock.lock();
@@ -2242,32 +2233,32 @@ export class AudioRecognition {
 
     // A speech segment may never produce a transcript or committed turn. End
     // its span after all recognition tasks stop so it is still exported.
-    this.endUserTurnSpan();
+    this._endUserTurnSpan();
   }
 
-  private _endUserTurnSpan({
-    transcript,
-    confidence,
-    transcriptionDelay,
-    endOfUtteranceDelay,
-  }: {
+  private _endUserTurnSpan(info?: {
     transcript: string;
     confidence: number;
     transcriptionDelay: number;
     endOfUtteranceDelay: number;
   }): void {
-    if (this.userTurnSpan) {
+    if (this.userTurnSpan && info) {
       this.userTurnSpan.setAttributes({
-        [traceTypes.ATTR_USER_TRANSCRIPT]: transcript,
-        [traceTypes.ATTR_TRANSCRIPT_CONFIDENCE]: confidence,
-        [traceTypes.ATTR_TRANSCRIPTION_DELAY]: transcriptionDelay,
-        [traceTypes.ATTR_END_OF_TURN_DELAY]: endOfUtteranceDelay,
+        [traceTypes.ATTR_USER_TRANSCRIPT]: info.transcript,
+        [traceTypes.ATTR_TRANSCRIPT_CONFIDENCE]: info.confidence,
+        [traceTypes.ATTR_TRANSCRIPTION_DELAY]: info.transcriptionDelay,
+        [traceTypes.ATTR_END_OF_TURN_DELAY]: info.endOfUtteranceDelay,
       });
       if (this.sttRequestIds.length) {
         this.userTurnSpan.setAttribute(traceTypes.ATTR_PROVIDER_REQUEST_IDS, this.sttRequestIds);
       }
     }
-    this.endUserTurnSpan();
+    if (this.userTurnSpan?.isRecording()) {
+      this.userTurnSpan.end();
+    }
+    this.userTurnSpan = undefined;
+    this.userTurnStart = undefined;
+    this.sttRequestIds = [];
   }
 
   private get vadBaseTurnDetection() {

--- a/agents/src/voice/audio_recognition_span.test.ts
+++ b/agents/src/voice/audio_recognition_span.test.ts
@@ -368,6 +368,68 @@ describe('AudioRecognition user_turn span', () => {
     expect(hooks.onEndOfSpeech).toHaveBeenCalled();
   });
 
+  it('ends an uncommitted user_turn span when audio recognition closes', async () => {
+    const { exporter } = setupInMemoryTracing();
+
+    const hooks: RecognitionHooks = {
+      onInterruption: vi.fn(),
+      onStartOfSpeech: vi.fn(),
+      onVADInferenceDone: vi.fn(),
+      onEndOfSpeech: vi.fn(),
+      onInterimTranscript: vi.fn(),
+      onFinalTranscript: vi.fn(),
+      onPreemptiveGeneration: vi.fn(),
+      onEotPrediction: vi.fn(),
+      onAgentBackchannelOpportunity: vi.fn(),
+      retrieveChatCtx: () => ChatContext.empty(),
+      onEndOfTurn: vi.fn(async () => true),
+    };
+
+    const now = Date.now();
+    const vadEvents: VADEvent[] = [
+      {
+        type: VADEventType.START_OF_SPEECH,
+        samplesIndex: 0,
+        timestamp: now,
+        speechDuration: 100,
+        silenceDuration: 0,
+        frames: [],
+        probability: 0,
+        inferenceDuration: 0,
+        speaking: true,
+        rawAccumulatedSilence: 0,
+        rawAccumulatedSpeech: 0,
+      },
+    ];
+
+    const sttNode: STTNode = async () =>
+      new ReadableStream<SpeechEvent | string>({
+        start(controller) {
+          controller.close();
+        },
+      });
+
+    const ar = new AudioRecognition({
+      recognitionHooks: hooks,
+      stt: sttNode,
+      vad: new FakeVAD(vadEvents),
+      turnDetector: alwaysTrueTurnDetector,
+      turnDetectionMode: 'vad',
+      minEndpointingDelay: 0,
+      maxEndpointingDelay: 0,
+    });
+
+    await ar.start();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(spanByName(exporter.getFinishedSpans(), 'user_turn')).toBeUndefined();
+
+    await ar.close();
+
+    expect(spanByName(exporter.getFinishedSpans(), 'user_turn')).toBeTruthy();
+    expect(hooks.onEndOfTurn).not.toHaveBeenCalled();
+  });
+
   it('parents user_speaking under user_turn when an explicit speech context is provided', () => {
     const { exporter } = setupInMemoryTracing();
     const sessionSpan = tracer.startSpan({ name: 'agent_session', context: ROOT_CONTEXT });


### PR DESCRIPTION
Fixes [AGT-3154](https://linear.app/livekit/issue/AGT-3154/export-uncommitted-user-turn-spans-on-session-shutdown).

**Bug:** VAD can open a `user_turn` without ever receiving a transcript. Session shutdown canceled the pending commit but left the span recording, so OpenTelemetry omitted the parent while exporting its `user_speaking` children.

**Fix:** end any active turn span after recognition tasks stop. A regression test covers closing after speech starts with no transcript.