### PR TITLE
fix(voice): stop a finished interruption from dropping the next reply

### DIFF
--- a/.changeset/stale-interruption-pause-gate.md
+++ b/.changeset/stale-interruption-pause-gate.md
@@ -1,0 +1,20 @@
+---
+'@livekit/agents': patch
+---
+
+Stop a finished interruption from silently discarding the next reply
+
+`ParticipantAudioOutput.clearBuffer()` resolves an `interruptedFuture` that frames parked at
+the pause gate consult to decide whether to bail. Nothing reset that signal until the _next_
+segment's `flush()`, which only runs after that segment's frames have all been captured — so
+for the whole of the following reply the signal still described an interruption that was
+already over. If the output was paused mid-reply during that window (an ordinary
+false-interruption pause, on by default), every remaining frame bailed at the gate and never
+reached the wire. The session still reported the reply as fully spoken and committed it to the
+chat context, so the loss was silent: in a reproduction with a real `AgentSession` and a real
+`ParticipantAudioOutput`, 18 of 20 frames — 360ms of a 400ms reply — were dropped.
+
+The gate is now scoped to the segment being captured: a frame bails only for an interruption
+raised at or after its own segment began. Frames parked at the gate are also woken by a
+per-frame signal, so a `flush()` that replaces `interruptedFuture` can no longer strand one
+there.

--- a/agents/src/voice/false_interruption_audio_loss.test.ts
+++ b/agents/src/voice/false_interruption_audio_loss.test.ts
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame, type Room, TrackPublishOptions, TrackSource } from '@livekit/rtc-node';
+import { ReadableStream } from 'node:stream/web';
+import { describe, expect, it } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { VADEventType } from '../vad.js';
+import { Agent } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AgentSessionEventTypes } from './events.js';
+import { ParticipantAudioOutput } from './room_io/_output.js';
+import { FakeLLM } from './testing/fake_llm.js';
+
+const SAMPLE_RATE = 24000;
+const FRAME_MS = 20;
+const FRAMES_PER_REPLY = 20;
+const FALSE_INTERRUPTION_TIMEOUT = 400;
+
+function frame(): AudioFrame {
+  const samples = (SAMPLE_RATE * FRAME_MS) / 1000;
+  return new AudioFrame(new Int16Array(samples), SAMPLE_RATE, 1, samples);
+}
+
+function vadEvent(type: VADEventType, speechDuration = 0, silenceDuration = 0) {
+  return {
+    type,
+    samplesIndex: 0,
+    timestamp: Date.now(),
+    speechDuration,
+    silenceDuration,
+    frames: [],
+    probability: 1,
+    inferenceDuration: 0,
+    speaking: type === VADEventType.START_OF_SPEECH,
+    rawAccumulatedSilence: 0,
+    rawAccumulatedSpeech: 0,
+  } as never;
+}
+
+function sttFinal(text: string) {
+  return {
+    type: 'final_transcript',
+    alternatives: [{ text, language: 'en', startTime: 0, endTime: 0, confidence: 1 }],
+  } as never;
+}
+
+/** The real ParticipantAudioOutput; only track publishing is skipped (no LiveKit server here). */
+class TestParticipantAudioOutput extends ParticipantAudioOutput {
+  constructor() {
+    super({} as Room, {
+      sampleRate: SAMPLE_RATE,
+      numChannels: 1,
+      trackPublishOptions: new TrackPublishOptions({ source: TrackSource.SOURCE_MICROPHONE }),
+      queueSizeMs: 100_000,
+    });
+    (this as unknown as { startedFuture: { resolve: () => void } }).startedFuture.resolve();
+  }
+
+  override async start(): Promise<void> {}
+}
+
+/** Emits `FRAMES_PER_REPLY` frames spaced out in time so a turn can be interleaved with VAD events. */
+class FrameAgent extends Agent {
+  produced = 0;
+  onFrame?: (produced: number) => void;
+
+  constructor() {
+    super({ instructions: 'test' });
+  }
+
+  async ttsNode(): Promise<ReadableStream<AudioFrame>> {
+    let emitted = 0;
+    const emit = () => {
+      this.produced++;
+      this.onFrame?.(this.produced);
+    };
+    return new ReadableStream<AudioFrame>({
+      pull: async (controller) => {
+        if (emitted >= FRAMES_PER_REPLY) {
+          controller.close();
+          return;
+        }
+        if (emitted > 0) await new Promise((resolve) => setTimeout(resolve, 15));
+        emitted++;
+        controller.enqueue(frame());
+        emit();
+      },
+    });
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function makeHarness() {
+  const session = new AgentSession({
+    llm: new FakeLLM([
+      { input: 'one', content: 'first reply' },
+      { input: 'two', content: 'second reply' },
+    ]),
+    aecWarmupDuration: null,
+    turnHandling: { interruption: { falseInterruptionTimeout: FALSE_INTERRUPTION_TIMEOUT } },
+  });
+
+  const out = new TestParticipantAudioOutput();
+  session.output.audio = out;
+
+  // Frame accounting at the boundary the bug lives on: how many frames actually reached
+  // the LiveKit AudioSource, i.e. the wire.
+  const source = (
+    out as unknown as { audioSource: { captureFrame: (f: AudioFrame) => Promise<void> } }
+  ).audioSource;
+  const captureFrame = source.captureFrame.bind(source);
+  let delivered = 0;
+  source.captureFrame = async (f: AudioFrame) => {
+    delivered++;
+    return captureFrame(f);
+  };
+
+  const falseInterruptions: boolean[] = [];
+  session.on(AgentSessionEventTypes.AgentFalseInterruption, (ev) =>
+    falseInterruptions.push(ev.resumed),
+  );
+
+  const agent = new FrameAgent();
+  await session.start({ agent });
+
+  const gate = out as unknown as { playbackEnabledFuture: { done: boolean } };
+
+  const waitForProduced = (n: number) =>
+    new Promise<void>((resolve) => {
+      agent.onFrame = (produced) => {
+        if (produced >= n) resolve();
+      };
+    });
+
+  return {
+    session,
+    out,
+    agent,
+    falseInterruptions,
+    delivered: () => delivered,
+    paused: () => !gate.done,
+    waitForProduced,
+    activity: () => session._activity!,
+    async close() {
+      await session.close();
+      await out.close();
+    },
+  };
+}
+
+type Harness = Awaited<ReturnType<typeof makeHarness>>;
+
+/**
+ * One reply that a backchannel pauses mid-flight and the false-interruption timer resumes.
+ * Every frame the TTS produced must reach the wire: the ones captured while the output was
+ * paused are held at the gate and pushed on resume.
+ */
+async function falseInterruptedReply(h: Harness, userInput: string) {
+  const producedBefore = h.agent.produced;
+  const deliveredBefore = h.delivered();
+
+  const handle = h.session.generateReply({ userInput });
+  await h.waitForProduced(producedBefore + 3);
+
+  h.activity().onStartOfSpeech(vadEvent(VADEventType.START_OF_SPEECH));
+  h.activity().onVADInferenceDone(vadEvent(VADEventType.INFERENCE_DONE, 600));
+  const pausedMidReply = h.paused();
+  // The user only said "mm-hmm": no final transcript follows, so the false-interruption
+  // timer is what resumes playback.
+  h.activity().onEndOfSpeech(vadEvent(VADEventType.END_OF_SPEECH, 0, 100));
+
+  await handle.waitForPlayout();
+  await sleep(FALSE_INTERRUPTION_TIMEOUT + 300);
+
+  return {
+    pausedMidReply,
+    produced: h.agent.produced - producedBefore,
+    delivered: h.delivered() - deliveredBefore,
+  };
+}
+
+describe('false interruption after a previous interruption', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('delivers the whole reply when nothing was interrupted before', async () => {
+    const h = await makeHarness();
+    try {
+      const reply = await falseInterruptedReply(h, 'one');
+
+      expect(reply.pausedMidReply).toBe(true);
+      expect(reply.produced).toBe(FRAMES_PER_REPLY);
+      expect(reply.delivered).toBe(reply.produced);
+      expect(h.falseInterruptions).toEqual([true]);
+    } finally {
+      await h.close();
+    }
+  }, 30000);
+
+  it('delivers the whole reply when the previous turn ended in a barge-in', async () => {
+    const h = await makeHarness();
+    try {
+      // A genuine barge-in: VAD pauses the output, the final transcript confirms the
+      // interruption, and the reply task calls clearBuffer() on the way out. That leaves
+      // interruptedFuture resolved, and nothing resets it until the *next* segment's flush —
+      // which only happens after that segment's frames have all been captured.
+      const bargedInto = h.session.generateReply({ userInput: 'one' });
+      await h.waitForProduced(3);
+      h.activity().onStartOfSpeech(vadEvent(VADEventType.START_OF_SPEECH));
+      h.activity().onVADInferenceDone(vadEvent(VADEventType.INFERENCE_DONE, 600));
+      h.activity().onFinalTranscript(sttFinal('stop please'), false);
+      await bargedInto.waitForPlayout();
+      await sleep(150);
+
+      // An ordinary false interruption on the next reply. Every frame captured during the
+      // pause used to bail at the gate on the stale signal, losing the rest of the reply
+      // while the session still recorded it as fully spoken.
+      const reply = await falseInterruptedReply(h, 'two');
+
+      expect(reply.pausedMidReply).toBe(true);
+      expect(reply.produced).toBe(FRAMES_PER_REPLY);
+      expect(reply.delivered).toBe(reply.produced);
+      expect(h.falseInterruptions).toEqual([true]);
+    } finally {
+      await h.close();
+    }
+  }, 30000);
+
+  it('delivers the whole reply when a paused reply completed and was then cancelled', async () => {
+    const h = await makeHarness();
+    try {
+      // The agent finishes its sentence while the user talks over the tail: all frames are
+      // captured, then the output is paused and the segment drains to a clean finish.
+      const completed = h.session.generateReply({ userInput: 'one' });
+      await h.waitForProduced(FRAMES_PER_REPLY);
+      for (let i = 0; i < 200 && h.delivered() < FRAMES_PER_REPLY; i++) await sleep(5);
+      await sleep(10);
+      h.activity().onStartOfSpeech(vadEvent(VADEventType.START_OF_SPEECH));
+      h.activity().onVADInferenceDone(vadEvent(VADEventType.INFERENCE_DONE, 600));
+      await completed.waitForPlayout();
+      await sleep(100);
+      expect(h.delivered()).toBe(FRAMES_PER_REPLY);
+
+      // The user's transcript finalizes and cancelSpeechPause un-gates the output.
+      h.activity().onFinalTranscript(sttFinal('okay thanks'), false);
+      await sleep(150);
+
+      const reply = await falseInterruptedReply(h, 'two');
+
+      expect(reply.pausedMidReply).toBe(true);
+      expect(reply.produced).toBe(FRAMES_PER_REPLY);
+      expect(reply.delivered).toBe(reply.produced);
+    } finally {
+      await h.close();
+    }
+  }, 30000);
+});

--- a/agents/src/voice/room_io/_output.test.ts
+++ b/agents/src/voice/room_io/_output.test.ts
@@ -164,13 +164,20 @@ describe('ParticipantAudioOutput captureFrame segment accounting', () => {
     firstFrameEmitted: boolean;
     pushedDuration: number;
     _capturing: boolean;
+    interruptCount: number;
+    segmentInterruptCount: number;
+    segmentOpen: boolean;
+    gatedFrames: Set<Future<void>>;
     playbackSegmentsCount: number;
     playbackFinishedCount: number;
     playbackFinishedFuture: Future<void>;
     onPlaybackStarted: (createdAt: number) => void;
+    logger: { error: () => void };
     audioSource: {
       clearQueue: () => void;
       captureFrame: (frame: CaptureFrameArg) => Promise<void>;
+      waitForPlayout: () => Promise<void>;
+      queuedDuration: number;
     };
   };
 
@@ -184,21 +191,39 @@ describe('ParticipantAudioOutput captureFrame segment accounting', () => {
     output.firstFrameEmitted = false;
     output.pushedDuration = 0;
     output._capturing = false;
+    output.interruptCount = 0;
+    output.segmentInterruptCount = 0;
+    output.segmentOpen = false;
+    output.gatedFrames = new Set();
     output.playbackSegmentsCount = 0;
     output.playbackFinishedCount = 0;
     output.playbackFinishedFuture = new Future<void>();
     output.onPlaybackStarted = vi.fn();
-    output.audioSource = { clearQueue: vi.fn(), captureFrame: vi.fn(async () => {}) };
+    output.logger = { error: vi.fn() };
+    output.audioSource = {
+      clearQueue: vi.fn(),
+      captureFrame: vi.fn(async () => {}),
+      // Playout never drains on its own, so a flush task stays pending like a real
+      // segment still on the wire.
+      waitForPlayout: () => new Promise<void>(() => {}),
+      queuedDuration: 0,
+    };
     return output;
   };
 
   const frame = () => ({ samplesPerChannel: 480, sampleRate: 24000 }) as unknown as CaptureFrameArg;
 
+  const settledWithin = async (promise: Promise<unknown>, ms: number) =>
+    Promise.race([
+      promise.then(() => 'settled' as const),
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), ms)),
+    ]);
+
   it('does not strand the segment counter when a frame is interrupted while paused', async () => {
     const output = makeOutput({ paused: true });
 
     const capture = output.captureFrame(frame());
-    output.interruptedFuture.resolve();
+    output.clearBuffer();
     await capture;
 
     expect(output.playbackSegmentsCount).toBe(0);
@@ -209,6 +234,46 @@ describe('ParticipantAudioOutput captureFrame segment accounting', () => {
       new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 1000)),
     ]);
     expect(result).toBe('resolved');
+  });
+
+  it('does not drop a new segment at the pause gate after the previous one was interrupted', async () => {
+    const output = makeOutput({ paused: false });
+
+    // Segment 1 plays, is flushed and then interrupted — the state a barge-in leaves behind.
+    await output.captureFrame(frame());
+    output.flush();
+    output.clearBuffer();
+    await nextTick();
+
+    // Segment 2 is a fresh reply that gets paused mid-flight by a new overlap. Its frames
+    // belong to a speech the earlier interruption knows nothing about, so they must wait
+    // for the resume rather than be discarded.
+    output.pause();
+    const capture = output.captureFrame(frame());
+    expect(await settledWithin(capture, 50)).toBe('pending');
+
+    output.resume();
+    await capture;
+
+    expect(output.audioSource.captureFrame).toHaveBeenCalledTimes(2);
+    expect(output.playbackSegmentsCount).toBe(2);
+  });
+
+  it('releases a parked frame when a concurrent flush has replaced the interruption signal', async () => {
+    const output = makeOutput({ paused: false });
+
+    await output.captureFrame(frame());
+    output.pause();
+    const capture = output.captureFrame(frame());
+    await nextTick();
+
+    // An overlapping segment's flush swaps interruptedFuture out from under the parked
+    // frame; the interruption that follows must still reach it.
+    output.flush();
+    output.clearBuffer();
+
+    expect(await settledWithin(capture, 500)).toBe('settled');
+    expect(output.audioSource.captureFrame).toHaveBeenCalledTimes(1);
   });
 
   it('registers a segment on the normal non-paused path', async () => {

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -384,6 +384,14 @@ export class ParticipantAudioOutput extends AudioOutput {
   private firstFrameEmitted: boolean = false;
   /** Gate held closed while the output is paused; frame forwarding awaits it. */
   private playbackEnabledFuture: Future<void> = new Future();
+  /** Monotonic count of interruptions signalled through clearBuffer(). */
+  private interruptCount: number = 0;
+  /** interruptCount as of the start of the segment currently being captured. */
+  private segmentInterruptCount: number = 0;
+  /** Whether a frame has been captured since the last flush boundary. */
+  private segmentOpen: boolean = false;
+  /** Wake-up futures for frames parked at the pause gate, all resolved by clearBuffer(). */
+  private gatedFrames: Set<Future<void>> = new Set();
 
   constructor(room: Room, options: AudioOutputOptions) {
     super(options.sampleRate, undefined, { pause: true });
@@ -423,13 +431,31 @@ export class ParticipantAudioOutput extends AudioOutput {
   }
 
   async captureFrame(frame: AudioFrame): Promise<void> {
+    if (!this.segmentOpen) {
+      this.segmentOpen = true;
+      // An interruption raised before this segment began belongs to a speech that is already
+      // over. interruptedFuture stays resolved until the next flush, so without this snapshot
+      // every frame of the new speech bails at the gate below and the reply is lost.
+      this.segmentInterruptCount = this.interruptCount;
+    }
+
     await this.startedFuture.await;
 
     if (!this.playbackEnabledFuture.done) {
       this.audioSource.clearQueue();
       // Race against interruption so a cancel-while-paused can't deadlock an in-flight frame.
-      await Promise.race([this.playbackEnabledFuture.await, this.interruptedFuture.await]);
-      if (this.interruptedFuture.done) {
+      // The wake-up is per frame rather than the shared interruptedFuture, which
+      // waitForPlayoutTask may replace while this frame is parked.
+      if (this.interruptCount === this.segmentInterruptCount) {
+        const gate = new Future<void>();
+        this.gatedFrames.add(gate);
+        try {
+          await Promise.race([this.playbackEnabledFuture.await, gate.await]);
+        } finally {
+          this.gatedFrames.delete(gate);
+        }
+      }
+      if (this.interruptCount > this.segmentInterruptCount) {
         return;
       }
     }
@@ -495,6 +521,7 @@ export class ParticipantAudioOutput extends AudioOutput {
    */
   flush(): void {
     super.flush();
+    this.segmentOpen = false;
 
     if (!this.pushedDuration) {
       return;
@@ -522,9 +549,15 @@ export class ParticipantAudioOutput extends AudioOutput {
   }
 
   clearBuffer(): void {
+    this.interruptCount++;
     // Signal interruption even if no frame has been pushed yet, so a gated captureFrame can bail.
     if (!this.interruptedFuture.done) {
       this.interruptedFuture.resolve();
+    }
+    for (const gate of this.gatedFrames) {
+      if (!gate.done) {
+        gate.resolve();
+      }
     }
   }
 


### PR DESCRIPTION
## Symptom

The agent produces a full reply, the user hears only the first fraction of a second of it, and the rest is silence. Nothing in the session reports a problem: no error, no `agent_false_interruption`, and the chat context records the reply as **fully spoken and not interrupted**. The next turn behaves normally, so it looks like a one-off TTS glitch.

It needs the default configuration and nothing else — `resumeFalseInterruption: true`, `falseInterruptionTimeout: 2000` and a `ParticipantAudioOutput` (`canPause: true`), which is what every RoomIO agent gets.

## Mechanism

`ParticipantAudioOutput.clearBuffer()` resolves an `interruptedFuture`. `captureFrame` consults it on the paused path so a frame parked at the pause gate can bail when an interruption lands:

https://github.com/livekit/agents-js/blob/c92d739b7d1deefb412255df4f83a993405fe747/agents/src/voice/room_io/_output.ts#L425-L435

The signal is level-triggered and was reset in exactly one place — `waitForPlayoutTask`, i.e. inside `flush()`:

https://github.com/livekit/agents-js/blob/c92d739b7d1deefb412255df4f83a993405fe747/agents/src/voice/room_io/_output.ts#L453-L458

`flush()` runs at the *end* of a segment (`forwardAudio`'s `finally` in `generation.ts`), after every frame of that segment has already been captured. So the reset always lands too late to protect the segment it opens, and the window where the signal is stale spans an entire reply:

1. A genuine barge-in ends turn N. The reply task calls `clearBuffer()` after `flush()` (`agent_activity.ts:3021`, `3606`, `2658`; `generation.ts:1049`), leaving `interruptedFuture` resolved.
2. Turn N+1 starts. `forwardAudio` calls `resume()`, so early frames flow normally and nothing looks wrong.
3. The user backchannels mid-reply. `interruptByAudioActivity` calls `audioOutput.pause()` (`agent_activity.ts:1531`) and the gate closes.
4. Every remaining frame now reads the turn-N signal, bails, and is discarded. Because bailing returns immediately, the forwarding loop drains the entire TTS stream at full speed instead of blocking — the whole rest of the reply is lost in milliseconds, not just the frames that overlap the pause.
5. The false-interruption timer then finds the handle already `done()` and emits `agent_false_interruption { resumed: false }` without resuming. `pushedDuration` reflects only the pre-pause frames, so `waitForPlayoutTask` reports `interrupted: false` and the turn is committed as complete.

Without the stale signal, step 4 parks one frame at the gate, the loop blocks, and the buffered audio is delivered on resume. That is what the control below shows.

## Evidence

Reproduction built on real in-tree components: a real `AgentSession` (`FakeLLM`, real `AgentActivity`, real recognition hooks), a real `ParticipantAudioOutput` and a real `AudioSource`. Only track publishing is stubbed, since there is no LiveKit server in the test. Frames are counted where they enter `AudioSource.captureFrame` — the wire — so "frames were lost" is measured, not inferred. Each reply is 20 frames x 20ms = 400ms.

`main`:

```
[control] interruptedFuture set before turn = false
[control] pausedMidTurn=true produced=20 delivered=20 lost=0
[control] falseInterruption events = [{"resumed":true}]

[bug] turn1 (genuine barge-in) produced=4 delivered=2
[bug] interruptedFuture set at start of turn 2 = true
[bug] pausedMidTurn=true produced=20 delivered=2 lost=18
[bug] falseInterruption events = [{"resumed":false}]
[bug] assistant chat ctx = [{"text":"first reply","interrupted":true},
                            {"text":"second reply","interrupted":false}]
```

18 of 20 frames — 360ms of a 400ms reply — never reached the wire, and the session recorded `second reply` as fully spoken. The control is the *same* false interruption on an output that has not seen a prior `clearBuffer()`: 0 lost. The only difference between the two is the leftover signal.

With this PR:

```
[bug] pausedMidTurn=true produced=20 delivered=20 lost=0
[bug] falseInterruption events = [{"resumed":true}]
```

Turn 1 is unchanged (`produced=4 delivered=2` — the barge-in still drops its parked frames).

## Fix

Scope the gate to the segment being captured. `clearBuffer()` bumps a monotonic `interruptCount`; the first frame after a flush boundary snapshots it; a frame bails only when the count has advanced past its own segment's snapshot. An interruption that belongs to a speech that is already over no longer applies to the next one.

The pre-existing deadlock guard is preserved and strengthened. A frame parked at the gate when an interruption arrives must still bail rather than hang, and it now waits on a per-frame signal that `clearBuffer()` resolves for every parked frame. Previously a concurrent `flush()` could replace `interruptedFuture` while a frame was parked on the old one, and the interruption that followed would resolve the new instance and never reach it — `_output.test.ts` has a regression test for that (it fails on `main`).

`waitForPlayoutTask`'s own use of `interruptedFuture` is untouched.

## Interaction with #2122

#2122 makes `cancelSpeechPause()` call `clearBuffer()` before `resume()` so that frames parked at the gate are dropped when an interruption is confirmed. That is a deliberate `clearBuffer()` while paused, and it **materially widens this window**. Measured on that branch with the same harness, for the case where a reply completes its playout while paused and the user's transcript then finalizes:

| | `interruptedFuture` after `cancelSpeechPause` | next reply |
| --- | --- | --- |
| `main` | not set | 20/20 delivered |
| #2122 | set | 2/20 delivered, **18 lost** |

On `main` that path never calls `clearBuffer()` at all — the reply task finished cleanly — so it is exposure #2122 introduces. It is a common shape: the agent finishes its sentence while the user talks over the tail, then the transcript finalizes.

This PR fixes both. Verified by applying it on top of #2122: all three scenarios deliver 20/20, and #2122's own behaviour is preserved (its parked frames of the confirmed barge-in are still dropped, `produced=4 delivered=2`, identical with and without this change). #2122 needs no modification — the two are compatible in either merge order. The third test added here (`a paused reply completed and was then cancelled`) passes on `main` today and guards that path from regressing.

Note for #2114, which adds `AudioOutput.abandonOpenSegment()`: that resets the base class's `_capturing` and should also clear `segmentOpen` here, so the two notions of "a segment is open" stay in sync. Not doing so is conservative (a stale snapshot is kept rather than refreshed), so there is no ordering hazard, but it is worth wiring up when both land.

## Test plan

- [x] `pnpm vitest run agents/src/voice` — 534 passed, 52 files
- [x] `npx vitest run agents/src` — 1463 passed, 5 skipped
- [x] New end-to-end test fails on `main` (2/20 frames) and passes here; run 5x for flakiness
- [x] New `_output.test.ts` cases fail on `main` for the right reasons (frame dropped instead of parked; parked frame stranded by a concurrent flush)
- [x] Existing pause-gate tests still pass, including the #1662 segment-counter guard
- [x] `pnpm build:agents`, eslint and prettier clean on touched files
- [x] `pnpm api:check` fails identically with and without this change (pre-existing `export * as` tooling issue); no public API surface changed — all new members are private

Made with [Cursor](https://cursor.com)