### PR TITLE
fix(agents): make mergeFrames linear instead of quadratic

### DIFF
--- a/.changeset/merge-frames-linear.md
+++ b/.changeset/merge-frames-linear.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Make `mergeFrames` linear instead of quadratic. It previously rebuilt the accumulated buffer with a boxed spread on every frame (`new Int16Array([...data, ...frame.data])`), costing O(total_samples x frame_count) copies. It now sums lengths in one pass and copies each frame once into a preallocated `Int16Array`. Merging a 30s utterance of 10ms frames drops from ~60s of blocked event loop to under a millisecond; callers include the Silero VAD inference loop, STT plugin `recognize` paths, and TTS `ChunkedStream.collect()`.

--- a/agents/src/utils.test.ts
+++ b/agents/src/utils.test.ts
@@ -13,6 +13,7 @@ import {
   dedent,
   delay,
   isPending,
+  mergeFrames,
   resampleStream,
   toStream,
 } from '../src/utils.js';
@@ -931,6 +932,45 @@ world
       const outputFrames = await streamToArray(outputStream);
 
       expect(outputFrames).toEqual([]);
+    });
+  });
+
+  describe('mergeFrames', () => {
+    const frame = (samples: number[], sampleRate = 16000, channels = 1): AudioFrame =>
+      new AudioFrame(new Int16Array(samples), sampleRate, channels, samples.length / channels);
+
+    it('returns a non-array frame as-is', () => {
+      const f = frame([1, 2, 3]);
+      expect(mergeFrames(f)).toBe(f);
+    });
+
+    it('concatenates frame data in order', () => {
+      const merged = mergeFrames([frame([1, 2]), frame([3]), frame([4, 5, 6])]);
+      expect(Array.from(merged.data)).toEqual([1, 2, 3, 4, 5, 6]);
+      expect(merged.samplesPerChannel).toBe(6);
+      expect(merged.sampleRate).toBe(16000);
+      expect(merged.channels).toBe(1);
+    });
+
+    it('handles multi-channel frames', () => {
+      const merged = mergeFrames([frame([1, 2, 3, 4], 48000, 2), frame([5, 6], 48000, 2)]);
+      expect(Array.from(merged.data)).toEqual([1, 2, 3, 4, 5, 6]);
+      expect(merged.samplesPerChannel).toBe(3);
+      expect(merged.channels).toBe(2);
+    });
+
+    it('throws on empty buffer', () => {
+      expect(() => mergeFrames([])).toThrow(TypeError);
+    });
+
+    it('throws on sample rate mismatch', () => {
+      expect(() => mergeFrames([frame([1]), frame([2], 48000)])).toThrow('sample rate mismatch');
+    });
+
+    it('throws on channel count mismatch', () => {
+      expect(() => mergeFrames([frame([1, 2], 16000, 1), frame([3, 4], 16000, 2)])).toThrow(
+        'channel count mismatch',
+      );
     });
   });
 });

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -70,7 +70,7 @@ export const mergeFrames = (buffer: AudioBuffer): AudioFrame => {
     const sampleRate = buffer[0]!.sampleRate;
     const channels = buffer[0]!.channels;
     let samplesPerChannel = 0;
-    let data = new Int16Array();
+    let dataLength = 0;
 
     for (const frame of buffer) {
       if (frame.sampleRate !== sampleRate) {
@@ -81,8 +81,15 @@ export const mergeFrames = (buffer: AudioBuffer): AudioFrame => {
         throw new TypeError('channel count mismatch');
       }
 
-      data = new Int16Array([...data, ...frame.data]);
+      dataLength += frame.data.length;
       samplesPerChannel += frame.samplesPerChannel;
+    }
+
+    const data = new Int16Array(dataLength);
+    let offset = 0;
+    for (const frame of buffer) {
+      data.set(frame.data, offset);
+      offset += frame.data.length;
     }
 
     return new AudioFrame(data, sampleRate, channels, samplesPerChannel);


### PR DESCRIPTION
## Description

Fixes #1995.

`mergeFrames` in `agents/src/utils.ts` rebuilt the accumulated buffer with a boxed spread on every iteration (`data = new Int16Array([...data, ...frame.data])`), so merging k frames of S total samples cost O(S*k) element copies with per-element boxing instead of O(S). This function sits on several hot paths: the Silero VAD inference loop calls it twice per 32ms window, all the buffer-based STT plugins' `recognize` paths pass whole-utterance frame arrays, and TTS `ChunkedStream.collect()` merges every synthesized frame.

Measured on the repro from the issue (10ms 48kHz mono frames, median of repeated runs):

| N frames | before (ms) | after (ms) |
|---|---|---|
| 10 | 0.63 | 0.002 |
| 100 | 65.9 | 0.013 |
| 500 | 1654 | 0.055 |
| 3000 (30s utterance) | 61957 | 0.219 |

Before the fix, ratios grow quadratically (N=500 is ~2600x N=10); after, growth is linear and a 30s utterance merge drops from ~62s of blocked event loop to 0.22ms.

## Changes Made

- `mergeFrames` now validates and sums frame lengths in one pass, then copies each frame once into a preallocated `Int16Array` via `set()` — same approach as the local helper already in `agents/src/inference/vad.ts`. Semantics are unchanged: same `TypeError`s for empty/mismatched buffers, always returns a fresh frame for array input, passthrough for single-frame input.
- Added unit tests for `mergeFrames` (ordering, multi-channel, error cases) — there was no existing coverage.
- Added a changeset (`@livekit/agents` patch).

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: N/A (no behavior change; perf fix with benchmark above)

## Testing
- [x] Automated tests added/updated (if applicable)
- [x] All tests pass

`pnpm build` (tsup + `tsc --declaration`), `eslint`, `prettier --check`, and the full `@livekit/agents` vitest suite (1336 passed) all pass locally. Note: `src/telemetry/traces.otel2.type.test.ts` fails to import on a clean checkout of `main` too (missing optional otel2 dep, see #1879) — unrelated to this change.

## Additional Notes

`@livekit/rtc-node`'s `combineAudioFrames` has the same shape of problem (`buffer.map((x) => [...x.data]).flat()` — linear but heavily boxed), which is why this PR fixes `mergeFrames` in place rather than delegating to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
