### PR TITLE
fix(voice): unwedge scheduler when reply is interrupted before playout starts

### DIFF
--- a/.changeset/pre-playout-interrupt-wedge.md
+++ b/.changeset/pre-playout-interrupt-wedge.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Bound the speech scheduler's wait on an interrupted generation and force-abort the reply tasks on timeout, so a reply interrupted before its playout starts no longer wedges `mainTask` and mutes the agent for the rest of the session.

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -254,6 +254,7 @@ export class AgentActivity implements RecognitionHooks {
   agentSession: AgentSession;
 
   private static readonly REPLY_TASK_CANCEL_TIMEOUT = 5000;
+  private static readonly INTERRUPTED_GENERATION_TIMEOUT = 3000;
 
   private started = false;
   private audioRecognition?: AudioRecognition;
@@ -2018,7 +2019,44 @@ export class AgentActivity implements RecognitionHooks {
         // Keep the shared outputs serialized through interrupted-generation cleanup.
         // Bare handles have no owner task that can settle the generation future.
         if (speechHandle.interrupted && speechHandle._tasks.length > 0) {
-          await ThrowsPromise.race([generation, abortFuture.await]);
+          // A reply interrupted before its playout starts can park the reply task on
+          // audioOutput.waitForPlayout() with nothing left to fire the playback event:
+          // the replyAbortController only aborts after the segment loop returns, and the
+          // segment loop is blocked on that same await. Generation then never settles and
+          // the scheduler stays wedged on this handle forever, leaving the agent mute for
+          // the rest of the session (#2065). Bound the wait; on timeout, cancel the
+          // handle's tasks — their abort path runs the normal interrupted-reply cleanup,
+          // which settles the generation future.
+          let generationSettled = false;
+          const watchedGeneration = generation.finally(() => {
+            generationSettled = true;
+          });
+          const forceAbortFut = new Future<void, never>();
+          const forceAbortTimer = setTimeout(
+            () => forceAbortFut.resolve(),
+            AgentActivity.INTERRUPTED_GENERATION_TIMEOUT,
+          );
+          try {
+            await ThrowsPromise.race([watchedGeneration, abortFuture.await, forceAbortFut.await]);
+          } finally {
+            clearTimeout(forceAbortTimer);
+          }
+          if (!generationSettled && !signal.aborted) {
+            this.logger.warn(
+              {
+                speech_id: speechHandle.id,
+                timeout_ms: AgentActivity.INTERRUPTED_GENERATION_TIMEOUT,
+              },
+              'interrupted speech generation is stuck, forcing pipeline abort',
+            );
+            await cancelAndWait(
+              speechHandle._tasks.filter((task) => !task.done),
+              AgentActivity.REPLY_TASK_CANCEL_TIMEOUT,
+            );
+            if (!speechHandle.done()) {
+              speechHandle._markDone();
+            }
+          }
         }
         this._currentSpeech = undefined;
       }

--- a/agents/src/voice/agent_activity_pre_playout_interrupt.test.ts
+++ b/agents/src/voice/agent_activity_pre_playout_interrupt.test.ts
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression test for livekit/agents-js#2065.
+ *
+ * When a pipeline reply is interrupted before its playout has started, the
+ * reply task parks on `audioOutput.waitForPlayout()` inside its interrupted
+ * branch: the playback-finished event never fires (playback never began) and
+ * the reply abort controller is only aborted by code that runs after the
+ * segment loop returns — which is blocked on that same await. The handle's
+ * generation future then never settles, `mainTask` never advances past the
+ * wedged handle, and the agent stays mute for the rest of the session.
+ *
+ * The fix bounds mainTask's interrupted-generation wait and, on timeout,
+ * cancels the handle's tasks; their abort path runs the normal
+ * interrupted-reply cleanup, which settles the generation future and lets the
+ * scheduler advance to the next speech.
+ */
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream } from 'node:stream/web';
+import { describe, expect, it, vi } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { Agent } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AudioOutput } from './io.js';
+import { FakeLLM } from './testing/fake_llm.js';
+
+function frame(durationMs = 20, sampleRate = 24000): AudioFrame {
+  const samples = Math.floor((sampleRate * durationMs) / 1000);
+  return new AudioFrame(new Int16Array(samples), sampleRate, 1, samples);
+}
+
+// Audio sink where playback never starts: frames are accepted but no
+// playback-started/-finished event is ever reported — the interruption lands
+// before the output began playing. `waitForPlayout()` on a captured segment
+// therefore never resolves, which is the wedge condition of #2065. Real
+// outputs behave this way when the interrupt wins the race against the first
+// played frame (e.g. a reply generated in an agent-handoff onEnter while the
+// user is still speaking).
+class NeverStartsOutput extends AudioOutput {
+  onFrameCaptured?: () => void;
+  framesCaptured = 0;
+
+  constructor() {
+    super(24000);
+  }
+
+  async captureFrame(f: AudioFrame): Promise<void> {
+    await super.captureFrame(f);
+    this.framesCaptured++;
+    this.onFrameCaptured?.();
+  }
+
+  flush(): void {
+    super.flush();
+  }
+
+  clearBuffer(): void {
+    // Playback never started, so there is no playback event to report.
+  }
+}
+
+// Agent that synthesizes a few real frames for whatever text it receives, so
+// the audio path produces frames without a TTS provider.
+class FrameAgent extends Agent {
+  constructor() {
+    super({ instructions: 'test' });
+  }
+
+  async ttsNode(): Promise<ReadableStream<AudioFrame> | null> {
+    return new ReadableStream<AudioFrame>({
+      start(controller) {
+        for (let i = 0; i < 10; i++) controller.enqueue(frame());
+        controller.close();
+      },
+    });
+  }
+}
+
+describe('pre-playout interruption (#2065)', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('unwedges the speech scheduler when a reply is interrupted before playout starts', async () => {
+    const session = new AgentSession({
+      llm: new FakeLLM([
+        { input: 'hello', content: 'A reply that never reaches the speaker.' },
+        { input: 'again', content: 'A follow-up reply.' },
+      ]),
+    });
+    const audioOut = new NeverStartsOutput();
+    session.output.audio = audioOut;
+
+    // Interrupt (non-force, like a new user turn) as soon as the first frame
+    // is captured — before the output ever reports playback start.
+    let interruptedOnce = false;
+    audioOut.onFrameCaptured = () => {
+      if (!interruptedOnce) {
+        interruptedOnce = true;
+        session.interrupt();
+      }
+    };
+
+    await session.start({ agent: new FrameAgent() });
+    try {
+      const wedged = session.generateReply({ userInput: 'hello' });
+      // Pre-fix, the interrupted handle's generation never settles and this
+      // await hangs until the test times out.
+      await wedged.waitForPlayout();
+
+      // The scheduler must have moved past the wedged handle: a follow-up
+      // reply gets authorized and its audio reaches the output.
+      const framesBefore = audioOut.framesCaptured;
+      session.generateReply({ userInput: 'again' });
+      await vi.waitFor(() => expect(audioOut.framesCaptured).toBeGreaterThan(framesBefore), {
+        timeout: 5000,
+      });
+    } finally {
+      await session.close();
+    }
+  }, 15000);
+});


### PR DESCRIPTION
Fixes #2065

## Problem

When a pipeline reply is interrupted before its playout has started, `AgentActivity.mainTask` hangs forever on the interrupted handle's generation future and `_currentSpeech` is never cleared — the agent goes permanently silent for the rest of the session, until an external mechanism (idle/duration guard, user disconnect) tears it down.

Mechanism (full trace in #2065): the reply task's interrupted branch awaits `raceWithAbort(audioOutput.waitForPlayout(), replyAbortController.signal)`. The playback-finished event never fires because playback never began, and `replyAbortController.abort()` only happens in code that runs after the segment loop returns — the same loop that is blocked on that await. The reply task therefore never settles the generation future, and `mainTask`'s second wait on it (`ThrowsPromise.race([generation, abortFuture.await])`) deadlocks, since `abortFuture` only resolves on activity teardown.

## Change

In `mainTask`'s interrupted-generation branch:

- bound the wait on the generation future (`INTERRUPTED_GENERATION_TIMEOUT`, 3 s) in addition to `abortFuture`;
- if the generation still hasn't settled (tracked by a settled flag, so a concurrent settle never triggers the fallback) and the activity isn't shutting down, log one warning and cancel the handle's pending tasks via the existing `cancelAndWait` util — cancelling the reply task trips its own `replyAbortController`, so the parked `raceWithAbort` resolves and the reply task runs its normal interrupted-reply cleanup (partial-transcript commit, speaking→listening transition, `_markGenerationDone()`);
- `_markDone()` only as a safety net if the tasks don't settle within `REPLY_TASK_CANCEL_TIMEOUT`.

Healthy paths are untouched: an uninterrupted reply never enters this branch; a post-playout-start interruption settles the generation within milliseconds (the timer is cleared in `finally`, and the settled flag prevents any force-abort); activity shutdown still exits via `abortFuture` / `signal.aborted`.

## Validation

- New regression test `agents/src/voice/agent_activity_pre_playout_interrupt.test.ts`: an audio output that accepts frames but never reports playback started/finished, plus a non-force interrupt fired on the first captured frame. Without the fix the test hangs until timeout; with the fix the wedged handle settles (~3 s) and a follow-up reply reaches the output.
- Full `agents` package suite passes (101 files / 1290 tests); `typecheck`, `throws:check`, and lint on the touched files are clean.
- Downstream validation in the production-shaped voice harness that originally reproduced #2065 (multi-agent handoff with user speech overlapping the handoff window, VAD turn detection): the trigger scenario went from a deterministic 0/3 to 3/3 with these exact wait-bound + force-abort semantics applied as a dist-level patch, with the agent recovering its voice ~5 s after the interrupt and no recurrence of the wedge signature.
