### PR TITLE
fix(transcription): stop the synchronizer reporting the previous reply's transcript after an interrupt

### DIFF
--- a/.changeset/fix-stale-synchronized-transcript.md
+++ b/.changeset/fix-stale-synchronized-transcript.md
@@ -1,0 +1,21 @@
+---
+'@livekit/agents': patch
+---
+
+fix(voice): stop the agent transcript from running one reply behind after an interruption
+
+Once a user interrupted the agent, the transcript could permanently desynchronize from the
+audio: every later reply was reported, committed to the chat context, and rendered to the
+user with the _previous_ reply's text while the new reply was the one actually being spoken.
+The lag was one turn and it never recovered for the remainder of the session — asked for a
+story and then for the weather, the agent would speak the weather answer while the transcript
+still showed the story. Late in a session the reported text degraded further, to empty.
+
+The trigger is an interrupted reply whose playback-finished event arrives before its text
+forwarding flushes, which is the ordinary ordering on a barge-in. The flush then lands on the
+freshly rotated segment, and the next reply's first text chunk mistakes that empty segment for
+one whose playback finish is still in flight and queues it. Nothing ever settles that entry on
+its own, so from then on each reply's real playback finish is consumed to settle the segment
+queued a turn earlier, and its transcript is what gets reported. A segment is now only queued
+when it genuinely still owes a playback finish — it carried audio downstream and has not been
+marked finished — so a segment that owes nothing can no longer displace the current one.

--- a/agents/src/voice/transcription/synchronizer.test.ts
+++ b/agents/src/voice/transcription/synchronizer.test.ts
@@ -414,3 +414,75 @@ describe('TranscriptionSynchronizer playback-counter drift on a dropped frame', 
     await synchronizer.close();
   });
 });
+
+describe('TranscriptionSynchronizer segment queued without an outstanding playback finish', () => {
+  const frame = () => new AudioFrame(new Int16Array(160), 8000, 1, 160);
+
+  /**
+   * An interrupted reply whose playback_finished lands before its text-forwarding task
+   * flushes. The finish rotates the segment, so the late flush ends the text input of the
+   * fresh impl instead — leaving a segment that looks "text ended" while carrying no audio
+   * and owing no finish of its own.
+   */
+  const interruptWithLateTextFlush = async (
+    synchronizer: TranscriptionSynchronizer,
+    downstream: MockAudioOutput,
+  ) => {
+    await synchronizer.textOutput.captureText('turn-one');
+    await synchronizer.audioOutput.captureFrame(frame());
+    synchronizer.audioOutput.onPlaybackStarted(Date.now());
+    synchronizer.audioOutput.flush();
+    downstream.onPlaybackFinished({ playbackPosition: 1, interrupted: true });
+    await synchronizer.barrier();
+    await synchronizer.textOutput.flush();
+    await synchronizer.barrier();
+  };
+
+  const playTurn = async (
+    synchronizer: TranscriptionSynchronizer,
+    downstream: MockAudioOutput,
+    text: string,
+    interrupted: boolean,
+  ) => {
+    await synchronizer.textOutput.captureText(text);
+    await synchronizer.barrier();
+    await synchronizer.audioOutput.captureFrame(frame());
+    synchronizer.audioOutput.onPlaybackStarted(Date.now());
+    await synchronizer.textOutput.flush();
+    synchronizer.audioOutput.flush();
+    downstream.onPlaybackFinished({ playbackPosition: 1, interrupted });
+    const ev = await synchronizer.audioOutput.waitForPlayout();
+    await synchronizer.barrier();
+    return ev;
+  };
+
+  it('does not queue a rotated segment that carried no audio', async () => {
+    const downstream = new MockAudioOutput();
+    const synchronizer = new TranscriptionSynchronizer(downstream, new MockTextOutput());
+
+    await interruptWithLateTextFlush(synchronizer, downstream);
+
+    await synchronizer.textOutput.captureText('turn-two-text');
+    await synchronizer.barrier();
+
+    expect(synchronizer._pendingRotatedSegments).toHaveLength(0);
+    await synchronizer.close();
+  });
+
+  it('does not report the previous reply as the next reply synchronized transcript', async () => {
+    const downstream = new MockAudioOutput();
+    const synchronizer = new TranscriptionSynchronizer(downstream, new MockTextOutput());
+
+    await interruptWithLateTextFlush(synchronizer, downstream);
+
+    const second = await playTurn(synchronizer, downstream, 'turn-two-text', false);
+    const third = await playTurn(synchronizer, downstream, 'turn-three-text', true);
+
+    // a bogus queue entry makes every later finish settle the previous reply's segment, so
+    // the queue stays off by one and each turn reports the text of the turn before it
+    expect(third.synchronizedTranscript ?? '').not.toContain('turn-two');
+    expect(second.synchronizedTranscript).toBe('turn-two-text');
+
+    await synchronizer.close();
+  });
+});

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -157,6 +157,7 @@ class SegmentSynchronizerImpl {
   private closedFuture: Future = new Future();
   private playbackCompleted: boolean = false;
   private interrupted: boolean = false;
+  private playbackFinishedReceived: boolean = false;
 
   private pausedWallTime?: number;
   /** Accumulated paused time in milliseconds; subtracted from wall-clock elapsed. */
@@ -225,6 +226,14 @@ class SegmentSynchronizerImpl {
 
   get hasPendingText(): boolean {
     return this.textData.pushedText.length > this.textData.forwardedText.length;
+  }
+
+  /**
+   * Whether a `playback_finished` for this segment is still outstanding. Only a segment that
+   * carried audio downstream is ever owed one, and only until it arrives.
+   */
+  get owesPlaybackFinished(): boolean {
+    return this.audioData.pushedDuration > 0 && !this.playbackFinishedReceived;
   }
 
   get readable(): ReadableStream<string | TimedString> {
@@ -353,6 +362,7 @@ class SegmentSynchronizerImpl {
     }
 
     this.interrupted = interrupted;
+    this.playbackFinishedReceived = true;
     if (!this.textData.done || !this.audioData.done) {
       this.logger.warn(
         { textDone: this.textData.done, audioDone: this.audioData.done },
@@ -988,13 +998,18 @@ class SyncedTextOutput extends TextOutput {
       this.logger.warn(
         'SegmentSynchronizerImpl text marked as ended in capture text, rotating segment',
       );
-      // This segment's text input already ended but its on_playback_finished hasn't arrived
-      // yet (interrupt + fast next reply). Remember it so the still-pending playback_finished
-      // settles *this* segment, not the new one we're about to rotate in.
-      this.synchronizer._pendingRotatedSegments.push({
-        impl: this.synchronizer._impl,
-        acceptedDownstream: this.synchronizer.audioOutput._rotationCandidateAccepted,
-      });
+      // Only queue a segment that still owes a playback_finished, so the pending finish settles
+      // *this* segment rather than the one we are about to rotate in. A segment whose finish
+      // already arrived, or one rotated in mid-flow that never carried audio, owes nothing:
+      // queuing it would make the next segment's finish settle this entry instead, leaving the
+      // queue permanently off by one and attributing every later reply the previous reply's
+      // transcript for the rest of the session.
+      if (this.synchronizer._impl.owesPlaybackFinished) {
+        this.synchronizer._pendingRotatedSegments.push({
+          impl: this.synchronizer._impl,
+          acceptedDownstream: this.synchronizer.audioOutput._rotationCandidateAccepted,
+        });
+      }
       this.synchronizer.rotateSegment();
       await this.synchronizer.barrier();
     }


### PR DESCRIPTION
## Problem

`SegmentSynchronizer` can get permanently stuck one segment behind. After an interrupt, every later reply is reported, committed to the chat context, and shown to the user with the **previous** reply's text while a different reply is the one actually being spoken; late in a session the reported text degrades further, to empty.

This is a text-path defect — the audio is correct throughout, only the transcript is wrong. It is **not** the production report of agent audio falling behind the transcript (see Scope).

## Cause

On a barge-in a reply's `playback_finished` usually arrives before its text-forwarding task flushes. The finish rotates the segment, so the late `flush()` ends text input on the *new* impl instead. The next reply's first text chunk sees that impl marked `textInputEnded` and queues it in `_pendingRotatedSegments`, assuming its playback finish must still be in flight — but that impl never carried audio and is owed no finish, so nothing settles it. From then on each real finish is consumed settling the segment queued a turn earlier, which re-queues the current one and makes the off-by-one self-sustaining.

## Fix

Add `SegmentSynchronizerImpl.owesPlaybackFinished` (carried audio downstream, not yet marked finished) and only enqueue a rotated-out segment when it is true. That is exactly the precondition the queue's own comment asserts, so the genuine interrupt-plus-fast-next-reply race it was built for still enqueues.

## Testing

Two regression tests, red before / green after. Voice suite green at 566 tests. The three existing `_pendingRotatedSegments` tests pass unchanged — notably the one covering the case the queue was introduced for.

## Scope — read this before merging

Written while investigating a live report of agent audio running behind the transcript after a barge-in. That report is now traced elsewhere: the gateway emits multiple `done` messages per `session.flush` on some TTS paths and the client returns on the first, truncating the reply and handing a still-streaming socket back to the pool. Fixes are in flight separately (#2144, #2146). The two defects share a vocabulary and are opposites: this one misreports text against correct audio, that one plays wrong audio against a correct transcript.

Also independent of the interruption stack (#2131 → #2142) — reproduces on `main` regardless of which of those is checked out. Python's `_SyncedAudioOutput.on_playback_finished` only ever reads the current impl and so cannot report another segment's text; this is a JS-only divergence.
