### PR TITLE
fix(interruption): keep the overlap armed when agent speech restarts mid-interrupt

### DIFF
--- a/.changeset/adaptive-interruption-overlap-state.md
+++ b/.changeset/adaptive-interruption-overlap-state.md
@@ -1,0 +1,22 @@
+---
+'@livekit/agents': patch
+---
+
+fix(interruption): keep adaptive interruption armed when agent speech restarts mid-overlap
+
+`overlapSpeechStarted` is the gate that lets a user's overlapping audio reach the interruption
+model, and only a VAD start-of-speech raises it. Two events cleared it while the user was still
+talking, and because VAD never re-announces speech that is already under way, nothing could re-arm
+it for the rest of the agent turn: every remaining frame was dropped, no inference request was
+made, and the agent talked straight through the interruption.
+
+- A transport failover rebuilt `InterruptionStreamBase` from scratch and replayed only
+  `agent-speech-started`, which marks the agent as speaking but leaves the overlap disarmed. The
+  in-progress overlap is now handed to the replacement stream.
+- A second speech segment in the same turn (a queued `SpeechHandle`, or the reply after a tool
+  call) raises `agent-speech-started` again with no `agent-speech-ended` in between, and was
+  treated as a new turn. An open overlap is now preserved across it; a genuine new turn still
+  resets the overlap, audio buffer, cache and counters.
+
+Also stops a rejected forwarding task from surfacing as an unhandled rejection during the failover
+backoff.

--- a/agents/src/inference/interruption/interruption_pipeline.test.ts
+++ b/agents/src/inference/interruption/interruption_pipeline.test.ts
@@ -91,6 +91,11 @@ interface Harness {
   close: () => Promise<void>;
 }
 
+/** Audio frames the transport pushed across every socket it has opened so far. */
+function totalAudioSendCount(): number {
+  return MockWebSocket.instances.reduce((total, ws) => total + audioSendCount(ws), 0);
+}
+
 interface OverlapEvent {
   isInterruption: boolean;
   numRequests: number;
@@ -117,6 +122,9 @@ async function createHarness({
 
   const events: OverlapEvent[] = [];
   detector.on('overlapping_speech', (ev) => events.push(ev));
+  // A simulated transport failure is emitted as a recoverable detector error; without a listener
+  // the EventEmitter would rethrow it as an unhandled 'error'.
+  detector.on('error', () => {});
 
   // Continuous room audio, pumped in the background for the whole test, exactly as a subscribed
   // track behaves — the interruption stream must pick it up on its own.
@@ -153,32 +161,44 @@ async function createHarness({
   await sleep(20);
 
   // Stand-in for the gateway: answer every audio frame promptly, as the real service does. Without
-  // this the transport's own 0.7s inference timeout tears the stream down.
-  let answered = 0;
+  // this the transport's own 0.7s inference timeout tears the stream down. Sockets opened later
+  // (an options reconnect, or the replacement stream built by a failover retry) are adopted too,
+  // so the gateway keeps behaving normally across a reconnect.
+  const answered = new Map<MockWebSocket, number>([[ws, 0]]);
   let bargeinPending = false;
   const responder = (async () => {
     while (pumping) {
-      const binary = ws.sent.filter((s): s is Uint8Array => s instanceof Uint8Array);
-      while (answered < binary.length) {
-        const createdAt = createdAtOf(binary[answered]!);
-        answered++;
-        if (bargeinPending) {
-          bargeinPending = false;
-          ws.simulateMessage({
-            type: 'bargein_detected',
-            created_at: createdAt,
-            probabilities: [0.91, 0.93, 0.95],
-            prediction_duration: 0.02,
-          });
-        } else {
-          ws.simulateMessage({
-            type: 'inference_done',
-            created_at: createdAt,
-            probabilities: [0.01, 0.02],
-            prediction_duration: 0.02,
-            is_bargein: false,
-          });
+      for (const socket of MockWebSocket.instances) {
+        if (!answered.has(socket)) {
+          answered.set(socket, 0);
+          socket.simulateOpen();
+          await sleep(1);
+          socket.simulateMessage({ type: 'session.created', default_threshold: 0.5 });
         }
+        const binary = socket.sent.filter((s): s is Uint8Array => s instanceof Uint8Array);
+        let seen = answered.get(socket)!;
+        while (seen < binary.length) {
+          const createdAt = createdAtOf(binary[seen]!);
+          seen++;
+          if (bargeinPending) {
+            bargeinPending = false;
+            socket.simulateMessage({
+              type: 'bargein_detected',
+              created_at: createdAt,
+              probabilities: [0.91, 0.93, 0.95],
+              prediction_duration: 0.02,
+            });
+          } else {
+            socket.simulateMessage({
+              type: 'inference_done',
+              created_at: createdAt,
+              probabilities: [0.01, 0.02],
+              prediction_duration: 0.02,
+              is_bargein: false,
+            });
+          }
+        }
+        answered.set(socket, seen);
       }
       await sleep(5);
     }
@@ -190,7 +210,7 @@ async function createHarness({
     hooks,
     ws,
     events,
-    requestCount: () => answered,
+    requestCount: () => [...answered.values()].reduce((a, b) => a + b, 0),
     bargeinOnNextRequest: () => {
       bargeinPending = true;
     },
@@ -267,6 +287,151 @@ describe('adaptive interruption pipeline', () => {
 
     await h.close();
   });
+});
+
+// ---------------------------------------------------------------------------
+// Overlap state must survive events that are not a new agent turn (regression)
+// ---------------------------------------------------------------------------
+
+/**
+ * `overlapSpeechStarted` is the gate that lets user audio reach the gateway at all, and the only
+ * thing that ever raises it is an `overlap-speech-started` sentinel, which in turn only comes from
+ * a VAD start-of-speech. VAD does not re-announce speech that is already under way, so once the
+ * flag is cleared mid-overlap nothing can re-arm it: every remaining frame of the interruption is
+ * dropped, no inference request is made, and the agent talks straight through the user.
+ *
+ * Two things clear the flag without the user's turn having ended.
+ */
+describe('adaptive interruption overlap state retention', () => {
+  beforeEach(() => {
+    MockWebSocket.instances.length = 0;
+  });
+
+  /**
+   * A transient socket failure fails the stream over. JS rebuilds `InterruptionStreamBase` from
+   * scratch on retry — all of its state lives in a `setupTransform()` closure — whereas Python
+   * keeps `_agent_speech_started` / `_overlap_started` on `self` and only reconnects the socket.
+   * Replaying `agent-speech-started` alone restores half the state: the agent is known to be
+   * speaking again, but the in-flight overlap is gone.
+   */
+  it('keeps sending user audio after the transport fails over mid-overlap', async () => {
+    const h = await createHarness();
+
+    await h.recognition.onStartOfAgentSpeech(Date.now());
+    await sleep(200);
+    await h.recognition.onStartOfOverlapSpeech(200, Date.now());
+    await sleep(400);
+
+    expect(totalAudioSendCount()).toBeGreaterThan(0);
+    const socketsBefore = MockWebSocket.instances.length;
+
+    // Transient socket failure while the user is mid-interrupt.
+    h.ws.emit('error', new Error('connection reset'));
+
+    // The failover sleeps intervalForRetry(0) (2s + jitter) before rebuilding the stream.
+    await waitFor(() => MockWebSocket.instances.length > socketsBefore, 8000);
+    await sleep(200);
+
+    // The user is still talking; from here on every frame must reach the new socket.
+    const sendsAfterFailover = totalAudioSendCount();
+    await sleep(800);
+
+    expect(totalAudioSendCount() - sendsAfterFailover).toBeGreaterThan(0);
+
+    await h.recognition.onEndOfOverlapSpeech(Date.now());
+    await waitFor(() => h.events.length > 0);
+    expect(h.events[h.events.length - 1]!.numRequests).toBeGreaterThan(0);
+
+    await h.close();
+  }, 30_000);
+
+  /**
+   * One user-perceived agent turn can contain several speech segments — a tool call sandwiched
+   * between two replies, or a queued `say()`. `AgentActivity.onPipelineReplyDone` only reports
+   * `onEndOfAgentSpeech` once the speech queue has drained, so the second segment raises
+   * `agent-speech-started` again with no `agent-speech-ended` in between. Treating that as a new
+   * turn resets the overlap the user is in the middle of.
+   */
+  it('keeps sending user audio when a second speech segment starts mid-overlap', async () => {
+    const h = await createHarness();
+
+    await h.recognition.onStartOfAgentSpeech(Date.now());
+    await sleep(200);
+    await h.recognition.onStartOfOverlapSpeech(200, Date.now());
+    await sleep(400);
+
+    const before = totalAudioSendCount();
+    expect(before).toBeGreaterThan(0);
+
+    // Second segment of the same turn: no `onEndOfAgentSpeech` precedes it.
+    await h.recognition.onStartOfAgentSpeech(Date.now());
+    await sleep(600);
+
+    expect(totalAudioSendCount() - before).toBeGreaterThan(0);
+
+    await h.recognition.onEndOfOverlapSpeech(Date.now());
+    await waitFor(() => h.events.length > 0);
+    expect(h.events[h.events.length - 1]!.numRequests).toBeGreaterThan(0);
+
+    await h.close();
+  }, 30_000);
+
+  /**
+   * The bargein verdict must still surface after a mid-overlap segment change — restoring the gate
+   * is only useful if the recovered audio can still produce `isInterruption: true`.
+   */
+  it('still reports a bargein after a second speech segment starts mid-overlap', async () => {
+    const h = await createHarness();
+
+    await h.recognition.onStartOfAgentSpeech(Date.now());
+    await sleep(200);
+    await h.recognition.onStartOfOverlapSpeech(200, Date.now());
+    await sleep(400);
+
+    await h.recognition.onStartOfAgentSpeech(Date.now());
+    await sleep(200);
+    h.bargeinOnNextRequest();
+    await waitFor(() => h.events.length > 0, 5000);
+
+    expect(h.events[0]!.isInterruption).toBe(true);
+    expect(h.events[0]!.numRequests).toBeGreaterThan(0);
+    await waitFor(() => vi.mocked(h.hooks.onInterruption).mock.calls.length > 0);
+
+    await h.close();
+  }, 30_000);
+
+  /** A genuine new turn must still wipe the overlap, the cache and the counters. */
+  it('resets overlap state on a new agent turn', async () => {
+    const h = await createHarness();
+
+    await h.recognition.onStartOfAgentSpeech(Date.now());
+    await sleep(200);
+    await h.recognition.onStartOfOverlapSpeech(200, Date.now());
+    await sleep(400);
+    expect(totalAudioSendCount()).toBeGreaterThan(0);
+
+    // The agent turn ends, then a new one begins. The user is no longer overlapping anything,
+    // so their audio must not be forwarded until a fresh overlap is announced.
+    await h.recognition.onEndOfAgentSpeech(Date.now());
+    await sleep(20);
+    await h.recognition.onStartOfAgentSpeech(Date.now());
+
+    const afterNewTurn = totalAudioSendCount();
+    await sleep(600);
+    expect(totalAudioSendCount()).toBe(afterNewTurn);
+
+    // ...and the new turn's first overlap starts from a clean counter.
+    await h.recognition.onStartOfOverlapSpeech(200, Date.now());
+    await sleep(400);
+    await h.recognition.onEndOfOverlapSpeech(Date.now());
+    await waitFor(() => h.events.length > 0);
+
+    const last = h.events[h.events.length - 1]!;
+    expect(last.numRequests).toBeGreaterThan(0);
+    expect(totalAudioSendCount()).toBeGreaterThan(afterNewTurn);
+
+    await h.close();
+  }, 30_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/agents/src/inference/interruption/interruption_stream.ts
+++ b/agents/src/inference/interruption/interruption_stream.ts
@@ -14,6 +14,7 @@ import { InterruptionCacheEntry } from './interruption_cache_entry.js';
 import type { AdaptiveInterruptionDetector } from './interruption_detector.js';
 import {
   type AgentSpeechEnded,
+  type AgentSpeechResumed,
   type AgentSpeechStarted,
   type ApiConnectOptions,
   type Flush,
@@ -30,6 +31,7 @@ import { createWsTransport } from './ws_transport.js';
 // Re-export sentinel types for backwards compatibility
 export type {
   AgentSpeechEnded,
+  AgentSpeechResumed,
   AgentSpeechStarted,
   ApiConnectOptions,
   Flush,
@@ -38,6 +40,12 @@ export type {
   OverlapSpeechStarted,
 };
 
+/** Snapshot of an overlap that is still being classified. */
+export interface ActiveOverlap {
+  startedAt: number;
+  userSpeakingSpan?: Span;
+}
+
 export class InterruptionStreamSentinel {
   static agentSpeechStarted(): AgentSpeechStarted {
     return { type: 'agent-speech-started' };
@@ -45,6 +53,14 @@ export class InterruptionStreamSentinel {
 
   static agentSpeechEnded(): AgentSpeechEnded {
     return { type: 'agent-speech-ended' };
+  }
+
+  static agentSpeechResumed(overlap?: ActiveOverlap): AgentSpeechResumed {
+    return {
+      type: 'agent-speech-resumed',
+      overlapStartedAt: overlap?.startedAt,
+      userSpeakingSpan: overlap?.userSpeakingSpan,
+    };
   }
 
   static overlapSpeechStarted(
@@ -101,6 +117,9 @@ export class InterruptionStreamBase {
 
   private wsClose?: () => void;
 
+  // The overlap flag lives in the setupTransform() closure; this exposes it for `activeOverlap`.
+  private readOverlapSpeechStarted?: () => boolean;
+
   // Mutable transport options that can be updated via updateOptions()
   private transportOptions: {
     baseUrl: string;
@@ -138,6 +157,21 @@ export class InterruptionStreamBase {
     };
 
     this.eventStream = this.setupTransform();
+  }
+
+  /**
+   * The overlap this stream is currently classifying, if any.
+   *
+   * Unlike Python — where the equivalent flags are attributes on the stream instance and a
+   * reconnect leaves them alone — every retry here builds a new stream and drops the state held in
+   * `setupTransform()`. Callers that recreate the stream use this to hand the in-progress overlap
+   * to its replacement via {@link InterruptionStreamSentinel.agentSpeechResumed}.
+   */
+  get activeOverlap(): ActiveOverlap | undefined {
+    if (!this.readOverlapSpeechStarted?.() || this.overlapSpeechStartedAt === undefined) {
+      return undefined;
+    }
+    return { startedAt: this.overlapSpeechStartedAt, userSpeakingSpan: this.userSpeakingSpan };
   }
 
   /**
@@ -188,6 +222,7 @@ export class InterruptionStreamBase {
         overlapSpeechStarted = partial.overlapSpeechStarted;
       }
     };
+    this.readOverlapSpeechStarted = () => overlapSpeechStarted;
     const handleSpanUpdate = (entry: InterruptionCacheEntry) => {
       if (this.userSpeakingSpan) {
         updateUserSpeakingSpan(this.userSpeakingSpan, entry);
@@ -248,15 +283,41 @@ export class InterruptionStreamBase {
               });
             }
           } else if (chunk.type === 'agent-speech-started') {
-            this.logger.debug('agent speech started');
+            // One agent turn can span several speech segments — a queued SpeechHandle, or the
+            // reply that follows a tool call — and `AgentActivity.onPipelineReplyDone` only
+            // reports `agent-speech-ended` once the speech queue has drained. The later segments
+            // therefore arrive here with no end in between. Resetting on those would strand an
+            // overlap the user is still in the middle of: `overlapSpeechStarted` is the gate that
+            // lets their audio reach the gateway at all, and only a VAD start-of-speech can raise
+            // it again — which never comes for speech that is already under way.
+            if (agentSpeechStarted && overlapSpeechStarted) {
+              this.logger.debug('agent speech continued into a new segment, keeping open overlap');
+            } else {
+              this.logger.debug('agent speech started');
+              agentSpeechStarted = true;
+              overlapSpeechStarted = false;
+              this.overlapSpeechStartedAt = undefined;
+              accumulatedSamples = 0;
+              overlapCount = 0;
+              startIdx = 0;
+              this.numRequests = 0;
+              cache.clear();
+            }
+          } else if (chunk.type === 'agent-speech-resumed') {
+            // This stream replaces one the transport failover tore down. Adopt what the previous
+            // stream knew instead of treating it as a new turn; everything else is already at its
+            // freshly-constructed value.
+            this.logger.debug(
+              { overlapStartedAt: chunk.overlapStartedAt },
+              'resuming agent speech on a replacement interruption stream',
+            );
             agentSpeechStarted = true;
-            overlapSpeechStarted = false;
-            this.overlapSpeechStartedAt = undefined;
-            accumulatedSamples = 0;
-            overlapCount = 0;
-            startIdx = 0;
-            this.numRequests = 0;
-            cache.clear();
+            if (chunk.overlapStartedAt !== undefined) {
+              overlapSpeechStarted = true;
+              overlapCount = 1;
+              this.overlapSpeechStartedAt = chunk.overlapStartedAt;
+              this.userSpeakingSpan = chunk.userSpeakingSpan;
+            }
           } else if (chunk.type === 'agent-speech-ended') {
             this.logger.debug('agent speech ended');
             agentSpeechStarted = false;

--- a/agents/src/inference/interruption/types.ts
+++ b/agents/src/inference/interruption/types.ts
@@ -72,6 +72,18 @@ export interface AgentSpeechEnded {
   type: 'agent-speech-ended';
 }
 
+/**
+ * Restores a replacement stream after the transport failed over, which builds a brand new
+ * `InterruptionStreamBase` with none of the previous one's state. Kept distinct from
+ * {@link AgentSpeechStarted} so that sentinel keeps meaning "a new agent turn began, reset".
+ */
+export interface AgentSpeechResumed {
+  type: 'agent-speech-resumed';
+  /** Absolute timestamp (ms) the overlap started at, when one was still open at failover. */
+  overlapStartedAt?: number;
+  userSpeakingSpan?: Span;
+}
+
 export interface OverlapSpeechStarted {
   type: 'overlap-speech-started';
   /** Duration of the speech segment in milliseconds (matches VADEvent.speechDuration units). */
@@ -99,6 +111,7 @@ export interface Flush {
 export type InterruptionSentinel =
   | AgentSpeechStarted
   | AgentSpeechEnded
+  | AgentSpeechResumed
   | OverlapSpeechStarted
   | OverlapSpeechEnded
   | Flush;

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -23,7 +23,10 @@ import {
 import { apiConnectDefaults, intervalForRetry } from '../inference/interruption/defaults.js';
 import { InterruptionDetectionError } from '../inference/interruption/errors.js';
 import type { AdaptiveInterruptionDetector } from '../inference/interruption/interruption_detector.js';
-import { InterruptionStreamSentinel } from '../inference/interruption/interruption_stream.js';
+import {
+  type ActiveOverlap,
+  InterruptionStreamSentinel,
+} from '../inference/interruption/interruption_stream.js';
 import {
   type InterruptionSentinel,
   type OverlappingSpeechEvent,
@@ -1960,6 +1963,8 @@ export class AudioRecognition {
 
     let numRetries = 0;
     const maxRetries = apiConnectDefaults.maxRetries;
+    // Overlap the torn-down stream was still classifying, handed to its replacement below.
+    let resumeOverlap: ActiveOverlap | undefined;
 
     while (!signal.aborted) {
       const stream = interruptionDetection.createStream();
@@ -1980,11 +1985,14 @@ export class AudioRecognition {
       let forwardTask: Promise<void> | undefined;
 
       try {
-        // Unlike Python where _agent_speech_started lives on `self` and survives retries,
-        // JS creates a fresh InterruptionStreamBase per retry with agentSpeechStarted = false.
-        // Re-inject the sentinel so the new stream knows the agent is mid-speech.
+        // Unlike Python where _agent_speech_started and _overlap_started live on `self` and are
+        // untouched by a reconnect, JS creates a fresh InterruptionStreamBase per retry and loses
+        // everything the previous one held. Hand it the whole picture, not just "the agent is
+        // speaking": an overlap that was open at failover can never be re-armed otherwise, since
+        // only a VAD start-of-speech raises the flag and VAD does not re-announce speech that is
+        // already under way. The rest of that turn's user audio would be dropped on the floor.
         if (numRetries > 0 && this.isAgentSpeaking) {
-          await stream.pushFrame(InterruptionStreamSentinel.agentSpeechStarted());
+          await stream.pushFrame(InterruptionStreamSentinel.agentSpeechResumed(resumeOverlap));
         }
 
         forwardTask = (async () => {
@@ -2005,6 +2013,10 @@ export class AudioRecognition {
             inputReader.releaseLock();
           }
         })();
+        // The stream this task pushes into is torn down as soon as the read loop below fails, so
+        // it rejects long before the `finally` attaches a handler — which only runs after the
+        // retry backoff. Mark it handled now so the rejection is not reported as unhandled.
+        forwardTask.catch(() => {});
 
         const abortPromise = waitForAbort(signal);
 
@@ -2069,6 +2081,8 @@ export class AudioRecognition {
           break;
         }
       } finally {
+        // Read before cleanup() closes the stream, so a retry can restore the open overlap.
+        resumeOverlap = stream.activeOverlap;
         await cleanup();
         await forwardTask?.catch((e) => {
           this.logger.debug({ err: e }, 'interruption task exited with error');


### PR DESCRIPTION
> Stacked on [#2116](<https://github.com/livekit/agents-js/issues/2116>) (`brian/fix-interruption-send-gate`), which adds the `interruption_pipeline.test.ts` harness this PR reuses. Until [#2116](<https://github.com/livekit/agents-js/issues/2116>) merges, the diff below also contains its commit; it will drop out on its own once [#2116](<https://github.com/livekit/agents-js/issues/2116>) lands.

## The gate

`overlapSpeechStarted` in `interruption_stream.ts` is what lets a user's overlapping audio reach the interruption model at all:

```ts
if (accumulatedSamples >= Math.floor(detectionIntervalInS * sampleRate) && overlapSpeechStarted) {
  controller.enqueue(audioSlice);
}
```

The only thing that ever raises it is an `overlap-speech-started` sentinel, which comes from a VAD start-of-speech. VAD does not re-announce speech that is already under way. So if the flag is cleared while the user is mid-interrupt, nothing can re-arm it for the rest of that agent turn: every remaining frame is dropped, `numRequests` stays 0, no `overlapping_speech` event is emitted, and the agent talks straight through the interruption.

Two things cleared it without the user's turn having ended.

## 1\. Transport failover rebuilds the stream and loses the overlap

`createInterruptionTask` builds a brand new `InterruptionStreamBase` on every retry, and all of that class's state (`agentSpeechStarted`, `overlapSpeechStarted`, `overlapCount`, `startIdx`, `cache`) lives in a `setupTransform()` closure. Python keeps the equivalent flags as instance attributes and only reconnects the socket inside `_run()`, so they survive:

```python
# livekit-agents/livekit/agents/inference/interruption.py:449-450
self._agent_speech_started: bool = False
self._overlap_started: bool = False
```

The existing JS mitigation replayed `agent-speech-started` after a retry, which restores only half the picture — the agent is known to be speaking again, but the overlap is disarmed, and that sentinel's handler additionally wipes the cache and counters.

This PR hands the in-progress overlap to the replacement stream through a new internal `agent-speech-resumed` sentinel. A separate sentinel (rather than teaching `agent-speech-started` about resumes) keeps the real one meaning exactly what it says: a new agent turn began, reset everything.

Any retryable transport error reaches this path — a socket `error` event or a server `{"type":"error"}` frame both become retryable `APIError`s — so an ordinary transient gateway blip during an interruption is enough.

## 2\. A second speech segment in the same turn is treated as a new turn

One user-perceived agent turn routinely contains several speech segments: a queued `SpeechHandle`, or the reply that follows a tool call. `AgentActivity.onPipelineReplyDone` only reports `onEndOfAgentSpeech` once the speech queue has drained, and the tool-call path moves straight to `thinking` without reporting it at all:

```ts
if (!this.speechQueue.peek() && (!this._currentSpeech || this._currentSpeech.done())) {
  this.agentSession._updateAgentState('listening');
  if (this.audioRecognition) this.audioRecognition.onEndOfAgentSpeech(Date.now());
```

So the second segment raises `agent-speech-started` with no `agent-speech-ended` in between, and the handler reset an overlap the user was in the middle of. An open overlap is now carried across; everything else is unchanged.

Note this second one is shared with Python, whose `_AgentSpeechStartedSentinel` handler calls `_reset_state()` unconditionally. This is a deliberate divergence, and worth porting back.

## Preserving the legitimate reset

The reset is skipped only when the stream already believes the agent is speaking *and* an overlap is open. Every other case — a first segment, a segment after `agent-speech-ended`, a resume after a paused false interruption — still clears the overlap, audio buffer, cache and counters exactly as before. `resets overlap state on a new agent turn` pins that, and passed both before and after the change.

## Also

`forwardTask` was a floating promise. It rejects the moment its stream is torn down, but the `finally` that attaches a handler only runs after the 2s retry backoff, so the rejection was reported as an unhandled rejection. It is now marked handled at creation; the `finally` still awaits and logs it.

## Test plan

Four tests added to `interruption_pipeline.test.ts`, driving real 48 kHz audio through `AudioRecognition` into the mocked gateway.

Verified red before the fix, and verified each test is coupled to its own change by reverting them individually:

<!-- linear:table-colwidths:400,400 -->
| reverted | failing |
| -- | -- |
| overlap handoff on failover only | `keeps sending user audio after the transport fails over mid-overlap` |
| segment-change guard only | `keeps sending user audio when a second speech segment starts mid-overlap`, `still reports a bargein after a second speech segment starts mid-overlap` |

The `resets overlap state on a new agent turn` guard test passes in every configuration.

- [X] `pnpm build` — exit 0
- [X] `pnpm vitest run agents/src/inference/interruption agents/src/voice` — 55 files, 564 tests passing
- [X] `pnpm lint` — no new findings on changed files
- [X] `pnpm format:check`
- [ ] `pnpm api:check` — fails identically on `main` (pre-existing `export * as ___` issue, 13 unrelated packages). No public API change here: `interruption_stream.ts` is not re-exported from any package index.

## Honest scope

This is a plausible mechanism that matches a user report of adaptive interruption always classifying interruptions as backchannel, not a confirmed root cause of it — no live reproduction was available. Both mechanisms above produce the user's primary symptom (the agent never stops speaking, and their audio never reaches the gateway) and are reproduced deterministically here. Neither, however, produces an emitted `overlapping_speech` event carrying `numRequests: 0`, which is what that report cited: the `overlap-speech-ended` handler only emits when `overlapSpeechStarted` is true, so these paths emit no event at all. If the reporter's instrumentation genuinely showed emitted events with `numRequests: 0`, there is at least one more mechanism still unaccounted for.

Related: livekit/agents-js#2118 tracks `remote_session.ts` dropping `probability` / `probabilities` / `numRequests` when mapping to `AgentSessionEvent_OverlappingSpeech`, which is why distributed-agent users cannot see these diagnostics at all.

Made with [Cursor](<https://cursor.com>)