### PR TITLE
chore: keep plain-chat-content release as patch

### DIFF
--- a/.changeset/plain-chat-content.md
+++ b/.changeset/plain-chat-content.md
@@ -1,5 +1,5 @@
 ---
-'@livekit/agents': minor
+'@livekit/agents': patch
 '@livekit/agents-plugin-anthropic': patch
 '@livekit/agents-plugin-google': patch
 '@livekit/agents-plugin-livekit': patch


### PR DESCRIPTION
## Summary
- Downgrade `.changeset/plain-chat-content.md` (`#2087`) from `minor` → `patch` for `@livekit/agents`.
- This is the only remaining minor changeset on `main`, and it was causing [Version Packages #2082](https://github.com/livekit/agents-js/pull/2082) to target `1.6.0` instead of `1.5.5`.

## Test plan
- [ ] Confirm the Changesets release PR (`#2082`) regenerates as `@livekit/agents@1.5.5` (patch) after this merges
- [ ] Confirm no other open changesets on `main` still declare `minor`


Made with [Cursor](https://cursor.com)