### PR TITLE
fix(elevenlabs): stop publishing Buffer pool memory as audio

### DIFF
--- a/.changeset/elevenlabs-buffer-pool-audio.md
+++ b/.changeset/elevenlabs-buffer-pool-audio.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-elevenlabs': patch
+---
+
+Pass the decoded audio chunk to `AudioByteStream` as a view rather than as its underlying `ArrayBuffer`. Node serves small `Buffer`s out of a shared pool, so the previous code discarded the chunk's `byteOffset` and `byteLength` and published the whole 8 KB pool as PCM, producing bursts of full-scale noise in the middle of synthesized speech.

--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -894,7 +894,7 @@ export class ChunkedStream extends tts.ChunkedStream {
         const { done, value } = await reader.read();
         if (done) break;
 
-        for (const frame of bstream.write(value.buffer)) {
+        for (const frame of bstream.write(value)) {
           if (lastFrame) {
             this.queue.put({ requestId, segmentId: requestId, frame: lastFrame, final: false });
           }
@@ -1098,7 +1098,7 @@ export class SynthesizeStream extends tts.SynthesizeStream {
         // Process audio queue
         while (this.#audioQueue.length > 0) {
           const audioData = this.#audioQueue.shift()!;
-          for (const frame of bstream.write(audioData.buffer)) {
+          for (const frame of bstream.write(audioData)) {
             sendLastFrame(false);
             lastFrame = frame;
           }


### PR DESCRIPTION
Fixes #2068

### Problem

`plugins/elevenlabs/src/tts.ts` hands `AudioByteStream.write()` the raw `ArrayBuffer` behind each decoded audio chunk instead of the `Buffer` view, on both the streaming and non streaming paths:

```ts
const audioData = Buffer.from(data.audio as string, 'base64');
...
for (const frame of bstream.write(audioData.buffer)) {
```

Node serves `Buffer`s below `Buffer.poolSize >>> 1` out of a shared 8 KB pool, so a small chunk is a window into a larger `ArrayBuffer`, described by `byteOffset` and `byteLength`. Passing `.buffer` discards both, and `write` honours them only for a value `ArrayBuffer.isView` accepts:

```ts
const bytes = ArrayBuffer.isView(data)
  ? new Int8Array(data.buffer, data.byteOffset, data.byteLength)
  : new Int8Array(data); // an ArrayBuffer lands here, so the whole pool is read
```

So any pooled chunk is published as the entire 8,192 byte pool: the real audio plus up to 7 KB of unrelated adjacent memory, interpreted as PCM. At the plugin's default `pcm_22050` that is 185.8 ms of audio emitted in place of the chunk.

On a live call it is a burst of loud broadband noise spliced into the middle of a sentence. It clips at full scale, so it is much louder than the speech around it, and nothing is logged.

`autoMode: true` makes it materially more likely, since letting the provider choose generation triggers produces small chunks routinely, especially at generation boundaries.

We hit this in production telephony. Across 175 call recordings every occurrence was on this plugin, and none were on Cartesia through `agents/src/inference/tts.ts`, which is not affected because it copies first: `new Int8Array(Buffer.from(...))` produces an exact size buffer, so its `.buffer` is just the chunk.

### Fix

Pass the view and let `write` apply the offset and length it already handles. Two call sites, no signature change: `write` already accepts `ArrayBufferLike | ArrayBufferView`.

### Verification

Against the real `AudioByteStream`, a 22.7 ms chunk:

| | samples emitted | duration | peak |
| --- | --- | --- | --- |
| before | 4096 | 185.8 ms | 32731 (full scale int16) |
| after | 500 | 22.7 ms | 3000 (the tone that was encoded) |

Repro script is in #2068 and needs no API key.

Also run:

- `pnpm -w format:write` and `pnpm -w lint:fix`, both clean. Note these two commands also reformat `agents/src/voice/audio_recognition.ts` and `agents/src/voice/tool_executor.ts` on a clean checkout of `main`; I reverted those so this diff stays focused.
- `@livekit/agents` and `@livekit/agents-plugin-elevenlabs` build, both pass.
- `plugins/elevenlabs/src/tts.test.ts`, 7 passed and 1 skipped.
- `api:check` for the plugin fails, but it fails identically on a clean checkout of `main`, so it looks unrelated to this change.

Added a patch changeset. Happy to drop it if maintainers would rather add release notes themselves, per CONTRIBUTING.