### PR TITLE
fix(room_io): respect outputOptions.audioPublishOptions when publishing audio track

### DIFF
--- a/.changeset/room-io-audio-publish-options.md
+++ b/.changeset/room-io-audio-publish-options.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Respect `outputOptions.audioPublishOptions` when publishing the agent's audio track. `ParticipantAudioOutput.publishTrack()` previously ignored the configured `trackPublishOptions` and always published with hardcoded defaults, making it impossible to disable DTX/RED on the output track.

--- a/agents/src/voice/room_io/_output.test.ts
+++ b/agents/src/voice/room_io/_output.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { LocalAudioTrack, TrackPublishOptions, TrackSource } from '@livekit/rtc-node';
 import { describe, expect, it, vi } from 'vitest';
 import { Future } from '../../utils.js';
 import { ParticipantAudioOutput } from './_output.js';
@@ -218,5 +219,43 @@ describe('ParticipantAudioOutput captureFrame segment accounting', () => {
     expect(output.playbackSegmentsCount).toBe(1);
     expect(output.audioSource.captureFrame).toHaveBeenCalledTimes(1);
     expect(output.pushedDuration).toBeGreaterThan(0);
+  });
+});
+
+describe('ParticipantAudioOutput publishTrack', () => {
+  it('publishes with the configured trackPublishOptions', async () => {
+    const trackPublishOptions = new TrackPublishOptions({
+      source: TrackSource.SOURCE_MICROPHONE,
+      dtx: false,
+      red: false,
+    });
+
+    const output = Object.create(ParticipantAudioOutput.prototype) as ParticipantAudioOutput & {
+      options: { trackPublishOptions: TrackPublishOptions };
+      audioSource: unknown;
+      startedFuture: Future<void>;
+      room: unknown;
+      publishTrack: (signal: AbortSignal) => Promise<void>;
+    };
+
+    const fakeTrack = {} as LocalAudioTrack;
+    const createAudioTrack = vi
+      .spyOn(LocalAudioTrack, 'createAudioTrack')
+      .mockReturnValue(fakeTrack);
+    const publishTrack = vi.fn(async () => ({ waitForSubscription: async () => {} }));
+
+    output.options = { trackPublishOptions };
+    output.audioSource = {};
+    output.startedFuture = new Future<void>();
+    output.room = { localParticipant: { publishTrack } };
+
+    try {
+      await output.publishTrack(new AbortController().signal);
+    } finally {
+      createAudioTrack.mockRestore();
+    }
+
+    expect(publishTrack).toHaveBeenCalledWith(fakeTrack, trackPublishOptions);
+    expect(output.startedFuture.done).toBe(true);
   });
 });

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -532,7 +532,8 @@ export class ParticipantAudioOutput extends AudioOutput {
     const track = LocalAudioTrack.createAudioTrack('roomio_audio', this.audioSource);
     this.publication = await this.room.localParticipant?.publishTrack(
       track,
-      new TrackPublishOptions({ source: TrackSource.SOURCE_MICROPHONE }),
+      this.options.trackPublishOptions ??
+        new TrackPublishOptions({ source: TrackSource.SOURCE_MICROPHONE }),
     );
 
     if (signal.aborted) {


### PR DESCRIPTION
## Description

Fixes #1954.

`RoomIO` accepts `outputOptions.audioPublishOptions` and threads it into `ParticipantAudioOutput` as `options.trackPublishOptions`, but `publishTrack()` never read it. It always published with a fresh hardcoded `new TrackPublishOptions({ source: TrackSource.SOURCE_MICROPHONE })`, so the configured option was silently dropped.

Because the proto fields are optional, unset `dtx`/`red` fall through to the Rust FFI defaults (`dtx: true, red: true`), which means agents could not disable Opus DTX or RED on their output track no matter what they passed. With DTX forced on, TTS audio containing silence padding produces audible gate/pop artifacts at sentence boundaries.

## Changes Made

- `ParticipantAudioOutput.publishTrack()` now publishes with `this.options.trackPublishOptions`, keeping the previous hardcoded options as a fallback. No behavior change for callers who don't pass `audioPublishOptions`: `DEFAULT_ROOM_OUTPUT_OPTIONS` already supplies `new TrackPublishOptions({ source: TrackSource.SOURCE_MICROPHONE })`.
- Added a regression test in `_output.test.ts` asserting `publishTrack()` uses the configured options (verified it fails against the previous implementation).
- Added a changeset (`@livekit/agents` patch).

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: N/A (no UI-facing change; see Testing)

## Testing
- [x] Automated tests added/updated (if applicable)
- [x] All tests pass

`pnpm build` (tsup + `tsc --declaration`), `eslint`, `prettier --check`, and `vitest run src/voice/room_io/_output.test.ts` (6/6) all pass locally. The new test fails without the one-line fix and passes with it.

## Additional Notes

The issue includes a runtime repro: publishing with `dtx: false, red: false` via `outputOptions.audioPublishOptions` and observing the publisher SDP still negotiating `usedtx=1`. After this change the configured options reach `localParticipant.publishTrack()` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
