### PR TITLE
fix(inference): finish the reply when the TTS gateway drops a session

### DIFF
--- a/.changeset/tidy-eels-repeat.md
+++ b/.changeset/tidy-eels-repeat.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(inference): finish the reply when the TTS gateway drops a session mid-synthesis

--- a/.changeset/tts-pool-drained-session-only.md
+++ b/.changeset/tts-pool-drained-session-only.md
@@ -1,0 +1,20 @@
+---
+'@livekit/agents': patch
+---
+
+fix(inference): only reuse a pooled TTS gateway socket once the session is drained
+
+`inference.TTS` keeps its gateway websockets in a `ConnectionPool` and reuses them across
+replies. A run only proves the gateway owes it no more audio when it receives `done`, but
+several other ways out of `SynthesizeStream.run` also returned normally — a `session.closed`
+event, a closed event channel, or an abort swallowed as `AbortError` — and each of those put
+the socket back in the pool while the gateway was still mid-synthesis.
+
+The next reply then picked up that socket and read the previous reply's outstanding audio as
+its own. In production this surfaced after a barge-in: the interrupted reply's remaining
+synthesis (~54s of it) was spoken by the _following_ reply, so the user heard the old answer
+continue while the transcript and chat context showed the new one, and the new reply's own
+audio was never heard. Nothing in the interruption path could stop it — the audio was
+legitimately new output belonging to an un-interrupted speech handle.
+
+The socket is now removed from the pool unless the run saw the gateway's `done`.

--- a/.changeset/tts-pool-drained-session-only.md
+++ b/.changeset/tts-pool-drained-session-only.md
@@ -5,10 +5,9 @@
 fix(inference): only reuse a pooled TTS gateway socket once the session is drained
 
 `inference.TTS` keeps its gateway websockets in a `ConnectionPool` and reuses them across
-replies. A run only proves the gateway owes it no more audio when it receives `done`, but
-several other ways out of `SynthesizeStream.run` also returned normally — a `session.closed`
-event, a closed event channel, or an abort swallowed as `AbortError` — and each of those put
-the socket back in the pool while the gateway was still mid-synthesis.
+replies. A run only proves the gateway owes it no more audio when it receives `done`, but a
+`session.closed` event mid-reply also returned normally from `SynthesizeStream.run`, which
+put the socket back in the pool while the gateway was still mid-synthesis.
 
 The next reply then picked up that socket and read the previous reply's outstanding audio as
 its own. In production this surfaced after a barge-in: the interrupted reply's remaining

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -639,13 +639,16 @@ export class SynthesizeStream<TModel extends TTSModels> extends BaseSynthesizeSt
     };
 
     const createInputTask = async (signal: AbortSignal) => {
-      for await (const data of this.input) {
-        if (signal.aborted || closing) break;
-        if (data === SynthesizeStream.FLUSH_SENTINEL) {
+      while (!signal.aborted && !closing) {
+        // Read with the signal so a cancelled attempt stops waiting instead of taking —
+        // and dropping — the next chunk of text, which belongs to the retry.
+        const { done, value } = await this.input.next({ signal });
+        if (done) break;
+        if (value === SynthesizeStream.FLUSH_SENTINEL) {
           sendTokenizerStream.flush();
           continue;
         }
-        sendTokenizerStream.pushText(data);
+        sendTokenizerStream.pushText(value);
       }
       // Only call endInput if the stream hasn't been closed by cleanup
       if (!closing) {
@@ -843,8 +846,24 @@ export class SynthesizeStream<TModel extends TTSModels> extends BaseSynthesizeSt
               completionFuture.resolve();
               return;
             case 'session.closed':
+              // The gateway dropped the session before it finished the reply. Hand over
+              // the audio it did produce, then fail the attempt: Python has no
+              // `session.closed` branch at all, so the dropped session surfaces there as
+              // a read timeout or a closed socket, i.e. an error that evicts the socket
+              // and lets the retry machinery resynthesize what is left. Resolving here
+              // instead reports a truncated reply as a completed one.
+              for (const frame of bstream.flush()) {
+                sendLastFrame(currentSessionId!, false);
+                lastFrame = frame;
+              }
+              sendLastFrame(currentSessionId!, true);
               await resourceCleanup();
-              completionFuture.resolve();
+              completionFuture.reject(
+                new APIStatusError({
+                  message: 'Gateway closed the TTS session before synthesis completed',
+                  options: { requestId },
+                }),
+              );
               return;
             case 'error':
               this.#logger.error(

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -581,10 +581,13 @@ export class SynthesizeStream<TModel extends TTSModels> extends BaseSynthesizeSt
   protected async run(): Promise<void> {
     let closing = false;
     let lastFrame: AudioFrame | undefined;
-    // Only a `done` from the gateway proves the session owes us no more audio. Every other
-    // way out of this run — `session.closed`, a closed event channel, a swallowed abort —
-    // leaves the gateway mid-synthesis, and a socket recycled in that state hands the
-    // leftover audio to whichever SynthesizeStream picks it up next.
+    // Only a `done` from the gateway proves the session owes us no more audio, and a socket
+    // recycled before that hands the leftover audio to whichever SynthesizeStream picks it
+    // up next. `session.closed` is the exit that reaches the pool: it returns from this run
+    // normally, so nothing else evicts the socket. The remaining non-`done` exits — a closed
+    // event channel, a swallowed abort — are only ever reached after `onClose` / `onAbort`
+    // has already removed the socket, so gating reuse on `done` is what keeps reuse tied to
+    // the one event that proves the session is drained rather than to each exit remembering.
     let sessionDrained = false;
     // Timestamps are delivered in their own WS message; buffer them and attach
     // to the next audio frame that we forward to the output emitter. This

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -581,6 +581,11 @@ export class SynthesizeStream<TModel extends TTSModels> extends BaseSynthesizeSt
   protected async run(): Promise<void> {
     let closing = false;
     let lastFrame: AudioFrame | undefined;
+    // Only a `done` from the gateway proves the session owes us no more audio. Every other
+    // way out of this run — `session.closed`, a closed event channel, a swallowed abort —
+    // leaves the gateway mid-synthesis, and a socket recycled in that state hands the
+    // leftover audio to whichever SynthesizeStream picks it up next.
+    let sessionDrained = false;
     // Timestamps are delivered in their own WS message; buffer them and attach
     // to the next audio frame that we forward to the output emitter. This
     // mirrors the semantics of `output_emitter.push_timed_transcript` on the
@@ -830,6 +835,7 @@ export class SynthesizeStream<TModel extends TTSModels> extends BaseSynthesizeSt
               }
               sendLastFrame(currentSessionId!, true);
               this.queue.put(SynthesizeStream.END_OF_STREAM);
+              sessionDrained = true;
               await resourceCleanup();
               completionFuture.resolve();
               return;
@@ -920,6 +926,9 @@ export class SynthesizeStream<TModel extends TTSModels> extends BaseSynthesizeSt
               await resourceCleanup();
               await cancelAndWait(tasks, 5000);
               this.abortController.signal.removeEventListener('abort', onStreamAbort);
+              if (!sessionDrained) {
+                this.tts.pool.remove(ws);
+              }
             }
           } catch (e) {
             // If aborted, don't throw - let cleanup handle it

--- a/agents/src/inference/tts_pool_reuse.test.ts
+++ b/agents/src/inference/tts_pool_reuse.test.ts
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { WebSocketServer } from 'ws';
+import type { WebSocket as WsSocket } from 'ws';
+import { initializeLogger } from '../log.js';
+import { TTS } from './tts.js';
+
+initializeLogger({ pretty: false });
+
+const SAMPLE_RATE = 16000;
+const FRAME_MS = 20;
+const SAMPLES_PER_FRAME = (SAMPLE_RATE * FRAME_MS) / 1000;
+
+/** Audio for the first reply and the second reply carry distinct constant samples so the
+ *  test can tell, per frame, which reply's synthesis a frame actually came from. */
+const REPLY_1_SAMPLE = 1000;
+const REPLY_2_SAMPLE = 2000;
+
+/** ~6s of already-synthesized audio the gateway still owes after it drops the session. */
+const BACKLOG_FRAMES = 300;
+const OWN_FRAMES = 25;
+
+function audioEvent(sessionId: string, sample: number): string {
+  const pcm = Buffer.alloc(SAMPLES_PER_FRAME * 2);
+  for (let i = 0; i < SAMPLES_PER_FRAME; i++) {
+    pcm.writeInt16LE(sample, i * 2);
+  }
+  return JSON.stringify({
+    type: 'output_audio',
+    session_id: sessionId,
+    audio: pcm.toString('base64'),
+  });
+}
+
+/**
+ * Gateway stand-in for the production trace in which the first reply's session was dropped
+ * with `session.closed` while ~90s of synthesis was still outstanding. On the first
+ * connection it streams a short prefix, drops the session without a `done`, then keeps
+ * flushing the rest of the backlog onto the same socket. Any later connection behaves
+ * normally.
+ */
+async function startFakeGateway() {
+  const wss = new WebSocketServer({ port: 0, host: '127.0.0.1' });
+  await new Promise<void>((resolve) => wss.once('listening', () => resolve()));
+  let connections = 0;
+  const sockets: WsSocket[] = [];
+
+  wss.on('connection', (ws: WsSocket) => {
+    sockets.push(ws);
+    const index = ++connections;
+    const sessionId = `session-${index}`;
+    const sample = index === 1 ? REPLY_1_SAMPLE : REPLY_2_SAMPLE;
+    let flushed = false;
+
+    const send = (payload: string) => {
+      if (ws.readyState === ws.OPEN) ws.send(payload);
+    };
+
+    ws.on('message', async (raw: Buffer) => {
+      const event = JSON.parse(raw.toString()) as { type: string };
+      if (event.type === 'session.create') {
+        send(JSON.stringify({ type: 'session.created', session_id: sessionId }));
+        return;
+      }
+      if (event.type !== 'session.flush' || flushed) return;
+      flushed = true;
+
+      if (index > 1) {
+        for (let i = 0; i < OWN_FRAMES; i++) send(audioEvent(sessionId, sample));
+        send(JSON.stringify({ type: 'done', session_id: sessionId }));
+        return;
+      }
+
+      // Reply 1: hand over a short prefix, then drop the session mid-synthesis.
+      for (let i = 0; i < OWN_FRAMES; i++) send(audioEvent(sessionId, sample));
+      send(JSON.stringify({ type: 'session.closed', session_id: sessionId }));
+      // The synthesis that was already in flight keeps arriving on this socket.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      for (let i = 0; i < BACKLOG_FRAMES; i++) send(audioEvent(sessionId, sample));
+      send(JSON.stringify({ type: 'done', session_id: sessionId }));
+    });
+  });
+
+  const { port } = wss.address() as AddressInfo;
+  return {
+    baseURL: `http://127.0.0.1:${port}/v1`,
+    get connections() {
+      return connections;
+    },
+    close: () => {
+      for (const socket of sockets) socket.terminate();
+      return new Promise<void>((resolve) => wss.close(() => resolve()));
+    },
+  };
+}
+
+async function synthesize(tts: TTS<string>, text: string) {
+  const stream = tts.stream();
+  stream.pushText(text);
+  stream.endInput();
+
+  const samples = new Set<number>();
+  let frames = 0;
+  for await (const event of stream) {
+    if (typeof event === 'symbol' || event.frame.samplesPerChannel === 0) continue;
+    frames++;
+    samples.add(event.frame.data[0]!);
+  }
+  await stream.close();
+  return { frames, samples };
+}
+
+describe('inference TTS pooled socket reuse', () => {
+  let gateway: Awaited<ReturnType<typeof startFakeGateway>>;
+
+  beforeEach(async () => {
+    gateway = await startFakeGateway();
+  });
+
+  afterEach(async () => {
+    await gateway.close();
+  });
+
+  it('does not hand a dropped session\u2019s outstanding audio to the next reply', async () => {
+    const tts = new TTS({
+      model: 'inworld/inworld-tts-2',
+      voice: 'Sarah',
+      sampleRate: SAMPLE_RATE,
+      baseURL: gateway.baseURL,
+      apiKey: 'devkey',
+      apiSecret: 'secret'.padEnd(32, 'x'),
+    });
+
+    const first = await synthesize(tts, 'Tell me a long story about the lighthouse.');
+    expect(first.samples).toEqual(new Set([REPLY_1_SAMPLE]));
+
+    const second = await synthesize(tts, 'Tell me a long joke about skeletons.');
+
+    // The second reply must speak only its own synthesis, and must not inherit the
+    // seconds of audio the first session never finished delivering.
+    expect(second.samples).toEqual(new Set([REPLY_2_SAMPLE]));
+    expect(second.frames).toBeLessThan(BACKLOG_FRAMES);
+    expect(gateway.connections).toBe(2);
+
+    await tts.close();
+  }, 20_000);
+});

--- a/agents/src/inference/tts_pool_reuse.test.ts
+++ b/agents/src/inference/tts_pool_reuse.test.ts
@@ -8,6 +8,17 @@ import type { WebSocket as WsSocket } from 'ws';
 import { initializeLogger } from '../log.js';
 import { TTS } from './tts.js';
 
+/**
+ * Pins the user-visible invariant: a reply must never inherit the audio a previous, dropped
+ * session never finished delivering.
+ *
+ * `session.closed` is the only route that reaches that leak. Once the `session.closed`
+ * handler rejects the attempt instead of resolving it, the exception path in
+ * `ConnectionPool.withConnection` evicts the socket by itself and this test passes with or
+ * without the `sessionDrained` eviction in `SynthesizeStream.run`. Read it as coverage of
+ * the behaviour, not of that eviction.
+ */
+
 initializeLogger({ pretty: false });
 
 const SAMPLE_RATE = 16000;

--- a/agents/src/inference/tts_pool_reuse.test.ts
+++ b/agents/src/inference/tts_pool_reuse.test.ts
@@ -25,10 +25,11 @@ const SAMPLE_RATE = 16000;
 const FRAME_MS = 20;
 const SAMPLES_PER_FRAME = (SAMPLE_RATE * FRAME_MS) / 1000;
 
-/** Audio for the first reply and the second reply carry distinct constant samples so the
- *  test can tell, per frame, which reply's synthesis a frame actually came from. */
-const REPLY_1_SAMPLE = 1000;
-const REPLY_2_SAMPLE = 2000;
+/** Audio from the session that gets dropped and audio from a healthy session carry
+ *  distinct constant samples so the test can tell, per frame, which session's synthesis a
+ *  frame actually came from. */
+const DROPPED_SESSION_SAMPLE = 1000;
+const HEALTHY_SESSION_SAMPLE = 2000;
 
 /** ~6s of already-synthesized audio the gateway still owes after it drops the session. */
 const BACKLOG_FRAMES = 300;
@@ -63,8 +64,8 @@ async function startFakeGateway() {
     sockets.push(ws);
     const index = ++connections;
     const sessionId = `session-${index}`;
-    const sample = index === 1 ? REPLY_1_SAMPLE : REPLY_2_SAMPLE;
-    let flushed = false;
+    const sample = index === 1 ? DROPPED_SESSION_SAMPLE : HEALTHY_SESSION_SAMPLE;
+    let dropped = false;
 
     const send = (payload: string) => {
       if (ws.readyState === ws.OPEN) ws.send(payload);
@@ -76,14 +77,18 @@ async function startFakeGateway() {
         send(JSON.stringify({ type: 'session.created', session_id: sessionId }));
         return;
       }
-      if (event.type !== 'session.flush' || flushed) return;
-      flushed = true;
+      if (event.type !== 'session.flush') return;
 
+      // A healthy session serves every reply it is asked for, so a pooled socket can be
+      // reused across replies.
       if (index > 1) {
         for (let i = 0; i < OWN_FRAMES; i++) send(audioEvent(sessionId, sample));
         send(JSON.stringify({ type: 'done', session_id: sessionId }));
         return;
       }
+
+      if (dropped) return;
+      dropped = true;
 
       // Reply 1: hand over a short prefix, then drop the session mid-synthesis.
       for (let i = 0; i < OWN_FRAMES; i++) send(audioEvent(sessionId, sample));
@@ -145,14 +150,16 @@ describe('inference TTS pooled socket reuse', () => {
       apiSecret: 'secret'.padEnd(32, 'x'),
     });
 
+    // The dropped session fails the attempt, so the first reply is the prefix it did
+    // deliver plus the audio from the retry that finishes it on a healthy session.
     const first = await synthesize(tts, 'Tell me a long story about the lighthouse.');
-    expect(first.samples).toEqual(new Set([REPLY_1_SAMPLE]));
+    expect(first.samples).toEqual(new Set([DROPPED_SESSION_SAMPLE, HEALTHY_SESSION_SAMPLE]));
 
     const second = await synthesize(tts, 'Tell me a long joke about skeletons.');
 
     // The second reply must speak only its own synthesis, and must not inherit the
     // seconds of audio the first session never finished delivering.
-    expect(second.samples).toEqual(new Set([REPLY_2_SAMPLE]));
+    expect(second.samples).toEqual(new Set([HEALTHY_SESSION_SAMPLE]));
     expect(second.frames).toBeLessThan(BACKLOG_FRAMES);
     expect(gateway.connections).toBe(2);
 

--- a/agents/src/inference/tts_session_closed.test.ts
+++ b/agents/src/inference/tts_session_closed.test.ts
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { WebSocketServer } from 'ws';
+import type { WebSocket as WsSocket } from 'ws';
+import { initializeLogger } from '../log.js';
+import { TTS } from './tts.js';
+
+initializeLogger({ pretty: false });
+
+const SAMPLE_RATE = 16000;
+const FRAME_MS = 20;
+const SAMPLES_PER_FRAME = (SAMPLE_RATE * FRAME_MS) / 1000;
+
+/** Audio for the dropped session and for the retry carry distinct constant samples so the
+ *  test can tell, per frame, which attempt a frame actually came from. */
+const DROPPED_SAMPLE = 1000;
+const RETRY_SAMPLE = 2000;
+
+/** Frames the gateway hands over before it drops the session mid-synthesis. */
+const FRAMES_BEFORE_DROP = 25;
+
+/** Upper bound on how long the test waits for a fresh attempt before giving up on it. */
+const RECONNECT_TIMEOUT_MS = 10_000;
+
+function audioEvent(sessionId: string, sample: number): string {
+  const pcm = Buffer.alloc(SAMPLES_PER_FRAME * 2);
+  for (let i = 0; i < SAMPLES_PER_FRAME; i++) {
+    pcm.writeInt16LE(sample, i * 2);
+  }
+  return JSON.stringify({
+    type: 'output_audio',
+    session_id: sessionId,
+    audio: pcm.toString('base64'),
+  });
+}
+
+interface GatewayConnection {
+  index: number;
+  sessionId: string;
+  transcripts: string[];
+}
+
+/**
+ * Gateway stand-in for the production trace in which a session was dropped with
+ * `session.closed` part-way through a long reply. The first connection streams a short
+ * prefix and then drops the session without ever sending `done`; any later connection
+ * behaves normally, so a fresh attempt is able to complete.
+ */
+async function startFakeGateway() {
+  const wss = new WebSocketServer({ port: 0, host: '127.0.0.1' });
+  await new Promise<void>((resolve) => wss.once('listening', () => resolve()));
+
+  const sockets: WsSocket[] = [];
+  const connections: GatewayConnection[] = [];
+
+  let markDropped!: () => void;
+  const sessionDropped = new Promise<void>((resolve) => (markDropped = resolve));
+  let markReconnected!: () => void;
+  const reconnected = new Promise<void>((resolve) => (markReconnected = resolve));
+
+  wss.on('connection', (ws: WsSocket) => {
+    sockets.push(ws);
+    const index = connections.length + 1;
+    const connection: GatewayConnection = {
+      index,
+      sessionId: `session-${index}`,
+      transcripts: [],
+    };
+    connections.push(connection);
+    if (index === 2) markReconnected();
+
+    const send = (payload: string) => {
+      if (ws.readyState === ws.OPEN) ws.send(payload);
+    };
+
+    let dropped = false;
+
+    ws.on('message', (raw: Buffer) => {
+      const event = JSON.parse(raw.toString()) as { type: string; transcript?: string };
+
+      if (event.type === 'session.create') {
+        send(JSON.stringify({ type: 'session.created', session_id: connection.sessionId }));
+        return;
+      }
+
+      if (event.type === 'input_transcript') {
+        connection.transcripts.push(event.transcript ?? '');
+        if (index === 1 && !dropped) {
+          dropped = true;
+          for (let i = 0; i < FRAMES_BEFORE_DROP; i++) {
+            send(audioEvent(connection.sessionId, DROPPED_SAMPLE));
+          }
+          send(JSON.stringify({ type: 'session.closed', session_id: connection.sessionId }));
+          markDropped();
+        }
+        return;
+      }
+
+      if (event.type === 'session.flush') {
+        // The dropped session owes nothing more, and never sends `done`.
+        if (index === 1) return;
+        send(audioEvent(connection.sessionId, RETRY_SAMPLE));
+        send(JSON.stringify({ type: 'done', session_id: connection.sessionId }));
+      }
+    });
+  });
+
+  const { port } = wss.address() as AddressInfo;
+  return {
+    baseURL: `http://127.0.0.1:${port}/v1`,
+    connections,
+    sessionDropped,
+    reconnected,
+    close: () => {
+      for (const socket of sockets) socket.terminate();
+      return new Promise<void>((resolve) => wss.close(() => resolve()));
+    },
+  };
+}
+
+function createTTS(baseURL: string) {
+  const tts = new TTS({
+    model: 'inworld/inworld-tts-2',
+    voice: 'Sarah',
+    sampleRate: SAMPLE_RATE,
+    baseURL,
+    apiKey: 'devkey',
+    apiSecret: 'secret'.padEnd(32, 'x'),
+  });
+  // A dropped session is surfaced as an error; without a listener node would rethrow it.
+  tts.on('error', () => {});
+  return tts;
+}
+
+describe('inference TTS dropped gateway session', () => {
+  let gateway: Awaited<ReturnType<typeof startFakeGateway>>;
+
+  beforeEach(async () => {
+    gateway = await startFakeGateway();
+  });
+
+  afterEach(async () => {
+    await gateway.close();
+  });
+
+  it('delivers the audio it already synthesized when the session is dropped', async () => {
+    const tts = createTTS(gateway.baseURL);
+    const stream = tts.stream();
+    stream.pushText('Tell me a long story about the lighthouse.');
+    stream.endInput();
+
+    let droppedSamples = 0;
+    let droppedSegmentFinals = 0;
+    for await (const event of stream) {
+      if (typeof event === 'symbol') continue;
+      if (event.segmentId === 'session-1' && event.final) droppedSegmentFinals++;
+      if (event.frame.data[0] === DROPPED_SAMPLE) droppedSamples += event.frame.samplesPerChannel;
+    }
+
+    // All of the audio the gateway handed over before dropping the session belongs to
+    // the user's reply, including the frame `run()` holds back so it can be marked final.
+    expect(droppedSamples).toBe(FRAMES_BEFORE_DROP * SAMPLES_PER_FRAME);
+    // The dropped segment also has to be terminated, otherwise downstream never learns
+    // that it ended.
+    expect(droppedSegmentFinals).toBe(1);
+
+    stream.close();
+    await tts.close();
+  }, 30_000);
+
+  it('still synthesizes the rest of the reply after the session is dropped', async () => {
+    const tts = createTTS(gateway.baseURL);
+    const stream = tts.stream();
+
+    const consumed = (async () => {
+      for await (const event of stream) void event;
+    })();
+
+    stream.pushText('The lighthouse keeper woke before dawn. ');
+    stream.pushText('The wind was already rising over the water. ');
+    await gateway.sessionDropped;
+
+    // The gateway dropped the session mid-reply, so the attempt failed. The rest of the
+    // reply must still be synthesized, which means a fresh attempt has to pick it up.
+    let giveUp: NodeJS.Timeout;
+    await Promise.race([
+      gateway.reconnected,
+      new Promise<void>((resolve) => (giveUp = setTimeout(resolve, RECONNECT_TIMEOUT_MS))),
+    ]).finally(() => clearTimeout(giveUp));
+
+    stream.pushText('He climbed the stairs and lit the lamp. ');
+    stream.endInput();
+    await consumed;
+
+    const submitted = gateway.connections
+      .filter((connection) => connection.index > 1)
+      .flatMap((connection) => connection.transcripts)
+      .join('');
+    expect(submitted).toContain('He climbed the stairs and lit the lamp.');
+
+    stream.close();
+    await tts.close();
+  }, 30_000);
+});


### PR DESCRIPTION
Stacked on #2144.

## Problem

When the inference gateway ends a TTS session with `session.closed` part-way through a
reply, the JS client treats it as a successful completion. The frame `run()` holds back so
it can mark it final is never emitted, and no segment is ever terminated — downstream gets
a segment that just stops. Worse, `resourceCleanup()` sets
`closing`, which kills the input task, so the rest of the reply's text is discarded with
no error, no warning and no retry. In the trace this came from, a ~9000-character reply
had only 2017 characters submitted before the drop; the user never heard the rest.

## Fix

Flush the buffered audio and mark the dropped segment's last frame final, then reject the
attempt with a retryable `APIStatusError` so the socket is evicted and the retry finishes
the reply. `END_OF_STREAM` is deliberately not emitted: it is the stream terminator that
`ttsNode` breaks on, and the stream is not done. The cancelled attempt's input task now
reads with its abort signal so it stops waiting instead of consuming — and dropping — the
chunk of text that belongs to the retry.

## Testing

`agents/src/inference/tts_session_closed.test.ts` fails on the parent branch with
`expected 6400 to be 8000` (100 ms of synthesized audio never delivered) and
`expected '' to contain 'He climbed the stairs and lit the lamp.'` (the rest of the reply
never resynthesized); both pass here. #2144's pool-reuse test is updated because its
premise — that a dropped session completes without a retry — no longer holds. It stays
green, but from here on the socket is evicted by this rejection rather than by #2144's
`sessionDrained` check, which leaves that check with no reachable route; see the note on
#2144.

## Python parity

`inference/tts.py` has no `session.closed` branch: the dropped session surfaces as a read
timeout or a closed socket, an exception leaves `_run`, and the pool's context manager
evicts the connection. Failing the attempt is that behaviour; resolving it was the
divergence.
