### PR TITLE
fix(voice): stop a confirmed interruption from resuming the interrupted speech

### DIFF
--- a/.changeset/commit-confirmed-interruption.md
+++ b/.changeset/commit-confirmed-interruption.md
@@ -1,0 +1,12 @@
+---
+'@livekit/agents': patch
+---
+
+Commit a confirmed interruption instead of leaving it resumable
+
+When adaptive interruption ruled an overlap a genuine barge-in, `onInterruption` only
+parked the speech through `interruptByAudioActivity`, leaving the false-interruption
+timer free to put the interrupted audio back on the wire once its timeout elapsed. That
+timer exists for overlaps nobody has ruled on yet, so a confirmed verdict now ends the
+pause outright. This also stops the agent roughly 700ms sooner, since committing the
+interruption no longer waits for the final transcript to arrive.

--- a/.changeset/commit-confirmed-interruption.md
+++ b/.changeset/commit-confirmed-interruption.md
@@ -2,11 +2,18 @@
 '@livekit/agents': patch
 ---
 
-Commit a confirmed interruption instead of leaving it resumable
+Stop a confirmed interruption from resuming the interrupted speech
 
-When adaptive interruption ruled an overlap a genuine barge-in, `onInterruption` only
-parked the speech through `interruptByAudioActivity`, leaving the false-interruption
-timer free to put the interrupted audio back on the wire once its timeout elapsed. That
-timer exists for overlaps nobody has ruled on yet, so a confirmed verdict now ends the
-pause outright. This also stops the agent roughly 700ms sooner, since committing the
-interruption no longer waits for the final transcript to arrive.
+Two defects let audio the model had already ruled a genuine barge-in get back on the wire.
+
+`cancelSpeechPause` un-gated the audio sink without first signalling the interruption to it.
+Frames of the speech it had just interrupted were parked at the sink's pause gate, so opening
+that gate — meant only to admit the next speech — released them and the interrupted speech
+continued from exactly where it stopped. The interruption is now signalled before the gate
+opens, so those frames are dropped.
+
+`onInterruption` also only parked the speech through `interruptByAudioActivity`, leaving the
+false-interruption timer free to resume it once its timeout elapsed. That timer exists for
+overlaps nobody has ruled on yet, so a confirmed verdict now ends the pause outright. This
+also stops the agent roughly 700ms sooner, since committing the interruption no longer waits
+for the final transcript to arrive.

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -413,7 +413,12 @@ describe('AgentActivity - mainTask', () => {
     const handle = SpeechHandle.create({ allowInterruptions: true });
     handle._authorizeGeneration();
 
-    const audioOutput = { canPause: true, pause: vi.fn(), resume: vi.fn() };
+    const audioOutput = {
+      canPause: true,
+      pause: vi.fn(),
+      resume: vi.fn(),
+      clearBuffer: vi.fn(),
+    };
     const fakeActivity = {
       cancelSpeechPauseTask: undefined as Promise<void> | undefined,
       falseInterruptionTimer: undefined as NodeJS.Timeout | undefined,
@@ -458,6 +463,55 @@ describe('AgentActivity - mainTask', () => {
     startFalseInterruptionTimer(1 as never);
     await new Promise((resolve) => setTimeout(resolve, 30));
     expect(audioOutput.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the sink buffer before un-gating it after interrupting the paused speech', async () => {
+    const handle = SpeechHandle.create({ allowInterruptions: true });
+    handle._authorizeGeneration();
+
+    const calls: string[] = [];
+    const audioOutput = {
+      canPause: true,
+      pause: vi.fn(() => {
+        calls.push('pause');
+      }),
+      resume: vi.fn(() => {
+        calls.push('resume');
+      }),
+      clearBuffer: vi.fn(() => {
+        calls.push('clearBuffer');
+      }),
+    };
+    const fakeActivity = {
+      cancelSpeechPauseTask: undefined as Promise<void> | undefined,
+      falseInterruptionTimer: undefined as NodeJS.Timeout | undefined,
+      pausedSpeech: { handle, agentState: 'speaking', timeout: 2000 } as
+        | { handle: SpeechHandle; agentState: string; timeout: number }
+        | undefined,
+      _currentSpeech: handle,
+      logger: { debug: vi.fn(), info: vi.fn() },
+      agentSession: {
+        sessionOptions: {
+          turnHandling: {
+            interruption: { resumeFalseInterruption: true, falseInterruptionTimeout: 2000 },
+          },
+        },
+        output: { audio: audioOutput },
+      },
+    };
+
+    const proto = AgentActivity.prototype as unknown as Record<
+      string,
+      (...args: never[]) => unknown
+    >;
+    const cancelSpeechPause = proto['cancelSpeechPause']!.bind(fakeActivity as never);
+    await raceTimeout(cancelSpeechPause() as Promise<void>, 2000);
+
+    // Frames of the speech just interrupted sit parked at the sink's pause gate. Un-gating before
+    // the interruption reaches the sink releases them, and the interrupted speech continues from
+    // exactly where it stopped.
+    expect(handle.interrupted).toBe(true);
+    expect(calls).toEqual(['clearBuffer', 'resume']);
   });
 });
 

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -408,6 +408,57 @@ describe('AgentActivity - mainTask', () => {
     expect(handle.interrupted).toBe(true);
     expect(fakeActivity.pausedSpeech).toBeUndefined();
   });
+
+  it('does not leave a confirmed interruption resumable by the false-interruption timer', async () => {
+    const handle = SpeechHandle.create({ allowInterruptions: true });
+    handle._authorizeGeneration();
+
+    const audioOutput = { canPause: true, pause: vi.fn(), resume: vi.fn() };
+    const fakeActivity = {
+      cancelSpeechPauseTask: undefined as Promise<void> | undefined,
+      falseInterruptionTimer: undefined as NodeJS.Timeout | undefined,
+      pausedSpeech: { handle, agentState: 'speaking', timeout: 20 } as
+        | { handle: SpeechHandle; agentState: string; timeout: number }
+        | undefined,
+      _currentSpeech: handle,
+      audioRecognition: { onEndOfAgentSpeech: vi.fn() },
+      isInterruptionDetectionEnabled: false,
+      logger: { debug: vi.fn(), info: vi.fn() },
+      agentSession: {
+        sessionOptions: {
+          turnHandling: {
+            interruption: { resumeFalseInterruption: true, falseInterruptionTimeout: 20 },
+          },
+        },
+        output: { audio: audioOutput },
+      },
+      restoreInterruptionByAudioActivity: vi.fn(),
+      interruptByAudioActivity: vi.fn(),
+    };
+
+    const proto = AgentActivity.prototype as unknown as Record<
+      string,
+      (...args: never[]) => unknown
+    >;
+    const bind = (name: string) => proto[name]!.bind(fakeActivity as never);
+    (fakeActivity as Record<string, unknown>).cancelSpeechPause = bind('cancelSpeechPause');
+    const onInterruption = bind('onInterruption');
+    const startFalseInterruptionTimer = bind('startFalseInterruptionTimer');
+
+    onInterruption({ isInterruption: true, detectedAt: Date.now() } as never);
+    await raceTimeout(fakeActivity.cancelSpeechPauseTask ?? Promise.resolve(), 2000);
+
+    // A verdict of "this really was a barge-in" must end the pause outright, otherwise the
+    // false-interruption timer resumes speech the model already ruled a genuine interruption.
+    expect(handle.interrupted).toBe(true);
+    expect(fakeActivity.pausedSpeech).toBeUndefined();
+    expect(fakeActivity.falseInterruptionTimer).toBeUndefined();
+
+    // Nothing is left for a late timer to put back on the wire.
+    startFalseInterruptionTimer(1 as never);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(audioOutput.resume).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('AgentActivity - speech completion', () => {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -4591,12 +4591,14 @@ export class AgentActivity implements RecognitionHooks {
       return;
     }
 
+    let interruptedPausedSpeech = false;
     if (
       interrupt &&
       !this.pausedSpeech.handle.interrupted &&
       this.pausedSpeech.handle.allowInterruptions
     ) {
       this.pausedSpeech.handle.interrupt();
+      interruptedPausedSpeech = true;
       // ensure the generation is done — but only if a generation
       // was actually started. Must be raced against interrupt: an interrupted
       // paused speech may never mark its generation done, and an un-raced
@@ -4611,6 +4613,13 @@ export class AgentActivity implements RecognitionHooks {
 
     const interruptionOptions = this.agentSession.sessionOptions.turnHandling.interruption;
     if (interruptionOptions.resumeFalseInterruption && this.agentSession.output.audio) {
+      // Frames of the speech just interrupted are parked at the sink's pause gate. Opening the
+      // gate is only meant to admit the *next* speech, but the parked frames are released first
+      // and the interrupted speech continues exactly where it stopped. Signalling the
+      // interruption first makes them bail instead.
+      if (interruptedPausedSpeech) {
+        this.agentSession.output.audio.clearBuffer();
+      }
       this.agentSession.output.audio.resume();
     }
   }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1559,6 +1559,11 @@ export class AgentActivity implements RecognitionHooks {
     if (this.audioRecognition) {
       this.audioRecognition.onEndOfAgentSpeech(ev.overlapStartedAt || ev.detectedAt);
     }
+    // `interruptByAudioActivity` only parks the speech when pausing is available, leaving it for
+    // the false-interruption timer to resume. That timer exists for overlaps nobody has ruled on
+    // yet — here the model already ruled this a genuine barge-in, so commit the interruption
+    // instead of letting a 2s timeout put the interrupted speech back on the wire.
+    this.cancelSpeechPauseTask = this.cancelSpeechPause();
   }
 
   onInterimTranscript(ev: SpeechEvent, speaking: boolean | undefined): void {


### PR DESCRIPTION
## Problem

When the adaptive model rules an overlap a genuine barge-in, the agent pauses — and then puts the
interrupted speech back on the wire, continuing from exactly where it stopped. Reported from a live
session: "when I interrupt after asking for a long story, it does pause, but then it continues the
audio from where it's been cut off."

Two independent defects produce that.

**1. The sink gate is opened before the interruption reaches the sink.**

`ParticipantAudioOutput.captureFrame` parks frames at a pause gate and races them against
`interruptedFuture`, which `clearBuffer()` resolves:

```ts
if (!this.playbackEnabledFuture.done) {
  this.audioSource.clearQueue();
  await Promise.race([this.playbackEnabledFuture.await, this.interruptedFuture.await]);
  if (this.interruptedFuture.done) {
    return;
  }
}
```

`cancelSpeechPause` interrupts the paused speech and then calls `audio.resume()` without calling
`clearBuffer()`. That resume is only meant to admit the *next* speech, but it also releases every
frame parked during the pause. Whether you hear the interrupted speech continue depends on which of
`clearBuffer()` (async, via the playout task) and `resume()` (sync, at the end of
`cancelSpeechPause`) wins — so it reproduces intermittently and needs no false-interruption timer,
which is why affected sessions show no `agent_false_interruption` event.

**2. A confirmed interruption was left resumable.**

`onInterruption` only parked the speech through `interruptByAudioActivity`, leaving the
false-interruption timer free to resume it after its timeout. That timer exists for overlaps nobody
has ruled on yet, so a confirmed verdict now ends the pause outright.

## Runtime evidence

Instrumented barge-in run, consecutive events:

| event | key fields |
| --- | --- |
| `_output.ts:pause` | gate closed, `interruptedAlready: false`, 1 pending segment |
| `cancelSpeechPause:ungateSink` | still 1 pending segment |
| `_output.ts:resume` | **`clearBufferAlreadyFired: false`** |
| `captureFrame` past the gate | **a frame parked during the pause reached the wire** |

Over that run 14 frames were parked: 13 dropped (clearBuffer won) and 1 released (resume won).

After the fix, across three runs every resume that actually opened a closed gate saw
`clearBufferAlreadyFired: true`, with zero violations and zero released frames.

## Changes

- `cancelSpeechPause` calls `clearBuffer()` before `resume()` when it interrupted the paused speech.
- `onInterruption` commits the interruption instead of leaving it parked. Side benefit: the agent
  stops roughly 700ms sooner, since it no longer waits for the final transcript.

## Test plan

- [x] New unit test asserts the `clearBuffer` → `resume` ordering; fails on `main`
      (`expected [ 'resume' ] to deeply equal [ 'clearBuffer', 'resume' ]`).
- [x] New unit test asserts a confirmed interruption is not resumable by the timer.
- [x] `agents/src/voice` + `agents/src/inference/interruption`: 557 passed.
- [x] cue-cli barge-in scenario, 3 iterations: agent stops and answers the new question.
- [ ] Live confirmation that the interrupted story no longer resumes. The cue-cli runs never parked
      a frame at the gate post-fix, so they exercise the ordering invariant but not the release path.