### PR TITLE
fix(voice): stop an interrupted reply from muting the session forever

### DIFF
--- a/.changeset/fix-interrupted-speech-wedges-session.md
+++ b/.changeset/fix-interrupted-speech-wedges-session.md
@@ -9,7 +9,10 @@ parked in the post-interrupt `waitForPlayout()`, which races only the reply's ow
 signal — a signal nothing on the ordinary interrupt path ever fires. The speech scheduling
 loop waits on that reply's generation, so `_currentSpeech` stayed pinned on the interrupted
 handle and every later turn was queued but never authorized: the agent went silent for the
-rest of the session.
+rest of the session. On the evidence so far this needs an audio sink whose playback-finished
+event the pipeline does not produce itself — remote avatar outputs (`DataStreamAudioOutput`
+and the avatar plugins built on it) and user-supplied `AudioOutput`s; a plain room output
+settled both of the affected waits on its own across six live runs.
 
 `SpeechHandle` now arms a 5s watchdog when a speech is interrupted (a port of python's
 `INTERRUPTION_TIMEOUT`): if the speech has not finished by then, its tasks are cancelled —

--- a/.changeset/fix-interrupted-speech-wedges-session.md
+++ b/.changeset/fix-interrupted-speech-wedges-session.md
@@ -1,0 +1,19 @@
+---
+'@livekit/agents': patch
+---
+
+fix(voice): stop an interrupted reply from muting the session forever
+
+A reply interrupted before its audio started playing could leave its pipeline reply task
+parked in the post-interrupt `waitForPlayout()`, which races only the reply's own abort
+signal — a signal nothing on the ordinary interrupt path ever fires. The speech scheduling
+loop waits on that reply's generation, so `_currentSpeech` stayed pinned on the interrupted
+handle and every later turn was queued but never authorized: the agent went silent for the
+rest of the session.
+
+`SpeechHandle` now arms a 5s watchdog when a speech is interrupted (a port of python's
+`INTERRUPTION_TIMEOUT`): if the speech has not finished by then, its tasks are cancelled —
+firing exactly the abort signal those waits are already watching — and the handle is marked
+done, releasing the scheduler.
+
+Fixes #2065.

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -25,6 +25,7 @@ import {
 import { LLM, type LLMStream } from '../llm/llm.js';
 import { type GenerationCreatedEvent, RealtimeError } from '../llm/realtime.js';
 import { type Tool, ToolContext, ToolFlag, Toolset, tool } from '../llm/tool_context.js';
+import { log } from '../log.js';
 import { Future, Task } from '../utils.js';
 import { AgentTask, _getActivityTaskInfo } from './agent.js';
 import { AgentActivity, onEnterStorage } from './agent_activity.js';
@@ -1236,6 +1237,7 @@ describe('AgentActivity - interruption while waiting for tools', () => {
     Object.assign(activity, {
       _backgroundSpeeches: new Set<SpeechHandle>(),
       _commitInterruptedToolOutputs: commitInterruptedToolOutputs,
+      logger: log(),
     });
     const waitForToolExecution = (
       activity as unknown as { _waitForToolExecution: WaitForToolExecution }
@@ -1286,5 +1288,30 @@ describe('AgentActivity - interruption while waiting for tools', () => {
     await expect(waiting).resolves.toBe(false);
     expect(commitInterruptedToolOutputs).toHaveBeenCalledWith(toolOutput, speechHandle, 456);
     expect(activity['_backgroundSpeeches']).not.toContain(speechHandle);
+  });
+
+  it('still commits outputs when cancelling the tool task overruns its budget', async () => {
+    // `Task.cancelAndWait` throws once the cooperative-cancel budget expires. A tool that
+    // ignores its abort signal must not take the commit down with it — the LLM has already
+    // seen these outputs, so dropping them leaves the function calls dangling.
+    const { commitInterruptedToolOutputs, waitForToolExecution } = buildActivity();
+    const speechHandle = SpeechHandle.create();
+    speechHandle.interrupt();
+    const toolOutput = buildToolOutput();
+
+    const shouldContinue = await waitForToolExecution({
+      executeToolsTask: {
+        result: new Promise<void>(() => {}),
+        cancelAndWait: vi.fn(async () => {
+          throw new Error('Task cancellation timed out');
+        }),
+      },
+      toolOutput,
+      speechHandle,
+      createdAt: 789,
+    });
+
+    expect(shouldContinue).toBe(false);
+    expect(commitInterruptedToolOutputs).toHaveBeenCalledWith(toolOutput, speechHandle, 789);
   });
 });

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -3215,7 +3215,7 @@ export class AgentActivity implements RecognitionHooks {
       if (speechHandle._hasGenerations) {
         speechHandle._markGenerationDone();
       }
-      await executeToolsTask.cancelAndWait(REPLY_TASK_CANCEL_TIMEOUT);
+      await this.cancelToolExecutions(executeToolsTask, speechHandle, toolOutput);
       this._commitInterruptedToolOutputs(toolOutput, speechHandle, replyStartedAt);
       return;
     }
@@ -3806,7 +3806,7 @@ export class AgentActivity implements RecognitionHooks {
         }
       }
       speechHandle._markGenerationDone();
-      await executeToolsTask.cancelAndWait(REPLY_TASK_CANCEL_TIMEOUT);
+      await this.cancelToolExecutions(executeToolsTask, speechHandle, toolOutput);
 
       // TODO(brian): close tees
       return;
@@ -3975,6 +3975,36 @@ export class AgentActivity implements RecognitionHooks {
     this.scheduleSpeech(replySpeechHandle, SpeechHandle.SPEECH_PRIORITY_NORMAL, true);
   }
 
+  /**
+   * Cancel the tool-execution task, tolerating a cancellation that overruns its budget.
+   *
+   * `Task.cancelAndWait` throws once the budget expires, and every caller still has work to do
+   * afterwards — committing the interrupted tool outputs above all. A tool that ignores its abort
+   * signal must degrade to a warning, not propagate and drop outputs the LLM has already seen.
+   */
+  private async cancelToolExecutions(
+    executeToolsTask: Pick<Task<void>, 'cancelAndWait'>,
+    speechHandle: SpeechHandle,
+    toolOutput: ToolOutput,
+  ): Promise<void> {
+    try {
+      await executeToolsTask.cancelAndWait(REPLY_TASK_CANCEL_TIMEOUT);
+    } catch (error) {
+      this.logger.warn(
+        {
+          error,
+          speech_id: speechHandle.id,
+          timeout: REPLY_TASK_CANCEL_TIMEOUT,
+          tool_calls: toolOutput.output.map((output) => ({
+            function: output.toolCall.name,
+            call_id: output.toolCall.callId,
+          })),
+        },
+        'tool execution task did not settle within the cancellation budget, continuing teardown',
+      );
+    }
+  }
+
   /** @internal */
   async _waitForToolExecution({
     executeToolsTask,
@@ -3988,7 +4018,7 @@ export class AgentActivity implements RecognitionHooks {
     createdAt: number;
   }): Promise<boolean> {
     if (speechHandle.interrupted) {
-      await executeToolsTask.cancelAndWait(REPLY_TASK_CANCEL_TIMEOUT);
+      await this.cancelToolExecutions(executeToolsTask, speechHandle, toolOutput);
       this._commitInterruptedToolOutputs(toolOutput, speechHandle, createdAt);
       return false;
     }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -136,7 +136,7 @@ import {
   updateInstructions,
 } from './generation.js';
 import type { PlaybackFinishedEvent, TimedString } from './io.js';
-import { type InputDetails, SpeechHandle } from './speech_handle.js';
+import { type InputDetails, REPLY_TASK_CANCEL_TIMEOUT, SpeechHandle } from './speech_handle.js';
 import {
   ToolExecutor,
   cancelTaskTool,
@@ -256,8 +256,6 @@ async function raceWithAbort<T>(
 export class AgentActivity implements RecognitionHooks {
   agent: Agent;
   agentSession: AgentSession;
-
-  private static readonly REPLY_TASK_CANCEL_TIMEOUT = 5000;
 
   private started = false;
   private audioRecognition?: AudioRecognition;
@@ -2653,7 +2651,7 @@ export class AgentActivity implements RecognitionHooks {
 
       if (speechHandle.interrupted) {
         replyAbortController.abort();
-        await cancelAndWait(tasks, AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+        await cancelAndWait(tasks, REPLY_TASK_CANCEL_TIMEOUT);
         if (audioOutput) {
           audioOutput.clearBuffer();
           await audioOutput.waitForPlayout();
@@ -2903,7 +2901,7 @@ export class AgentActivity implements RecognitionHooks {
 
     if (speechHandle.interrupted) {
       replyAbortController.abort();
-      await cancelAndWait(tasks, AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+      await cancelAndWait(tasks, REPLY_TASK_CANCEL_TIMEOUT);
       return;
     }
 
@@ -3016,7 +3014,7 @@ export class AgentActivity implements RecognitionHooks {
         }
 
         if (speechHandle.interrupted) {
-          await cancelAndWait(forwardTasks, AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+          await cancelAndWait(forwardTasks, REPLY_TASK_CANCEL_TIMEOUT);
           if (audioOutput) {
             audioOutput.clearBuffer();
             // During shutdown (room disconnected / activity closing) the
@@ -3071,7 +3069,7 @@ export class AgentActivity implements RecognitionHooks {
         return output;
       } finally {
         replyAbortController.signal.removeEventListener('abort', abortSegment);
-        await cancelAndWait(forwardTasks, AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+        await cancelAndWait(forwardTasks, REPLY_TASK_CANCEL_TIMEOUT);
         // The segment's playout window is over; settle a still-pending
         // firstFrameFut so the playback-started listener is detached.
         this.settleFirstFrameFut(output.audioOut);
@@ -3176,7 +3174,7 @@ export class AgentActivity implements RecognitionHooks {
       );
 
       replyAbortController.abort();
-      await cancelAndWait(tasks, AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+      await cancelAndWait(tasks, REPLY_TASK_CANCEL_TIMEOUT);
 
       const forwardedText = segmentOutputs.map(forwardedTextFor).join('');
 
@@ -3217,7 +3215,7 @@ export class AgentActivity implements RecognitionHooks {
       if (speechHandle._hasGenerations) {
         speechHandle._markGenerationDone();
       }
-      await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+      await executeToolsTask.cancelAndWait(REPLY_TASK_CANCEL_TIMEOUT);
       this._commitInterruptedToolOutputs(toolOutput, speechHandle, replyStartedAt);
       return;
     }
@@ -3601,7 +3599,7 @@ export class AgentActivity implements RecognitionHooks {
         }
 
         if (speechHandle.interrupted) {
-          await cancelAndWait(forwardTasks, AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+          await cancelAndWait(forwardTasks, REPLY_TASK_CANCEL_TIMEOUT);
           if (audioOutput) {
             audioOutput.clearBuffer();
             const playbackEv = await audioOutput.waitForPlayout();
@@ -3639,7 +3637,7 @@ export class AgentActivity implements RecognitionHooks {
         return output;
       } finally {
         abortController.signal.removeEventListener('abort', abortMessage);
-        await cancelAndWait(forwardTasks, AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+        await cancelAndWait(forwardTasks, REPLY_TASK_CANCEL_TIMEOUT);
         // The message's playout window is over; settle a still-pending
         // firstFrameFut so the playback-started listener is detached.
         this.settleFirstFrameFut(output.audioOut);
@@ -3786,7 +3784,7 @@ export class AgentActivity implements RecognitionHooks {
         'Aborting all realtime generation tasks due to interruption',
       );
       replyAbortController.abort();
-      await cancelAndWait(tasks, AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+      await cancelAndWait(tasks, REPLY_TASK_CANCEL_TIMEOUT);
       addRealtimeMessageOutputs(messageOutputs);
 
       const anySkipped = messageOutputs.some((output) => output.played === 'skipped');
@@ -3808,7 +3806,7 @@ export class AgentActivity implements RecognitionHooks {
         }
       }
       speechHandle._markGenerationDone();
-      await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+      await executeToolsTask.cancelAndWait(REPLY_TASK_CANCEL_TIMEOUT);
 
       // TODO(brian): close tees
       return;
@@ -3990,7 +3988,7 @@ export class AgentActivity implements RecognitionHooks {
     createdAt: number;
   }): Promise<boolean> {
     if (speechHandle.interrupted) {
-      await executeToolsTask.cancelAndWait(AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+      await executeToolsTask.cancelAndWait(REPLY_TASK_CANCEL_TIMEOUT);
       this._commitInterruptedToolOutputs(toolOutput, speechHandle, createdAt);
       return false;
     }
@@ -4373,7 +4371,7 @@ export class AgentActivity implements RecognitionHooks {
         this._currentSpeech._cancel();
       }
 
-      await cancelAndWait(Array.from(this.speechTasks), AgentActivity.REPLY_TASK_CANCEL_TIMEOUT);
+      await cancelAndWait(Array.from(this.speechTasks), REPLY_TASK_CANCEL_TIMEOUT);
       await this._toolExecutor.drain();
 
       if (this._currentSpeech && !this._currentSpeech.done()) {

--- a/agents/src/voice/interrupt_before_playout_deadlock.test.ts
+++ b/agents/src/voice/interrupt_before_playout_deadlock.test.ts
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression test for livekit/agents-js#2065.
+ *
+ * A reply that is interrupted before its audio ever starts playing can leave the pipeline
+ * reply task parked in `forwardSegment`'s post-interrupt `waitForPlayout()`. That wait races
+ * the reply's own abort signal, but nothing on the ordinary interrupt path fires it — the
+ * `replyAbortController.abort()` call lives past the segment loop the wait is blocking. The
+ * speech scheduling loop then waits on that reply's generation future, so `_currentSpeech`
+ * stays pinned on the interrupted handle and every later turn is queued but never authorized:
+ * the agent goes silent for the rest of the session.
+ *
+ * The output below stands in for the class of sinks whose playback-finished event is not the
+ * pipeline's to produce — remote avatar outputs (`DataStreamAudioOutput` and every avatar
+ * plugin built on it) and any user-supplied `AudioOutput`. It honors the `AudioOutput`
+ * contract: every segment it counts is eventually finished exactly once. It just cannot report
+ * a segment the remote never began playing until the next turn's audio reaches it, which is
+ * what closes the loop — the next turn cannot start until the wedged one lets go.
+ *
+ * The fix is `SpeechHandle`'s interruption watchdog (a port of python's `INTERRUPTION_TIMEOUT`
+ * in `voice/speech_handle.py`), which cancels an interrupted speech's tasks — firing exactly
+ * the abort signal those waits are already watching — and marks the handle done.
+ */
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream } from 'node:stream/web';
+import { describe, expect, it } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { Agent } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AudioOutput } from './io.js';
+import { FakeLLM } from './testing/fake_llm.js';
+
+function frame(durationMs = 20, sampleRate = 24000): AudioFrame {
+  const samples = Math.floor((sampleRate * durationMs) / 1000);
+  return new AudioFrame(new Int16Array(samples), sampleRate, 1, samples);
+}
+
+type TtsControls = { push: (frame: AudioFrame) => void; close: () => void };
+
+/** Hands each reply's TTS frame stream back to the test so interrupts can be timed exactly. */
+class ScriptedTtsAgent extends Agent {
+  readonly replies: TtsControls[] = [];
+
+  constructor() {
+    super({ instructions: 'test' });
+  }
+
+  async ttsNode(): Promise<ReadableStream<AudioFrame>> {
+    let push!: (frame: AudioFrame) => void;
+    let close!: () => void;
+    const stream = new ReadableStream<AudioFrame>({
+      start(controller) {
+        push = (f) => {
+          try {
+            controller.enqueue(f);
+          } catch {
+            // stream already closed by a previous interrupt
+          }
+        };
+        close = () => {
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+        };
+      },
+    });
+    this.replies.push({ push, close });
+    return stream;
+  }
+}
+
+/**
+ * A remote sink: frames are handed to a worker that plays them and reports back.
+ *
+ * `startPlayout` decides whether the worker gets far enough to start playing this turn's
+ * audio. A segment it never started is not reported when the turn ends — the worker only
+ * learns the turn is over when the next turn's audio arrives, and settles the old segment
+ * then. Every counted segment is still finished exactly once.
+ */
+class RemoteWorkerAudioOutput extends AudioOutput {
+  startPlayout = true;
+  private unreportedSegments = 0;
+  private playingSegment = false;
+
+  constructor() {
+    super(24000, undefined, { pause: false });
+  }
+
+  async captureFrame(f: AudioFrame): Promise<void> {
+    while (this.unreportedSegments > 0) {
+      this.unreportedSegments--;
+      this.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
+    }
+    await super.captureFrame(f);
+    if (this.startPlayout && !this.playingSegment) {
+      this.playingSegment = true;
+      this.onPlaybackStarted(Date.now());
+    }
+  }
+
+  flush(): void {
+    const played = this.playingSegment;
+    this.playingSegment = false;
+    super.flush();
+    if (played) {
+      this.onPlaybackFinished({ playbackPosition: 0.02, interrupted: false });
+    } else if (this.pendingPlayoutSegments > this.unreportedSegments) {
+      this.unreportedSegments++;
+    }
+  }
+
+  clearBuffer(): void {}
+}
+
+/** Surfaces a stall as a value, so a hang fails the test instead of hanging the suite. */
+async function settleOrStall<T>(promise: Promise<T>, timeoutMs: number) {
+  let timer: NodeJS.Timeout | undefined;
+  const watchdog = new Promise<'did not settle'>((resolve) => {
+    timer = setTimeout(() => resolve('did not settle'), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, watchdog]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForReply(agent: ScriptedTtsAgent, index: number): Promise<TtsControls> {
+  for (let i = 0; i < 400 && agent.replies.length <= index; i++) {
+    await sleep(5);
+  }
+  const controls = agent.replies[index];
+  if (!controls) throw new Error(`reply ${index} never reached the TTS node`);
+  return controls;
+}
+
+describe('reply interrupted before playout start (#2065)', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('keeps speaking after a reply is interrupted before its audio starts playing', async () => {
+    const spoken: string[] = [];
+    const agent = new ScriptedTtsAgent();
+    const session = new AgentSession({
+      llm: new FakeLLM([
+        { input: 'one', content: 'first reply' },
+        { input: 'two', content: 'second reply' },
+      ]),
+    });
+    const audioOutput = new RemoteWorkerAudioOutput();
+    session.output.audio = audioOutput;
+    session.on('conversation_item_added', (ev) => {
+      if (ev.item.role === 'assistant') spoken.push(ev.item.textContent);
+    });
+
+    await session.start({ agent });
+    try {
+      // The reply's audio reaches the sink but the remote never starts playing it, and the
+      // user's next turn interrupts in that window.
+      audioOutput.startPlayout = false;
+      const first = session.generateReply({ userInput: 'one' });
+      const firstTts = await waitForReply(agent, 0);
+      await sleep(50);
+      firstTts.push(frame());
+      await sleep(50);
+      session.interrupt();
+      firstTts.close();
+      await settleOrStall(first.waitForPlayout(), 10_000);
+
+      // The turn the customer never hears: a later reply must still be spoken.
+      audioOutput.startPlayout = true;
+      const second = session.generateReply({ userInput: 'two' });
+      const secondTts = await waitForReply(agent, 1);
+      for (let i = 0; i < 5; i++) {
+        secondTts.push(frame());
+        await sleep(5);
+      }
+      secondTts.close();
+
+      expect(await settleOrStall(second.waitForPlayout(), 15_000)).not.toBe('did not settle');
+      expect(spoken).toContain('second reply');
+    } finally {
+      await settleOrStall(session.close(), 5000);
+    }
+  }, 60_000);
+});

--- a/agents/src/voice/speech_handle.test.ts
+++ b/agents/src/voice/speech_handle.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { FunctionCall } from '../llm/chat_context.js';
 import { Task, waitForAbort } from '../utils.js';
 import { functionCallStorage } from './agent.js';
-import { SpeechHandle } from './speech_handle.js';
+import { REPLY_TASK_CANCEL_TIMEOUT, SpeechHandle } from './speech_handle.js';
 
 async function raceTimeout(promise: Promise<unknown>, ms: number): Promise<'resolved' | 'timeout'> {
   let timer: ReturnType<typeof setTimeout>;
@@ -204,7 +204,13 @@ describe('SpeechHandle interruption watchdog (#2065)', () => {
       handle.interrupt();
       expect(handle.done()).toBe(false);
 
-      await vi.advanceTimersByTimeAsync(5000);
+      // A reply that unwinds slowly is allowed the whole cooperative-cancel budget before the
+      // watchdog is entitled to act. Firing inside that window would cut off a teardown that is
+      // still on its way to committing the turn.
+      await vi.advanceTimersByTimeAsync(REPLY_TASK_CANCEL_TIMEOUT);
+      expect(handle.done()).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(10_000);
 
       expect(task.done).toBe(true);
       expect(handle.done()).toBe(true);

--- a/agents/src/voice/speech_handle.test.ts
+++ b/agents/src/voice/speech_handle.test.ts
@@ -9,6 +9,7 @@
 // only, and make SpeechHandle itself awaitable.
 import { describe, expect, it, vi } from 'vitest';
 import { FunctionCall } from '../llm/chat_context.js';
+import { Task, waitForAbort } from '../utils.js';
 import { functionCallStorage } from './agent.js';
 import { SpeechHandle } from './speech_handle.js';
 
@@ -182,6 +183,54 @@ describe('SpeechHandle._markDone - generation completion', () => {
 
     const outcome = await raceTimeout(generationWait, 1000);
     expect(outcome).toBe('resolved');
+  });
+});
+
+describe('SpeechHandle interruption watchdog (#2065)', () => {
+  it('cancels the owned tasks and marks the handle done when an interrupt is ignored', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = SpeechHandle.create();
+      // A reply task that never observes its interruption — the shape of the #2065 hang,
+      // where the only escape from the post-interrupt playout wait is this abort signal.
+      const task = Task.from(
+        (controller) =>
+          new Promise<void>((resolve) => waitForAbort(controller.signal).then(resolve)),
+      );
+      handle._tasks.push(task);
+      handle._authorizeGeneration();
+      const generationWait = handle._waitForGeneration();
+
+      handle.interrupt();
+      expect(handle.done()).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(task.done).toBe(true);
+      expect(handle.done()).toBe(true);
+      // The scheduling loop's wait is released, so the next queued speech can be authorized.
+      await expect(generationWait).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not cancel a speech that finishes within the grace period', async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = SpeechHandle.create();
+      const task = Task.from(() => Promise.resolve());
+      const cancel = vi.spyOn(task, 'cancel');
+      handle._tasks.push(task);
+
+      handle.interrupt();
+      handle._markDone();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(cancel).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -19,26 +19,38 @@ const SPEECH_HANDLE_SYMBOL = Symbol.for('livekit.agents.SpeechHandle');
  * so `utils.aio.cancel_and_wait` needs no ceiling at all. Nothing here can cancel a pending
  * promise, so tasks are aborted cooperatively and waited on with this bound instead.
  *
- * Moved here from `AgentActivity` only so {@link INTERRUPTION_TIMEOUT} can be expressed against it.
- * The value is unchanged, deliberately: this budget also governs tool-execution cancellation and
- * the shutdown drain, so shrinking it to buy the ordering below would abandon teardown work that
- * legitimately takes seconds, on paths that have nothing to do with an interrupted reply.
+ * All it bounds is how long an *aborted task body* takes to reach its own return — not how long
+ * the work it started takes. The pipeline's tasks are stream pumps that re-check `signal.aborted`
+ * each iteration, and `performToolExecutions` never awaits a user tool promise on this path: it
+ * races the abort signal (`_waitForToolExecutionResult`), while `ToolExecutor` abandons a cancelled
+ * tool outright and only *logs* if `execute()` is still running after `DRAIN_TOOL_TIMEOUT_MS`.
+ * Non-cancellable tools are awaited to completion by `ToolExecutor.drain()` with no ceiling at all,
+ * and the shutdown drain is a separate unbounded await that runs *after* this budget — so tool
+ * cleanup is governed by the executor's own design, never by this value.
+ *
+ * Measured `performToolExecutions` settle latency after `abort()`: 0.04–0.33 ms across a tool that
+ * observes its abort signal, a 4s tool that ignores it, a non-cancellable 4s tool, three concurrent
+ * tools, and a tool body that never settles at all. The one shape that exceeds 2s is a task parked
+ * on a tool-call stream that is never closed — it never settles, so no finite ceiling rescues it.
+ *
+ * 2s is therefore ample, and small enough that the two budgets an interrupted reply spends in
+ * sequence (its task group, then its tool-execution task) still fit inside
+ * {@link INTERRUPTION_TIMEOUT}; at 5s they would not.
  */
-export const REPLY_TASK_CANCEL_TIMEOUT = 5000;
+export const REPLY_TASK_CANCEL_TIMEOUT = 2000;
 
 /**
  * How long an interrupted speech may keep running before its tasks are cancelled outright.
  *
- * Ports `INTERRUPTION_TIMEOUT` from `livekit-agents/livekit/agents/voice/speech_handle.py`, but
- * cannot reuse python's 5s: python has no cooperative-cancel budget to collide with, because
- * cancellation there lands at the next await point. Here a teardown may legitimately spend the
- * whole of {@link REPLY_TASK_CANCEL_TIMEOUT}, and its clock starts *after* the interrupt that arms
- * this watchdog — so at equal values the watchdog always preempts a slow-but-healthy teardown and
- * marks the handle done just as it resumes to commit its turn, trading a muted session for a lost
- * assistant message. The margin is what this watchdog costs: it is dead air the user hears before
- * the session recovers, against a session that on current `main` never recovers at all.
+ * Ports `INTERRUPTION_TIMEOUT` from `livekit-agents/livekit/agents/voice/speech_handle.py`,
+ * including its value. It must stay strictly greater than {@link REPLY_TASK_CANCEL_TIMEOUT}: a
+ * teardown may legitimately spend that whole budget, and its clock starts *after* the interrupt
+ * that arms this watchdog, so at equal values the watchdog always preempts a slow-but-healthy
+ * teardown and marks the handle done just as it resumes to commit its turn — trading a muted
+ * session for a lost assistant message. The margin is what this watchdog costs: dead air the user
+ * hears before the session recovers, against a session that without it never recovers at all.
  */
-const INTERRUPTION_TIMEOUT = REPLY_TASK_CANCEL_TIMEOUT + 3000;
+const INTERRUPTION_TIMEOUT = 5000;
 
 /**
  * Type guard to check if a value is a SpeechHandle.

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -13,12 +13,25 @@ import { functionCallStorage } from './agent.js';
 const SPEECH_HANDLE_SYMBOL = Symbol.for('livekit.agents.SpeechHandle');
 
 /**
+ * How long a reply task may take to unwind after its abort signal fires.
+ *
+ * Python cancels a task outright and the `CancelledError` lands at its next await point, so
+ * `utils.aio.cancel_and_wait` needs no ceiling. Nothing here can cancel a pending promise, so the
+ * reply tasks are aborted cooperatively and waited on with this bound instead.
+ */
+export const REPLY_TASK_CANCEL_TIMEOUT = 5000;
+
+/**
  * How long an interrupted speech may keep running before its tasks are cancelled outright.
  *
  * Mirrors `INTERRUPTION_TIMEOUT` in the python implementation
- * (`livekit-agents/livekit/agents/voice/speech_handle.py`).
+ * (`livekit-agents/livekit/agents/voice/speech_handle.py`), but must stay strictly greater than
+ * {@link REPLY_TASK_CANCEL_TIMEOUT}. Python's 5s can only elapse when a reply is genuinely stuck;
+ * here a reply that unwinds slowly may legitimately spend the whole cancel budget first. Were the
+ * two equal, this watchdog would mark the handle done at the very moment such a reply resumes to
+ * commit its turn, turning a slow teardown into a lost assistant message.
  */
-const INTERRUPTION_TIMEOUT = 5000;
+const INTERRUPTION_TIMEOUT = REPLY_TASK_CANCEL_TIMEOUT + 3000;
 
 /**
  * Type guard to check if a value is a SpeechHandle.

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -15,23 +15,24 @@ const SPEECH_HANDLE_SYMBOL = Symbol.for('livekit.agents.SpeechHandle');
 /**
  * How long a reply task may take to unwind after its abort signal fires.
  *
- * Python cancels a task outright and the `CancelledError` lands at its next await point, so
- * `utils.aio.cancel_and_wait` needs no ceiling. Nothing here can cancel a pending promise, so the
- * reply tasks are aborted cooperatively and waited on with this bound instead.
+ * Has no python counterpart: there a cancelled task takes `CancelledError` at its next await point,
+ * so `utils.aio.cancel_and_wait` needs no ceiling at all. Nothing here can cancel a pending
+ * promise, so reply tasks are aborted cooperatively and waited on with this bound instead. It has
+ * to stay comfortably below {@link INTERRUPTION_TIMEOUT}: a reply that spends its whole budget and
+ * a watchdog that fires at the same instant would mark the handle done just as that reply resumes
+ * to commit its turn, trading a muted session for a lost assistant message.
  */
-export const REPLY_TASK_CANCEL_TIMEOUT = 5000;
+export const REPLY_TASK_CANCEL_TIMEOUT = 2000;
 
 /**
  * How long an interrupted speech may keep running before its tasks are cancelled outright.
  *
  * Mirrors `INTERRUPTION_TIMEOUT` in the python implementation
- * (`livekit-agents/livekit/agents/voice/speech_handle.py`), but must stay strictly greater than
- * {@link REPLY_TASK_CANCEL_TIMEOUT}. Python's 5s can only elapse when a reply is genuinely stuck;
- * here a reply that unwinds slowly may legitimately spend the whole cancel budget first. Were the
- * two equal, this watchdog would mark the handle done at the very moment such a reply resumes to
- * commit its turn, turning a slow teardown into a lost assistant message.
+ * (`livekit-agents/livekit/agents/voice/speech_handle.py`). This is dead air the user hears before
+ * the session recovers, so it tracks python's value rather than being padded; the ordering against
+ * {@link REPLY_TASK_CANCEL_TIMEOUT} is bought by keeping that budget small instead.
  */
-const INTERRUPTION_TIMEOUT = REPLY_TASK_CANCEL_TIMEOUT + 3000;
+const INTERRUPTION_TIMEOUT = 5000;
 
 /**
  * Type guard to check if a value is a SpeechHandle.

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -13,26 +13,32 @@ import { functionCallStorage } from './agent.js';
 const SPEECH_HANDLE_SYMBOL = Symbol.for('livekit.agents.SpeechHandle');
 
 /**
- * How long a reply task may take to unwind after its abort signal fires.
+ * How long a cooperatively cancelled task may take to unwind after its abort signal fires.
  *
  * Has no python counterpart: there a cancelled task takes `CancelledError` at its next await point,
  * so `utils.aio.cancel_and_wait` needs no ceiling at all. Nothing here can cancel a pending
- * promise, so reply tasks are aborted cooperatively and waited on with this bound instead. It has
- * to stay comfortably below {@link INTERRUPTION_TIMEOUT}: a reply that spends its whole budget and
- * a watchdog that fires at the same instant would mark the handle done just as that reply resumes
- * to commit its turn, trading a muted session for a lost assistant message.
+ * promise, so tasks are aborted cooperatively and waited on with this bound instead.
+ *
+ * Moved here from `AgentActivity` only so {@link INTERRUPTION_TIMEOUT} can be expressed against it.
+ * The value is unchanged, deliberately: this budget also governs tool-execution cancellation and
+ * the shutdown drain, so shrinking it to buy the ordering below would abandon teardown work that
+ * legitimately takes seconds, on paths that have nothing to do with an interrupted reply.
  */
-export const REPLY_TASK_CANCEL_TIMEOUT = 2000;
+export const REPLY_TASK_CANCEL_TIMEOUT = 5000;
 
 /**
  * How long an interrupted speech may keep running before its tasks are cancelled outright.
  *
- * Mirrors `INTERRUPTION_TIMEOUT` in the python implementation
- * (`livekit-agents/livekit/agents/voice/speech_handle.py`). This is dead air the user hears before
- * the session recovers, so it tracks python's value rather than being padded; the ordering against
- * {@link REPLY_TASK_CANCEL_TIMEOUT} is bought by keeping that budget small instead.
+ * Ports `INTERRUPTION_TIMEOUT` from `livekit-agents/livekit/agents/voice/speech_handle.py`, but
+ * cannot reuse python's 5s: python has no cooperative-cancel budget to collide with, because
+ * cancellation there lands at the next await point. Here a teardown may legitimately spend the
+ * whole of {@link REPLY_TASK_CANCEL_TIMEOUT}, and its clock starts *after* the interrupt that arms
+ * this watchdog — so at equal values the watchdog always preempts a slow-but-healthy teardown and
+ * marks the handle done just as it resumes to commit its turn, trading a muted session for a lost
+ * assistant message. The margin is what this watchdog costs: it is dead air the user hears before
+ * the session recovers, against a session that on current `main` never recovers at all.
  */
-const INTERRUPTION_TIMEOUT = 5000;
+const INTERRUPTION_TIMEOUT = REPLY_TASK_CANCEL_TIMEOUT + 3000;
 
 /**
  * Type guard to check if a value is a SpeechHandle.

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -4,12 +4,21 @@
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import type { Context } from '@opentelemetry/api';
 import type { ChatItem } from '../llm/index.js';
+import { log } from '../log.js';
 import type { Task } from '../utils.js';
 import { Event, Future, dedent, shortuuid } from '../utils.js';
 import { functionCallStorage } from './agent.js';
 
 /** Symbol used to identify SpeechHandle instances */
 const SPEECH_HANDLE_SYMBOL = Symbol.for('livekit.agents.SpeechHandle');
+
+/**
+ * How long an interrupted speech may keep running before its tasks are cancelled outright.
+ *
+ * Mirrors `INTERRUPTION_TIMEOUT` in the python implementation
+ * (`livekit-agents/livekit/agents/voice/speech_handle.py`).
+ */
+const INTERRUPTION_TIMEOUT = 5000;
 
 /**
  * Type guard to check if a value is a SpeechHandle.
@@ -96,6 +105,8 @@ export class SpeechHandle {
 
   private itemAddedCallbacks: Set<(item: ChatItem) => void> = new Set();
   private doneCallbacks: Set<(sh: SpeechHandle) => void> = new Set();
+  private interruptTimeout?: ReturnType<typeof setTimeout>;
+  private logger = log();
 
   /** @internal Symbol marker for type identification */
   readonly [SPEECH_HANDLE_SYMBOL] = true;
@@ -312,9 +323,48 @@ export class SpeechHandle {
 
     if (!this.interruptFut.done) {
       this.interruptFut.resolve();
+      this.startInterruptTimeout();
     }
 
     return this;
+  }
+
+  /**
+   * Arm the watchdog that force-cancels an interrupted speech that refuses to finish.
+   *
+   * Interrupting only resolves `interruptFut`; it is up to the owning reply task to notice and
+   * unwind. A task parked on something the interruption itself cannot settle — most of the
+   * pipeline reply's post-interrupt waits race the reply's abort signal, and nothing on the
+   * ordinary interrupt path ever fires it — would otherwise never reach
+   * `_markGenerationDone()`. The speech scheduling loop waits on that generation, so a single
+   * stuck reply silently mutes the session for the rest of its life (#2065). Cancelling the
+   * owned tasks aborts exactly the signal those waits are watching; `_markDone` then releases
+   * the scheduler even if a task ignores its signal.
+   *
+   * Ported from python's `SpeechHandle._cancel`.
+   */
+  private startInterruptTimeout(): void {
+    this.interruptTimeout = setTimeout(() => {
+      this.interruptTimeout = undefined;
+      this.logger.error(
+        { speech_id: this._id, timeout: INTERRUPTION_TIMEOUT },
+        'speech not done in time after interruption, cancelling the speech arbitrarily.',
+      );
+      for (const task of this._tasks) {
+        task.cancel();
+      }
+      this._markDone();
+    }, INTERRUPTION_TIMEOUT);
+    // A pending watchdog must not be what keeps a process alive: handles that are interrupted
+    // and then abandoned (never scheduled, so never marked done) would hold the loop open.
+    this.interruptTimeout.unref?.();
+  }
+
+  private clearInterruptTimeout(): void {
+    if (this.interruptTimeout !== undefined) {
+      clearTimeout(this.interruptTimeout);
+      this.interruptTimeout = undefined;
+    }
   }
 
   /** @internal */
@@ -384,6 +434,8 @@ export class SpeechHandle {
     if (this.generations.length > 0) {
       this._markGenerationDone();
     }
+
+    this.clearInterruptTimeout();
   }
 
   /** @internal */


### PR DESCRIPTION
## Summary

A reply that is interrupted **before its audio ever starts playing** can permanently mute an `AgentSession`. The reply task parks forever, the speech scheduling loop parks behind it, `_currentSpeech` stays pinned on the interrupted handle, and every later user turn creates a speech handle that is queued but never authorized. The session only ends via an external idle/duration guard — it never recovers on its own.

Reproduced deterministically offline on `origin/main` (evidence below), and fixed by porting python's `INTERRUPTION_TIMEOUT` watchdog.

**Scope, up front.** On the evidence so far, reaching this needs an audio sink whose playback-finished event the pipeline does not produce itself — remote avatar outputs (`DataStreamAudioOutput` and every avatar plugin built on it) and any user-supplied `AudioOutput`. A live reproduction built to the reporter's description but driving a plain room output did not wedge in six runs ([details](https://github.com/livekit/agents-js/pull/2127#issuecomment-5096040584)): `ParticipantAudioOutput` settles both of the affected waits on its own. That is six runs plus a code-path argument, not a proof of immunity, and the reporter has not said which sink they use — but the verified red-to-green below is on the affected sink class, not on the plain STT-LLM-TTS room pipeline.

Fixes livekit/agents-js#2065.

## Mechanism

Three links, and the third is the one that turns a lost turn into a dead session.

**1. The reply task cannot observe its own interruption.** In `forwardSegment`'s interrupted branch (`agent_activity.ts`):

```ts
audioOutput.clearBuffer();
const interruptedPlaybackEv = await raceWithAbort(
  audioOutput.waitForPlayout(),
  replyAbortController.signal,
);
```

`waitForPlayout()` resolves when the output reports a playback-finished for every segment it counted. If the reply was interrupted before the sink began playing its segment, that event may not be available yet. The only other escape is `replyAbortController.signal` — and `replyAbortController.abort()` lives **past the segment loop this await is sitting in**, in the `if (speechHandle.interrupted)` block after the loop returns. The loop cannot return, because it is blocked on this await. Nothing else on the ordinary interrupt path aborts that controller, so the race has no second runner.

**2. So the generation future never settles.** The reply task never reaches `_markGenerationDone()`; its owned task never completes, so `createSpeechTask`'s done callback never calls `_markDone()` either. This is the reporter's log signature: no `"Aborting all pipeline reply tasks due to interruption"` line for the wedged speech id. That is what the wedged path produces with a sink of the affected class — but it is not what a room output does. In the six live room-output runs that line always appeared, 35 ms after the interrupt in the cleanest one.

**3. And the scheduler waits on it with no escape.** `mainTask`:

```ts
this._currentSpeech = speechHandle;
speechHandle._authorizeGeneration();
const generation = speechHandle._waitForGeneration();
await speechHandle.waitIfNotInterrupted([generation]);
// Keep the shared outputs serialized through interrupted-generation cleanup.
if (speechHandle.interrupted && speechHandle._tasks.length > 0) {
  await ThrowsPromise.race([generation, abortFuture.await]);
}
this._currentSpeech = undefined;
```

The first wait returns immediately on interrupt (that's livekit/agents-js#1124's guard). The second, added in livekit/agents-js#1966, is unguarded: `generation` never settles and `abortFuture` only settles when the whole activity is torn down. `_currentSpeech` is pinned forever.

## The fix

`SpeechHandle._cancel()` now arms a watchdog when a speech is interrupted. If the speech has not finished 5s later, it cancels the handle's owned tasks and marks the handle done.

This is a direct port of `SpeechHandle._cancel` in `livekit-agents/livekit/agents/voice/speech_handle.py` (`INTERRUPTION_TIMEOUT = 5.0`), which JS never picked up.

Why this is a cause fix rather than a symptom bound: a reply task's owned `Task` **is** the task whose `AbortController` is `replyAbortController`. `task.cancel()` therefore fires *exactly the signal* `raceWithAbort` *is already watching* — the code was written expecting something to abort that controller, and this supplies the missing firing mechanism. `_markDone()` then releases the scheduler even for a task that ignores its signal. It covers the whole class rather than one call site: the `say()` path (`await audioOutput.waitForPlayout()` with no race at all) and the realtime path have the same exposure, as does any reply task parked in user-supplied `transcriptionNode`/`ttsNode` code.

I deliberately did **not** touch `mainTask`. Per git history, the second wait was added in livekit/agents-js#1966 to keep the shared audio/text outputs serialized through interrupted-generation cleanup, so a following reply cannot start capturing into the same sink while the interrupted one is still tearing down (bare handles, with no owner task, are excluded by the `_tasks.length > 0` condition). Deleting or racing a timeout there would reintroduce that overlap. The wait is preserved verbatim; the watchdog makes the thing it waits on guaranteed to settle, so serialization still holds — it is now just bounded rather than unbounded.

The timer is `unref()`d so an interrupted-then-abandoned handle (interrupted while queued, so never scheduled and never marked done) cannot hold a process open. `_markDone()` clears it, so the timer never outlives the handle.

## Python parity

* Python's `_scheduling_task` does a single **completely unguarded** `await speech._wait_for_generation()` — weaker than JS, no `wait_if_not_interrupted` guard at all.
* What makes that safe is `SpeechHandle._cancel()`, which installs `loop.call_later(INTERRUPTION_TIMEOUT, _on_timeout)`; on timeout it logs `"speech not done in time after interruption, cancelling the speech arbitrarily."`, cancels every task in `self._tasks`, and calls `self._mark_done()`.
* Python's own interrupted-branch playout wait (`await audio_output.wait_for_playout()`, `agent_activity.py`) is unguarded too, but asyncio task cancellation *interrupts an await*, so the watchdog's `task.cancel()` genuinely unblocks it. In JS an `AbortController` cannot interrupt an await, which is why the JS code needs the explicit `raceWithAbort` — and why the missing watchdog is fatal here rather than merely slow.

**Verdict: python does not have this bug, and the shape of the JS fix is its design.** Nothing to port upstream.

## Reproduction

`agents/src/voice/interrupt_before_playout_deadlock.test.ts` — a real `AgentSession` with `FakeLLM` and an `Agent` whose `ttsNode` hands each reply's frame stream back to the test, so the interrupt can be timed exactly in the window before playout starts. No room, no recorder, no network.

The audio output stands in for the class of sinks whose playback-finished is not the pipeline's to produce — `DataStreamAudioOutput` and every avatar plugin built on it, plus any user-supplied `AudioOutput`. It honors the `AudioOutput` contract (every segment it counts is finished exactly once); it just cannot report a segment the remote never began playing until the next turn's audio reaches it. That closes the loop, and is the same self-referential shape as the bug one level in: the next turn cannot start until the wedged one lets go.

The assertion is the customer-facing observable — after the interrupt, a **subsequent** `generateReply()` must actually be spoken — with bounded waits so a hang fails instead of hanging the suite. `agents/src/voice/speech_handle.test.ts` adds a focused unit test pinning the watchdog itself (fake timers, no wall-clock cost).

### Which trigger paths are live on `main`

Worth stating explicitly, since livekit/agents-js#2114 landed in this area two commits ago:

* **This is not** livekit/agents-js#2114**.** No recorder is involved; livekit/agents-js#2114's `RecorderAudioOutput` accounting fix does not touch this.
* I probed the **bare** `ParticipantAudioOutput` and the **default** `SyncedAudioOutput` **→** `ParticipantAudioOutput` chain with a real session across interrupt timings (interrupt before any frame, after the first frame, and across a `pause()`/`clearBuffer()` boundary). Both self-heal on current `main`: the `#1662` gate keeps `ParticipantAudioOutput` from counting a segment it drops at the pause gate, and `SyncedAudioOutput.waitForPlayout` reconciles drift against `nextInChain.pendingPlayoutSegments`. Instrumented `waitForPlayout` never exceeded \~100 ms on either.
* What is still live is the **scheduler**: any output that cannot answer promptly — remote/avatar sinks, user sinks, and the several in-tree accounting bugs that keep recurring here ([#1662](<https://github.com/livekit/agents-js/issues/1662>), livekit/agents-js#1909, livekit/agents-js#2041, livekit/agents-js#2114) — escalates from *one lost turn* to *a permanently silent agent*. That escalation is what this PR removes.
* Also fixed incidentally: a speech interrupted while still queued is skipped by `mainTask` without `_markDone()`, so its reply task waits on `_waitForAuthorization()` forever. The watchdog now reaps those (they are what the existing `"skipping mainTask self-await during drain to avoid a deadlock"` guard was working around).

## Before / after

Both new tests, on `origin/main` with only `speech_handle.ts` reverted:

```
     × keeps speaking after a reply is interrupted before its audio starts playing 25179ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  |nodejs| src/voice/interrupt_before_playout_deadlock.test.ts > reply interrupted before playout start (#2065) > keeps speaking after a reply is interrupted before its audio starts playing
AssertionError: expected 'did not settle' not to be 'did not settle' // Object.is equality
 ❯ src/voice/interrupt_before_playout_deadlock.test.ts:186:72
    184|       secondTts.close();
    185|
    186|       expect(await settleOrStall(second.waitForPlayout(), 15_000)).not…
       |                                                                        ^
    187|       expect(spoken).toContain('second reply');
    188|     } finally {
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
 FAIL  |nodejs| src/voice/speech_handle.test.ts > SpeechHandle interruption watchdog (#2065) > cancels the owned tasks and marks the handle done when an interrupt is ignored
AssertionError: expected false to be true // Object.is equality
- Expected
+ Received
- true
+ false
 ❯ src/voice/speech_handle.test.ts:209:25
    207|       await vi.advanceTimersByTimeAsync(5000);
    208|
    209|       expect(task.done).toBe(true);
       |                         ^
    210|       expect(handle.done()).toBe(true);
    211|       // The scheduling loop's wait is released, so the next queued sp…
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯
 Test Files  2 failed (2)
      Tests  2 failed | 14 passed (16)
   Start at  22:08:21
   Duration  26.00s (transform 865ms, setup 186ms, import 1.32s, tests 25.28s, environment 0ms)
```

With the fix:

```
 RUN  v4.1.0 /private/tmp/wt-2065-deadlock/agents
 Test Files  2 passed (2)
      Tests  16 passed (16)
   Start at  22:08:51
   Duration  6.12s (transform 857ms, setup 272ms, import 1.46s, tests 5.28s, environment 0ms)
```

The 25 s on `main` is the test's own two bounded waits expiring; the wedge is permanent, not slow. The 5 s with the fix is the watchdog interval.

Instrumented run on `main` showing the wedge (debug logs, timestamps in ms) — note the 10 s of nothing between the second speech handle being created and anything happening, and that both replies only unwind when `session.close()` force-interrupts:

```
1785121281521 speech_id=speech_213839b6-348  Creating speech handle
1785121289600 speech_id=speech_69aab672-d10  Creating speech handle      <- queued, never authorized
1785121299603 speech_id=speech_69aab672-d10  Aborting all pipeline reply tasks due to interruption   <- session.close()
1785121299604 speech_id=speech_213839b6-348  Aborting all pipeline reply tasks due to interruption
1785121299605 mainTask: scheduling paused and no more speech tasks to wait
```

## Verification

- [X] New tests fail on `origin/main`, pass with the fix (verbatim output above).
- [X] Full `pnpm vitest run agents/src`: **1490 tests, 1485 passed, 5 skipped, 0 failed** (111 files).
- [X] Adjacent interruption/pause coverage all green, specifically checked: `agent_activity.test.ts`, `agent_activity_interrupted_commit.test.ts`, `generation_interrupt_before_first_frame.test.ts`, `recorder_io/recorder_io.test.ts`, `recorder_io/recorder_session_interrupt.test.ts`.
- [X] No new log noise: the watchdog's error line does not fire once across the whole suite, so no existing interrupted speech relies on the grace period.
- [X] `pnpm build:agents` clean; `eslint` and `prettier --check` clean on all four touched files.
- [X] `pnpm api:check` fails identically to pristine `main` — pre-existing `ERROR: The "export * as ___" syntax is not supported yet` at `agents/dist/index.d.ts:10:8`, unrelated to this change (no public API surface changed).
- [ ] Manual check in Agent Playground with an avatar plugin: interrupt a handoff `onEnter` reply before its audio starts, confirm the agent still answers the next turn.

## Notes for the reviewer

* The reporter's downstream workaround (timeout + force-cancel `speechHandle._tasks` + a `_markDone()` safety net) converges on the same shape as python's watchdog — good independent evidence, but this lands it in the right place with the upstream semantics rather than patching `mainTask`.
* 5000 ms matches both python's `INTERRUPTION_TIMEOUT` and the existing `AgentActivity.REPLY_TASK_CANCEL_TIMEOUT`. Worth a look if you'd prefer it shorter: it is the worst-case dead air on the paths where the sink genuinely cannot answer.
* The sink-level accounting bugs remain the right place to fix individual triggers (this does not replace livekit/agents-js#2114 or [#1662](<https://github.com/livekit/agents-js/issues/1662>)); this only stops any one of them from taking down the whole session.