### PR TITLE
fix(openai): restore realtime context across task transitions

### DIFF
--- a/.changeset/calm-realtime-context.md
+++ b/.changeset/calm-realtime-context.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+Ignore agent metadata records when synchronizing OpenAI realtime chat context.

--- a/.changeset/calm-realtime-context.md
+++ b/.changeset/calm-realtime-context.md
@@ -2,4 +2,5 @@
 '@livekit/agents-plugin-openai': patch
 ---
 
-Ignore agent metadata records when synchronizing OpenAI realtime chat context.
+Ignore agent metadata records and preserve item ordering when synchronizing OpenAI realtime chat
+context.

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -957,7 +957,7 @@ describe('RealtimeSession chat context update events', () => {
     expect(events[0]?.type).toBe('conversation.item.create');
     const createEvent = events[0] as api_proto.ConversationItemCreateEvent;
     expect(createEvent.item.id).toBe('parent_message');
-    expect(createEvent.previous_item_id).toBeUndefined();
+    expect(createEvent.previous_item_id).toBe('root');
   });
 });
 

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -919,6 +919,46 @@ describe('RealtimeSession chat context update events', () => {
     expect((events[0] as api_proto.ConversationItemDeleteEvent).item_id).toBe('item_1');
     expect((events[1] as api_proto.ConversationItemCreateEvent).item.id).toBe('item_1');
   });
+
+  it.each([
+    [
+      'agent config updates',
+      new llm.AgentConfigUpdate({ id: 'parent_config', instructions: 'parent instructions' }),
+    ],
+    [
+      'agent handoffs',
+      new llm.AgentHandoffItem({
+        id: 'task_handoff',
+        oldAgentId: 'task',
+        newAgentId: 'parent',
+      }),
+    ],
+  ])('ignores %s while restoring conversation history', async (_label, metadataItem) => {
+    const taskMessage = llm.ChatMessage.create({
+      id: 'task_message',
+      role: 'assistant',
+      content: ['task complete'],
+    });
+    const session = createChatCtxUpdateSession(taskMessage);
+
+    const events = await session.createChatCtxUpdateEvents(
+      new llm.ChatContext([
+        metadataItem,
+        llm.ChatMessage.create({
+          id: 'parent_message',
+          role: 'user',
+          content: ['remember this'],
+        }),
+        taskMessage,
+      ]),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe('conversation.item.create');
+    const createEvent = events[0] as api_proto.ConversationItemCreateEvent;
+    expect(createEvent.item.id).toBe('parent_message');
+    expect(createEvent.previous_item_id).toBeUndefined();
+  });
 });
 
 describe('RealtimeSession.updateOptions', () => {

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -684,7 +684,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     chatCtx: llm.ChatContext,
     addMockAudio: boolean = false,
   ): Promise<(api_proto.ConversationItemCreateEvent | api_proto.ConversationItemDeleteEvent)[]> {
-    const newChatCtx = chatCtx.copy();
+    const newChatCtx = chatCtx.copy({ excludeHandoff: true, excludeConfigUpdate: true });
     if (addMockAudio) {
       newChatCtx.items.push(createMockAudioItem());
     } else {

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -722,7 +722,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       events.push({
         type: 'conversation.item.create',
         item: await livekitItemToOpenAIItem(chatItem),
-        previous_item_id: previousId ?? undefined,
+        previous_item_id: previousId ?? 'root',
         event_id: shortuuid('chat_ctx_create_'),
       } as api_proto.ConversationItemCreateEvent);
     };


### PR DESCRIPTION
## Problem
Exiting an `AgentTask` can reuse an OpenAI realtime session with framework-only metadata in the merged chat context. Serialization then fails, leaving provider history stale; restored items were also appended instead of inserted before the task history.

## Fix
Filter agent handoff and configuration records before computing provider updates, and use OpenAI's `root` anchor when prepending restored history.

## Testing
OpenAI realtime suite: 45 tests passed. Full build and formatting checks pass.

## Python parity
Matches all three metadata-filtering paths in Python OpenAI realtime—chat updates, reconnect, and transcript synchronization—through their shared JS event builder. Root insertion also matches Python's `previous_item_id="root"` behavior.