### PR TITLE
feat(workflows): support deterministic warm-transfer hangup notices

### DIFF
--- a/.changeset/deterministic-warm-transfer-hangup-notice.md
+++ b/.changeset/deterministic-warm-transfer-hangup-notice.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-feat(workflows): support deterministic caller-hangup notices during warm transfers
+Support deterministic caller-hangup notices during warm transfers.

--- a/.changeset/deterministic-warm-transfer-hangup-notice.md
+++ b/.changeset/deterministic-warm-transfer-hangup-notice.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+feat(workflows): support deterministic caller-hangup notices during warm transfers

--- a/agents/src/workflows/index.ts
+++ b/agents/src/workflows/index.ts
@@ -10,6 +10,7 @@ export {
 export {
   WarmTransferTask,
   createWarmTransferTask,
+  type CallerHangupNotice,
   type WarmTransferResult,
   type WarmTransferTaskOptions,
 } from './warm_transfer.js';

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -57,17 +57,6 @@ describe('createWarmTransferTask', () => {
     ).toThrow(/must not be empty/);
   });
 
-  it('rejects both caller hangup options together', () => {
-    expect(() =>
-      createWarmTransferTask({
-        sipCallTo: '+15551234567',
-        sipTrunkId: 'ST_dummy',
-        callerHangupNotice: { text: 'The caller disconnected. Hanging up now.' },
-        callerHangupInstruction: 'Generate a short notice.',
-      }),
-    ).toThrow(/cannot both be set/);
-  });
-
   it('rejects an empty deterministic notice', () => {
     expect(() =>
       createWarmTransferTask({
@@ -205,7 +194,7 @@ describe('startCallerHangupSpeech', () => {
     await expect(stream?.getReader().read()).resolves.toEqual({ value: frame, done: false });
   });
 
-  it('cancels decoded audio and falls back when say throws', () => {
+  it('uses a supplied fallback instruction when the deterministic notice cannot be played', () => {
     const { session, say, generateReply, generatedHandle } = createSession();
     const error = new Error('AgentSession is closing, cannot use say()');
     const cancel = vi.fn();

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -2,14 +2,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { AudioFrame } from '@livekit/rtc-node';
-import { describe, expect, it, vi } from 'vitest';
+import { ReadableStream } from 'node:stream/web';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type * as AudioModule from '../audio.js';
+import { log } from '../log.js';
 import type { AgentSession } from '../voice/agent_session.js';
+import { BuiltinAudioClip } from '../voice/background_audio.js';
 import { SpeechHandle } from '../voice/speech_handle.js';
 import {
-  createCallerHangupSpeech,
   createWarmTransferTask,
+  notifyHumanAgentOfHangup,
   resolveHumanAgentRoomName,
+  startCallerHangupSpeech,
 } from './warm_transfer.js';
+
+const { audioFramesFromFileMock } = vi.hoisted(() => ({
+  audioFramesFromFileMock: vi.fn(),
+}));
+
+vi.mock('../audio.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof AudioModule>();
+  return { ...actual, audioFramesFromFile: audioFramesFromFileMock };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  audioFramesFromFileMock.mockReset();
+});
 
 describe('resolveHumanAgentRoomName', () => {
   it('defaults to `<callerRoom>-human-agent` when no override is given', () => {
@@ -37,76 +56,292 @@ describe('createWarmTransferTask', () => {
       }),
     ).toThrow(/must not be empty/);
   });
+
+  it('rejects both caller hangup options together', () => {
+    expect(() =>
+      createWarmTransferTask({
+        sipCallTo: '+15551234567',
+        sipTrunkId: 'ST_dummy',
+        callerHangupNotice: { text: 'The caller disconnected. Hanging up now.' },
+        callerHangupInstruction: 'Generate a short notice.',
+      }),
+    ).toThrow(/cannot both be set/);
+  });
+
+  it('rejects an empty deterministic notice', () => {
+    expect(() =>
+      createWarmTransferTask({
+        sipCallTo: '+15551234567',
+        sipTrunkId: 'ST_dummy',
+        callerHangupNotice: { text: '   ' },
+      }),
+    ).toThrow(/callerHangupNotice\.text.*must not be empty/);
+  });
 });
 
-describe('createCallerHangupSpeech', () => {
-  function createSession() {
-    const sayHandle = SpeechHandle.create();
-    const generatedHandle = SpeechHandle.create();
-    const say = vi.fn(() => sayHandle);
-    const generateReply = vi.fn(() => generatedHandle);
-    const session = { say, generateReply } as unknown as Pick<
-      AgentSession,
-      'generateReply' | 'say'
-    >;
+type HangupSession = Pick<AgentSession, 'interrupt' | 'say' | 'generateReply' | 'shutdown'>;
 
-    return { session, say, sayHandle, generateReply, generatedHandle };
-  }
+function completedSpeechHandle(): SpeechHandle {
+  const handle = SpeechHandle.create();
+  handle._markDone();
+  return handle;
+}
 
+function createSession() {
+  const calls: string[] = [];
+  const sayHandle = completedSpeechHandle();
+  const generatedHandle = completedSpeechHandle();
+  const interrupt = vi.fn(() => {
+    calls.push('interrupt');
+  });
+  const say = vi.fn(() => {
+    calls.push('say');
+    return sayHandle;
+  });
+  const generateReply = vi.fn(() => {
+    calls.push('generateReply');
+    return generatedHandle;
+  });
+  const shutdown = vi.fn(() => {
+    calls.push('shutdown');
+  });
+  const session = { interrupt, say, generateReply, shutdown } as unknown as HangupSession;
+
+  return {
+    calls,
+    session,
+    interrupt,
+    say,
+    sayHandle,
+    generateReply,
+    generatedHandle,
+    shutdown,
+  };
+}
+
+describe('startCallerHangupSpeech', () => {
   it('uses fixed text without generating a reply', () => {
     const { session, say, sayHandle, generateReply } = createSession();
 
     expect(
-      createCallerHangupSpeech(
+      startCallerHangupSpeech(
         session,
         { text: 'The caller disconnected. Hanging up now.' },
         'Generate a notice.',
+        new AbortController().signal,
       ),
     ).toBe(sayHandle);
     expect(say).toHaveBeenCalledWith('The caller disconnected. Hanging up now.', {
       audio: undefined,
       allowInterruptions: false,
-      addToChatCtx: false,
     });
     expect(generateReply).not.toHaveBeenCalled();
   });
 
-  it('creates prerecorded audio only when starting the notice', () => {
+  it('decodes a file path with the playout abort signal', () => {
     const { session, say, sayHandle, generateReply } = createSession();
     const audio = new ReadableStream<AudioFrame>();
-    const createAudio = vi.fn(() => audio);
+    const abortSignal = new AbortController().signal;
+    audioFramesFromFileMock.mockReturnValue(audio);
 
-    expect(createAudio).not.toHaveBeenCalled();
     expect(
-      createCallerHangupSpeech(
+      startCallerHangupSpeech(
         session,
         {
           text: 'The caller disconnected. Hanging up now.',
-          audio: createAudio,
+          audio: './caller-left.wav',
         },
         undefined,
+        abortSignal,
       ),
     ).toBe(sayHandle);
-    expect(createAudio).toHaveBeenCalledOnce();
+    expect(audioFramesFromFileMock).toHaveBeenCalledWith('./caller-left.wav', { abortSignal });
     expect(say).toHaveBeenCalledWith('The caller disconnected. Hanging up now.', {
       audio,
       allowInterruptions: false,
-      addToChatCtx: false,
     });
     expect(generateReply).not.toHaveBeenCalled();
+  });
+
+  it('resolves builtin audio clips to their file path', () => {
+    const { session } = createSession();
+    const audio = new ReadableStream<AudioFrame>();
+    audioFramesFromFileMock.mockReturnValue(audio);
+
+    startCallerHangupSpeech(
+      session,
+      {
+        text: 'The caller disconnected. Hanging up now.',
+        audio: BuiltinAudioClip.HOLD_MUSIC,
+      },
+      undefined,
+      new AbortController().signal,
+    );
+
+    expect(audioFramesFromFileMock).toHaveBeenCalledWith(
+      expect.stringMatching(/resources[/\\]hold_music\.ogg$/),
+      expect.any(Object),
+    );
+  });
+
+  it('converts async iterable audio to a readable stream', async () => {
+    const { session, say } = createSession();
+    const frame = {} as AudioFrame;
+    const audio = {
+      async *[Symbol.asyncIterator]() {
+        yield frame;
+      },
+    };
+
+    startCallerHangupSpeech(
+      session,
+      { text: 'The caller disconnected. Hanging up now.', audio },
+      undefined,
+      new AbortController().signal,
+    );
+
+    const stream = say.mock.calls[0]?.[1]?.audio;
+    expect(stream).toBeInstanceOf(ReadableStream);
+    await expect(stream?.getReader().read()).resolves.toEqual({ value: frame, done: false });
+  });
+
+  it('cancels decoded audio and falls back when say throws', () => {
+    const { session, say, generateReply, generatedHandle } = createSession();
+    const error = new Error('AgentSession is closing, cannot use say()');
+    const cancel = vi.fn();
+    const audio = new ReadableStream<AudioFrame>({ cancel });
+    audioFramesFromFileMock.mockReturnValue(audio);
+    say.mockImplementation(() => {
+      throw error;
+    });
+    const warn = vi.spyOn(log(), 'warn');
+
+    expect(
+      startCallerHangupSpeech(
+        session,
+        {
+          text: 'The caller disconnected. Hanging up now.',
+          audio: './caller-left.wav',
+        },
+        'Generate a short notice.',
+        new AbortController().signal,
+      ),
+    ).toBe(generatedHandle);
+
+    expect(cancel).toHaveBeenCalledWith(error);
+    expect(generateReply).toHaveBeenCalledWith({
+      instructions: 'Generate a short notice.',
+      allowInterruptions: false,
+      toolChoice: 'none',
+    });
+    expect(warn).toHaveBeenCalledWith(
+      { error },
+      'failed to play deterministic caller hangup notice, falling back to generated reply',
+    );
   });
 
   it('preserves generated replies when no deterministic notice is configured', () => {
     const { session, say, generateReply, generatedHandle } = createSession();
 
-    expect(createCallerHangupSpeech(session, undefined, 'Generate a short notice.')).toBe(
-      generatedHandle,
-    );
+    expect(
+      startCallerHangupSpeech(
+        session,
+        undefined,
+        'Generate a short notice.',
+        new AbortController().signal,
+      ),
+    ).toBe(generatedHandle);
     expect(generateReply).toHaveBeenCalledWith({
       instructions: 'Generate a short notice.',
       allowInterruptions: false,
       toolChoice: 'none',
     });
     expect(say).not.toHaveBeenCalled();
+  });
+
+  it('uses the default instruction when no instruction is configured', () => {
+    const { session, generateReply } = createSession();
+
+    startCallerHangupSpeech(session, undefined, undefined, new AbortController().signal);
+
+    expect(generateReply).toHaveBeenCalledWith({
+      instructions:
+        'The caller has hung up before the transfer could be completed.\nBriefly inform the human agent that the caller has left and that you are ending the call now.',
+      allowInterruptions: false,
+      toolChoice: 'none',
+    });
+  });
+});
+
+describe('notifyHumanAgentOfHangup', () => {
+  it('interrupts before saying the notice and shuts down after playout', async () => {
+    const { session, calls, interrupt, say, shutdown } = createSession();
+
+    await notifyHumanAgentOfHangup(
+      session,
+      { text: 'The caller disconnected. Hanging up now.' },
+      undefined,
+    );
+
+    expect(calls).toEqual(['interrupt', 'say', 'shutdown']);
+    expect(interrupt).toHaveBeenCalledOnce();
+    expect(say).toHaveBeenCalledOnce();
+    expect(shutdown).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to a generated reply when say throws', async () => {
+    const { session, calls, say, generateReply, shutdown } = createSession();
+    const error = new Error('trying to generate speech from text without a TTS model');
+    say.mockImplementation(() => {
+      calls.push('say');
+      throw error;
+    });
+    const warn = vi.spyOn(log(), 'warn');
+
+    await notifyHumanAgentOfHangup(
+      session,
+      { text: 'The caller disconnected. Hanging up now.' },
+      undefined,
+    );
+
+    expect(calls).toEqual(['interrupt', 'say', 'generateReply', 'shutdown']);
+    expect(generateReply).toHaveBeenCalledOnce();
+    expect(shutdown).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      { error },
+      'failed to play deterministic caller hangup notice, falling back to generated reply',
+    );
+  });
+
+  it('still shuts down when both notice paths throw', async () => {
+    const { session, say, generateReply, shutdown } = createSession();
+    say.mockImplementation(() => {
+      throw new Error('say failed');
+    });
+    generateReply.mockImplementation(() => {
+      throw new Error('generate failed');
+    });
+
+    await notifyHumanAgentOfHangup(
+      session,
+      { text: 'The caller disconnected. Hanging up now.' },
+      undefined,
+    );
+
+    expect(shutdown).toHaveBeenCalledOnce();
+  });
+
+  it('bounds the playout wait before shutting down', async () => {
+    const { session, say, shutdown } = createSession();
+    say.mockReturnValue(SpeechHandle.create());
+
+    await notifyHumanAgentOfHangup(
+      session,
+      { text: 'The caller disconnected. Hanging up now.' },
+      undefined,
+      1,
+    );
+
+    expect(shutdown).toHaveBeenCalledOnce();
   });
 });

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -1,8 +1,15 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { describe, expect, it } from 'vitest';
-import { createWarmTransferTask, resolveHumanAgentRoomName } from './warm_transfer.js';
+import type { AudioFrame } from '@livekit/rtc-node';
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentSession } from '../voice/agent_session.js';
+import { SpeechHandle } from '../voice/speech_handle.js';
+import {
+  createCallerHangupSpeech,
+  createWarmTransferTask,
+  resolveHumanAgentRoomName,
+} from './warm_transfer.js';
 
 describe('resolveHumanAgentRoomName', () => {
   it('defaults to `<callerRoom>-human-agent` when no override is given', () => {
@@ -29,5 +36,77 @@ describe('createWarmTransferTask', () => {
         roomName: '',
       }),
     ).toThrow(/must not be empty/);
+  });
+});
+
+describe('createCallerHangupSpeech', () => {
+  function createSession() {
+    const sayHandle = SpeechHandle.create();
+    const generatedHandle = SpeechHandle.create();
+    const say = vi.fn(() => sayHandle);
+    const generateReply = vi.fn(() => generatedHandle);
+    const session = { say, generateReply } as unknown as Pick<
+      AgentSession,
+      'generateReply' | 'say'
+    >;
+
+    return { session, say, sayHandle, generateReply, generatedHandle };
+  }
+
+  it('uses fixed text without generating a reply', () => {
+    const { session, say, sayHandle, generateReply } = createSession();
+
+    expect(
+      createCallerHangupSpeech(
+        session,
+        { text: 'The caller disconnected. Hanging up now.' },
+        'Generate a notice.',
+      ),
+    ).toBe(sayHandle);
+    expect(say).toHaveBeenCalledWith('The caller disconnected. Hanging up now.', {
+      audio: undefined,
+      allowInterruptions: false,
+      addToChatCtx: false,
+    });
+    expect(generateReply).not.toHaveBeenCalled();
+  });
+
+  it('creates prerecorded audio only when starting the notice', () => {
+    const { session, say, sayHandle, generateReply } = createSession();
+    const audio = new ReadableStream<AudioFrame>();
+    const createAudio = vi.fn(() => audio);
+
+    expect(createAudio).not.toHaveBeenCalled();
+    expect(
+      createCallerHangupSpeech(
+        session,
+        {
+          text: 'The caller disconnected. Hanging up now.',
+          audio: createAudio,
+        },
+        undefined,
+      ),
+    ).toBe(sayHandle);
+    expect(createAudio).toHaveBeenCalledOnce();
+    expect(say).toHaveBeenCalledWith('The caller disconnected. Hanging up now.', {
+      audio,
+      allowInterruptions: false,
+      addToChatCtx: false,
+    });
+    expect(generateReply).not.toHaveBeenCalled();
+  });
+
+  it('preserves generated replies when no deterministic notice is configured', () => {
+    const { session, say, generateReply, generatedHandle } = createSession();
+
+    expect(createCallerHangupSpeech(session, undefined, 'Generate a short notice.')).toBe(
+      generatedHandle,
+    );
+    expect(generateReply).toHaveBeenCalledWith({
+      instructions: 'Generate a short notice.',
+      allowInterruptions: false,
+      toolChoice: 'none',
+    });
+    expect(say).not.toHaveBeenCalled();
   });
 });

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -10,8 +10,9 @@ import {
   RoomEvent,
 } from '@livekit/rtc-node';
 import { AccessToken, RoomServiceClient, SipClient, type VideoGrant } from 'livekit-server-sdk';
-import type { ReadableStream } from 'node:stream/web';
+import { ReadableStream } from 'node:stream/web';
 import { z } from 'zod';
+import { audioFramesFromFile } from '../audio.js';
 import type { LLMModels, STTModelString, TTSModelString } from '../inference/index.js';
 import { type JobContext, getJobContext } from '../job.js';
 import type {
@@ -35,6 +36,8 @@ import {
   BackgroundAudioPlayer,
   BuiltinAudioClip,
   type PlayHandle,
+  getBuiltinAudioPath,
+  isBuiltinAudioClip,
 } from '../voice/background_audio.js';
 import { DEFAULT_PARTICIPANT_KINDS } from '../voice/room_io/index.js';
 import type { SpeechHandle } from '../voice/speech_handle.js';
@@ -49,13 +52,14 @@ export interface WarmTransferResult {
  * is completed.
  */
 export interface CallerHangupNotice {
-  /** Exact text forwarded to transcription output and synthesized when {@link audio} is omitted. */
+  /** Exact text spoken to the human agent. */
   text: string;
   /**
-   * Optional factory for prerecorded audio matching {@link text}. The factory is called only after
-   * the human agent has answered and the caller hangs up before the merge.
+   * Optional prerecorded audio matching {@link text}. Accepts a file path, a
+   * {@link BuiltinAudioClip}, or an async iterable of audio frames. When omitted, the task uses the
+   * configured TTS model, falling back to a generated reply when TTS is unavailable.
    */
-  audio?: () => ReadableStream<AudioFrame>;
+  audio?: AudioSourceType;
 }
 
 export interface WarmTransferTaskOptions {
@@ -104,8 +108,7 @@ export interface WarmTransferTaskOptions {
   holdAudio?: AudioSourceType | AudioConfig | AudioConfig[] | null;
   /**
    * Deterministic notice spoken to the human agent before their call is ended when the caller
-   * hangs up mid-transfer. When provided, this takes precedence over
-   * {@link callerHangupInstruction}.
+   * hangs up mid-transfer. Cannot be combined with {@link callerHangupInstruction}.
    */
   callerHangupNotice?: CallerHangupNotice;
   /**
@@ -179,6 +182,14 @@ export function createWarmTransferTask({
 
   if (rawRoomName !== undefined && rawRoomName.length === 0) {
     throw new Error('`roomName` must not be empty');
+  }
+
+  if (callerHangupNotice && callerHangupInstruction != null) {
+    throw new Error('`callerHangupNotice` and `callerHangupInstruction` cannot both be set');
+  }
+
+  if (callerHangupNotice && callerHangupNotice.text.trim().length === 0) {
+    throw new Error('`callerHangupNotice.text` must not be empty');
   }
 
   // Resolve the SIP trunk: an explicit id wins, then a custom connection (which
@@ -287,21 +298,6 @@ export function createWarmTransferTask({
     return false;
   };
 
-  // Announces the caller hangup to the human agent, then hangs up on them by
-  // shutting the session down (deleteRoomOnClose ends the SIP call).
-  const notifyHumanAgentOfHangup = async (session: AgentSession): Promise<void> => {
-    try {
-      session.interrupt();
-      const handle = createCallerHangupSpeech(session, callerHangupNotice, callerHangupInstruction);
-      // Cap the wait so teardown can't hang on a stuck playout.
-      await waitUntilAborted(handle.waitForPlayout(), AbortSignal.timeout(10_000));
-    } catch (error) {
-      logger.warn({ error }, 'failed to notify human agent of caller hangup');
-    } finally {
-      session.shutdown();
-    }
-  };
-
   const cancelForCallerHangup = (participantIdentity?: string): void => {
     if (task.done) return;
     logger.info(
@@ -318,7 +314,7 @@ export function createWarmTransferTask({
       transferAgentSession = null;
       humanAgentRoom = null;
       hangupNotifySession = session;
-      void notifyHumanAgentOfHangup(session);
+      void notifyHumanAgentOfHangup(session, callerHangupNotice, callerHangupInstruction);
     }
     setResult(new ToolError('caller hung up before the transfer completed'));
   };
@@ -724,21 +720,36 @@ export function resolveHumanAgentRoomName(callerRoomName: string, override?: str
 
 /**
  * Start the caller-hangup speech using a deterministic notice when configured, otherwise preserve
- * the generated-reply behavior.
+ * the generated-reply behavior. If the deterministic notice cannot be scheduled, fall back to a
+ * generated reply so the human agent is not disconnected without an explanation.
  *
  * Exported for testing; not re-exported from the package index.
  */
-export function createCallerHangupSpeech(
+export function startCallerHangupSpeech(
   session: Pick<AgentSession, 'generateReply' | 'say'>,
   callerHangupNotice: CallerHangupNotice | undefined,
   callerHangupInstruction: string | null | undefined,
+  abortSignal: AbortSignal,
 ): SpeechHandle {
   if (callerHangupNotice) {
-    return session.say(callerHangupNotice.text, {
-      audio: callerHangupNotice.audio?.(),
-      allowInterruptions: false,
-      addToChatCtx: false,
-    });
+    let audio: ReadableStream<AudioFrame> | undefined;
+    try {
+      audio = resolveNoticeAudio(callerHangupNotice.audio, abortSignal);
+      return session.say(callerHangupNotice.text, {
+        audio,
+        allowInterruptions: false,
+      });
+    } catch (error) {
+      if (audio) {
+        void audio.cancel(error).catch((cancelError) => {
+          log().warn({ error: cancelError }, 'failed to cancel caller hangup notice audio');
+        });
+      }
+      log().warn(
+        { error },
+        'failed to play deterministic caller hangup notice, falling back to generated reply',
+      );
+    }
   }
 
   return session.generateReply({
@@ -748,6 +759,52 @@ export function createCallerHangupSpeech(
     // connect_to_caller/decline_transfer.
     toolChoice: 'none',
   });
+}
+
+/**
+ * Announce the caller hangup to the human agent, then end their call.
+ *
+ * Exported for testing; not re-exported from the package index.
+ */
+export async function notifyHumanAgentOfHangup(
+  session: Pick<AgentSession, 'interrupt' | 'say' | 'generateReply' | 'shutdown'>,
+  callerHangupNotice: CallerHangupNotice | undefined,
+  callerHangupInstruction: string | null | undefined,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+  try {
+    session.interrupt();
+    const handle = startCallerHangupSpeech(
+      session,
+      callerHangupNotice,
+      callerHangupInstruction,
+      abortController.signal,
+    );
+    // Cap the wait so teardown can't hang on a stuck playout. The same signal stops file decoding.
+    await waitUntilAborted(handle.waitForPlayout(), abortController.signal);
+  } catch (error) {
+    log().warn({ error }, 'failed to notify human agent of caller hangup');
+  } finally {
+    clearTimeout(timeout);
+    abortController.abort();
+    session.shutdown();
+  }
+}
+
+function resolveNoticeAudio(
+  audio: AudioSourceType | undefined,
+  abortSignal: AbortSignal,
+): ReadableStream<AudioFrame> | undefined {
+  if (audio === undefined) {
+    return undefined;
+  }
+
+  const source = isBuiltinAudioClip(audio) ? getBuiltinAudioPath(audio) : audio;
+  return typeof source === 'string'
+    ? audioFramesFromFile(source, { abortSignal })
+    : ReadableStream.from(source);
 }
 
 const CALLER_HANGUP_INSTRUCTION = `The caller has hung up before the transfer could be completed.

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -2,8 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { SIPOutboundConfig } from '@livekit/protocol';
-import { type DisconnectReason, type ParticipantKind, Room, RoomEvent } from '@livekit/rtc-node';
+import {
+  type AudioFrame,
+  type DisconnectReason,
+  type ParticipantKind,
+  Room,
+  RoomEvent,
+} from '@livekit/rtc-node';
 import { AccessToken, RoomServiceClient, SipClient, type VideoGrant } from 'livekit-server-sdk';
+import type { ReadableStream } from 'node:stream/web';
 import { z } from 'zod';
 import type { LLMModels, STTModelString, TTSModelString } from '../inference/index.js';
 import { type JobContext, getJobContext } from '../job.js';
@@ -30,10 +37,25 @@ import {
   type PlayHandle,
 } from '../voice/background_audio.js';
 import { DEFAULT_PARTICIPANT_KINDS } from '../voice/room_io/index.js';
+import type { SpeechHandle } from '../voice/speech_handle.js';
 import type { InstructionParts } from './utils.js';
 
 export interface WarmTransferResult {
   humanAgentIdentity: string;
+}
+
+/**
+ * A deterministic notice spoken to the human agent when the caller hangs up before the transfer
+ * is completed.
+ */
+export interface CallerHangupNotice {
+  /** Exact text forwarded to transcription output and synthesized when {@link audio} is omitted. */
+  text: string;
+  /**
+   * Optional factory for prerecorded audio matching {@link text}. The factory is called only after
+   * the human agent has answered and the caller hangs up before the merge.
+   */
+  audio?: () => ReadableStream<AudioFrame>;
 }
 
 export interface WarmTransferTaskOptions {
@@ -81,9 +103,16 @@ export interface WarmTransferTaskOptions {
   /** Audio played to the caller while they are on hold during the transfer. */
   holdAudio?: AudioSourceType | AudioConfig | AudioConfig[] | null;
   /**
+   * Deterministic notice spoken to the human agent before their call is ended when the caller
+   * hangs up mid-transfer. When provided, this takes precedence over
+   * {@link callerHangupInstruction}.
+   */
+  callerHangupNotice?: CallerHangupNotice;
+  /**
    * Instructions used to generate the reply spoken to the human agent before their call is
    * ended when the caller hangs up mid-transfer (after the human agent answered but before
-   * the merge). Falls back to a built-in instruction when not provided.
+   * the merge). Used only when {@link callerHangupNotice} is not provided, and falls back to a
+   * built-in instruction when omitted.
    */
   callerHangupInstruction?: string | null;
   /**
@@ -115,8 +144,10 @@ type IoState = {
  * If the caller hangs up before the merge — including while the human agent's phone is
  * still ringing — the transfer is cancelled: the pending dial is aborted, the human agent
  * room is torn down (ending the SIP call), and the task completes with a {@link ToolError}.
- * A human agent who already answered is told the caller left (a reply generated from
- * {@link WarmTransferTaskOptions.callerHangupInstruction}) before their call is ended.
+ * A human agent who already answered is told the caller left using
+ * {@link WarmTransferTaskOptions.callerHangupNotice}, or a reply generated from
+ * {@link WarmTransferTaskOptions.callerHangupInstruction} when no deterministic notice is
+ * provided, before their call is ended.
  *
  * This is the functional core; {@link WarmTransferTask} is a thin class wrapper over it.
  */
@@ -130,6 +161,7 @@ export function createWarmTransferTask({
   ringingTimeout,
   roomName: rawRoomName,
   holdAudio = { source: BuiltinAudioClip.HOLD_MUSIC, volume: 0.8 },
+  callerHangupNotice,
   callerHangupInstruction,
   instructions,
   chatCtx,
@@ -260,13 +292,7 @@ export function createWarmTransferTask({
   const notifyHumanAgentOfHangup = async (session: AgentSession): Promise<void> => {
     try {
       session.interrupt();
-      const handle = session.generateReply({
-        instructions: callerHangupInstruction ?? CALLER_HANGUP_INSTRUCTION,
-        allowInterruptions: false,
-        // The transfer is already cancelled; the reply must speak, not call
-        // connect_to_caller/decline_transfer.
-        toolChoice: 'none',
-      });
+      const handle = createCallerHangupSpeech(session, callerHangupNotice, callerHangupInstruction);
       // Cap the wait so teardown can't hang on a stuck playout.
       await waitUntilAborted(handle.waitForPlayout(), AbortSignal.timeout(10_000));
     } catch (error) {
@@ -694,6 +720,34 @@ export function resolveHumanAgentRoomName(callerRoomName: string, override?: str
     throw new Error('`roomName` must differ from the caller room name');
   }
   return override;
+}
+
+/**
+ * Start the caller-hangup speech using a deterministic notice when configured, otherwise preserve
+ * the generated-reply behavior.
+ *
+ * Exported for testing; not re-exported from the package index.
+ */
+export function createCallerHangupSpeech(
+  session: Pick<AgentSession, 'generateReply' | 'say'>,
+  callerHangupNotice: CallerHangupNotice | undefined,
+  callerHangupInstruction: string | null | undefined,
+): SpeechHandle {
+  if (callerHangupNotice) {
+    return session.say(callerHangupNotice.text, {
+      audio: callerHangupNotice.audio?.(),
+      allowInterruptions: false,
+      addToChatCtx: false,
+    });
+  }
+
+  return session.generateReply({
+    instructions: callerHangupInstruction ?? CALLER_HANGUP_INSTRUCTION,
+    allowInterruptions: false,
+    // The transfer is already cancelled; the reply must speak, not call
+    // connect_to_caller/decline_transfer.
+    toolChoice: 'none',
+  });
 }
 
 const CALLER_HANGUP_INSTRUCTION = `The caller has hung up before the transfer could be completed.

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -109,15 +109,15 @@ export interface WarmTransferTaskOptions {
   /**
    * Deterministic notice spoken to the human agent before their call is ended when the caller
    * hangs up mid-transfer. If the notice cannot be scheduled, the error is logged and the task
-   * falls back to a generated reply using the built-in caller-hangup instruction. Cannot be
-   * combined with {@link callerHangupInstruction}.
+   * falls back to a generated reply using {@link callerHangupInstruction}, or the built-in
+   * instruction when none is provided.
    */
   callerHangupNotice?: CallerHangupNotice;
   /**
    * Instructions used to generate the reply spoken to the human agent before their call is
    * ended when the caller hangs up mid-transfer (after the human agent answered but before
-   * the merge). Used only when {@link callerHangupNotice} is not provided, and falls back to a
-   * built-in instruction when omitted.
+   * the merge). Used when no {@link callerHangupNotice} is configured, or when a configured notice
+   * cannot be played. Falls back to a built-in instruction when omitted.
    */
   callerHangupInstruction?: string | null;
   /**
@@ -184,10 +184,6 @@ export function createWarmTransferTask({
 
   if (rawRoomName !== undefined && rawRoomName.length === 0) {
     throw new Error('`roomName` must not be empty');
-  }
-
-  if (callerHangupNotice && callerHangupInstruction != null) {
-    throw new Error('`callerHangupNotice` and `callerHangupInstruction` cannot both be set');
   }
 
   if (callerHangupNotice && callerHangupNotice.text.trim().length === 0) {

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -56,8 +56,8 @@ export interface CallerHangupNotice {
   text: string;
   /**
    * Optional prerecorded audio matching {@link text}. Accepts a file path, a
-   * {@link BuiltinAudioClip}, or an async iterable of audio frames. When omitted, the task uses the
-   * configured TTS model, falling back to a generated reply when TTS is unavailable.
+   * {@link BuiltinAudioClip}, or an async iterable of audio frames. When omitted, the task attempts
+   * to synthesize {@link text} with the configured TTS model.
    */
   audio?: AudioSourceType;
 }
@@ -108,7 +108,9 @@ export interface WarmTransferTaskOptions {
   holdAudio?: AudioSourceType | AudioConfig | AudioConfig[] | null;
   /**
    * Deterministic notice spoken to the human agent before their call is ended when the caller
-   * hangs up mid-transfer. Cannot be combined with {@link callerHangupInstruction}.
+   * hangs up mid-transfer. If the notice cannot be scheduled, the error is logged and the task
+   * falls back to a generated reply using the built-in caller-hangup instruction. Cannot be
+   * combined with {@link callerHangupInstruction}.
    */
   callerHangupNotice?: CallerHangupNotice;
   /**
@@ -770,10 +772,11 @@ export async function notifyHumanAgentOfHangup(
   session: Pick<AgentSession, 'interrupt' | 'say' | 'generateReply' | 'shutdown'>,
   callerHangupNotice: CallerHangupNotice | undefined,
   callerHangupInstruction: string | null | undefined,
-  timeoutMs = 10_000,
+  timeoutMs = CALLER_HANGUP_NOTICE_TIMEOUT_MS,
 ): Promise<void> {
   const abortController = new AbortController();
   const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+  timeout.unref();
   try {
     session.interrupt();
     const handle = startCallerHangupSpeech(
@@ -802,11 +805,14 @@ function resolveNoticeAudio(
   }
 
   const source = isBuiltinAudioClip(audio) ? getBuiltinAudioPath(audio) : audio;
-  return typeof source === 'string'
-    ? audioFramesFromFile(source, { abortSignal })
-    : ReadableStream.from(source);
+  if (typeof source === 'string') {
+    // Decode to 48 kHz mono: RoomIO expects mono, and rate mismatches are resampled downstream.
+    return audioFramesFromFile(source, { abortSignal });
+  }
+  return ReadableStream.from(source);
 }
 
+const CALLER_HANGUP_NOTICE_TIMEOUT_MS = 10_000;
 const CALLER_HANGUP_INSTRUCTION = `The caller has hung up before the transfer could be completed.
 Briefly inform the human agent that the caller has left and that you are ending the call now.`;
 


### PR DESCRIPTION
## Description

Adds an optional deterministic caller-hangup notice for warm transfers. When the caller disconnects after the human agent answers but before the merge, applications can provide exact text and, optionally, prerecorded audio for the notice played before teardown.

This fixes the confusing case where the interrupted consult briefing can be repeated or completed before the generated hangup message. `session.interrupt()` stops active playout, but `generateReply()` still has the consult persona, conversation history, and truncated assistant turn. A caller-hangup notice is a finite-state notification, so the deterministic path uses `session.say()` instead of asking the model to compose it.

Text-only notices use configured TTS. Prerecorded notices accept the existing `AudioSourceType` (`string`, `BuiltinAudioClip`, or `AsyncIterable<AudioFrame>`), so file paths receive the same 48 kHz mono decoding behavior as other framework audio and rate mismatches are resampled downstream. If `say()` cannot be scheduled—for example, a realtime-model session has no TTS—the task logs the error and falls back to `generateReply()` using `callerHangupInstruction` when provided, or the built-in instruction otherwise.

The two options are layers: `callerHangupNotice` is the deterministic primary behavior, while `callerHangupInstruction` controls generated speech when no notice is configured or when the notice cannot be played. Existing applications that only use `callerHangupInstruction` retain their current behavior.

Fixes #2167.

## Changes Made

- Add `callerHangupNotice` with exact `text` and optional `AudioSourceType` audio.
- Resolve file paths and builtin clips through `audioFramesFromFile`; convert async iterables with `ReadableStream.from()`.
- Use one bounded, unref'd timeout signal for audio decoding and playout, and clean up the stream when `say()` throws.
- Fall back to `generateReply()` using a caller-supplied instruction or the built-in default when deterministic speech cannot be scheduled.
- Preserve the normal `say()` conversation-item behavior for transcript consumers.
- Validate empty notice text.
- Test the full `interrupt → notice → await playout → shutdown` lifecycle, customized fallback, timeout, and supported audio forms.
- Add a patch changeset for `@livekit/agents`.

## Pre-Review Checklist

- [x] Build passes (`pnpm build`)
- [x] AI-generated code was reviewed and tested
- [x] The change is scoped to warm-transfer caller abandonment
- [x] Public API behavior is documented
- [ ] Video demo — requires a live two-leg SIP transfer; issue #2167 includes the observed runtime transcript and timing

## Testing

- [x] `pnpm vitest run agents/src/workflows/warm_transfer.test.ts` — 16 passed
- [x] `pnpm test agents/src`
- [x] `pnpm build` — 40 packages built
- [x] `pnpm --filter @livekit/agents typecheck`
- [x] `pnpm --filter @livekit/agents throws:check`
- [x] `pnpm -w lint:fix`
- [x] `pnpm -w format:write`
- [x] `pnpm format:check`

## Additional Notes

The public API shape remains open to maintainer input. In particular: should v1 include the optional `audio: AudioSourceType`, or ship `text` only and add prerecorded audio later? Python parity and naming are also open questions before stabilizing the public option.

Design tradeoffs called out for review:

- The generated-reply fallback favors giving the human agent an audible explanation over silently dropping the call. It logs the underlying `say()` error at `warn`, and applications can supply `callerHangupInstruction` to control the degraded path. The catch is intentionally broader than the no-TTS case because narrowing it would couple this workflow to a private error-message string; an explicit fallback opt-out could be added if exact-wording/compliance use cases require it.
- `AudioConfig` is intentionally not accepted. Its volume scaling is implemented in `BackgroundAudioPlayer`'s mixer, while `session.say({ audio })` uses `performAudioForwarding`, which has no volume stage. Supporting `AudioConfig` here would require a separate per-frame gain implementation.
- The 10-second notice timeout remains an internal teardown safety bound, not a public tuning option, and its timer is unref'd so it cannot keep a worker process alive during shutdown.
- `session.interrupt()` remains the pre-existing synchronous call; the replacement notice is scheduled through the normal speech queue while the interrupted speech unwinds.

The repository-wide `pnpm test` also runs credentialed examples/plugins. Locally it reports unrelated failures from missing `OPENAI_API_KEY` / `CEREBRAS_API_KEY`, one Silero VAD assertion, and two pre-existing unhandled errors in the survey example; the complete `agents/src` suite passes.

`pnpm --filter @livekit/agents api:check` reaches the existing API Extractor limitation at `agents/dist/index.d.ts:10` (`export * as` is not supported). The package build and typecheck pass.