### PR TITLE
fix(worker): resolve pending assignment promise on timeout to prevent worker hang

### DIFF
--- a/agents/src/worker.ts
+++ b/agents/src/worker.ts
@@ -224,10 +224,14 @@ export class ServerOptions {
 }
 
 class PendingAssignment {
-  promise = new Promise<JobAssignment>((resolve) => {
+  promise = new Promise<JobAssignment>((resolve, reject) => {
     this.resolve = resolve; // this is how JavaScript lets you resolve promises externally
+    this.reject = reject;
   });
   resolve(arg: JobAssignment) {
+    arg; // useless call to counteract TypeScript E6133
+  }
+  reject(arg: Error) {
     arg; // useless call to counteract TypeScript E6133
   }
 }
@@ -709,13 +713,22 @@ export class AgentServer {
 
       this.#pending[req.id] = new PendingAssignment();
       const timer = setTimeout(() => {
-        this.#logger.child({ req }).warn(`assignment for job ${req.id} timed out`);
-        return;
+        const pending = this.#pending[req.id];
+        if (pending) {
+          delete this.#pending[req.id];
+          pending.reject(new Error(`assignment timeout for job ${req.id}`));
+        }
       }, ASSIGNMENT_TIMEOUT);
-      const asgn = await this.#pending[req.id]?.promise.then(async (asgn) => {
-        clearTimeout(timer);
-        return asgn;
-      });
+      const asgn = await this.#pending[req.id]?.promise
+        .then(async (asgn) => {
+          clearTimeout(timer);
+          return asgn;
+        })
+        .catch((e) => {
+          clearTimeout(timer);
+          delete this.#pending[req.id];
+          return undefined;
+        });
 
       if (asgn) {
         await this.#procPool.launchJob({


### PR DESCRIPTION
## Summary

Fixes #2151

The `ASSIGNMENT_TIMEOUT` handler in `AgentServer` was logging a warning and returning without ever resolving or rejecting the `PendingAssignment` promise. This caused:

1. **Permanent hang**: `await` on the promise never completed after timeout
2. **Memory leak**: `#pending` map entry was never cleaned up on timeout

## Changes

- Add `reject` method to `PendingAssignment` class to support promise rejection
- Timer now deletes pending entry from `#pending` map and rejects the promise with an Error
- Add `.catch()` handler to clean up on rejection (clear timer + delete pending entry)

## Testing

The fix ensures that:
- Timeout triggers `pending.reject()` which resolves the promise with an Error
- The `.catch()` block executes, clearing the timer and deleting the `#pending` entry
- Worker no longer hangs on timeout
- No memory leak from orphaned `#pending` entries

---
*Made with ❤️ by Flocky (GitHub Agent)*