### PR TITLE
fix(telemetry): order uploaded chat items by when speech was heard

### DIFF
--- a/.changeset/olive-pans-listen.md
+++ b/.changeset/olive-pans-listen.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix out-of-order turns in the Cloud transcript by uploading chat items in the order they were heard rather than the order they were committed

--- a/agents/src/telemetry/traces.test.ts
+++ b/agents/src/telemetry/traces.test.ts
@@ -573,6 +573,78 @@ describe('uploadSessionReport chat item ordering', () => {
       'functionCallOutput',
     ]);
   });
+
+  it('keeps a tool call with the assistant turn that requested it', async () => {
+    // Timings from a real session: the reply's function call is committed 0.4s before TTS
+    // starts playing the text that introduced it, so on commit time alone the call sorts
+    // ahead of the message it belongs to.
+    const agentTurn = ChatMessage.create({
+      role: 'assistant',
+      content: 'Let me check that referral for you.',
+      createdAt: T + 24_218,
+      metrics: { startedSpeakingAt: (T + 25_832) / 1000 },
+    });
+    const call = FunctionCall.create({
+      callId: 'call1',
+      name: 'checkReferral',
+      args: '{}',
+      createdAt: T + 25_433,
+    });
+    const output = FunctionCallOutput.create({
+      callId: 'call1',
+      output: 'found',
+      isError: false,
+      createdAt: T + 30_861,
+    });
+
+    const records = await exportChatItems(new ChatContext([agentTurn, call, output]));
+
+    expect(records.map((r) => r.timestampMs)).toEqual([T + 25_832, T + 25_832.001, T + 30_861]);
+    expect(records.map((r) => Object.keys(r.attributes['chat.item'] as object)[0])).toEqual([
+      'message',
+      'functionCall',
+      'functionCallOutput',
+    ]);
+  });
+
+  it('leaves a slow tool output after a user turn heard while the tool ran', async () => {
+    const agentTurn = ChatMessage.create({
+      role: 'assistant',
+      content: 'One moment while I look that up.',
+      createdAt: T + 1_000,
+      metrics: { startedSpeakingAt: (T + 1_200) / 1000 },
+    });
+    const call = FunctionCall.create({
+      callId: 'call1',
+      name: 'lookup',
+      args: '{}',
+      createdAt: T + 1_400,
+    });
+    const userTurn = ChatMessage.create({
+      role: 'user',
+      content: 'Are you still there?',
+      createdAt: T + 6_000,
+      metrics: { startedSpeakingAt: (T + 4_000) / 1000 },
+    });
+    const output = FunctionCallOutput.create({
+      callId: 'call1',
+      output: 'ok',
+      isError: false,
+      createdAt: T + 9_000,
+    });
+
+    const records = await exportChatItems(new ChatContext([agentTurn, call, userTurn, output]));
+
+    // the output is held at its own commit time rather than dragged up to the turn that
+    // requested it, so the user turn heard mid-tool stays ahead of it
+    expect(records.map((r) => r.timestampMs)).toEqual([T + 1_200, T + 1_400, T + 4_000, T + 9_000]);
+    expect(records.map((r) => Object.keys(r.attributes['chat.item'] as object)[0])).toEqual([
+      'message',
+      'functionCall',
+      'message',
+      'functionCallOutput',
+    ]);
+  });
 });
 
 describe('setupCloudTracer resource identity (fresh provider)', () => {

--- a/agents/src/telemetry/traces.test.ts
+++ b/agents/src/telemetry/traces.test.ts
@@ -14,7 +14,7 @@ import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace
 import FormData from 'form-data';
 import { PassThrough } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ChatContext } from '../llm/chat_context.js';
+import { ChatContext, ChatMessage, FunctionCall, FunctionCallOutput } from '../llm/chat_context.js';
 import type { SessionReport } from '../voice/report.js';
 import { SimpleOTLPHttpLogExporter } from './otel_http_exporter.js';
 import { setTracerProvider, setupCloudTracer, tracer, uploadSessionReport } from './traces.js';
@@ -339,14 +339,17 @@ describe('setupCloudTracer with a user-configured provider', () => {
   });
 });
 
-function makeReport(recordingOptions: SessionReport['recordingOptions']): SessionReport {
+function makeReport(
+  recordingOptions: SessionReport['recordingOptions'],
+  chatHistory: ChatContext = ChatContext.empty(),
+): SessionReport {
   return {
     jobId: 'job1',
     roomId: 'room1',
     room: 'room-name',
     options: {},
     events: [],
-    chatHistory: ChatContext.empty(),
+    chatHistory,
     enableRecording: true,
     recordingOptions,
     startedAt: 1_700_000_000_000,
@@ -480,6 +483,95 @@ describe('uploadSessionReport metadata', () => {
 
     expect(exportSpy).not.toHaveBeenCalled();
     expect(submitSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('uploadSessionReport chat item ordering', () => {
+  const T = 1_700_000_000_000;
+  let prevKey: string | undefined;
+  let prevSecret: string | undefined;
+
+  beforeEach(() => {
+    prevKey = process.env.LIVEKIT_API_KEY;
+    prevSecret = process.env.LIVEKIT_API_SECRET;
+    process.env.LIVEKIT_API_KEY = 'devkey';
+    process.env.LIVEKIT_API_SECRET = 'secretsecretsecretsecretsecretsecret';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (prevKey === undefined) delete process.env.LIVEKIT_API_KEY;
+    else process.env.LIVEKIT_API_KEY = prevKey;
+    if (prevSecret === undefined) delete process.env.LIVEKIT_API_SECRET;
+    else process.env.LIVEKIT_API_SECRET = prevSecret;
+  });
+
+  async function exportChatItems(chatHistory: ChatContext) {
+    const exportSpy = vi
+      .spyOn(SimpleOTLPHttpLogExporter.prototype, 'export')
+      .mockResolvedValue(undefined);
+    mockSuccessfulFormSubmit();
+
+    await uploadSessionReport({
+      agentName: 'agent',
+      cloudHostname: 'example.livekit.cloud',
+      report: makeReport(
+        { audio: false, traces: false, logs: false, transcript: true, redaction: false },
+        chatHistory,
+      ),
+    });
+
+    const records = exportSpy.mock.calls[0]?.[0] ?? [];
+    return records.filter((record) => record.body === 'chat item');
+  }
+
+  it('orders chat items by when speech was heard, not when the item was committed', async () => {
+    // Mirrors a real session: the agent's reply to a previous turn is committed
+    // (createdAt) while the user is already barging in, and the user turn is only
+    // committed once its transcript is final — so committed order is the reverse of
+    // the order the two turns were actually heard in.
+    const agentTurn = ChatMessage.create({
+      role: 'assistant',
+      content: 'Do you have a physician referral for this visit?',
+      createdAt: T + 1_000,
+      metrics: { startedSpeakingAt: (T + 4_000) / 1000 },
+    });
+    const userTurn = ChatMessage.create({
+      role: 'user',
+      content: 'Are you there?',
+      createdAt: T + 3_000,
+      metrics: { startedSpeakingAt: (T + 500) / 1000 },
+    });
+
+    const records = await exportChatItems(new ChatContext([agentTurn, userTurn]));
+
+    expect(records.map((r) => r.timestampMs)).toEqual([T + 500, T + 4_000]);
+    expect(
+      records.map((r) => (r.attributes['chat.item'] as { message: { role: string } }).message.role),
+    ).toEqual(['USER', 'ASSISTANT']);
+  });
+
+  it('keeps items without speech metrics on createdAt, nudging collisions to stay ordered', async () => {
+    const call = FunctionCall.create({
+      callId: 'call1',
+      name: 'lookup',
+      args: '{}',
+      createdAt: T + 2_000,
+    });
+    const output = FunctionCallOutput.create({
+      callId: 'call1',
+      output: 'ok',
+      isError: false,
+      createdAt: T + 2_000,
+    });
+
+    const records = await exportChatItems(new ChatContext([call, output]));
+
+    expect(records.map((r) => r.timestampMs)).toEqual([T + 2_000, T + 2_000.001]);
+    expect(records.map((r) => Object.keys(r.attributes['chat.item'] as object)[0])).toEqual([
+      'functionCall',
+      'functionCallOutput',
+    ]);
   });
 });
 

--- a/agents/src/telemetry/traces.ts
+++ b/agents/src/telemetry/traces.ts
@@ -731,8 +731,18 @@ function toRFC3339(valueMs: number | Date): string {
   return truncated.toISOString();
 }
 
+/** When a chat item's own speech began, in milliseconds, if it has any. */
+function speechStartMs(item: ChatItem): number | undefined {
+  const startedSpeakingAt = item.type === 'message' ? item.metrics?.startedSpeakingAt : undefined;
+  if (startedSpeakingAt === undefined || !Number.isFinite(startedSpeakingAt)) {
+    return undefined;
+  }
+  return startedSpeakingAt * 1000; // metrics are in seconds
+}
+
 /**
- * Where a chat item belongs on the session timeline, in milliseconds.
+ * Chat items paired with where they belong on the session timeline, in milliseconds,
+ * ordered as the session was heard.
  *
  * `createdAt` records when an item was committed to the chat context, which is a
  * different point in the turn for each role: a user message is committed once its
@@ -741,15 +751,27 @@ function toRFC3339(valueMs: number | Date): string {
  * dashboard places each turn at `metrics.startedSpeakingAt`, so ordering by `createdAt`
  * makes turns render out of order — most visibly when the user barges in while a reply
  * is being generated.
+ *
+ * Items with no speech of their own (tool calls and their output, handoffs, config
+ * updates) are positioned at their own `createdAt`, but never earlier than the item they
+ * follow: a tool call is committed while its reply is still being generated, so on its own
+ * commit time it would sort ahead of the assistant message that requested it.
  */
-function timelineTimestampMs(item: ChatItem): number {
-  const startedSpeakingAt = item.type === 'message' ? item.metrics?.startedSpeakingAt : undefined;
-  if (startedSpeakingAt !== undefined && Number.isFinite(startedSpeakingAt)) {
-    return startedSpeakingAt * 1000; // metrics are in seconds
-  }
-  // Items with no speech of their own (tool calls, handoffs, config updates), plus a
-  // defensive fallback for turns whose playout never reported a start time.
-  return Number.isFinite(item.createdAt) ? item.createdAt : Date.now();
+function timelineOrder(items: ChatItem[]): { item: ChatItem; timestampMs: number }[] {
+  let earliestAllowedMs = Number.NEGATIVE_INFINITY;
+
+  return (
+    items
+      .map((item, index) => {
+        // defensive fallback for items whose commit time never landed
+        const createdAt = Number.isFinite(item.createdAt) ? item.createdAt : Date.now();
+        const timestampMs = speechStartMs(item) ?? Math.max(createdAt, earliestAllowedMs);
+        earliestAllowedMs = Math.max(earliestAllowedMs, timestampMs);
+        return { item, index, timestampMs };
+      })
+      // ties keep their chat context order, which holds a tool call next to its output
+      .sort((a, b) => a.timestampMs - b.timestampMs || a.index - b.index)
+  );
 }
 
 /**
@@ -812,11 +834,9 @@ export async function uploadSessionReport(options: {
 
   // The dashboard orders the transcript by log timestamp, so emit the items in the order
   // they were heard rather than the order they were committed to the chat context.
-  const chatItems = (report.recordingOptions.transcript ? report.chatHistory.items : [])
-    .filter((item) => item) // skip null/undefined items
-    .map((item, index) => ({ item, index, timestampMs: timelineTimestampMs(item) }))
-    // ties keep their chat context order, which holds a tool call next to its output
-    .sort((a, b) => a.timestampMs - b.timestampMs || a.index - b.index);
+  const chatItems = timelineOrder(
+    (report.recordingOptions.transcript ? report.chatHistory.items : []).filter((item) => item), // skip null/undefined items
+  );
 
   // Track last timestamp to ensure monotonic ordering when items have identical timestamps
   // This fixes the issue where function_call and function_call_output with same timestamp

--- a/agents/src/telemetry/traces.ts
+++ b/agents/src/telemetry/traces.ts
@@ -732,6 +732,27 @@ function toRFC3339(valueMs: number | Date): string {
 }
 
 /**
+ * Where a chat item belongs on the session timeline, in milliseconds.
+ *
+ * `createdAt` records when an item was committed to the chat context, which is a
+ * different point in the turn for each role: a user message is committed once its
+ * transcript is final (after the user stopped speaking), while an assistant message is
+ * committed when its reply started generating (before any audio reached the room). The
+ * dashboard places each turn at `metrics.startedSpeakingAt`, so ordering by `createdAt`
+ * makes turns render out of order — most visibly when the user barges in while a reply
+ * is being generated.
+ */
+function timelineTimestampMs(item: ChatItem): number {
+  const startedSpeakingAt = item.type === 'message' ? item.metrics?.startedSpeakingAt : undefined;
+  if (startedSpeakingAt !== undefined && Number.isFinite(startedSpeakingAt)) {
+    return startedSpeakingAt * 1000; // metrics are in seconds
+  }
+  // Items with no speech of their own (tool calls, handoffs, config updates), plus a
+  // defensive fallback for turns whose playout never reported a start time.
+  return Number.isFinite(item.createdAt) ? item.createdAt : Date.now();
+}
+
+/**
  * Upload session report to LiveKit Cloud observability.
  * @param options - Configuration with agentName, cloudHostname, and report
  */
@@ -789,21 +810,22 @@ export async function uploadSessionReport(options: {
     },
   });
 
+  // The dashboard orders the transcript by log timestamp, so emit the items in the order
+  // they were heard rather than the order they were committed to the chat context.
+  const chatItems = (report.recordingOptions.transcript ? report.chatHistory.items : [])
+    .filter((item) => item) // skip null/undefined items
+    .map((item, index) => ({ item, index, timestampMs: timelineTimestampMs(item) }))
+    // ties keep their chat context order, which holds a tool call next to its output
+    .sort((a, b) => a.timestampMs - b.timestampMs || a.index - b.index);
+
   // Track last timestamp to ensure monotonic ordering when items have identical timestamps
   // This fixes the issue where function_call and function_call_output with same timestamp
   // get reordered by the dashboard
   let lastTimestamp = 0;
-  const chatItems = report.recordingOptions.transcript ? report.chatHistory.items : [];
-  for (const item of chatItems) {
-    // Skip null/undefined items
-    if (!item) continue;
-
+  for (const { item, timestampMs } of chatItems) {
     // Ensure monotonically increasing timestamps for proper ordering
     // Add 0.001ms (1 microsecond) offset when timestamps collide
-    // Also handle undefined/NaN timestamps from realtime mode (defensive)
-    const hasValidTimestamp = Number.isFinite(item.createdAt);
-    let itemTimestamp = hasValidTimestamp ? item.createdAt : Date.now();
-
+    let itemTimestamp = timestampMs;
     if (itemTimestamp <= lastTimestamp) {
       itemTimestamp = lastTimestamp + 0.001; // Add 1 microsecond
     }


### PR DESCRIPTION
## Problem

Turns render out of order in the Cloud transcript — an agent turn shown at 00:36.84 sits above a user turn shown at 00:34.27. Chat items are uploaded as log records timestamped with `created_at`, which is what the dashboard sorts by, but each row is rendered at `metrics.started_speaking_at`. Those clocks are anchored to different moments, and the gap differs per role: a user message is committed once its transcript is final, while an assistant message is committed when its reply starts generating — 2.3s before any audio reached the room in the reported session. When the user barges in while a reply is being generated, the agent turn wins the sort despite being heard second.

## Fix

Position each chat item at `metrics.startedSpeakingAt` when it has one and `createdAt` otherwise, and sort on that before the existing microsecond collision nudge. Items with no speech of their own — tool calls and their output, handoffs, config updates — are additionally held no earlier than the item they follow in chat context: a function call is committed while its reply is still generating, so on its own commit time it would sort ahead of the assistant message that requested it. `created_at` on the items is untouched, so chat context ordering and the LLM prompt are unaffected — moving a user message ahead of an in-flight assistant turn would make the reply look like an answer to a question the model never saw.

## Testing

Three new tests: the barge-in shape fails on `main` (committed order `[assistant, user]`) and passes here; a tool call committed 0.4s before its assistant turn started speaking stays behind that turn; and a slow tool's output stays after a user turn heard while the tool ran, rather than being dragged up to the turn that requested it. Full agents suite: 1507 passing.

Also verified live against Cloud on a barge-in session: the transcript now renders the user turn at 01:08.26 above the agent reply at 01:11.70, with every row increasing top to bottom. That pair is committed the other way round — the agent message 3.4s earlier — so it inverts on `main`. This also confirms the dashboard sorts on the log-record timestamp, so no Cloud-side change is needed. Replaying that session's 35 items through the new ordering leaves no item ahead of one it follows in chat context.