### PR TITLE
fix(interruption): surface a duplicated @livekit/rtc-node instead of dropping all audio

### DIFF
--- a/.changeset/interruption-duplicate-rtc-node.md
+++ b/.changeset/interruption-duplicate-rtc-node.md
@@ -1,0 +1,29 @@
+---
+'@livekit/agents': patch
+---
+
+fix(interruption): stop silently dropping all audio when `@livekit/rtc-node` is loaded twice
+
+When an application and `@livekit/agents` resolve two different installs of `@livekit/rtc-node` —
+easily done by linking a local checkout, or by a transitive version split — room audio is built by
+one `AudioFrame` constructor and type-checked against the other. Every `frame instanceof AudioFrame`
+went false, so audio was pushed into the interruption stream as if it were a control sentinel,
+matched none of the sentinel branches in the transform, and disappeared: no accept, no drop, no
+counter, no log. Adaptive interruption had nothing left to classify and answered **every** overlap
+with the default backchannel verdict, so the agent never yielded to the user — with no error, no
+warning and no failover to give the cause away.
+
+- Audio is now recognised by shape rather than by constructor identity. A frame from another copy
+  of the module is rebuilt as a local `AudioFrame` (over the same sample buffer, so no copy) and
+  keeps flowing, which also stops a foreign frame being handed to a resampler backed by a different
+  FFI runtime.
+- The first such frame raises a once-per-process `error` naming the duplicate dependency and how to
+  find and collapse it, instead of leaving the failure to be inferred from a classifier that only
+  ever says "backchannel".
+- The transform's sentinel dispatch is now an exhaustive `switch`, and anything it cannot classify
+  is reported at `error` (rate limited, with a running count of discarded chunks) rather than
+  falling off the end of the chain.
+
+Two other cross-package `instanceof` checks that would fail the same way are now structural:
+`RoomIO`'s participant audio input no longer mistakes a `RemoteParticipant` for an identity string
+and subscribes to nothing, and `waitForParticipantAttribute` no longer waits forever.

--- a/agents/src/audio_frame_guard.test.ts
+++ b/agents/src/audio_frame_guard.test.ts
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { asAudioFrame, describeUnknownChunk, isAudioFrameShaped } from './audio_frame_guard.js';
+import { initializeLogger, log } from './log.js';
+
+initializeLogger({ pretty: false, level: 'silent' });
+
+/** An audio frame built by a second copy of `@livekit/rtc-node`: same shape, other constructor. */
+class ForeignAudioFrame {
+  constructor(
+    readonly data: Int16Array,
+    readonly sampleRate: number,
+    readonly channels: number,
+    readonly samplesPerChannel: number,
+    private readonly _userdata: Record<string, unknown> = {},
+  ) {}
+
+  get userdata(): Record<string, unknown> {
+    return this._userdata;
+  }
+}
+
+/**
+ * A fresh copy of the module, so the once-per-process report can be observed from its initial
+ * state. `log()` reads a `globalThis` singleton, so the logger survives the module reset and the
+ * spy below still sees the call.
+ */
+async function freshGuard() {
+  vi.resetModules();
+  return import('./audio_frame_guard.js');
+}
+
+describe('audio frame guard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('passes a genuine AudioFrame through untouched', () => {
+    const frame = new AudioFrame(new Int16Array(160), 16000, 1, 160);
+    expect(asAudioFrame(frame)).toBe(frame);
+  });
+
+  it('rebuilds a frame from another copy of the module as one of ours', () => {
+    const data = new Int16Array([1, -2, 3, -4]);
+    const foreign = new ForeignAudioFrame(data, 16000, 1, 4, { tag: 'kept' });
+
+    const frame = asAudioFrame(foreign as unknown as AudioFrame);
+
+    expect(frame).toBeInstanceOf(AudioFrame);
+    expect(frame!.sampleRate).toBe(16000);
+    expect(frame!.channels).toBe(1);
+    expect(frame!.samplesPerChannel).toBe(4);
+    // The same samples, not a copy of them — rebuilding must not cost an allocation per frame.
+    expect(frame!.data).toBe(data);
+    expect(frame!.userdata).toEqual({ tag: 'kept' });
+  });
+
+  it('reports the duplicate module loudly, once per process', async () => {
+    const { asAudioFrame: freshAsAudioFrame } = await freshGuard();
+    const errorSpy = vi.spyOn(log(), 'error').mockImplementation(() => undefined as never);
+
+    const foreign = () =>
+      new ForeignAudioFrame(new Int16Array(160), 16000, 1, 160) as unknown as AudioFrame;
+    freshAsAudioFrame(foreign());
+    freshAsAudioFrame(foreign());
+    freshAsAudioFrame(foreign());
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const message = String(errorSpy.mock.calls[0]![1]);
+    expect(message).toContain('@livekit/rtc-node is loaded twice');
+    expect(message).toContain('instanceof AudioFrame');
+    expect(message).toContain('backchannel');
+  });
+
+  it('does not mistake sentinels or other values for audio', () => {
+    expect(asAudioFrame({ type: 'flush' })).toBeUndefined();
+    expect(asAudioFrame(null)).toBeUndefined();
+    expect(asAudioFrame('frame')).toBeUndefined();
+    // Shaped like a frame but carrying no buffer.
+    expect(asAudioFrame({ sampleRate: 16000, samplesPerChannel: 1, channels: 1 })).toBeUndefined();
+    expect(
+      isAudioFrameShaped({
+        sampleRate: 16000,
+        samplesPerChannel: 1,
+        channels: 1,
+        data: new DataView(new ArrayBuffer(2)),
+      }),
+    ).toBe(false);
+  });
+
+  it('describes an unrecognised chunk without throwing on it', () => {
+    expect(describeUnknownChunk({ type: 'mystery' })).toEqual({
+      chunkType: 'object',
+      chunkConstructor: 'Object',
+      chunkTag: 'mystery',
+    });
+    expect(describeUnknownChunk(undefined)).toEqual({
+      chunkType: 'undefined',
+      chunkConstructor: null,
+      chunkTag: null,
+    });
+    expect(describeUnknownChunk(Object.create(null))).toEqual({
+      chunkType: 'object',
+      chunkConstructor: null,
+      chunkTag: null,
+    });
+  });
+});

--- a/agents/src/audio_frame_guard.ts
+++ b/agents/src/audio_frame_guard.ts
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { log } from './log.js';
+
+/**
+ * The structural half of an {@link AudioFrame}: every field the framework reads off a frame, and
+ * every argument the constructor needs to rebuild one.
+ */
+interface AudioFrameShape {
+  data: ArrayBufferView;
+  sampleRate: number;
+  samplesPerChannel: number;
+  channels: number;
+}
+
+/**
+ * True for anything carrying an audio frame's payload, whichever copy of `@livekit/rtc-node`
+ * built it.
+ *
+ * `value instanceof AudioFrame` answers a narrower question — "did *this* copy of the module
+ * build it" — and routing audio on that answer is what makes a duplicated dependency look like
+ * silence rather than an error.
+ */
+export function isAudioFrameShaped(value: unknown): value is AudioFrameShape {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<AudioFrameShape>;
+  return (
+    typeof candidate.sampleRate === 'number' &&
+    typeof candidate.samplesPerChannel === 'number' &&
+    typeof candidate.channels === 'number' &&
+    ArrayBuffer.isView(candidate.data) &&
+    !(candidate.data instanceof DataView)
+  );
+}
+
+let duplicateRtcNodeReported = false;
+
+/**
+ * Announce, once per process, that a frame arrived from a second copy of `@livekit/rtc-node`.
+ *
+ * There is no way to notice the duplicate before a frame crosses the boundary: the other copy is
+ * loaded by the application, not by us, so nothing at import time can see it. The first frame of
+ * the first session is therefore the earliest possible signal — and it is early, arriving within
+ * milliseconds of the session starting and long before any interruption verdict.
+ */
+function reportDuplicateRtcNode(frame: AudioFrameShape): void {
+  if (duplicateRtcNodeReported) return;
+  duplicateRtcNodeReported = true;
+  log().error(
+    {
+      frameConstructor: (frame as object).constructor?.name ?? null,
+      sampleRate: frame.sampleRate,
+      channels: frame.channels,
+      samplesPerChannel: frame.samplesPerChannel,
+    },
+    '@livekit/rtc-node is loaded twice in this process. An audio frame arrived with the exact ' +
+      'shape of an AudioFrame but was built by a different copy of the module, so ' +
+      '`frame instanceof AudioFrame` is false inside @livekit/agents. Unhandled, that silently ' +
+      'discards every audio frame: adaptive interruption stops receiving audio and reports every ' +
+      'overlap as a backchannel, so the agent never yields to the user. The frame has been ' +
+      'converted and accepted so audio keeps flowing, but the duplicate must be removed — run ' +
+      '`npm ls @livekit/rtc-node` (or `pnpm why @livekit/rtc-node`) to find both copies and ' +
+      'collapse them onto one install with `pnpm dedupe`, an npm `overrides` / pnpm `resolutions` ' +
+      'entry, or, if you have linked a local @livekit/agents checkout, by linking its ' +
+      '@livekit/rtc-node as well. Reported once per process.',
+  );
+}
+
+function asInt16Array(data: ArrayBufferView): Int16Array {
+  if (data instanceof Int16Array) return data;
+  return new Int16Array(data.buffer, data.byteOffset, Math.floor(data.byteLength / 2));
+}
+
+/**
+ * Return `value` as an {@link AudioFrame} this module's `@livekit/rtc-node` owns, or `undefined`
+ * if it is not audio at all.
+ *
+ * A frame from a second copy of the module is rebuilt rather than passed through. That is not
+ * cosmetic: `AudioResampler.push()` calls `frame.protoInfo()`, which resolves pointers through
+ * the frame's own `FfiClient` singleton, so handing a foreign frame to a local resampler mixes
+ * two FFI runtimes. Rebuilding is a plain object allocation over the same sample buffer — no
+ * copy — and leaves every downstream consumer holding a frame whose native side matches ours.
+ */
+export function asAudioFrame(value: unknown): AudioFrame | undefined {
+  if (value instanceof AudioFrame) return value;
+  if (!isAudioFrameShaped(value)) return undefined;
+
+  reportDuplicateRtcNode(value);
+
+  const userdata = (value as { userdata?: unknown }).userdata;
+  return new AudioFrame(
+    asInt16Array(value.data),
+    value.sampleRate,
+    value.channels,
+    value.samplesPerChannel,
+    typeof userdata === 'object' && userdata !== null
+      ? (userdata as Record<string, unknown>)
+      : undefined,
+  );
+}
+
+/** Log-safe description of a value that reached a branch nothing knows how to handle. */
+export function describeUnknownChunk(chunk: unknown): {
+  chunkType: string;
+  chunkConstructor: string | null;
+  chunkTag: string | null;
+} {
+  if (typeof chunk !== 'object' || chunk === null) {
+    return { chunkType: typeof chunk, chunkConstructor: null, chunkTag: null };
+  }
+  const tag = (chunk as { type?: unknown }).type;
+  return {
+    chunkType: 'object',
+    chunkConstructor: chunk.constructor?.name ?? null,
+    chunkTag: typeof tag === 'string' ? tag : null,
+  };
+}

--- a/agents/src/inference/interruption/interruption_dual_copy.test.ts
+++ b/agents/src/inference/interruption/interruption_dual_copy.test.ts
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression coverage for "every overlap is a backchannel" caused by two copies of
+// `@livekit/rtc-node` in one process.
+//
+// When the application and `@livekit/agents` resolve different installs of the module, room audio
+// is built by one `AudioFrame` constructor and type-checked against the other. Every
+// `frame instanceof AudioFrame` goes false, so audio was written through `pushFrame` as if it were
+// a control sentinel, then matched none of the sentinel branches in the transform and disappeared:
+// no accept, no drop, no counter, no log. Adaptive interruption then had nothing to classify and
+// fell back to a backchannel verdict on every overlap, forever, without an error.
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream } from 'node:stream/web';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../../llm/chat_context.js';
+import { initializeLogger, log } from '../../log.js';
+import { AudioRecognition, type RecognitionHooks } from '../../voice/audio_recognition.js';
+import { createEndpointing } from '../../voice/turn_config/endpointing.js';
+import { MockWebSocket } from './_mock_ws.js';
+import { AdaptiveInterruptionDetector } from './interruption_detector.js';
+
+vi.mock('ws', async () => {
+  const { MockWebSocket } = await import('./_mock_ws.js');
+  return { default: MockWebSocket, WebSocket: MockWebSocket };
+});
+
+initializeLogger({ pretty: false, level: 'silent' });
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = performance.now();
+  while (!predicate()) {
+    if (performance.now() - start > timeoutMs) {
+      throw new Error('condition not met within timeout');
+    }
+    await sleep(5);
+  }
+}
+
+/**
+ * An audio frame from a *different* copy of `@livekit/rtc-node`.
+ *
+ * The dual-copy hazard in miniature: identical field names, identical values, identical payload —
+ * only the constructor differs, which is enough to make `instanceof AudioFrame` false while every
+ * consumer that just reads the fields keeps working.
+ */
+class ForeignAudioFrame {
+  constructor(
+    readonly data: Int16Array,
+    readonly sampleRate: number,
+    readonly channels: number,
+    readonly samplesPerChannel: number,
+  ) {}
+
+  get userdata(): Record<string, unknown> {
+    return {};
+  }
+}
+
+/** 10ms of non-silent mono PCM, as a room track would deliver it. */
+function samplesFor(sampleRate: number): Int16Array {
+  const samples = Math.floor(sampleRate / 100);
+  const data = new Int16Array(samples);
+  for (let i = 0; i < samples; i++) {
+    data[i] = Math.round(8000 * Math.sin((2 * Math.PI * 220 * i) / sampleRate));
+  }
+  return data;
+}
+
+function makeForeignFrame(sampleRate: number): AudioFrame {
+  const data = samplesFor(sampleRate);
+  // The cast is the point of the test: at the type level this is an AudioFrame, at runtime it was
+  // built somewhere else — exactly what a duplicated dependency produces.
+  return new ForeignAudioFrame(data, sampleRate, 1, data.length) as unknown as AudioFrame;
+}
+
+function createHooks(): RecognitionHooks {
+  return {
+    onInterruption: vi.fn(),
+    onBackchannelConfirmed: vi.fn(),
+    onStartOfSpeech: vi.fn(),
+    onVADInferenceDone: vi.fn(),
+    onEndOfSpeech: vi.fn(),
+    onInterimTranscript: vi.fn(),
+    onFinalTranscript: vi.fn(),
+    onPreemptiveGeneration: vi.fn(),
+    onAgentBackchannelOpportunity: vi.fn(),
+    retrieveChatCtx: () => ChatContext.empty(),
+    onEndOfTurn: vi.fn(async () => true),
+  } as unknown as RecognitionHooks;
+}
+
+/** Number of binary (audio) frames the transport pushed onto a socket. */
+function audioSendCount(ws: MockWebSocket): number {
+  return ws.sent.filter((s) => s instanceof Uint8Array).length;
+}
+
+/** Audio frames the transport pushed across every socket it has opened so far. */
+function totalAudioSendCount(): number {
+  return MockWebSocket.instances.reduce((total, ws) => total + audioSendCount(ws), 0);
+}
+
+/** `created_at` header the transport stamped on a binary frame. */
+function createdAtOf(buf: Uint8Array): number {
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  return view.getUint32(4, true) * 0x100000000 + view.getUint32(0, true);
+}
+
+interface Harness {
+  recognition: AudioRecognition;
+  detector: AdaptiveInterruptionDetector;
+  events: { isInterruption: boolean; numRequests: number }[];
+  close: () => Promise<void>;
+}
+
+/**
+ * The pipeline as AudioRecognition wires it: room audio into the interruption stream channel, on
+ * through the audio transformer and out to the WS transport. Frames come from `makeFrame`, so a
+ * caller can supply them from a second copy of the module.
+ */
+async function createHarness(makeFrame: (sampleRate: number) => AudioFrame): Promise<Harness> {
+  const sampleRate = 48000;
+  const detector = new AdaptiveInterruptionDetector({
+    baseUrl: 'http://localhost:9999',
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+  });
+  const hooks = createHooks();
+  const recognition = new AudioRecognition({
+    recognitionHooks: hooks,
+    interruptionDetection: detector,
+    endpointing: createEndpointing({ mode: 'dynamic', minDelay: 500, maxDelay: 3000, alpha: 0.9 }),
+  });
+  // The pipeline wiring keys off `interruptionDetection`; the enabled flag additionally requires a
+  // VAD, which this test substitutes for by driving the overlap callbacks directly.
+  (recognition as unknown as { isInterruptionEnabled: boolean }).isInterruptionEnabled = true;
+
+  const events: { isInterruption: boolean; numRequests: number }[] = [];
+  detector.on('overlapping_speech', (ev) => events.push(ev));
+  detector.on('error', () => {});
+
+  let pumping = true;
+  let pushFrame!: (frame: AudioFrame) => void;
+  const audioStream = new ReadableStream<AudioFrame>({
+    start(controller) {
+      pushFrame = (frame) => controller.enqueue(frame);
+    },
+  });
+  recognition.setInputAudioStream(audioStream);
+  const pump = (async () => {
+    while (pumping) {
+      pushFrame(makeFrame(sampleRate));
+      await sleep(10);
+    }
+  })();
+
+  const ac = new AbortController();
+  const task = (
+    recognition as unknown as {
+      createInterruptionTask: (
+        d: AdaptiveInterruptionDetector,
+        signal: AbortSignal,
+      ) => Promise<void>;
+    }
+  ).createInterruptionTask(detector, ac.signal);
+
+  await waitFor(() => MockWebSocket.instances.length > 0);
+  const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1]!;
+  ws.simulateOpen();
+  await waitFor(() => ws.sent.length > 0); // session.create
+  ws.simulateMessage({ type: 'session.created', default_threshold: 0.5 });
+  await sleep(20);
+
+  // Stand-in for the gateway: answer every audio frame promptly, as the real service does.
+  // Without this the transport's own inference timeout tears the stream down.
+  const answered = new Map<MockWebSocket, number>([[ws, 0]]);
+  const responder = (async () => {
+    while (pumping) {
+      for (const socket of MockWebSocket.instances) {
+        if (!answered.has(socket)) {
+          answered.set(socket, 0);
+          socket.simulateOpen();
+          await sleep(1);
+          socket.simulateMessage({ type: 'session.created', default_threshold: 0.5 });
+        }
+        const binary = socket.sent.filter((s): s is Uint8Array => s instanceof Uint8Array);
+        let seen = answered.get(socket)!;
+        while (seen < binary.length) {
+          socket.simulateMessage({
+            type: 'inference_done',
+            created_at: createdAtOf(binary[seen]!),
+            probabilities: [0.01, 0.02],
+            prediction_duration: 0.02,
+            is_bargein: false,
+          });
+          seen++;
+        }
+        answered.set(socket, seen);
+      }
+      await sleep(5);
+    }
+  })();
+
+  return {
+    recognition,
+    detector,
+    events,
+    close: async () => {
+      pumping = false;
+      await pump;
+      await responder;
+      ac.abort();
+      await task.catch(() => {});
+      await recognition.close().catch(() => {});
+    },
+  };
+}
+
+/** Every message the logger was asked to emit at `error`, flattened to searchable text. */
+function errorMessages(spy: ReturnType<typeof vi.spyOn>): string[] {
+  return spy.mock.calls.map((call) => call.map((arg) => JSON.stringify(arg) ?? '').join(' '));
+}
+
+describe('adaptive interruption with two copies of @livekit/rtc-node', () => {
+  beforeEach(() => {
+    MockWebSocket.instances.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it('builds a frame that is shaped like an AudioFrame but fails instanceof', () => {
+    const frame = makeForeignFrame(48000);
+    expect(frame instanceof AudioFrame).toBe(false);
+    expect(frame.sampleRate).toBe(48000);
+    expect(frame.samplesPerChannel).toBe(480);
+  });
+
+  it('keeps user audio flowing and says why, instead of discarding every frame', async () => {
+    const errorSpy = vi.spyOn(log(), 'error').mockImplementation(() => undefined as never);
+    const h = await createHarness(makeForeignFrame);
+
+    await h.recognition.onStartOfAgentSpeech(Date.now());
+    await sleep(200);
+    await h.recognition.onStartOfOverlapSpeech(200, Date.now());
+    await sleep(600);
+
+    // The bug: not one frame ever reached the gateway, so the overlap could only ever be
+    // answered with the default backchannel verdict.
+    expect(totalAudioSendCount()).toBeGreaterThan(0);
+
+    await h.recognition.onEndOfOverlapSpeech(Date.now());
+    await waitFor(() => h.events.length > 0);
+    expect(h.events[h.events.length - 1]!.numRequests).toBeGreaterThan(0);
+
+    // And the operator is told exactly what is wrong rather than left to infer it from a
+    // classifier that only ever says "backchannel".
+    const messages = errorMessages(errorSpy);
+    expect(messages.some((m) => m.includes('@livekit/rtc-node is loaded twice'))).toBe(true);
+
+    await h.close();
+  }, 30_000);
+
+  it('reports a chunk it cannot classify instead of dropping it in silence', async () => {
+    const detector = new AdaptiveInterruptionDetector({
+      baseUrl: 'http://localhost:9999',
+      apiKey: 'test-key',
+      apiSecret: 'test-secret',
+    });
+    detector.on('error', () => {});
+    const stream = detector.createStream();
+    const errorSpy = vi.spyOn(log(), 'error').mockImplementation(() => undefined as never);
+
+    // Neither audio nor any sentinel the transform knows. Before, this fell off the end of the
+    // dispatch chain and vanished.
+    await stream.pushFrame({ type: 'not-a-real-sentinel' } as never);
+    await stream.pushFrame({ nothing: 'like a chunk' } as never);
+    await sleep(50);
+
+    const messages = errorMessages(errorSpy);
+    expect(messages.some((m) => m.includes('neither an audio frame nor a known'))).toBe(true);
+
+    // Rate limited: the first is reported at once, the rest only fold into the running count.
+    const reports = messages.filter((m) => m.includes('neither an audio frame nor a known'));
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toContain('discardedChunks');
+
+    await stream.close();
+  }, 30_000);
+});

--- a/agents/src/inference/interruption/interruption_stream.ts
+++ b/agents/src/inference/interruption/interruption_stream.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { AudioFrame, AudioResampler } from '@livekit/rtc-node';
+import { type AudioFrame, AudioResampler } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import { type ReadableStream, TransformStream } from 'stream/web';
+import { asAudioFrame, describeUnknownChunk } from '../../audio_frame_guard.js';
 import { log } from '../../log.js';
 import type { InterruptionMetrics } from '../../metrics/base.js';
 import { type StreamChannel, createStreamChannel } from '../../stream/stream_channel.js';
@@ -39,6 +40,9 @@ export type {
   OverlapSpeechEnded,
   OverlapSpeechStarted,
 };
+
+/** Minimum gap between repeat reports of chunks the transform could not classify. */
+const DISCARDED_CHUNK_LOG_INTERVAL = 10_000;
 
 /** Snapshot of an overlap that is still being classified. */
 export interface ActiveOverlap {
@@ -244,6 +248,26 @@ export class InterruptionStreamBase {
       return n;
     };
 
+    // A chunk that is neither audio nor a sentinel used to fall off the end of the dispatch below
+    // and vanish — no accept, no drop, no counter. Audio arrives at ~100 chunks/s, so a log per
+    // chunk would be unusable: report the first one at once, then at most one per interval,
+    // carrying the running total so the scale of the loss is visible.
+    let discardedChunks = 0;
+    let discardedChunkLoggedAt = 0;
+    const reportDiscardedChunk = (chunk: unknown) => {
+      discardedChunks++;
+      const now = Date.now();
+      if (discardedChunks > 1 && now - discardedChunkLoggedAt < DISCARDED_CHUNK_LOG_INTERVAL) {
+        return;
+      }
+      discardedChunkLoggedAt = now;
+      this.logger.error(
+        { ...describeUnknownChunk(chunk), discardedChunks },
+        'interruption stream discarded a chunk that is neither an audio frame nor a known ' +
+          'sentinel; interruption detection is running blind for as long as this continues',
+      );
+    };
+
     // First transform: process input frames/sentinels and output audio slices or events
     const audioTransformer = new TransformStream<
       InterruptionSentinel | AudioFrame,
@@ -251,17 +275,18 @@ export class InterruptionStreamBase {
     >(
       {
         transform: (chunk, controller) => {
-          if (chunk instanceof AudioFrame) {
+          const frame = asAudioFrame(chunk);
+          if (frame) {
             if (!agentSpeechStarted) {
               return;
             }
-            if (this.options.sampleRate !== chunk.sampleRate) {
+            if (this.options.sampleRate !== frame.sampleRate) {
               controller.error('the sample rate of the input frames must be consistent');
               this.logger.error('the sample rate of the input frames must be consistent');
               return;
             }
             const result = writeToInferenceS16Data(
-              chunk,
+              frame,
               startIdx,
               inferenceS16Data,
               this.options.maxAudioDurationInS,
@@ -282,19 +307,61 @@ export class InterruptionStreamBase {
                 overlapGeneration,
               });
             }
-          } else if (chunk.type === 'agent-speech-started') {
-            // One agent turn can span several speech segments — a queued SpeechHandle, or the
-            // reply that follows a tool call — and `AgentActivity.onPipelineReplyDone` only
-            // reports `agent-speech-ended` once the speech queue has drained. The later segments
-            // therefore arrive here with no end in between. Resetting on those would strand an
-            // overlap the user is still in the middle of: `overlapSpeechStarted` is the gate that
-            // lets their audio reach the gateway at all, and only a VAD start-of-speech can raise
-            // it again — which never comes for speech that is already under way.
-            if (agentSpeechStarted && overlapSpeechStarted) {
-              this.logger.debug('agent speech continued into a new segment, keeping open overlap');
-            } else {
-              this.logger.debug('agent speech started');
+            return;
+          }
+
+          // Not audio, so it should be a sentinel — but `chunk` is only typed as one, and an
+          // unrecognised object reaching here is exactly the failure this switch exists to
+          // surface, so the `default` below has to be a real runtime guard and not just the
+          // compile-time exhaustiveness check.
+          const sentinel = chunk as InterruptionSentinel;
+          switch (sentinel.type) {
+            case 'agent-speech-started': {
+              // One agent turn can span several speech segments — a queued SpeechHandle, or the
+              // reply that follows a tool call — and `AgentActivity.onPipelineReplyDone` only
+              // reports `agent-speech-ended` once the speech queue has drained. The later
+              // segments therefore arrive here with no end in between. Resetting on those would
+              // strand an overlap the user is still in the middle of: `overlapSpeechStarted` is
+              // the gate that lets their audio reach the gateway at all, and only a VAD
+              // start-of-speech can raise it again — which never comes for speech that is
+              // already under way.
+              if (agentSpeechStarted && overlapSpeechStarted) {
+                this.logger.debug(
+                  'agent speech continued into a new segment, keeping open overlap',
+                );
+              } else {
+                this.logger.debug('agent speech started');
+                agentSpeechStarted = true;
+                overlapSpeechStarted = false;
+                this.overlapSpeechStartedAt = undefined;
+                accumulatedSamples = 0;
+                overlapCount = 0;
+                startIdx = 0;
+                this.numRequests = 0;
+                cache.clear();
+              }
+              break;
+            }
+            case 'agent-speech-resumed': {
+              // This stream replaces one the transport failover tore down. Adopt what the
+              // previous stream knew instead of treating it as a new turn; everything else is
+              // already at its freshly-constructed value.
+              this.logger.debug(
+                { overlapStartedAt: sentinel.overlapStartedAt },
+                'resuming agent speech on a replacement interruption stream',
+              );
               agentSpeechStarted = true;
+              if (sentinel.overlapStartedAt !== undefined) {
+                overlapSpeechStarted = true;
+                overlapCount = 1;
+                this.overlapSpeechStartedAt = sentinel.overlapStartedAt;
+                this.userSpeakingSpan = sentinel.userSpeakingSpan;
+              }
+              break;
+            }
+            case 'agent-speech-ended': {
+              this.logger.debug('agent speech ended');
+              agentSpeechStarted = false;
               overlapSpeechStarted = false;
               this.overlapSpeechStartedAt = undefined;
               accumulatedSamples = 0;
@@ -302,98 +369,88 @@ export class InterruptionStreamBase {
               startIdx = 0;
               this.numRequests = 0;
               cache.clear();
+              break;
             }
-          } else if (chunk.type === 'agent-speech-resumed') {
-            // This stream replaces one the transport failover tore down. Adopt what the previous
-            // stream knew instead of treating it as a new turn; everything else is already at its
-            // freshly-constructed value.
-            this.logger.debug(
-              { overlapStartedAt: chunk.overlapStartedAt },
-              'resuming agent speech on a replacement interruption stream',
-            );
-            agentSpeechStarted = true;
-            if (chunk.overlapStartedAt !== undefined) {
+            case 'overlap-speech-started': {
+              // An overlap only means something while the agent holds the floor.
+              if (!agentSpeechStarted) break;
+              this.overlapSpeechStartedAt = sentinel.startedAt;
+              this.userSpeakingSpan = sentinel.userSpeakingSpan;
+              this.logger.debug('overlap speech started, starting interruption inference');
               overlapSpeechStarted = true;
-              overlapCount = 1;
-              this.overlapSpeechStartedAt = chunk.overlapStartedAt;
-              this.userSpeakingSpan = chunk.userSpeakingSpan;
-            }
-          } else if (chunk.type === 'agent-speech-ended') {
-            this.logger.debug('agent speech ended');
-            agentSpeechStarted = false;
-            overlapSpeechStarted = false;
-            this.overlapSpeechStartedAt = undefined;
-            accumulatedSamples = 0;
-            overlapCount = 0;
-            startIdx = 0;
-            this.numRequests = 0;
-            cache.clear();
-          } else if (chunk.type === 'overlap-speech-started' && agentSpeechStarted) {
-            this.overlapSpeechStartedAt = chunk.startedAt;
-            this.userSpeakingSpan = chunk.userSpeakingSpan;
-            this.logger.debug('overlap speech started, starting interruption inference');
-            overlapSpeechStarted = true;
-            accumulatedSamples = 0;
-            overlapCount += 1;
-            overlapGeneration += 1;
-            if (overlapCount <= 1) {
-              const keepSize =
-                Math.round((chunk.speechDuration / 1000) * this.options.sampleRate) +
-                Math.round(this.options.audioPrefixDurationInS * this.options.sampleRate);
-              const shiftCount = Math.max(0, startIdx - keepSize);
-              inferenceS16Data.copyWithin(0, shiftCount, startIdx);
-              startIdx -= shiftCount;
-            }
-            cache.clear();
-          } else if (chunk.type === 'overlap-speech-ended') {
-            this.logger.debug('overlap speech ended');
-            if (overlapSpeechStarted) {
-              this.userSpeakingSpan = undefined;
-              let latestEntry = cache.pop(
-                (entry) => entry.totalDurationInS !== undefined && entry.totalDurationInS > 0,
-              );
-              const numRequests = getAndResetNumRequests();
-              if (!latestEntry) {
-                // The verdict below is a fallback, not a model decision. Warn rather than debug:
-                // without this, an unanswered overlap is indistinguishable from a genuine
-                // low-probability backchannel in production logs.
-                this.logger.warn(
-                  {
-                    overlapDuration:
-                      this.overlapSpeechStartedAt !== undefined
-                        ? chunk.endedAt - this.overlapSpeechStartedAt
-                        : undefined,
-                    numRequests,
-                    accumulatedSamples,
-                    agentSpeechStarted,
-                    agentEnded: chunk.agentEnded,
-                  },
-                  'no interruption inference result for overlap speech, defaulting to backchannel',
-                );
-                latestEntry = InterruptionCacheEntry.default();
-              }
-              const e = latestEntry ?? InterruptionCacheEntry.default();
-              const event: OverlappingSpeechEvent = {
-                type: 'overlapping_speech',
-                detectedAt: chunk.endedAt,
-                isInterruption: false,
-                agentEnded: chunk.agentEnded,
-                overlapStartedAt: this.overlapSpeechStartedAt,
-                speechInput: e.speechInput,
-                probabilities: e.probabilities,
-                totalDurationInS: e.totalDurationInS,
-                detectionDelayInS: e.detectionDelayInS,
-                predictionDurationInS: e.predictionDurationInS,
-                probability: e.probability,
-                numRequests,
-              };
-              controller.enqueue(event);
-              overlapSpeechStarted = false;
               accumulatedSamples = 0;
+              overlapCount += 1;
+              overlapGeneration += 1;
+              if (overlapCount <= 1) {
+                const keepSize =
+                  Math.round((sentinel.speechDuration / 1000) * this.options.sampleRate) +
+                  Math.round(this.options.audioPrefixDurationInS * this.options.sampleRate);
+                const shiftCount = Math.max(0, startIdx - keepSize);
+                inferenceS16Data.copyWithin(0, shiftCount, startIdx);
+                startIdx -= shiftCount;
+              }
+              cache.clear();
+              break;
             }
-            this.overlapSpeechStartedAt = undefined;
-          } else if (chunk.type === 'flush') {
-            // no-op
+            case 'overlap-speech-ended': {
+              this.logger.debug('overlap speech ended');
+              if (overlapSpeechStarted) {
+                this.userSpeakingSpan = undefined;
+                let latestEntry = cache.pop(
+                  (entry) => entry.totalDurationInS !== undefined && entry.totalDurationInS > 0,
+                );
+                const numRequests = getAndResetNumRequests();
+                if (!latestEntry) {
+                  // The verdict below is a fallback, not a model decision. Warn rather than
+                  // debug: without this, an unanswered overlap is indistinguishable from a
+                  // genuine low-probability backchannel in production logs.
+                  this.logger.warn(
+                    {
+                      overlapDuration:
+                        this.overlapSpeechStartedAt !== undefined
+                          ? sentinel.endedAt - this.overlapSpeechStartedAt
+                          : undefined,
+                      numRequests,
+                      accumulatedSamples,
+                      agentSpeechStarted,
+                      agentEnded: sentinel.agentEnded,
+                    },
+                    'no interruption inference result for overlap speech, defaulting to backchannel',
+                  );
+                  latestEntry = InterruptionCacheEntry.default();
+                }
+                const e = latestEntry ?? InterruptionCacheEntry.default();
+                const event: OverlappingSpeechEvent = {
+                  type: 'overlapping_speech',
+                  detectedAt: sentinel.endedAt,
+                  isInterruption: false,
+                  agentEnded: sentinel.agentEnded,
+                  overlapStartedAt: this.overlapSpeechStartedAt,
+                  speechInput: e.speechInput,
+                  probabilities: e.probabilities,
+                  totalDurationInS: e.totalDurationInS,
+                  detectionDelayInS: e.detectionDelayInS,
+                  predictionDurationInS: e.predictionDurationInS,
+                  probability: e.probability,
+                  numRequests,
+                };
+                controller.enqueue(event);
+                overlapSpeechStarted = false;
+                accumulatedSamples = 0;
+              }
+              this.overlapSpeechStartedAt = undefined;
+              break;
+            }
+            case 'flush':
+              break;
+            default: {
+              // `never` at compile time, so a new sentinel cannot be added without handling it
+              // here. At runtime this is reached by anything the stream cannot classify, which
+              // used to be dropped in silence.
+              const unhandled: never = sentinel;
+              reportDiscardedChunk(unhandled);
+              break;
+            }
           }
         },
       },
@@ -484,18 +541,22 @@ export class InterruptionStreamBase {
 
   async pushFrame(frame: InterruptionSentinel | AudioFrame): Promise<void> {
     this.ensureStreamsNotEnded();
-    if (!(frame instanceof AudioFrame)) {
-      return this.inputStream.write(frame);
-    } else if (this.options.sampleRate !== frame.sampleRate) {
-      const resampler = this.getResamplerFor(frame.sampleRate);
-      if (resampler.inputRate !== frame.sampleRate) {
+    // Audio is recognised by shape, not by constructor identity: a frame built by a second copy
+    // of @livekit/rtc-node used to fail the check and be written through as if it were a
+    // sentinel, skipping the resampler on the way to a transform that then discarded it.
+    const audioFrame = asAudioFrame(frame);
+    if (!audioFrame) {
+      return this.inputStream.write(frame as InterruptionSentinel);
+    } else if (this.options.sampleRate !== audioFrame.sampleRate) {
+      const resampler = this.getResamplerFor(audioFrame.sampleRate);
+      if (resampler.inputRate !== audioFrame.sampleRate) {
         throw new Error('the sample rate of the input frames must be consistent');
       }
-      for (const resampledFrame of resampler.push(frame)) {
+      for (const resampledFrame of resampler.push(audioFrame)) {
         await this.inputStream.write(resampledFrame);
       }
     } else {
-      await this.inputStream.write(frame);
+      await this.inputStream.write(audioFrame);
     }
   }
 

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -9,7 +9,7 @@ import type {
   Room,
   TrackKind,
 } from '@livekit/rtc-node';
-import { AudioFrame, AudioResampler, RemoteParticipant, RoomEvent } from '@livekit/rtc-node';
+import { AudioFrame, AudioResampler, type RemoteParticipant, RoomEvent } from '@livekit/rtc-node';
 import { type Throws, ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { randomUUID } from 'node:crypto';
@@ -1149,8 +1149,11 @@ export async function waitForParticipantAttribute({
 
   const fut = new Future<void>();
 
-  const isMatch = (p: Participant) =>
-    p instanceof RemoteParticipant && p.identity === identity && p.attributes[attribute] === value;
+  // Matching on identity alone is enough — `identity` was just resolved out of
+  // `room.remoteParticipants`, and identities are unique within a room, so no local participant
+  // can collide with it. The `instanceof RemoteParticipant` this replaces would go false whenever
+  // the room came from a second copy of @livekit/rtc-node, leaving this future to hang forever.
+  const isMatch = (p: Participant) => p.identity === identity && p.attributes[attribute] === value;
 
   const onParticipantAttributesChanged = (
     _changedAttributes: Record<string, string>,

--- a/agents/src/voice/room_io/_input.ts
+++ b/agents/src/voice/room_io/_input.ts
@@ -6,7 +6,7 @@ import {
   AudioStream,
   type FrameProcessor,
   type NoiseCancellationOptions,
-  RemoteParticipant,
+  type RemoteParticipant,
   type RemoteTrack,
   type RemoteTrackPublication,
   type Room,
@@ -57,8 +57,12 @@ export class ParticipantAudioInputStream extends AudioInput {
 
   setParticipant(participant: RemoteParticipant | string | null) {
     this.logger.debug({ participant }, 'setting participant audio input');
+    // Discriminate on the primitive, not on `instanceof RemoteParticipant`: a participant handed
+    // in by application code comes from whichever copy of @livekit/rtc-node the application
+    // resolved, and a failed `instanceof` here would quietly store an object as the identity and
+    // subscribe to nothing. Matches BaseParticipantTranscriptionOutput.setParticipant.
     const participantIdentity =
-      participant instanceof RemoteParticipant ? participant.identity : participant;
+      typeof participant === 'string' ? participant : participant?.identity ?? null;
 
     if (this.participantIdentity === participantIdentity) {
       return;
@@ -73,9 +77,9 @@ export class ParticipantAudioInputStream extends AudioInput {
     }
 
     const participantValue =
-      participant instanceof RemoteParticipant
-        ? participant
-        : this.room.remoteParticipants.get(participantIdentity);
+      typeof participant === 'string' || participant === null
+        ? this.room.remoteParticipants.get(participantIdentity)
+        : participant;
 
     // Convert Map iterator to array for Pino serialization
     const trackPublicationsArray = Array.from(participantValue?.trackPublications.values() ?? []);


### PR DESCRIPTION
## The failure

A user's adaptive interruption returned `backchannel` for every overlap, forever, with no error and no failover. Instrumented counters from their live session:

```
broadcastFrames      2945   room audio frames reaching the source
forwardedAudio          0   frames the forward loop classified as audio
forwardedSentinels   2960   = 2945 audio frames + 15 real sentinels
```

Two copies of `@livekit/rtc-node` were loaded in one process, so the `AudioFrame` constructor that built the frames was not the one `@livekit/agents` compared against. Every `frame instanceof AudioFrame` went false:

1. `InterruptionStreamBase.pushFrame` took the `!(frame instanceof AudioFrame)` branch and wrote the raw frame into `inputStream` as if it were a sentinel, skipping resampling.
2. The transform's `if (chunk instanceof AudioFrame)` also failed, so it fell through to the `chunk.type === ...` comparisons. A real `AudioFrame` has no `type`, so every branch missed and the frame was **silently discarded** — no accept, no drop, no counter, no log.
3. Adaptive interruption had nothing to classify and fell back to a backchannel verdict on every overlap.

## What this changes

**Audio is recognised by shape, not by constructor identity.** A frame from another copy of the module is rebuilt as a local `AudioFrame` over the same sample buffer (no copy) and keeps flowing. That is not cosmetic: `AudioResampler.push()` calls `frame.protoInfo()`, which resolves pointers through the frame's *own* `FfiClient` singleton, so passing a foreign frame to a local resampler would mix two FFI runtimes.

**The first such frame raises a once-per-process `error`** naming the duplicate dependency and how to find and collapse it, so the user is told the cause instead of inferring it from a classifier that only ever says "backchannel". Accepting the frame rather than throwing is deliberate — hard-failing a live voice session over a dependency-resolution problem trades a silent degradation for a dropped call, and the diagnostic is loud enough that this cannot pass unnoticed.

**The sentinel dispatch is now an exhaustive `switch`.** Its `default` is both a compile-time `never` check (so a new sentinel cannot be added without handling it) and a real runtime guard: anything the stream cannot classify is reported at `error`, rate limited to the first occurrence plus one per 10s, carrying a running count of discarded chunks.

**Two other cross-package `instanceof` checks that fail the same way are now structural.** `ParticipantAudioInputStream.setParticipant` discriminates on `typeof participant === 'string'` (matching the existing `BaseParticipantTranscriptionOutput.setParticipant`) instead of `instanceof RemoteParticipant`, which would have stored an object as the identity and subscribed to nothing; `waitForParticipantAttribute` matches on identity alone, which is already unique within a room, instead of hanging forever.

## Audit of `instanceof` against `@livekit/rtc-node` types in `agents/src`

| Site | Failure mode on a false negative | Action |
| --- | --- | --- |
| `interruption/interruption_stream.ts` transform | **Silent** — frame matched no branch and vanished | Fixed |
| `interruption/interruption_stream.ts` `pushFrame` | **Silent** — frame written through as a sentinel, resampling skipped | Fixed |
| `voice/room_io/_input.ts` ×2 (`RemoteParticipant`) | **Silent** — object stored as identity, no track subscribed, no audio input | Fixed |
| `utils.ts` `waitForParticipantAttribute` (`RemoteParticipant`) | **Silent** — future never resolves, caller hangs | Fixed |
| `llm/utils.ts` (`VideoFrame`) | **Loud** — falls to `throw new Error('Unsupported image type')` | Left alone |

`room_io.ts` (`RealtimeModel`, `ParticipantTranscriptionOutput`) and the `LLM` / `STT` / `TTS` / `VAD` / `ChatMessage` checks are against `@livekit/agents`' own classes, not `@livekit/rtc-node`, and `worker.ts` / `eot/transports.ts` check JS builtins.

## Tests

`agents/src/inference/interruption/interruption_dual_copy.test.ts` drives the real pipeline (room audio into the interruption stream channel, through the audio transformer, out to a mocked WS transport) with frames from a locally-declared class of identical shape, so `instanceof AudioFrame` is false exactly as it is under a duplicated dependency.

Verified red before green. Against the pre-fix transform:

```
 ❯ src/inference/interruption/interruption_dual_copy.test.ts (3 tests | 2 failed)
   × keeps user audio flowing and says why, instead of discarding every frame
   × reports a chunk it cannot classify instead of dropping it in silence

AssertionError: expected 0 to be greater than 0
 ❯ src/inference/interruption/interruption_dual_copy.test.ts:256:35
    256|     expect(totalAudioSendCount()).toBeGreaterThan(0);
```

Zero frames reached the gateway — the reported symptom reproduced exactly. After the fix all 8 tests across the two new files pass, and the full `agents` suite is green at 1491 passed / 5 skipped across 112 files.

## Test plan

- [x] `pnpm build` exits 0
- [x] `pnpm vitest run` in `agents/` — 1491 passed, 5 skipped, 0 failed
- [x] `pnpm lint` exits 0 with no new warnings
- [x] `pnpm format:check` clean
- [ ] `pnpm api:check` — fails identically on `main`, not evaluated

Made with [Cursor](https://cursor.com)