### PR TITLE
fix(krisp): adopt processed frames into the local rtc-node binding

### DIFF
--- a/.changeset/fix-krisp-frame-identity.md
+++ b/.changeset/fix-krisp-frame-identity.md
@@ -1,0 +1,13 @@
+---
+'@livekit/agents-plugin-krisp': patch
+---
+
+Fix Krisp-processed audio being invisible to the rest of the pipeline
+
+The LiveKit Cloud backend is reached through `createRequire`, which resolves the internal
+package's `require` condition and so loads the CJS build of `@livekit/rtc-node` next to the
+ESM one the framework uses. Frames returned by that backend were instances of the CJS copy's
+`AudioFrame`, so every `instanceof AudioFrame` downstream failed. Adaptive interruption saw
+zero audio and classified every barge-in as a backchannel, making it impossible to interrupt
+an agent that had noise cancellation enabled. Frames are now adopted into the local binding
+before leaving the filter, sharing their samples rather than copying them.

--- a/plugins/krisp/src/_frame_identity.test.ts
+++ b/plugins/krisp/src/_frame_identity.test.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { describe, expect, it } from 'vitest';
+import { adoptLocalAudioFrame } from './_frame_identity.js';
+
+/**
+ * Stands in for the `AudioFrame` of a second copy of `@livekit/rtc-node`: identical shape, same
+ * constructor name, unrelated identity. That is exactly what the CJS build produces when the
+ * Cloud backend pulls it in through `createRequire`.
+ */
+class ForeignAudioFrame {
+  constructor(
+    readonly data: Int16Array,
+    readonly sampleRate: number,
+    readonly channels: number,
+    readonly samplesPerChannel: number,
+    private readonly _userdata: Record<string, unknown> = {},
+  ) {}
+
+  get userdata(): Record<string, unknown> {
+    return this._userdata;
+  }
+}
+
+describe('adoptLocalAudioFrame', () => {
+  it('adopts a frame built by another copy of rtc-node', () => {
+    const samples = new Int16Array([1, -2, 3, -4]);
+    const foreign = new ForeignAudioFrame(samples, 16000, 1, 4, { source: 'krisp' });
+
+    // The premise of the bug: this lookalike fails the identity check every consumer relies on.
+    expect(foreign instanceof AudioFrame).toBe(false);
+
+    const adopted = adoptLocalAudioFrame(foreign as unknown as AudioFrame);
+
+    expect(adopted instanceof AudioFrame).toBe(true);
+    expect(adopted.sampleRate).toBe(16000);
+    expect(adopted.channels).toBe(1);
+    expect(adopted.samplesPerChannel).toBe(4);
+    expect(adopted.userdata).toEqual({ source: 'krisp' });
+    // Adopting must not copy the audio: this runs on every frame of every session.
+    expect(adopted.data).toBe(samples);
+  });
+
+  it('returns a local frame untouched', () => {
+    const local = new AudioFrame(new Int16Array([5, 6]), 48000, 1, 2);
+
+    expect(adoptLocalAudioFrame(local)).toBe(local);
+  });
+});

--- a/plugins/krisp/src/_frame_identity.ts
+++ b/plugins/krisp/src/_frame_identity.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+
+/**
+ * Return a frame that belongs to *this* copy of `@livekit/rtc-node`.
+ *
+ * The Cloud backend is reached through `createRequire`, which resolves the internal package's
+ * `require` condition and so loads the CJS build of `@livekit/rtc-node` next to our ESM one.
+ * Frames it hands back are instances of that copy's `AudioFrame`, so `instanceof AudioFrame`
+ * fails everywhere downstream: audio recognition treats them as unrecognised sentinels and
+ * drops them, and adaptive interruption — never fed any audio — rules every barge-in a
+ * backchannel. `AudioFrame` is a plain data holder, so adopting one shares its samples rather
+ * than copying them.
+ */
+export function adoptLocalAudioFrame(frame: AudioFrame): AudioFrame {
+  if (frame instanceof AudioFrame) {
+    return frame;
+  }
+
+  // Statically unreachable — the declared type *is* `AudioFrame`. It is reachable at runtime
+  // precisely because that type came from a different copy of the module.
+  const foreign = frame as unknown as {
+    data: Int16Array;
+    sampleRate: number;
+    channels: number;
+    samplesPerChannel: number;
+    userdata?: Record<string, unknown>;
+  };
+
+  return new AudioFrame(
+    foreign.data,
+    foreign.sampleRate,
+    foreign.channels,
+    foreign.samplesPerChannel,
+    foreign.userdata,
+  );
+}

--- a/plugins/krisp/src/viva_filter.ts
+++ b/plugins/krisp/src/viva_filter.ts
@@ -22,6 +22,7 @@ import type {
 } from '@livekit/rtc-node';
 import { FrameProcessor } from '@livekit/rtc-node';
 import { createRequire } from 'node:module';
+import { adoptLocalAudioFrame } from './_frame_identity.js';
 import { KrispLicenseFrameProcessor } from './_krisp.js';
 import {
   type AuthProvider,
@@ -182,7 +183,7 @@ export class KrispVivaFilter extends FrameProcessor<AudioFrame> {
   }
 
   process(frame: AudioFrame): AudioFrame {
-    return this.inner.process(frame);
+    return adoptLocalAudioFrame(this.inner.process(frame));
   }
 
   close(): void {


### PR DESCRIPTION
**Stack 1/5** — split out of #2126. Base: `main`.

This is the one that caused the reported symptom. Everything above it in the stack is a real defect found on the way, but none of them is what the user hit.

## The defect

The Krisp plugin reaches the LiveKit Cloud backend through `createRequire`, which resolves the internal package's `require` condition and loads the **CJS** build of `@livekit/rtc-node` alongside the ESM one the framework uses. Frames coming back out of the filter are instances of that second copy's `AudioFrame`, so `instanceof AudioFrame` fails everywhere downstream. The adaptive interruption stream treats an unrecognised object as a sentinel and drops it, so the classifier is fed **zero** audio — and with no audio it can only ever fall back to `backchannel`. Every barge-in was ruled a backchannel.

## Evidence

Driven end to end: frames built by the *real* second copy of `@livekit/rtc-node` (resolved with `createRequire` rooted at `plugins/krisp`, exactly as the Cloud backend resolves it) pushed through the real interruption pipeline as `AudioRecognition` wires it, with a mock gateway that rules the first request a barge-in.

```
[repro-2123] cjs constructor=AudioFrame instanceof(esm AudioFrame)=false
[repro-2123] WITHOUT adoption -> {"framesSentToGateway":0,"verdicts":[{"isInterruption":false,"numRequests":0}],"onInterruptionCalls":0}
[repro-2123] WITH adoption    -> {"framesSentToGateway":1,"verdicts":[{"isInterruption":true,"numRequests":1}],"onInterruptionCalls":1}
```

The committed unit test pins the adoption function itself.

## Why this is still needed after the upstream fix

The producer-side fix (livekit/plugin-krisp-viva-internal#13) has merged, but it is unreleased, and the krisp plugin tracks `rtc-node` through a version range rather than a pin — nothing prevents the duplicate resolution from coming back. The root fix (livekit/node-sdks#699, `Symbol.hasInstance` branding) has also merged and is likewise unreleased.

## Python parity

Structurally impossible in Python. `viva_filter.py:262` forwards the backend's frame with no adoption and is correct, because Python resolves through the process-global `sys.modules` — one `livekit.rtc`, one `AudioFrame` per interpreter, no ESM/CJS dual build.

Closes #2123.

Made with [Cursor](https://cursor.com)