### PR TITLE
fix(voice): don't re-issue in-flight tool calls

### DIFF
--- a/.changeset/prevent-running-tool-duplicates.md
+++ b/.changeset/prevent-running-tool-duplicates.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Prevent in-flight tool calls from being re-issued on later turns and preserve completed tool outputs when a turn is interrupted.

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -965,10 +965,12 @@ describe('AgentActivity - interrupted tool completion', () => {
     const toolItemsAdded = vi.fn();
     const activity = Object.create(AgentActivity.prototype) as AgentActivity;
     const chatCtx = ChatContext.empty();
+    const sessionHistory = ChatContext.empty();
     Object.assign(activity, {
       agent: { _chatCtx: chatCtx },
       agentSession: {
         emit,
+        history: sessionHistory,
         _toolItemsAdded: toolItemsAdded,
       },
       logger: { info() {}, debug() {}, warn() {}, error() {} },
@@ -984,6 +986,8 @@ describe('AgentActivity - interrupted tool completion', () => {
       output: 'transferred',
       isError: false,
     });
+    chatCtx.insert(call);
+    sessionHistory.insert(call);
     const toolOutput = {
       output: [
         ToolExecutionOutput.create({
@@ -1007,7 +1011,9 @@ describe('AgentActivity - interrupted tool completion', () => {
       }
     )._commitInterruptedToolOutputs(toolOutput, SpeechHandle.create(), 123);
 
+    expect(chatCtx.items).not.toContain(call);
     expect(chatCtx.items).not.toContain(output);
+    expect(sessionHistory.items).not.toContain(call);
     expect(emit).not.toHaveBeenCalled();
     expect(toolItemsAdded).not.toHaveBeenCalled();
   });
@@ -1017,9 +1023,10 @@ describe('AgentActivity - interrupted tool completion', () => {
     const toolItemsAdded = vi.fn();
     const activity = Object.create(AgentActivity.prototype) as AgentActivity;
     const chatCtx = ChatContext.empty();
+    const sessionHistory = ChatContext.empty();
     Object.assign(activity, {
       agent: { _chatCtx: chatCtx },
-      agentSession: { emit, _toolItemsAdded: toolItemsAdded },
+      agentSession: { emit, history: sessionHistory, _toolItemsAdded: toolItemsAdded },
       logger: { info() {}, debug() {}, warn() {}, error() {} },
     });
     const completedCall = FunctionCall.create({
@@ -1044,6 +1051,8 @@ describe('AgentActivity - interrupted tool completion', () => {
       output: 'transferred',
       isError: false,
     });
+    chatCtx.insert([completedCall, handoffCall]);
+    sessionHistory.insert([completedCall, handoffCall]);
     const toolOutput = {
       output: [
         ToolExecutionOutput.create({
@@ -1073,7 +1082,9 @@ describe('AgentActivity - interrupted tool completion', () => {
       }
     )._commitInterruptedToolOutputs(toolOutput, SpeechHandle.create(), 123);
 
-    expect(chatCtx.items).toEqual([completedOutput]);
+    expect(chatCtx.items).toHaveLength(2);
+    expect(chatCtx.items).toEqual(expect.arrayContaining([completedCall, completedOutput]));
+    expect(sessionHistory.items).toEqual([completedCall]);
     expect(toolItemsAdded).toHaveBeenCalledWith([completedOutput]);
     expect(emit).toHaveBeenCalledWith(
       AgentSessionEventTypes.FunctionToolsExecuted,

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -16,14 +16,20 @@
  */
 import { Heap } from 'heap-js';
 import { describe, expect, it, vi } from 'vitest';
-import { AgentConfigUpdate, ChatContext } from '../llm/chat_context.js';
+import {
+  AgentConfigUpdate,
+  ChatContext,
+  FunctionCall,
+  FunctionCallOutput,
+} from '../llm/chat_context.js';
 import { LLM, type LLMStream } from '../llm/llm.js';
 import { type Tool, ToolContext, ToolFlag, Toolset, tool } from '../llm/tool_context.js';
 import { Future, Task } from '../utils.js';
-import { _getActivityTaskInfo } from './agent.js';
+import { AgentTask, _getActivityTaskInfo } from './agent.js';
 import { AgentActivity, onEnterStorage } from './agent_activity.js';
 import type { PreemptiveGenerationInfo } from './audio_recognition.js';
-import type { AgentSessionEventTypes, UserInputTranscribedEvent } from './events.js';
+import { AgentSessionEventTypes, type UserInputTranscribedEvent } from './events.js';
+import { ToolExecutionOutput } from './generation.js';
 import { SpeechHandle } from './speech_handle.js';
 
 const agentMocks = vi.hoisted(() => ({
@@ -898,5 +904,278 @@ describe('AgentActivity - waitForIdle close abort', () => {
     // close() aborts the shared signal; the wait must unblock.
     closeAbort.abort();
     expect(await raceTimeout(pending, 1000)).toBe('resolved');
+  });
+});
+
+describe('AgentActivity - interrupted tool completion', () => {
+  it('preserves completed outputs without starting a tool-reply generation', () => {
+    const generateReply = vi.fn();
+    const toolItemsAdded = vi.fn();
+    const activity = Object.create(AgentActivity.prototype) as AgentActivity;
+    const chatCtx = ChatContext.empty();
+    Object.assign(activity, {
+      agent: { _chatCtx: chatCtx },
+      agentSession: {
+        emit: vi.fn(),
+        _toolItemsAdded: toolItemsAdded,
+        generateReply,
+      },
+      logger: { info() {}, debug() {}, warn() {}, error() {} },
+    });
+    const call = FunctionCall.create({
+      callId: 'call_completed',
+      name: 'charge_card',
+      args: '{}',
+    });
+    const output = FunctionCallOutput.create({
+      callId: call.callId,
+      name: call.name,
+      output: 'charged',
+      isError: false,
+    });
+    const toolOutput = {
+      output: [
+        ToolExecutionOutput.create({
+          toolCall: call,
+          toolCallOutput: output,
+          rawOutput: 'charged',
+          replyRequired: true,
+        }),
+      ],
+      firstToolStartedFuture: new Future<void>(),
+    };
+
+    (
+      activity as unknown as {
+        _commitInterruptedToolOutputs: (
+          toolOutput: typeof toolOutput,
+          speechHandle: SpeechHandle,
+          createdAt: number,
+        ) => void;
+      }
+    )._commitInterruptedToolOutputs(toolOutput, SpeechHandle.create(), 123);
+
+    expect(chatCtx.items).toContain(output);
+    expect(toolItemsAdded).toHaveBeenCalledWith([output]);
+    expect(generateReply).not.toHaveBeenCalled();
+  });
+
+  it('does not persist an interrupted handoff as completed', () => {
+    const emit = vi.fn();
+    const toolItemsAdded = vi.fn();
+    const activity = Object.create(AgentActivity.prototype) as AgentActivity;
+    const chatCtx = ChatContext.empty();
+    Object.assign(activity, {
+      agent: { _chatCtx: chatCtx },
+      agentSession: {
+        emit,
+        _toolItemsAdded: toolItemsAdded,
+      },
+      logger: { info() {}, debug() {}, warn() {}, error() {} },
+    });
+    const call = FunctionCall.create({
+      callId: 'call_handoff',
+      name: 'transfer_to_specialist',
+      args: '{}',
+    });
+    const output = FunctionCallOutput.create({
+      callId: call.callId,
+      name: call.name,
+      output: 'transferred',
+      isError: false,
+    });
+    const toolOutput = {
+      output: [
+        ToolExecutionOutput.create({
+          toolCall: call,
+          toolCallOutput: output,
+          rawOutput: 'transferred',
+          replyRequired: false,
+          agentTask: new AgentTask({ instructions: 'Handle the specialist request.' }),
+        }),
+      ],
+      firstToolStartedFuture: new Future<void>(),
+    };
+
+    (
+      activity as unknown as {
+        _commitInterruptedToolOutputs: (
+          toolOutput: typeof toolOutput,
+          speechHandle: SpeechHandle,
+          createdAt: number,
+        ) => void;
+      }
+    )._commitInterruptedToolOutputs(toolOutput, SpeechHandle.create(), 123);
+
+    expect(chatCtx.items).not.toContain(output);
+    expect(emit).not.toHaveBeenCalled();
+    expect(toolItemsAdded).not.toHaveBeenCalled();
+  });
+
+  it('commits and emits only completed regular tools from a mixed interrupted batch', () => {
+    const emit = vi.fn();
+    const toolItemsAdded = vi.fn();
+    const activity = Object.create(AgentActivity.prototype) as AgentActivity;
+    const chatCtx = ChatContext.empty();
+    Object.assign(activity, {
+      agent: { _chatCtx: chatCtx },
+      agentSession: { emit, _toolItemsAdded: toolItemsAdded },
+      logger: { info() {}, debug() {}, warn() {}, error() {} },
+    });
+    const completedCall = FunctionCall.create({
+      callId: 'call_completed_mixed',
+      name: 'save_note',
+      args: '{}',
+    });
+    const completedOutput = FunctionCallOutput.create({
+      callId: completedCall.callId,
+      name: completedCall.name,
+      output: 'saved',
+      isError: false,
+    });
+    const handoffCall = FunctionCall.create({
+      callId: 'call_handoff_mixed',
+      name: 'transfer_to_specialist',
+      args: '{}',
+    });
+    const handoffOutput = FunctionCallOutput.create({
+      callId: handoffCall.callId,
+      name: handoffCall.name,
+      output: 'transferred',
+      isError: false,
+    });
+    const toolOutput = {
+      output: [
+        ToolExecutionOutput.create({
+          toolCall: completedCall,
+          toolCallOutput: completedOutput,
+          rawOutput: 'saved',
+          replyRequired: true,
+        }),
+        ToolExecutionOutput.create({
+          toolCall: handoffCall,
+          toolCallOutput: handoffOutput,
+          rawOutput: 'transferred',
+          replyRequired: false,
+          agentTask: new AgentTask({ instructions: 'Handle the specialist request.' }),
+        }),
+      ],
+      firstToolStartedFuture: new Future<void>(),
+    };
+
+    (
+      activity as unknown as {
+        _commitInterruptedToolOutputs: (
+          toolOutput: typeof toolOutput,
+          speechHandle: SpeechHandle,
+          createdAt: number,
+        ) => void;
+      }
+    )._commitInterruptedToolOutputs(toolOutput, SpeechHandle.create(), 123);
+
+    expect(chatCtx.items).toEqual([completedOutput]);
+    expect(toolItemsAdded).toHaveBeenCalledWith([completedOutput]);
+    expect(emit).toHaveBeenCalledWith(
+      AgentSessionEventTypes.FunctionToolsExecuted,
+      expect.objectContaining({
+        functionCalls: [completedCall],
+        functionCallOutputs: [completedOutput],
+      }),
+    );
+  });
+});
+
+describe('AgentActivity - interruption while waiting for tools', () => {
+  function buildToolOutput() {
+    const call = FunctionCall.create({
+      callId: 'call_waiting',
+      name: 'save_note',
+      args: '{}',
+    });
+    const output = FunctionCallOutput.create({
+      callId: call.callId,
+      name: call.name,
+      output: 'saved',
+      isError: false,
+    });
+    return {
+      output: [
+        ToolExecutionOutput.create({
+          toolCall: call,
+          toolCallOutput: output,
+          rawOutput: 'saved',
+          replyRequired: true,
+        }),
+      ],
+      firstToolStartedFuture: new Future<void>(),
+    };
+  }
+
+  type WaitForToolExecution = (options: {
+    executeToolsTask: {
+      result: Promise<void>;
+      cancelAndWait: (timeout: number) => Promise<void>;
+    };
+    toolOutput: ReturnType<typeof buildToolOutput>;
+    speechHandle: SpeechHandle;
+    createdAt: number;
+  }) => Promise<boolean>;
+
+  function buildActivity() {
+    const commitInterruptedToolOutputs = vi.fn();
+    const activity = Object.create(AgentActivity.prototype) as AgentActivity;
+    Object.assign(activity, {
+      _backgroundSpeeches: new Set<SpeechHandle>(),
+      _commitInterruptedToolOutputs: commitInterruptedToolOutputs,
+    });
+    const waitForToolExecution = (
+      activity as unknown as { _waitForToolExecution: WaitForToolExecution }
+    )._waitForToolExecution.bind(activity);
+    return { activity, commitInterruptedToolOutputs, waitForToolExecution };
+  }
+
+  it('commits completed outputs when already interrupted before waiting', async () => {
+    const { activity, commitInterruptedToolOutputs, waitForToolExecution } = buildActivity();
+    const speechHandle = SpeechHandle.create();
+    speechHandle.interrupt();
+    const cancelAndWait = vi.fn(async () => {});
+    const toolOutput = buildToolOutput();
+
+    const shouldContinue = await waitForToolExecution({
+      executeToolsTask: { result: Promise.resolve(), cancelAndWait },
+      toolOutput,
+      speechHandle,
+      createdAt: 123,
+    });
+
+    expect(shouldContinue).toBe(false);
+    expect(cancelAndWait).toHaveBeenCalledOnce();
+    expect(commitInterruptedToolOutputs).toHaveBeenCalledWith(toolOutput, speechHandle, 123);
+    expect(activity['_backgroundSpeeches']).not.toContain(speechHandle);
+  });
+
+  it('rechecks interruption after tool execution settles', async () => {
+    const { activity, commitInterruptedToolOutputs, waitForToolExecution } = buildActivity();
+    const speechHandle = SpeechHandle.create();
+    const executionFinished = new Future<void>();
+    const toolOutput = buildToolOutput();
+
+    const waiting = waitForToolExecution({
+      executeToolsTask: {
+        result: executionFinished.await,
+        cancelAndWait: vi.fn(async () => {}),
+      },
+      toolOutput,
+      speechHandle,
+      createdAt: 456,
+    });
+    expect(activity['_backgroundSpeeches']).toContain(speechHandle);
+
+    speechHandle.interrupt();
+    executionFinished.resolve();
+
+    await expect(waiting).resolves.toBe(false);
+    expect(commitInterruptedToolOutputs).toHaveBeenCalledWith(toolOutput, speechHandle, 456);
+    expect(activity['_backgroundSpeeches']).not.toContain(speechHandle);
   });
 });

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -3969,6 +3969,17 @@ export class AgentActivity implements RecognitionHooks {
     speechHandle: SpeechHandle,
     createdAt: number,
   ): void {
+    const interruptedHandoffCallIds = toolOutput.output
+      .filter((output) => output.agentTask !== undefined)
+      .map((output) => output.toolCall.callId);
+    if (interruptedHandoffCallIds.length > 0) {
+      const interruptedHandoffCallIdSet = new Set(interruptedHandoffCallIds);
+      for (const chatCtx of [this.agent._chatCtx, this.agentSession.history]) {
+        chatCtx.items = chatCtx.items.filter(
+          (item) => item.type !== 'function_call' || !interruptedHandoffCallIdSet.has(item.callId),
+        );
+      }
+    }
     const completedOutputs = toolOutput.output.filter((output) => output.agentTask === undefined);
     if (completedOutputs.length === 0) return;
     const { functionToolsExecutedEvent } = this.summarizeToolExecutionOutput(

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -122,6 +122,8 @@ import type { ToolExecutionOutput, ToolOutput, _TTSGenerationData } from './gene
 import {
   type _AudioOut,
   type _TextOut,
+  _injectRunningToolCalls,
+  _stripRunningToolCalls,
   applyInstructionsModality,
   forwardedTextFor,
   performAudioForwarding,
@@ -137,6 +139,7 @@ import { type InputDetails, SpeechHandle } from './speech_handle.js';
 import {
   ToolExecutor,
   cancelTaskTool,
+  getRunningTasks,
   getRunningTasksTool,
   hasCancellableTool,
 } from './tool_executor.js';
@@ -2740,6 +2743,8 @@ export class AgentActivity implements RecognitionHooks {
     // apply the correct variant of the instructions for the turn's input modality
     applyInstructionsModality(chatCtx, { modality: speechHandle.inputDetails.modality });
 
+    const runningCalls = getRunningTasks(this.agentSession);
+    _injectRunningToolCalls(chatCtx, runningCalls);
     const tasks: Array<Task<void>> = [];
     const [llmTask, llmGenData] = performLLMInference(
       // preserve  `this` context in llmNode
@@ -3173,6 +3178,7 @@ export class AgentActivity implements RecognitionHooks {
         speechHandle._markGenerationDone();
       }
       await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+      this._commitInterruptedToolOutputs(toolOutput, speechHandle, replyStartedAt);
       return;
     }
 
@@ -3218,17 +3224,13 @@ export class AgentActivity implements RecognitionHooks {
       speechHandle._markGenerationDone();
     }
 
-    if (speechHandle.interrupted) {
-      await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
-      return;
-    }
-
-    this._backgroundSpeeches.add(speechHandle);
-    try {
-      await executeToolsTask.result;
-    } finally {
-      this._backgroundSpeeches.delete(speechHandle);
-    }
+    const toolExecutionCompleted = await this._waitForToolExecution({
+      executeToolsTask,
+      toolOutput,
+      speechHandle,
+      createdAt: replyStartedAt,
+    });
+    if (!toolExecutionCompleted) return;
 
     if (toolOutput.output.length === 0) return;
 
@@ -3261,6 +3263,7 @@ export class AgentActivity implements RecognitionHooks {
       ...functionToolsExecutedEvent.functionCallOutputs,
     ] as ChatItem[];
     if (shouldGenerateToolReply) {
+      _stripRunningToolCalls(chatCtx);
       chatCtx.insert(toolMessages);
 
       // Increment step count on the existing handle.
@@ -3926,6 +3929,64 @@ export class AgentActivity implements RecognitionHooks {
     });
 
     this.scheduleSpeech(replySpeechHandle, SpeechHandle.SPEECH_PRIORITY_NORMAL, true);
+  }
+
+  /** @internal */
+  async _waitForToolExecution({
+    executeToolsTask,
+    toolOutput,
+    speechHandle,
+    createdAt,
+  }: {
+    executeToolsTask: Pick<Task<void>, 'result' | 'cancelAndWait'>;
+    toolOutput: ToolOutput;
+    speechHandle: SpeechHandle;
+    createdAt: number;
+  }): Promise<boolean> {
+    if (speechHandle.interrupted) {
+      await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+      this._commitInterruptedToolOutputs(toolOutput, speechHandle, createdAt);
+      return false;
+    }
+
+    this._backgroundSpeeches.add(speechHandle);
+    try {
+      await executeToolsTask.result;
+    } finally {
+      this._backgroundSpeeches.delete(speechHandle);
+    }
+
+    if (speechHandle.interrupted) {
+      this._commitInterruptedToolOutputs(toolOutput, speechHandle, createdAt);
+      return false;
+    }
+    return true;
+  }
+
+  /** @internal */
+  _commitInterruptedToolOutputs(
+    toolOutput: ToolOutput,
+    speechHandle: SpeechHandle,
+    createdAt: number,
+  ): void {
+    const completedOutputs = toolOutput.output.filter((output) => output.agentTask === undefined);
+    if (completedOutputs.length === 0) return;
+    const { functionToolsExecutedEvent } = this.summarizeToolExecutionOutput(
+      { ...toolOutput, output: completedOutputs },
+      speechHandle,
+    );
+    this.agentSession.emit(
+      AgentSessionEventTypes.FunctionToolsExecuted,
+      functionToolsExecutedEvent,
+    );
+    const outputs = functionToolsExecutedEvent.functionCallOutputs;
+    for (const output of outputs) {
+      output.createdAt = createdAt;
+    }
+    if (outputs.length > 0) {
+      this.agent._chatCtx.insert(outputs);
+      this.agentSession._toolItemsAdded(outputs);
+    }
   }
 
   private summarizeToolExecutionOutput(toolOutput: ToolOutput, speechHandle: SpeechHandle) {

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -38,13 +38,13 @@ import {
   isFlushSentinel,
 } from '../types.js';
 import {
+  type Aborted,
   Future,
   IdleTimeoutError,
   Task,
   shortuuid,
   toError,
   waitForAbort,
-  waitUntilAborted,
   waitUntilTimeout,
 } from '../utils.js';
 import {
@@ -73,6 +73,68 @@ import { type TextTransform, applyTextTransforms } from './transcription/text_tr
 
 export const DEFAULT_TTS_READ_IDLE_TIMEOUT_MS = 10_000;
 export const DEFAULT_FORWARD_AUDIO_IDLE_TIMEOUT_MS = 10_000;
+export const RUNNING_TOOL_PLACEHOLDER = 'The tool call is still in progress.';
+export const RUNNING_TOOL_PLACEHOLDER_KEY = '__lk_running_placeholder__';
+const RUNNING_TOOL_PLACEHOLDER_OUTPUT_ID_PREFIX = 'lk_running_placeholder/';
+
+export function _injectRunningToolCalls(
+  chatCtx: ChatContext,
+  runningCalls: Iterable<FunctionCall>,
+): void {
+  const existingCallIds = new Set(
+    chatCtx.items
+      .filter((item): item is FunctionCall => item.type === 'function_call')
+      .map((item) => item.callId),
+  );
+  const existingOutputIds = new Set(
+    chatCtx.items
+      .filter((item): item is FunctionCallOutput => item.type === 'function_call_output')
+      .map((item) => item.callId),
+  );
+
+  for (const runningCall of runningCalls) {
+    if (existingOutputIds.has(runningCall.callId)) continue;
+    if (!existingCallIds.has(runningCall.callId)) {
+      existingCallIds.add(runningCall.callId);
+      chatCtx.insert(
+        FunctionCall.create({
+          ...runningCall,
+          extra: { ...runningCall.extra, [RUNNING_TOOL_PLACEHOLDER_KEY]: true },
+        }),
+      );
+    }
+    existingOutputIds.add(runningCall.callId);
+    chatCtx.insert(
+      FunctionCallOutput.create({
+        id: `${RUNNING_TOOL_PLACEHOLDER_OUTPUT_ID_PREFIX}${runningCall.callId}`,
+        callId: runningCall.callId,
+        name: runningCall.name,
+        output: RUNNING_TOOL_PLACEHOLDER,
+        isError: false,
+        createdAt: runningCall.createdAt,
+      }),
+    );
+  }
+}
+
+export function _stripRunningToolCalls(chatCtx: ChatContext): void {
+  const injectedCallIds = new Set(
+    chatCtx.items
+      .filter(
+        (item): item is FunctionCall =>
+          item.type === 'function_call' && item.extra[RUNNING_TOOL_PLACEHOLDER_KEY] === true,
+      )
+      .map((item) => item.callId),
+  );
+  chatCtx.items = chatCtx.items.filter(
+    (item) =>
+      !(
+        (item.type === 'function_call' && injectedCallIds.has(item.callId)) ||
+        (item.type === 'function_call_output' &&
+          item.id.startsWith(RUNNING_TOOL_PLACEHOLDER_OUTPUT_ID_PREFIX))
+      ),
+  );
+}
 
 /** @internal */
 export class _LLMGenerationData {
@@ -1198,14 +1260,16 @@ export function performToolExecutions({
         span.setAttribute(traceTypes.ATTR_FUNCTION_TOOL_NAME, toolCall.name);
         span.setAttribute(traceTypes.ATTR_FUNCTION_TOOL_ARGS, toolCall.args);
 
-        // await for task to complete, if task is aborted, set exception
+        // Only completed executions produce tool output. An interrupted execution may still
+        // finish in the background and must remain retryable rather than becoming a synthetic
+        // error result in conversation history.
         let toolOutput: ToolExecutionOutput | undefined;
         try {
-          const { result, isAborted } = await waitUntilAborted(toolExecTask, signal);
+          const { result, isAborted } = await _waitForToolExecutionResult(toolExecTask, signal);
+          if (isAborted) return;
           toolOutput = createToolOutput({
             toolCall,
-            exception: isAborted ? new Error('tool call was aborted') : undefined,
-            output: isAborted ? undefined : result,
+            output: result,
           });
 
           if (toolOutput.toolCallOutput) {
@@ -1240,8 +1304,7 @@ export function performToolExecutions({
             span.setAttribute(traceTypes.ATTR_FUNCTION_TOOL_IS_ERROR, true);
           }
         } finally {
-          if (!toolOutput) throw new Error('toolOutput is undefined');
-          toolCompleted(toolOutput);
+          if (toolOutput) toolCompleted(toolOutput);
         }
       };
 
@@ -1322,6 +1385,40 @@ export function performToolExecutions({
   };
 
   return [Task.from(executeToolsTask, controller, 'performToolExecutions'), toolOutput];
+}
+
+/**
+ * Race tool completion against interruption while preferring an already-settled result.
+ *
+ * A plain pre-abort short circuit can discard a result that settled earlier in the same
+ * JavaScript turn but whose reaction has not run yet. Passing the original promise first to
+ * `Promise.race` preserves the settlement order in that case.
+ *
+ * @internal
+ */
+export async function _waitForToolExecutionResult<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<Aborted<T>> {
+  const aborted = Symbol('tool execution aborted');
+  let onAbort: (() => void) | undefined;
+  const abortPromise = new Promise<typeof aborted>((resolve) => {
+    onAbort = () => resolve(aborted);
+    if (signal.aborted) {
+      resolve(aborted);
+    } else {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+
+  try {
+    const result = await Promise.race([promise, abortPromise]);
+    return result === aborted
+      ? { result: undefined, isAborted: true }
+      : { result, isAborted: false };
+  } finally {
+    if (onAbort) signal.removeEventListener('abort', onAbort);
+  }
 }
 
 export function removeInstructions(chatCtx: ChatContext) {

--- a/agents/src/voice/generation_tools.test.ts
+++ b/agents/src/voice/generation_tools.test.ts
@@ -8,8 +8,14 @@ import { FunctionCall, ToolContext, ToolError, tool } from '../llm/index.js';
 import { initializeLogger } from '../log.js';
 import type { Task } from '../utils.js';
 import { cancelAndWait, delay } from '../utils.js';
+import { AgentTask } from './agent.js';
 import type { AgentSession } from './agent_session.js';
-import { type _TextOut, performTextForwarding, performToolExecutions } from './generation.js';
+import {
+  type _TextOut,
+  _waitForToolExecutionResult,
+  performTextForwarding,
+  performToolExecutions,
+} from './generation.js';
 import type { SpeechHandle } from './speech_handle.js';
 import { ToolExecutor } from './tool_executor.js';
 
@@ -233,10 +239,90 @@ describe('Generation + Tool Execution', () => {
     await execTask.result;
 
     expect(aborted).toBe(true);
-    expect(toolOutput.output.length).toBe(1);
-    const out = toolOutput.output[0];
-    expect(out?.toolCallOutput?.isError).toBe(true);
+    expect(toolOutput.output).toHaveLength(0);
   }, 20_000);
+
+  it('keeps a settled tool result when abort is observed in the same tick', async () => {
+    const replyAbortController = new AbortController();
+    const settled = Promise.resolve('completed');
+    replyAbortController.abort();
+
+    await expect(
+      _waitForToolExecutionResult(settled, replyAbortController.signal),
+    ).resolves.toEqual({
+      result: 'completed',
+      isAborted: false,
+    });
+  });
+
+  it('keeps completed output while omitting interrupted regular tools and handoffs', async () => {
+    const replyAbortController = new AbortController();
+    const neverFinish = new Promise<void>(() => {});
+    let signalSlowStarted!: () => void;
+    const slowStarted = new Promise<void>((resolve) => {
+      signalSlowStarted = resolve;
+    });
+    let signalHandoffStarted!: () => void;
+    const handoffStarted = new Promise<void>((resolve) => {
+      signalHandoffStarted = resolve;
+    });
+    let signalCompleted!: () => void;
+    const completed = new Promise<void>((resolve) => {
+      signalCompleted = resolve;
+    });
+
+    const immediate = tool({
+      name: 'immediate',
+      description: 'Completes before interruption.',
+      parameters: z.object({}),
+      execute: async () => 'completed',
+    });
+    const slow = tool({
+      name: 'slow',
+      description: 'Remains in flight during interruption.',
+      parameters: z.object({}),
+      execute: async () => {
+        signalSlowStarted();
+        await neverFinish;
+        return 'unreachable';
+      },
+    });
+    const handoff = tool({
+      name: 'handoff',
+      description: 'Returns a handoff only if allowed to finish.',
+      parameters: z.object({}),
+      execute: async () => {
+        signalHandoffStarted();
+        await neverFinish;
+        return new AgentTask({ instructions: 'Handle the transferred request.' });
+      },
+    });
+    const calls = [
+      FunctionCall.create({ callId: 'call_completed', name: immediate.name, args: '{}' }),
+      FunctionCall.create({ callId: 'call_slow', name: slow.name, args: '{}' }),
+      FunctionCall.create({ callId: 'call_handoff', name: handoff.name, args: '{}' }),
+    ];
+    const completedCallIds: string[] = [];
+
+    const [execTask, toolOutput] = performToolExecutions({
+      session: {} as any,
+      speechHandle: { id: 'speech_mixed_abort', _itemAdded: () => {} } as any,
+      toolCtx: new ToolContext([immediate, slow, handoff]) as any,
+      toolCallStream: createFunctionCallStreamFromArray(calls),
+      controller: replyAbortController,
+      onToolExecutionCompleted: (output) => {
+        completedCallIds.push(output.toolCall.callId);
+        if (output.toolCall.callId === 'call_completed') signalCompleted();
+      },
+    });
+
+    await Promise.all([completed, slowStarted, handoffStarted]);
+    replyAbortController.abort();
+    await execTask.result;
+
+    expect(toolOutput.output.map((output) => output.toolCall.callId)).toEqual(['call_completed']);
+    expect(completedCallIds).toEqual(['call_completed']);
+  });
 
   it('resolves firstToolStartedFuture even when the only tool call is duplicate-rejected', async () => {
     const sharedExecutor = new ToolExecutor({ owningActivity: null });

--- a/agents/src/voice/run_context.ts
+++ b/agents/src/voice/run_context.ts
@@ -56,6 +56,7 @@ export interface AttachedToolExecutor<UserData = UnknownUserData> {
 export class RunContext<UserData = UnknownUserData> {
   private readonly initialStepIdx: number;
   private _executor?: AttachedToolExecutor<UserData>;
+  private _executorAttachment?: object;
   private _firstUpdateFuture?: Future<unknown>;
   private _updates: Array<[FunctionCall, FunctionCallOutput]> = [];
   private _fillerSchedulers: FillerScheduler<UserData>[] = [];
@@ -206,16 +207,21 @@ export class RunContext<UserData = UnknownUserData> {
   _attachExecutor(
     executor: AttachedToolExecutor<UserData>,
     firstUpdateFuture: Future<unknown>,
-  ): void {
+  ): object {
     if (this._firstUpdateFuture !== undefined) {
       throw new Error('Executor already attached');
     }
+    const attachment = {};
     this._executor = executor;
+    this._executorAttachment = attachment;
     this._firstUpdateFuture = firstUpdateFuture;
+    return attachment;
   }
 
-  _detachExecutor(): void {
+  _detachExecutor(attachment: object): void {
+    if (this._executorAttachment !== attachment) return;
     this._executor = undefined;
+    this._executorAttachment = undefined;
     this._firstUpdateFuture = undefined;
   }
 

--- a/agents/src/voice/running_tool_placeholders.test.ts
+++ b/agents/src/voice/running_tool_placeholders.test.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { ChatContext, ChatMessage, FunctionCall } from '../llm/chat_context.js';
+import { _injectRunningToolCalls, _stripRunningToolCalls } from './generation.js';
+
+describe('running tool placeholders', () => {
+  it('adds a valid in-progress pair for a running call missing from the LLM context', () => {
+    const chatCtx = ChatContext.empty();
+    const running = FunctionCall.create({
+      callId: 'call_1',
+      name: 'book_flight',
+      args: '{}',
+    });
+
+    _injectRunningToolCalls(chatCtx, [running]);
+
+    expect(
+      chatCtx.items.filter(
+        (item) => item.type === 'function_call' && item.callId === running.callId,
+      ),
+    ).toHaveLength(1);
+    expect(
+      chatCtx.items.filter(
+        (item) => item.type === 'function_call_output' && item.callId === running.callId,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('adds only the missing output when the running call is already in context', () => {
+    const running = FunctionCall.create({
+      callId: 'call_orphan',
+      name: 'charge_card',
+      args: '{}',
+    });
+    const chatCtx = new ChatContext([running]);
+
+    _injectRunningToolCalls(chatCtx, [running]);
+
+    expect(
+      chatCtx.items.filter(
+        (item) => item.type === 'function_call' && item.callId === running.callId,
+      ),
+    ).toHaveLength(1);
+    expect(
+      chatCtx.items.filter(
+        (item) => item.type === 'function_call_output' && item.callId === running.callId,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('strips only ephemeral items while preserving an original orphan call and custom edits', () => {
+    const orphan = FunctionCall.create({
+      callId: 'call_orphan',
+      name: 'charge_card',
+      args: '{}',
+    });
+    const fullyMissing = FunctionCall.create({
+      callId: 'call_missing',
+      name: 'send_email',
+      args: '{}',
+    });
+    const custom = ChatMessage.create({ role: 'system', content: 'custom llm node context' });
+    const chatCtx = new ChatContext([orphan]);
+
+    _injectRunningToolCalls(chatCtx, [orphan, fullyMissing]);
+    chatCtx.insert(custom);
+    _stripRunningToolCalls(chatCtx);
+
+    expect(chatCtx.items).toContain(orphan);
+    expect(chatCtx.items).toContain(custom);
+    expect(chatCtx.items.some((item) => item.type === 'function_call_output')).toBe(false);
+    expect(
+      chatCtx.items.some(
+        (item) => item.type === 'function_call' && item.callId === fullyMissing.callId,
+      ),
+    ).toBe(false);
+  });
+});

--- a/agents/src/voice/tool_executor.test.ts
+++ b/agents/src/voice/tool_executor.test.ts
@@ -9,7 +9,7 @@ import { Future } from '../utils.js';
 import type { AgentSession } from './agent_session.js';
 import { RunContext } from './run_context.js';
 import { SpeechHandle } from './speech_handle.js';
-import { ToolExecutor, getRunningTasks } from './tool_executor.js';
+import { ToolExecutor, _getCancellableRunningTasks, getRunningTasks } from './tool_executor.js';
 
 describe('ToolExecutor', () => {
   function buildRunContext(
@@ -185,6 +185,7 @@ describe('ToolExecutor', () => {
 
     expect(cancelled).toBe('cancelled');
     expect(getRunningTasks(runCtx.session)).toHaveLength(1);
+    expect(_getCancellableRunningTasks(runCtx.session)).toHaveLength(0);
 
     neverFinish.resolve();
     await new Promise((resolve) => setTimeout(resolve, 0));

--- a/agents/src/voice/tool_executor.test.ts
+++ b/agents/src/voice/tool_executor.test.ts
@@ -161,7 +161,7 @@ describe('ToolExecutor', () => {
     await executor.waitForAll();
   });
 
-  it('returns from cancel even when a cancellable tool ignores abortSignal', async () => {
+  it('returns from cancel but keeps a non-cooperative tool visible until it actually settles', async () => {
     const executor = new ToolExecutor();
     const { runCtx } = buildRunContext('non_cooperative_cancel');
     const neverFinish = new Future<void>();
@@ -184,6 +184,125 @@ describe('ToolExecutor', () => {
     ]);
 
     expect(cancelled).toBe('cancelled');
+    expect(getRunningTasks(runCtx.session)).toHaveLength(1);
+
+    neverFinish.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getRunningTasks(runCtx.session)).toHaveLength(0);
+  });
+
+  it('detaches a cancelled non-cooperative tool before it sends a late update', async () => {
+    const executor = new ToolExecutor();
+    const { runCtx, history } = buildRunContext('late_update_after_cancel');
+    const releaseLateUpdate = new Future<void>();
+    const lateUpdateFinished = new Future<void>();
+    const releaseTool = new Future<void>();
+    const lookup = tool({
+      name: 'late_update_after_cancel',
+      description: 'Non-cooperative cancellable lookup',
+      flags: ToolFlag.CANCELLABLE,
+      execute: async (_, { ctx }) => {
+        await ctx.update('started');
+        await releaseLateUpdate.await;
+        await ctx.update('late');
+        lateUpdateFinished.resolve();
+        await releaseTool.await;
+        return 'done';
+      },
+    });
+
+    await executor.execute({ tool: lookup, runCtx, rawArguments: {} });
+    await executor.cancel(runCtx.functionCall.callId);
+    releaseLateUpdate.resolve();
+    await lateUpdateFinished.await;
+
+    expect(history.items).toHaveLength(0);
+    expect(getRunningTasks(runCtx.session)).toHaveLength(1);
+
+    releaseTool.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getRunningTasks(runCtx.session)).toHaveLength(0);
+  });
+
+  it('detaches closed tools before they send late updates', async () => {
+    const executor = new ToolExecutor();
+    const { runCtx, history } = buildRunContext('late_update_after_close');
+    const releaseLateUpdate = new Future<void>();
+    const lateUpdateFinished = new Future<void>();
+    const releaseTool = new Future<void>();
+    const lookup = tool({
+      name: 'late_update_after_close',
+      description: 'Non-cooperative lookup',
+      execute: async (_, { ctx }) => {
+        await ctx.update('started');
+        await releaseLateUpdate.await;
+        await ctx.update('late');
+        lateUpdateFinished.resolve();
+        await releaseTool.await;
+        return 'done';
+      },
+    });
+
+    await executor.execute({ tool: lookup, runCtx, rawArguments: {} });
+    await executor.aclose();
+    releaseLateUpdate.resolve();
+    await lateUpdateFinished.await;
+
+    expect(history.items).toHaveLength(0);
+
+    releaseTool.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  it('does not let an abandoned task clean up its same-call replacement', async () => {
+    const executor = new ToolExecutor();
+    const { runCtx, history } = buildRunContext('same_call_replacement');
+    const releaseOriginal = new Future<void>();
+    const original = tool({
+      name: 'same_call_replacement',
+      description: 'Original non-cooperative tool',
+      flags: ToolFlag.CANCELLABLE,
+      execute: async (_, { ctx }) => {
+        await ctx.update('original started');
+        await releaseOriginal.await;
+        return 'original done';
+      },
+    });
+
+    await executor.execute({ tool: original, runCtx, rawArguments: {} });
+    await executor.cancel(runCtx.functionCall.callId);
+
+    const releaseReplacementUpdate = new Future<void>();
+    const replacementUpdateFinished = new Future<void>();
+    const releaseReplacement = new Future<void>();
+    const replacement = tool({
+      name: 'same_call_replacement',
+      description: 'Replacement tool',
+      flags: ToolFlag.CANCELLABLE,
+      execute: async (_, { ctx }) => {
+        await ctx.update('replacement started');
+        await releaseReplacementUpdate.await;
+        await ctx.update('replacement still running');
+        replacementUpdateFinished.resolve();
+        await releaseReplacement.await;
+        return 'replacement done';
+      },
+    });
+
+    await executor.execute({ tool: replacement, runCtx, rawArguments: {} });
+    expect(getRunningTasks(runCtx.session)).toHaveLength(1);
+
+    releaseOriginal.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(executor.hasRunningTasks).toBe(true);
+    expect(getRunningTasks(runCtx.session)).toHaveLength(1);
+
+    releaseReplacementUpdate.resolve();
+    await replacementUpdateFinished.await;
+    expect(history.items).toHaveLength(2);
+
+    releaseReplacement.resolve();
+    await executor.waitForAll();
     expect(getRunningTasks(runCtx.session)).toHaveLength(0);
   });
 
@@ -302,6 +421,30 @@ describe('ToolExecutor', () => {
     expect(getRunningTasks(second.runCtx.session)).toHaveLength(0);
 
     neverFinish.resolve();
+    await executor.waitForAll();
+  });
+
+  it('exposes non-cancellable calls through the session-wide running registry', async () => {
+    const executor = new ToolExecutor();
+    const { runCtx } = buildRunContext('non_cancellable_running');
+    const release = new Future<void>();
+    const lookup = tool({
+      name: 'non_cancellable_running',
+      description: 'Non-cancellable running lookup',
+      execute: async (_, { ctx }) => {
+        await ctx.update('started');
+        await release.await;
+        return 'done';
+      },
+    });
+
+    await executor.execute({ tool: lookup, runCtx, rawArguments: {} });
+
+    expect(getRunningTasks(runCtx.session).map((call) => call.callId)).toEqual([
+      runCtx.functionCall.callId,
+    ]);
+
+    release.resolve();
     await executor.waitForAll();
   });
 });

--- a/agents/src/voice/tool_executor.ts
+++ b/agents/src/voice/tool_executor.ts
@@ -131,7 +131,7 @@ export const getRunningTasksTool = tool({
   name: 'lk_agents_get_running_tasks',
   description: 'Get the list of running tool calls that are cancellable.',
   execute: async (_, { ctx }) =>
-    getCancellableRunningTasks(ctx.session).map((call) => call.toJSON(true)),
+    _getCancellableRunningTasks(ctx.session).map((call) => call.toJSON(true)),
 });
 
 export const cancelTaskTool = tool({
@@ -671,9 +671,10 @@ export function getRunningTasks(session: AgentSession): FunctionCall[] {
   );
 }
 
-function getCancellableRunningTasks(session: AgentSession): FunctionCall[] {
+/** @internal */
+export function _getCancellableRunningTasks(session: AgentSession): FunctionCall[] {
   return [...(runningTasks.get(session)?.values() ?? [])]
-    .filter((task) => task.allowCancellation)
+    .filter((task) => task.allowCancellation && !task.controller.signal.aborted)
     .map((task) => FunctionCall.create({ ...task.ctx.functionCall }));
 }
 

--- a/agents/src/voice/tool_executor.ts
+++ b/agents/src/voice/tool_executor.ts
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Mutex } from '@livekit/mutex';
 import { z } from 'zod';
-import { ChatContext, FunctionCall, FunctionCallOutput } from '../llm/chat_context.js';
+import type { ChatContext, FunctionCallOutput } from '../llm/chat_context.js';
+import { FunctionCall } from '../llm/chat_context.js';
 import {
   CONFIRM_DUPLICATE_PARAM,
   type DuplicateMode,
@@ -111,6 +112,7 @@ type RunningTask = {
   controller: AbortController;
   firstUpdateFuture: Future<unknown>;
   executor: ToolExecutor;
+  attachment: object;
   allowCancellation: boolean;
   // Guarded handle to the raw user `execute()` promise (never rejects). `drain()`
   // waits on this to detect tools that keep running after being aborted.
@@ -128,7 +130,8 @@ const runningTasks = new WeakMap<AgentSession<any>, Map<string, RunningTask>>();
 export const getRunningTasksTool = tool({
   name: 'lk_agents_get_running_tasks',
   description: 'Get the list of running tool calls that are cancellable.',
-  execute: async (_, { ctx }) => getRunningTasks(ctx.session).map((call) => call.toJSON(true)),
+  execute: async (_, { ctx }) =>
+    getCancellableRunningTasks(ctx.session).map((call) => call.toJSON(true)),
 });
 
 export const cancelTaskTool = tool({
@@ -222,7 +225,7 @@ export class ToolExecutor {
       }
 
       const firstUpdateFuture = new Future<unknown>();
-      runCtx._attachExecutor(this, firstUpdateFuture);
+      const attachment = runCtx._attachExecutor(this, firstUpdateFuture);
 
       const controller = new AbortController();
       const abort = () => {
@@ -258,10 +261,15 @@ export class ToolExecutor {
         controller,
         toolPromiseRef,
       }).finally(() => {
-        this.runningTasks.delete(callId);
-        runningTasks.get(runCtx.session)?.delete(callId);
+        if (this.runningTasks.get(callId)?.attachment === attachment) {
+          this.runningTasks.delete(callId);
+        }
+        const sessionTasks = runningTasks.get(runCtx.session);
+        if (sessionTasks?.get(callId)?.attachment === attachment) {
+          sessionTasks.delete(callId);
+        }
         abortSignal?.removeEventListener('abort', abort);
-        runCtx._detachExecutor();
+        runCtx._detachExecutor(attachment);
       });
 
       const task: RunningTask = {
@@ -270,6 +278,7 @@ export class ToolExecutor {
         controller,
         firstUpdateFuture,
         executor: this,
+        attachment,
         allowCancellation: Boolean(tool.flags & ToolFlag.CANCELLABLE),
         toolPromiseRef,
       };
@@ -319,10 +328,9 @@ export class ToolExecutor {
     if (!task.firstUpdateFuture.done) {
       task.firstUpdateFuture.resolve(undefined);
     }
+    task.ctx._detachExecutor(task.attachment);
 
     this.runningTasks.delete(callId);
-    runningTasks.get(task.ctx.session)?.delete(callId);
-    task.ctx._detachExecutor();
     void task.promise.catch(() => undefined);
     // We've abandoned the wait, but the user's execute() may ignore the abort
     // signal and keep running. Error if it hasn't stopped by the deadline.
@@ -402,8 +410,7 @@ export class ToolExecutor {
       if (!task.firstUpdateFuture.done) {
         task.firstUpdateFuture.resolve(undefined);
       }
-      runningTasks.get(task.ctx.session)?.delete(task.ctx.functionCall.callId);
-      task.ctx._detachExecutor();
+      task.ctx._detachExecutor(task.attachment);
       void task.promise.catch(() => undefined);
     }
     this.runningTasks.clear();
@@ -659,6 +666,12 @@ export function buildExecutorMap({
 }
 
 export function getRunningTasks(session: AgentSession): FunctionCall[] {
+  return [...(runningTasks.get(session)?.values() ?? [])].map((task) =>
+    FunctionCall.create({ ...task.ctx.functionCall }),
+  );
+}
+
+function getCancellableRunningTasks(session: AgentSession): FunctionCall[] {
   return [...(runningTasks.get(session)?.values() ?? [])]
     .filter((task) => task.allowCancellation)
     .map((task) => FunctionCall.create({ ...task.ctx.functionCall }));


### PR DESCRIPTION
## Summary
- inject ephemeral call/output placeholders for every session-wide in-flight tool before LLM inference
- preserve completed regular outputs across interruption while keeping interrupted tools and handoffs retryable
- prevent abandoned or stale tool tasks from emitting late replies or cleaning up same-call replacements
- supersedes #1890 with a clean one-commit branch from current `main`

## Test plan
- [x] `pnpm test agents/src/voice/running_tool_placeholders.test.ts agents/src/voice/tool_executor.test.ts agents/src/voice/agent_activity.test.ts agents/src/voice/generation_tools.test.ts` (52 tests)
- [x] `pnpm build`
- [x] Cue CLI voice-mode red/green: baseline `sid_35a508903005` reproduced `INFLIGHT PLACEHOLDER FAIL DUPLICATE ISSUED`; final `sid_7b0f00cb2ee9` resolved `INFLIGHT PLACEHOLDER PASS`
- [x] Independent spec and code-quality review approved