### PR TITLE
fix(voice): reset tool call createdAt to tool execution start

### DIFF
--- a/.changeset/tame-clocks-agree.md
+++ b/.changeset/tame-clocks-agree.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+stamp a tool call's `createdAt` when its execution begins rather than when it was parsed off the model stream, so it no longer sorts ahead of the assistant message that requested it

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -3080,7 +3080,11 @@ export class AgentActivity implements RecognitionHooks {
     //TODO(AJS-272): before executing tools, make sure we generated all the text
     // (this ensure everything is kept ordered)
 
+    // items are ordered by `createdAt`
     const onToolExecutionStarted = (f: FunctionCall) => {
+      // function call is created during LLM generation, might be before the speech is authorized
+      // reset the `createdAt` to the start time of the tool execution
+      f.createdAt = Date.now();
       speechHandle._itemAdded([f]);
       this.agent._chatCtx.items.push(f);
       this.agentSession._toolItemsAdded([f]);
@@ -3754,7 +3758,11 @@ export class AgentActivity implements RecognitionHooks {
       ),
     );
 
+    // items are ordered by `createdAt`
     const onToolExecutionStarted = (f: FunctionCall) => {
+      // function call is created during the model generation, might be before the speech is
+      // authorized; reset the `createdAt` to the start time of the tool execution
+      f.createdAt = Date.now();
       speechHandle._itemAdded([f]);
       this.agent._chatCtx.items.push(f);
       this.agentSession._toolItemsAdded([f]);


### PR DESCRIPTION
A `FunctionCall` is constructed while the model stream is parsed, before the speech is authorized, so its `createdAt` sorts it ahead of the assistant message that requested it — in chat context, in `RunResult`, and in the uploaded transcript. Reset it when execution begins, as Python does in `_tool_execution_started_cb` (livekit/agents `voice/agent_activity.py`).

No new test: the reset lives in the reply paths' `onToolExecutionStarted` closures, which the existing harnesses mock rather than drive; Python has no dedicated test either. Full agents suite: 1505 passing.