### PR TITLE
fix(voice): place a realtime user turn where the turn began

### DIFF
--- a/.changeset/lucky-otters-listen.md
+++ b/.changeset/lucky-otters-listen.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix realtime user turns appearing after the reply they prompted, by placing the user message at the time its turn began rather than at the time the provider delivered the transcript

--- a/agents/src/llm/realtime.ts
+++ b/agents/src/llm/realtime.ts
@@ -87,6 +87,14 @@ export interface InputTranscriptionCompleted {
   itemId: string;
   transcript: string;
   isFinal: boolean;
+  /**
+   * When the turn this transcript belongs to began, in milliseconds since epoch.
+   *
+   * A provider that withholds the final transcript until its reply has finished
+   * generating should set this, so the user message can be placed on the session
+   * timeline where the turn happened rather than where the transcript arrived.
+   */
+  turnStartedAt?: number;
 }
 
 export interface RealtimeSessionReconnectedEvent {}

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   AgentConfigUpdate,
   ChatContext,
+  ChatMessage,
   FunctionCall,
   FunctionCallOutput,
 } from '../llm/chat_context.js';
@@ -1366,5 +1367,121 @@ describe('AgentActivity - interruption while waiting for tools', () => {
 
     expect(shouldContinue).toBe(false);
     expect(commitInterruptedToolOutputs).toHaveBeenCalledWith(toolOutput, speechHandle, 789);
+  });
+});
+
+/**
+ * A realtime provider only publishes the final user transcript once the reply has
+ * finished generating, so committing the message at that moment stamps the user turn
+ * later than the reply it prompted and the transcript renders them out of order. The
+ * provider reports when the turn began via `turnStartedAt`.
+ */
+describe('AgentActivity - realtime user turn timing', () => {
+  function buildRealtimeActivity() {
+    const chatCtx = new ChatContext();
+    const fakeActivity = {
+      vad: undefined,
+      stt: undefined,
+      audioRecognition: undefined,
+      isInterruptionDetectionEnabled: false,
+      agent: { _chatCtx: chatCtx },
+      agentSession: {
+        emit: vi.fn(),
+        _updateUserState: vi.fn(),
+        _conversationItemAdded: vi.fn(),
+      },
+      interrupt: vi.fn(),
+      logger: { info() {}, debug() {}, warn() {}, error() {} },
+    };
+    Object.setPrototypeOf(fakeActivity, AgentActivity.prototype);
+
+    const proto = AgentActivity.prototype as unknown as Record<string, (...args: never[]) => void>;
+    return {
+      chatCtx,
+      transcribed: (transcript: string, itemId: string, turnStartedAt?: number) =>
+        proto.onInputAudioTranscriptionCompleted!.call(fakeActivity, {
+          transcript,
+          itemId,
+          isFinal: true,
+          turnStartedAt,
+        } as never),
+    };
+  }
+
+  it('stamps the user message where the turn began, not at transcript delivery', () => {
+    vi.useFakeTimers();
+    try {
+      // the provider withholds the transcript until its reply is done generating
+      vi.setSystemTime(1_007_000);
+      const { chatCtx, transcribed } = buildRealtimeActivity();
+
+      transcribed('what is my name?', 'item_1', 1_000_000);
+
+      const message = chatCtx.items[0]!;
+      if (message.type !== 'message') throw new Error('expected a chat message');
+      expect(message.createdAt).toBe(1_000_000);
+      // seconds, so the dashboard can place the turn where it happened
+      expect(message.metrics?.startedSpeakingAt).toBe(1_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('places the turn before the reply it prompted when its transcript lands later', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_007_000);
+      const { chatCtx, transcribed } = buildRealtimeActivity();
+
+      // the reply is committed first, because the provider held the user transcript back
+      chatCtx.insert(
+        ChatMessage.create({ role: 'assistant', content: 'you are Brian', createdAt: 1_003_000 }),
+      );
+      transcribed('what is my name?', 'item_1', 1_000_000);
+
+      expect(
+        chatCtx.items.map((item) => (item.type === 'message' ? item.role : item.type)),
+      ).toEqual(['user', 'assistant']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('pairs each turn with its own start, even when transcripts arrive late', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_010_000);
+      const { chatCtx, transcribed } = buildRealtimeActivity();
+
+      // both transcripts land after the second turn began; each keeps its own start
+      transcribed('first', 'item_1', 1_000_000);
+      transcribed('second', 'item_2', 1_005_000);
+
+      const [first, second] = chatCtx.items;
+      if (first?.type !== 'message' || second?.type !== 'message') {
+        throw new Error('expected chat messages');
+      }
+      expect(first.createdAt).toBe(1_000_000);
+      expect(second.createdAt).toBe(1_005_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to delivery time when the provider reports no turn start', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_002_000);
+      const { chatCtx, transcribed } = buildRealtimeActivity();
+
+      transcribed('text injected turn', 'item_1');
+
+      const message = chatCtx.items[0]!;
+      if (message.type !== 'message') throw new Error('expected a chat message');
+      expect(message.createdAt).toBe(1_002_000);
+      expect(message.metrics?.startedSpeakingAt).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1315,12 +1315,23 @@ export class AgentActivity implements RecognitionHooks {
         this.agentSession.amd?.onTranscript(ev.transcript);
       }
 
+      const turnStartedAt = ev.turnStartedAt;
+
+      const userMetrics: MetricsReport = {};
+      if (turnStartedAt !== undefined) {
+        userMetrics.startedSpeakingAt = turnStartedAt / 1000; // ms -> seconds
+      }
+
       const message = ChatMessage.create({
         role: 'user',
         content: ev.transcript,
         id: ev.itemId,
+        createdAt: turnStartedAt,
+        metrics: userMetrics,
       });
-      this.agent._chatCtx.items.push(message);
+      // insert rather than append: this transcript can arrive after the reply that
+      // answered it, and the turn it belongs to began before that reply
+      this.agent._chatCtx.insert(message);
       this.agentSession._conversationItemAdded(message);
     }
   }
@@ -3707,6 +3718,9 @@ export class AgentActivity implements RecognitionHooks {
           const assistantMetrics: MetricsReport = {};
           if (ev.responseId) {
             assistantMetrics.providerRequestIds = [ev.responseId];
+          }
+          if (startedSpeakingAt !== undefined) {
+            assistantMetrics.startedSpeakingAt = startedSpeakingAt / 1000; // ms -> seconds
           }
 
           const message = ChatMessage.create({


### PR DESCRIPTION
## Problem

With a realtime model, the provider publishes the final user transcript only after the
reply has finished generating. The user message was appended to the chat context at that
moment, so it landed *after* the reply it prompted — the Cloud transcript shows the agent
answering a question the user has not asked yet.

## Fix

The Gemini plugin now reports when the turn began (`turnStartedAt` on
`InputTranscriptionCompleted`), and the commit path stamps the user message with that time
and `insert`s it by `createdAt` instead of appending. Same call the realtime *assistant*
path already uses, so no change to the uploader.

## Testing

`agents/src/voice/agent_activity.test.ts` — the new ordering test fails on `main`
(`['assistant', 'user']`) and passes here (`['user', 'assistant']`).

## Python parity

Python carries a `TODO` for exactly this gap: *"for realtime models, the created_at field
is off. it should be set to when the user started speaking. but we don't have that
information here."* This closes it on the JS side by having the plugin supply that
information.