### PR TITLE
fix(voice): prevent recorder interruption deadlock

### DIFF
--- a/.changeset/delegate-recorder-playout-waits.md
+++ b/.changeset/delegate-recorder-playout-waits.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Prevent interrupted voice replies from deadlocking when audio recording wraps synchronized playout.

--- a/agents/src/voice/recorder_io/recorder_io.test.ts
+++ b/agents/src/voice/recorder_io/recorder_io.test.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { initializeLogger } from '../../log.js';
 import { type StreamChannel, createStreamChannel } from '../../stream/stream_channel.js';
-import { isWritableStreamClosedError } from '../../utils.js';
+import { Future, isWritableStreamClosedError } from '../../utils.js';
 import type { AgentSession } from '../agent_session.js';
 import { AudioInput, AudioOutput } from '../io.js';
 import { RecorderIO } from './recorder_io.js';
@@ -35,12 +35,19 @@ class FakeAudioOutput extends AudioOutput {
 }
 
 class WaitAwareAudioOutput extends FakeAudioOutput {
-  waitCalled = false;
+  readonly waitStarted = new Future<void>();
+  private readonly continueWait = new Future<void>();
 
   async waitForPlayout() {
-    this.waitCalled = true;
+    const waitForCurrentSegment = super.waitForPlayout();
+    this.waitStarted.resolve();
+    await this.continueWait.await;
     this.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
-    return super.waitForPlayout();
+    return waitForCurrentSegment;
+  }
+
+  releaseWait() {
+    this.continueWait.resolve();
   }
 }
 
@@ -132,16 +139,23 @@ describe('RecorderIO close', () => {
 });
 
 describe('RecorderAudioOutput', () => {
-  it('delegates playout waits to the wrapped output', async () => {
+  it('snapshots its segment before delegating the playout wait', async () => {
     const recorder = new RecorderIO({ agentSession: {} as AgentSession });
     const downstream = new WaitAwareAudioOutput();
     const output = recorder.recordOutput(downstream);
 
     await output.captureFrame(makeFrame(20));
-    const event = await output.waitForPlayout();
+    const waitForFirstSegment = output.waitForPlayout();
+    await downstream.waitStarted.await;
 
-    expect(downstream.waitCalled).toBe(true);
+    output.flush();
+    await output.captureFrame(makeFrame(20));
+    downstream.releaseWait();
+
+    const event = await waitForFirstSegment;
+
     expect(event).toEqual({ playbackPosition: 0, interrupted: true });
+    downstream.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
     await recorder.close();
   });
 });

--- a/agents/src/voice/recorder_io/recorder_io.test.ts
+++ b/agents/src/voice/recorder_io/recorder_io.test.ts
@@ -34,6 +34,16 @@ class FakeAudioOutput extends AudioOutput {
   clearBuffer(): void {}
 }
 
+class WaitAwareAudioOutput extends FakeAudioOutput {
+  waitCalled = false;
+
+  async waitForPlayout() {
+    this.waitCalled = true;
+    this.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
+    return super.waitForPlayout();
+  }
+}
+
 function makeFrame(durationMs: number, sampleRate = 48000, channels = 1): AudioFrame {
   const samplesPerChannel = Math.floor((durationMs / 1000) * sampleRate);
   return new AudioFrame(
@@ -119,6 +129,21 @@ describe('RecorderIO close', () => {
     expect(fs.existsSync(outputPath)).toBe(true);
     expect(fs.statSync(outputPath).size).toBeGreaterThan(0);
   }, 15000);
+});
+
+describe('RecorderAudioOutput', () => {
+  it('delegates playout waits to the wrapped output', async () => {
+    const recorder = new RecorderIO({ agentSession: {} as AgentSession });
+    const downstream = new WaitAwareAudioOutput();
+    const output = recorder.recordOutput(downstream);
+
+    await output.captureFrame(makeFrame(20));
+    const event = await output.waitForPlayout();
+
+    expect(downstream.waitCalled).toBe(true);
+    expect(event).toEqual({ playbackPosition: 0, interrupted: true });
+    await recorder.close();
+  });
 });
 
 describe('RecorderIO writable stream error detection', () => {

--- a/agents/src/voice/recorder_io/recorder_io.ts
+++ b/agents/src/voice/recorder_io/recorder_io.ts
@@ -790,6 +790,13 @@ class RecorderAudioOutput extends AudioOutput {
     }
   }
 
+  async waitForPlayout(): Promise<PlaybackFinishedEvent> {
+    if (this.nextInChain) {
+      await this.nextInChain.waitForPlayout();
+    }
+    return super.waitForPlayout();
+  }
+
   flush(): void {
     super.flush();
 

--- a/agents/src/voice/recorder_io/recorder_io.ts
+++ b/agents/src/voice/recorder_io/recorder_io.ts
@@ -791,10 +791,11 @@ class RecorderAudioOutput extends AudioOutput {
   }
 
   async waitForPlayout(): Promise<PlaybackFinishedEvent> {
+    const waitForRecorder = super.waitForPlayout();
     if (this.nextInChain) {
       await this.nextInChain.waitForPlayout();
     }
-    return super.waitForPlayout();
+    return waitForRecorder;
   }
 
   flush(): void {


### PR DESCRIPTION
## Summary
- delegate recorder playout waits to the wrapped audio output so synchronized outputs can reconcile dropped interrupted segments
- add a regression test covering downstream wait delegation
- add a patch changeset for `@livekit/agents`

## Test plan
- [x] Reproduced the pre-fix deadlock with chained Cue turns using Deepgram Nova-3, GPT-5.4, and Inworld TTS
- [x] Verified the same Cue scenario resolves after the fix
- [x] `pnpm exec vitest run agents/src/voice/recorder_io/recorder_io.test.ts --exclude '.worktrees/**'`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`