### PR TITLE
plugins/phonic: add configsForTools for per-tool behavior overrides

### DIFF
--- a/.changeset/phonic-configs-for-tools.md
+++ b/.changeset/phonic-configs-for-tools.md
@@ -2,4 +2,4 @@
 '@livekit/agents-plugin-phonic': patch
 ---
 
-Add `configsForTools` to the Phonic realtime model — a per-tool config passthrough (`[{ name, ... }]`) where each object may carry up to the full behavior set (`wait_for_speech_before_tool_call`, `forbid_speech_after_tool_call`, `forbid_tool_call_after_speech`, `allow_tool_chaining`); omitted fields fall back to the plugin defaults. Replaces the earlier `forbidSpeechAfterToolCall: string[]` option and adds `forbid_tool_call_after_speech` (Phonic drops the tool call if the agent already spoke that turn).
+Add `configsForTools` to the Phonic realtime model — per-tool behavior overrides (`[{ name, ... }]`) forwarded to Phonic's tool config. Each entry may set `require_speech_before_tool_call`, `wait_for_speech_before_tool_call`, `forbid_speech_after_tool_call`, `forbid_tool_call_after_speech`, and `allow_tool_chaining`; omitted fields fall back to the plugin defaults. See the README for details.

--- a/.changeset/phonic-configs-for-tools.md
+++ b/.changeset/phonic-configs-for-tools.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-phonic': patch
+---
+
+Add `configsForTools` to the Phonic realtime model — a per-tool config passthrough (`[{ name, ... }]`) where each object may carry up to the full behavior set (`wait_for_speech_before_tool_call`, `forbid_speech_after_tool_call`, `forbid_tool_call_after_speech`, `allow_tool_chaining`); omitted fields fall back to the plugin defaults. Replaces the earlier `forbidSpeechAfterToolCall: string[]` option and adds `forbid_tool_call_after_speech` (Phonic drops the tool call if the agent already spoke that turn).

--- a/.changeset/phonic-configs-for-tools.md
+++ b/.changeset/phonic-configs-for-tools.md
@@ -2,4 +2,4 @@
 '@livekit/agents-plugin-phonic': patch
 ---
 
-Add `configsForTools` to the Phonic realtime model — per-tool behavior overrides (`[{ name, ... }]`) forwarded to Phonic's tool config. Each entry may set `require_speech_before_tool_call`, `forbid_speech_after_tool_call`, and `forbid_tool_call_after_speech`; omitted fields fall back to the plugin defaults. See the README for details.
+Add `configsForTools` to the Phonic realtime model — per-tool behavior overrides (`[{ name, ... }]`) forwarded to Phonic's tool config. Each entry may set `require_speech_before_tool_call`, `forbid_speech_after_tool_call`, and `forbid_tool_call_after_speech`; omitted fields fall back to the plugin defaults. The existing `forbidSpeechAfterToolCall: string[]` option is deprecated but still supported — it folds into `configsForTools` and logs a warning. See the README for details.

--- a/.changeset/phonic-configs-for-tools.md
+++ b/.changeset/phonic-configs-for-tools.md
@@ -2,4 +2,4 @@
 '@livekit/agents-plugin-phonic': patch
 ---
 
-Add `configsForTools` to the Phonic realtime model — per-tool behavior overrides (`[{ name, ... }]`) forwarded to Phonic's tool config. Each entry may set `require_speech_before_tool_call`, `wait_for_speech_before_tool_call`, `forbid_speech_after_tool_call`, `forbid_tool_call_after_speech`, and `allow_tool_chaining`; omitted fields fall back to the plugin defaults. See the README for details.
+Add `configsForTools` to the Phonic realtime model — per-tool behavior overrides (`[{ name, ... }]`) forwarded to Phonic's tool config. Each entry may set `require_speech_before_tool_call`, `forbid_speech_after_tool_call`, and `forbid_tool_call_after_speech`; omitted fields fall back to the plugin defaults. See the README for details.

--- a/plugins/phonic/README.md
+++ b/plugins/phonic/README.md
@@ -109,6 +109,8 @@ new phonic.realtime.RealtimeModel({
 
 The plugin always sends tool calls with `wait_for_speech_before_tool_call` on and `allow_tool_chaining` off; these are not configurable per tool.
 
+> **Deprecated:** the top-level `forbidSpeechAfterToolCall: string[]` option still works but is deprecated — it now folds each listed tool into `configsForTools` as `forbid_speech_after_tool_call: true` (an explicit `configsForTools` entry wins) and logs a warning. Prefer `configsForTools`.
+
 If you already have an agent set up on the Phonic platform, you can use the `phonicAgent` option to specify the agent name. As a note, configuration options you set in the LiveKit Agents SDK will override the agent settings set on the Phonic platform. This means the system prompt you have set on the Phonic platform will be ignored in favor of the `instructions` field set on the LiveKit `voice.Agent`. Likewise, options explicitly set in the `RealtimeModel` constructor will override the Phonic agent's settings. 
 
 If you have Webhook tools set up on the Phonic platform, you can use `phonicTools` to make them available to your agent. Only [Phonic Webhook tools](https://docs.phonic.co/docs/using-tools/tools_overview#webhook-tools) are supported with LiveKit Agents.

--- a/plugins/phonic/README.md
+++ b/plugins/phonic/README.md
@@ -84,6 +84,29 @@ Set the `PHONIC_API_KEY` environment variable, or pass `apiKey` directly to `Rea
 | `noInputPokeSec` | `number` | Seconds of silence before sending poke message |
 | `noInputPokeText` | `string` | Poke message text (ignored when `generateNoInputPokeText` is true) |
 | `noInputEndConversationSec` | `number` | Seconds of silence before ending conversation |
+| `configsForTools` | `PhonicToolConfig[]` | Per-tool behavior overrides (see [Per-tool configuration](#per-tool-configuration)) |
+
+### Per-tool configuration
+
+`configsForTools` takes one entry per tool you want to customize. Each entry is keyed by the tool `name`; every other field is optional and falls back to the plugin default when omitted. Tools with no entry keep the defaults.
+
+```typescript
+new phonic.realtime.RealtimeModel({
+  configsForTools: [
+    { name: 'transfer_call', forbid_speech_after_tool_call: true },
+    { name: 'submit_form', forbid_tool_call_after_speech: true },
+  ],
+});
+```
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | — | Tool this config applies to (required) |
+| `require_speech_before_tool_call` | `boolean` | `false` | Require the agent to speak before the tool can be called |
+| `wait_for_speech_before_tool_call` | `boolean` | `true` | Hold the tool call until the agent's speech for the turn has been sent |
+| `forbid_speech_after_tool_call` | `boolean` | `false` | Suppress the auto-generated spoken reply after the tool. Use for tools that always hand off to another agent (a non-handoff tool set here would leave the agent silent) |
+| `forbid_tool_call_after_speech` | `boolean` | `false` | Drop the tool call if the agent already spoke this turn |
+| `allow_tool_chaining` | `boolean` | `false` | Allow another tool call immediately after this tool's output |
 
 If you already have an agent set up on the Phonic platform, you can use the `phonicAgent` option to specify the agent name. As a note, configuration options you set in the LiveKit Agents SDK will override the agent settings set on the Phonic platform. This means the system prompt you have set on the Phonic platform will be ignored in favor of the `instructions` field set on the LiveKit `voice.Agent`. Likewise, options explicitly set in the `RealtimeModel` constructor will override the Phonic agent's settings. 
 

--- a/plugins/phonic/README.md
+++ b/plugins/phonic/README.md
@@ -103,10 +103,10 @@ new phonic.realtime.RealtimeModel({
 | --- | --- | --- | --- |
 | `name` | `string` | — | Tool this config applies to (required) |
 | `require_speech_before_tool_call` | `boolean` | `false` | Require the agent to speak before the tool can be called |
-| `wait_for_speech_before_tool_call` | `boolean` | `true` | Hold the tool call until the agent's speech for the turn has been sent |
 | `forbid_speech_after_tool_call` | `boolean` | `false` | Suppress the auto-generated spoken reply after the tool. Use for tools that always hand off to another agent (a non-handoff tool set here would leave the agent silent) |
 | `forbid_tool_call_after_speech` | `boolean` | `false` | Drop the tool call if the agent already spoke this turn |
-| `allow_tool_chaining` | `boolean` | `false` | Allow another tool call immediately after this tool's output |
+
+The plugin always sends tool calls with `wait_for_speech_before_tool_call` on and `allow_tool_chaining` off; these are not configurable per tool.
 
 If you already have an agent set up on the Phonic platform, you can use the `phonicAgent` option to specify the agent name. As a note, configuration options you set in the LiveKit Agents SDK will override the agent settings set on the Phonic platform. This means the system prompt you have set on the Phonic platform will be ignored in favor of the `instructions` field set on the LiveKit `voice.Agent`. Likewise, options explicitly set in the `RealtimeModel` constructor will override the Phonic agent's settings. 
 

--- a/plugins/phonic/src/realtime/index.ts
+++ b/plugins/phonic/src/realtime/index.ts
@@ -1,5 +1,9 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-export { RealtimeModel, type RealtimeModelOptions } from './realtime_model.js';
+export {
+  RealtimeModel,
+  type RealtimeModelOptions,
+  type PhonicToolConfig,
+} from './realtime_model.js';
 export type { Voice } from './api_proto.js';

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -51,6 +51,7 @@ export interface RealtimeModelOptions {
   noInputPokeSec?: number;
   noInputPokeText?: string;
   noInputEndConversationSec?: number;
+  forbidSpeechAfterToolCall?: string[];
   /** Set by `updateInstructions` via `voice.Agent` rather than the RealtimeModel constructor */
   instructions?: string;
 }
@@ -152,6 +153,19 @@ export class RealtimeModel extends llm.RealtimeModel {
        */
       noInputEndConversationSec?: number;
       /**
+       * Names of tools after which Phonic should NOT auto-generate a spoken reply.
+       *
+       * Use for tools that always hand off / trigger an agent switch (e.g. advancing
+       * a task in a `TaskGroup`). After such a tool, the outgoing agent would otherwise
+       * speak a reply that the handoff's session reset immediately cancels, producing a
+       * race / double-speak. Forbidding speech lets only the incoming agent speak.
+       *
+       * Only list tools that ALWAYS hand off — a listed tool that returns without
+       * handing off will leave the agent silent (no reply is generated). Tools not
+       * listed keep the default behavior (a reply is generated after the tool output).
+       */
+      forbidSpeechAfterToolCall?: string[];
+      /**
        * Connection options for the API connection
        */
       connOptions?: APIConnectOptions;
@@ -210,6 +224,7 @@ export class RealtimeModel extends llm.RealtimeModel {
       noInputPokeSec: options.noInputPokeSec,
       noInputPokeText: options.noInputPokeText,
       noInputEndConversationSec: options.noInputEndConversationSec,
+      forbidSpeechAfterToolCall: options.forbidSpeechAfterToolCall,
       connOptions: options.connOptions ?? DEFAULT_API_CONNECT_OPTIONS,
       model: options.model ?? DEFAULT_MODEL,
       baseUrl: options.baseUrl,
@@ -368,8 +383,15 @@ export class RealtimeSession extends llm.RealtimeSession {
     }
 
     this._tools = { ...tools };
-    this.toolDefinitions = Object.entries(tools)
-      .filter(([_, tool]) => llm.isFunctionTool(tool))
+    this.toolDefinitions = this.buildToolDefinitions(tools);
+
+    this.toolsReady.resolve();
+  }
+
+  private buildToolDefinitions(tools: llm.ToolContext): Record<string, unknown>[] {
+    const forbidSpeechAfterToolCall = new Set(this.options.forbidSpeechAfterToolCall ?? []);
+    return Object.entries(tools)
+      .filter(([, tool]) => llm.isFunctionTool(tool))
       .map(([name, tool]) => ({
         type: 'custom_websocket',
         tool_schema: {
@@ -386,9 +408,11 @@ export class RealtimeSession extends llm.RealtimeSession {
         // for ease of implementation within the RealtimeSession generations framework
         wait_for_speech_before_tool_call: true,
         allow_tool_chaining: false,
+        // When true, Phonic does not auto-generate a spoken reply after this tool's
+        // output. Used for tools that always hand off so the outgoing agent doesn't
+        // speak a reply that the handoff's session reset would cancel.
+        forbid_speech_after_tool_call: forbidSpeechAfterToolCall.has(name),
       }));
-
-    this.toolsReady.resolve();
   }
 
   override async _updateSession(
@@ -406,23 +430,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     }
     if (tools !== undefined) {
       this._tools = { ...tools };
-      this.toolDefinitions = Object.entries(tools)
-        .filter(([, tool]) => llm.isFunctionTool(tool))
-        .map(([name, tool]) => ({
-          type: 'custom_websocket',
-          tool_schema: {
-            type: 'function',
-            function: {
-              name,
-              description: tool.description,
-              parameters: llm.toJsonSchema(tool.parameters),
-              strict: true,
-            },
-          },
-          tool_call_output_timeout_ms: TOOL_CALL_OUTPUT_TIMEOUT_MS,
-          wait_for_speech_before_tool_call: true,
-          allow_tool_chaining: false,
-        }));
+      this.toolDefinitions = this.buildToolDefinitions(tools);
     }
     if (chatCtx !== undefined) {
       this._chatCtx = chatCtx.copy();

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -275,6 +275,7 @@ export class RealtimeSession extends llm.RealtimeSession {
   private closedFuture = new Future<void, never>();
   private connectTask: Promise<void>;
   private toolDefinitions: Record<string, unknown>[] = [];
+  private forbidSpeechAfterToolCall = new Set<string>();
   private pendingToolCallIds = new Set<string>();
   private readyToStart = new Future<void>();
   private pendingGenerateReplyFut?: Future<llm.GenerationCreatedEvent>;
@@ -337,6 +338,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     const diffOps = llm.computeChatCtxDiff(this._chatCtx, chatCtx);
     let sentToolCallOutput = false;
     let sentAddSystemMessage = false;
+    let forbidSpeech = false;
 
     for (const [, itemId] of diffOps.toCreate) {
       const item = chatCtx.getById(itemId);
@@ -349,6 +351,9 @@ export class RealtimeSession extends llm.RealtimeSession {
           output: item.output,
         });
         sentToolCallOutput = true;
+        if (item.name && this.forbidSpeechAfterToolCall.has(item.name)) {
+          forbidSpeech = true;
+        }
       }
       if (item?.type === 'message') {
         if ((item.role === 'system' || item.role === 'developer') && item.textContent) {
@@ -369,7 +374,10 @@ export class RealtimeSession extends llm.RealtimeSession {
         'updateChatCtx called but no new tool call outputs to send. Phonic does not support general chat context updates.',
       );
     }
-    if (sentToolCallOutput) {
+    // Skip opening a new assistant turn when the tool forbids speech after its call:
+    // Phonic will not speak, so the generation would otherwise dangle open (never
+    // receiving audio nor a finished-speaking event) until the handoff reset / close.
+    if (sentToolCallOutput && !forbidSpeech) {
       this.startNewAssistantTurn({ userInitiated: false });
     }
   }
@@ -389,7 +397,7 @@ export class RealtimeSession extends llm.RealtimeSession {
   }
 
   private buildToolDefinitions(tools: llm.ToolContext): Record<string, unknown>[] {
-    const forbidSpeechAfterToolCall = new Set(this.options.forbidSpeechAfterToolCall ?? []);
+    this.forbidSpeechAfterToolCall = new Set(this.options.forbidSpeechAfterToolCall ?? []);
     return Object.entries(tools)
       .filter(([, tool]) => llm.isFunctionTool(tool))
       .map(([name, tool]) => ({
@@ -411,7 +419,7 @@ export class RealtimeSession extends llm.RealtimeSession {
         // When true, Phonic does not auto-generate a spoken reply after this tool's
         // output. Used for tools that always hand off so the outgoing agent doesn't
         // speak a reply that the handoff's session reset would cancel.
-        forbid_speech_after_tool_call: forbidSpeechAfterToolCall.has(name),
+        forbid_speech_after_tool_call: this.forbidSpeechAfterToolCall.has(name),
       }));
   }
 

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -51,9 +51,22 @@ export interface RealtimeModelOptions {
   noInputPokeSec?: number;
   noInputPokeText?: string;
   noInputEndConversationSec?: number;
-  forbidSpeechAfterToolCall?: string[];
+  configsForTools?: PhonicToolConfig[];
   /** Set by `updateInstructions` via `voice.Agent` rather than the RealtimeModel constructor */
   instructions?: string;
+}
+
+/**
+ * Per-tool behavior overrides passed through to Phonic's tool_config. `name` is required; every
+ * other field is optional and falls back to the plugin default when omitted. Keys are snake_case
+ * to match Phonic's wire format (direct passthrough).
+ */
+export interface PhonicToolConfig {
+  name: string;
+  wait_for_speech_before_tool_call?: boolean;
+  forbid_speech_after_tool_call?: boolean;
+  forbid_tool_call_after_speech?: boolean;
+  allow_tool_chaining?: boolean;
 }
 
 export class RealtimeModel extends llm.RealtimeModel {
@@ -153,18 +166,18 @@ export class RealtimeModel extends llm.RealtimeModel {
        */
       noInputEndConversationSec?: number;
       /**
-       * Names of tools after which Phonic should NOT auto-generate a spoken reply.
+       * Per-tool behavior overrides, one entry per tool (`{ name, ... }`). Each object may carry
+       * up to the full behavior set — `wait_for_speech_before_tool_call`,
+       * `forbid_speech_after_tool_call`, `forbid_tool_call_after_speech`, `allow_tool_chaining`
+       * — and any omitted field falls back to the plugin default. Tools with no entry keep the
+       * defaults.
        *
-       * Use for tools that always hand off / trigger an agent switch (e.g. advancing
-       * a task in a `TaskGroup`). After such a tool, the outgoing agent would otherwise
-       * speak a reply that the handoff's session reset immediately cancels, producing a
-       * race / double-speak. Forbidding speech lets only the incoming agent speak.
-       *
-       * Only list tools that ALWAYS hand off — a listed tool that returns without
-       * handing off will leave the agent silent (no reply is generated). Tools not
-       * listed keep the default behavior (a reply is generated after the tool output).
+       * `forbid_speech_after_tool_call` suppresses Phonic's auto-generated reply after the tool
+       * (for tools that always hand off; a non-handoff tool set here leaves the agent silent).
+       * `forbid_tool_call_after_speech` makes Phonic drop the tool call if the agent already
+       * spoke that turn.
        */
-      forbidSpeechAfterToolCall?: string[];
+      configsForTools?: PhonicToolConfig[];
       /**
        * Connection options for the API connection
        */
@@ -224,7 +237,7 @@ export class RealtimeModel extends llm.RealtimeModel {
       noInputPokeSec: options.noInputPokeSec,
       noInputPokeText: options.noInputPokeText,
       noInputEndConversationSec: options.noInputEndConversationSec,
-      forbidSpeechAfterToolCall: options.forbidSpeechAfterToolCall,
+      configsForTools: options.configsForTools,
       connOptions: options.connOptions ?? DEFAULT_API_CONNECT_OPTIONS,
       model: options.model ?? DEFAULT_MODEL,
       baseUrl: options.baseUrl,
@@ -275,7 +288,7 @@ export class RealtimeSession extends llm.RealtimeSession {
   private closedFuture = new Future<void, never>();
   private connectTask: Promise<void>;
   private toolDefinitions: Record<string, unknown>[] = [];
-  private forbidSpeechAfterToolCall = new Set<string>();
+  private configsForTools = new Map<string, PhonicToolConfig>();
   private pendingToolCallIds = new Set<string>();
   private readyToStart = new Future<void>();
   private pendingGenerateReplyFut?: Future<llm.GenerationCreatedEvent>;
@@ -351,7 +364,7 @@ export class RealtimeSession extends llm.RealtimeSession {
           output: item.output,
         });
         sentToolCallOutput = true;
-        if (item.name && this.forbidSpeechAfterToolCall.has(item.name)) {
+        if (item.name && this.configsForTools.get(item.name)?.forbid_speech_after_tool_call) {
           forbidSpeech = true;
         }
       }
@@ -397,30 +410,34 @@ export class RealtimeSession extends llm.RealtimeSession {
   }
 
   private buildToolDefinitions(tools: llm.ToolContext): Record<string, unknown>[] {
-    this.forbidSpeechAfterToolCall = new Set(this.options.forbidSpeechAfterToolCall ?? []);
+    this.configsForTools = new Map((this.options.configsForTools ?? []).map((c) => [c.name, c]));
     return Object.entries(tools)
       .filter(([, tool]) => llm.isFunctionTool(tool))
-      .map(([name, tool]) => ({
-        type: 'custom_websocket',
-        tool_schema: {
-          type: 'function',
-          function: {
-            name,
-            description: tool.description,
-            parameters: llm.toJsonSchema(tool.parameters),
-            strict: true,
+      .map(([name, tool]) => {
+        // Per-tool overrides from configsForTools; omitted fields fall back to the defaults
+        // below. Tool chaining and tool calls during speech are disabled by default for ease
+        // of implementation within the RealtimeSession generations framework.
+        const cfg = this.configsForTools.get(name);
+        return {
+          type: 'custom_websocket',
+          tool_schema: {
+            type: 'function',
+            function: {
+              name,
+              description: tool.description,
+              parameters: llm.toJsonSchema(tool.parameters),
+              strict: true,
+            },
           },
-        },
-        tool_call_output_timeout_ms: TOOL_CALL_OUTPUT_TIMEOUT_MS,
-        // Tool chaining and tool calls during speech are not supported at this time
-        // for ease of implementation within the RealtimeSession generations framework
-        wait_for_speech_before_tool_call: true,
-        allow_tool_chaining: false,
-        // When true, Phonic does not auto-generate a spoken reply after this tool's
-        // output. Used for tools that always hand off so the outgoing agent doesn't
-        // speak a reply that the handoff's session reset would cancel.
-        forbid_speech_after_tool_call: this.forbidSpeechAfterToolCall.has(name),
-      }));
+          tool_call_output_timeout_ms: TOOL_CALL_OUTPUT_TIMEOUT_MS,
+          wait_for_speech_before_tool_call: cfg?.wait_for_speech_before_tool_call ?? true,
+          allow_tool_chaining: cfg?.allow_tool_chaining ?? false,
+          // Phonic does not auto-generate a spoken reply after this tool (tools that hand off).
+          forbid_speech_after_tool_call: cfg?.forbid_speech_after_tool_call ?? false,
+          // Phonic drops this tool's call if the agent already spoke this turn.
+          forbid_tool_call_after_speech: cfg?.forbid_tool_call_after_speech ?? false,
+        };
+      });
   }
 
   override async _updateSession(

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -55,6 +55,8 @@ export interface RealtimeModelOptions {
   noInputEndConversationSec?: number;
   additionalParams?: NonNullable<Phonic.ConfigOptions['additional_params']>;
   configsForTools?: PhonicToolConfig[];
+  /** @deprecated Use `configsForTools` with `forbid_speech_after_tool_call` per tool instead. */
+  forbidSpeechAfterToolCall?: string[];
   onConversationCreated?: (conversationId: string) => void;
   /** Set by `updateInstructions` via `voice.Agent` rather than the RealtimeModel constructor */
   instructions?: string;
@@ -178,6 +180,12 @@ export class RealtimeModel extends llm.RealtimeModel {
        */
       configsForTools?: PhonicToolConfig[];
       /**
+       * @deprecated Use `configsForTools` with `forbid_speech_after_tool_call` per tool instead.
+       * When set, each listed tool is merged into `configsForTools` as
+       * `forbid_speech_after_tool_call: true` (an explicit `configsForTools` entry wins).
+       */
+      forbidSpeechAfterToolCall?: string[];
+      /**
        * Called with the Phonic conversation ID once the conversation is created
        */
       onConversationCreated?: (conversationId: string) => void;
@@ -241,11 +249,19 @@ export class RealtimeModel extends llm.RealtimeModel {
       noInputEndConversationSec: options.noInputEndConversationSec,
       additionalParams: options.additionalParams,
       configsForTools: options.configsForTools,
+      forbidSpeechAfterToolCall: options.forbidSpeechAfterToolCall,
       onConversationCreated: options.onConversationCreated,
       connOptions: options.connOptions ?? DEFAULT_API_CONNECT_OPTIONS,
       model: options.model ?? DEFAULT_MODEL,
       baseUrl: options.baseUrl,
     };
+
+    if (options.forbidSpeechAfterToolCall) {
+      log().warn(
+        '`forbidSpeechAfterToolCall` is deprecated and will be removed in a future release; ' +
+          'set `forbid_speech_after_tool_call` per tool via `configsForTools` instead.',
+      );
+    }
   }
 
   /**
@@ -427,6 +443,16 @@ export class RealtimeSession extends llm.RealtimeSession {
 
   private buildToolDefinitions(tools: llm.ToolContext): Phonic.InlineWebSocketTool[] {
     this.configsForTools = new Map((this.options.configsForTools ?? []).map((c) => [c.name, c]));
+    // Deprecated: fold forbidSpeechAfterToolCall (list of tool names) into the per-tool configs;
+    // an explicit configsForTools entry for the same tool wins.
+    for (const name of this.options.forbidSpeechAfterToolCall ?? []) {
+      const cfg = this.configsForTools.get(name);
+      if (cfg === undefined) {
+        this.configsForTools.set(name, { name, forbid_speech_after_tool_call: true });
+      } else if (cfg.forbid_speech_after_tool_call === undefined) {
+        this.configsForTools.set(name, { ...cfg, forbid_speech_after_tool_call: true });
+      }
+    }
     // TODO: support provider tools in the Phonic schema.
     return tools
       .flatten()

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -57,12 +57,13 @@ export interface RealtimeModelOptions {
 }
 
 /**
- * Per-tool behavior overrides passed through to Phonic's tool_config. `name` is required; every
- * other field is optional and falls back to the plugin default when omitted. Keys are snake_case
- * to match Phonic's wire format (direct passthrough).
+ * Per-tool behavior overrides for `configsForTools` (see README). `name` is required; every other
+ * field is optional and falls back to the plugin default when omitted. Keys are snake_case to match
+ * Phonic's wire format (direct passthrough).
  */
 export interface PhonicToolConfig {
   name: string;
+  require_speech_before_tool_call?: boolean;
   wait_for_speech_before_tool_call?: boolean;
   forbid_speech_after_tool_call?: boolean;
   forbid_tool_call_after_speech?: boolean;
@@ -166,16 +167,8 @@ export class RealtimeModel extends llm.RealtimeModel {
        */
       noInputEndConversationSec?: number;
       /**
-       * Per-tool behavior overrides, one entry per tool (`{ name, ... }`). Each object may carry
-       * up to the full behavior set — `wait_for_speech_before_tool_call`,
-       * `forbid_speech_after_tool_call`, `forbid_tool_call_after_speech`, `allow_tool_chaining`
-       * — and any omitted field falls back to the plugin default. Tools with no entry keep the
-       * defaults.
-       *
-       * `forbid_speech_after_tool_call` suppresses Phonic's auto-generated reply after the tool
-       * (for tools that always hand off; a non-handoff tool set here leaves the agent silent).
-       * `forbid_tool_call_after_speech` makes Phonic drop the tool call if the agent already
-       * spoke that turn.
+       * Per-tool behavior overrides, one `PhonicToolConfig` per tool (keyed by `name`); omitted
+       * fields fall back to the plugin defaults. See the README for the available fields.
        */
       configsForTools?: PhonicToolConfig[];
       /**
@@ -414,9 +407,6 @@ export class RealtimeSession extends llm.RealtimeSession {
     return Object.entries(tools)
       .filter(([, tool]) => llm.isFunctionTool(tool))
       .map(([name, tool]) => {
-        // Per-tool overrides from configsForTools; omitted fields fall back to the defaults
-        // below. Tool chaining and tool calls during speech are disabled by default for ease
-        // of implementation within the RealtimeSession generations framework.
         const cfg = this.configsForTools.get(name);
         return {
           type: 'custom_websocket',
@@ -430,11 +420,10 @@ export class RealtimeSession extends llm.RealtimeSession {
             },
           },
           tool_call_output_timeout_ms: TOOL_CALL_OUTPUT_TIMEOUT_MS,
+          require_speech_before_tool_call: cfg?.require_speech_before_tool_call ?? false,
           wait_for_speech_before_tool_call: cfg?.wait_for_speech_before_tool_call ?? true,
           allow_tool_chaining: cfg?.allow_tool_chaining ?? false,
-          // Phonic does not auto-generate a spoken reply after this tool (tools that hand off).
           forbid_speech_after_tool_call: cfg?.forbid_speech_after_tool_call ?? false,
-          // Phonic drops this tool's call if the agent already spoke this turn.
           forbid_tool_call_after_speech: cfg?.forbid_tool_call_after_speech ?? false,
         };
       });

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -64,10 +64,8 @@ export interface RealtimeModelOptions {
 export interface PhonicToolConfig {
   name: string;
   require_speech_before_tool_call?: boolean;
-  wait_for_speech_before_tool_call?: boolean;
   forbid_speech_after_tool_call?: boolean;
   forbid_tool_call_after_speech?: boolean;
-  allow_tool_chaining?: boolean;
 }
 
 export class RealtimeModel extends llm.RealtimeModel {
@@ -420,9 +418,11 @@ export class RealtimeSession extends llm.RealtimeSession {
             },
           },
           tool_call_output_timeout_ms: TOOL_CALL_OUTPUT_TIMEOUT_MS,
+          // fixed, not configurable: the plugin does not support tool chaining or tool calls
+          // during agent speech within the RealtimeSession generations framework
+          wait_for_speech_before_tool_call: true,
+          allow_tool_chaining: false,
           require_speech_before_tool_call: cfg?.require_speech_before_tool_call ?? false,
-          wait_for_speech_before_tool_call: cfg?.wait_for_speech_before_tool_call ?? true,
-          allow_tool_chaining: cfg?.allow_tool_chaining ?? false,
           forbid_speech_after_tool_call: cfg?.forbid_speech_after_tool_call ?? false,
           forbid_tool_call_after_speech: cfg?.forbid_tool_call_after_speech ?? false,
         };


### PR DESCRIPTION
## What

Adds `configsForTools` to the Phonic realtime model — per-tool behavior overrides forwarded to Phonic's tool config. One entry per tool (keyed by `name`); each may set `require_speech_before_tool_call`, `forbid_speech_after_tool_call`, and `forbid_tool_call_after_speech`. Omitted fields fall back to the plugin defaults; tools with no entry are unchanged. `wait_for_speech_before_tool_call` (on) and `allow_tool_chaining` (off) remain fixed by the plugin.

This generalizes the existing `forbidSpeechAfterToolCall: string[]` option into a single per-tool config object, and adds `forbid_tool_call_after_speech` (drop a tool call if the agent already spoke that turn). See the plugin README for the field reference. Changeset included.