### PR TITLE
chore(krisp): adjust default noise suppression level

### DIFF
--- a/.changeset/stale-ravens-crash.md
+++ b/.changeset/stale-ravens-crash.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-krisp": patch
+---
+
+Set default noiseSuppressionLevel to 75

--- a/plugins/krisp/src/viva_filter.ts
+++ b/plugins/krisp/src/viva_filter.ts
@@ -58,7 +58,7 @@ export interface KrispVivaFilterOptions {
    * otherwise it falls back to LiveKit Cloud auth ({@link LiveKitCloudAuthProvider}).
    */
   authProvider: AuthProvider;
-  /** Noise suppression strength, 0..=100 where 100 is maximum suppression. Default 100. */
+  /** Noise suppression strength, 0..=100 where 100 is maximum suppression. Default 75. */
   noiseSuppressionLevel: number;
 }
 

--- a/plugins/krisp/src/viva_filter.ts
+++ b/plugins/krisp/src/viva_filter.ts
@@ -154,7 +154,7 @@ export class KrispVivaFilter extends FrameProcessor<AudioFrame> {
   ) {
     super();
     const provider = resolveAuthProvider(opts.authProvider);
-    this.inner = buildBackend(mode, provider, opts.noiseSuppressionLevel ?? 100);
+    this.inner = buildBackend(mode, provider, opts.noiseSuppressionLevel ?? 75);
   }
 
   isEnabled(): boolean {


### PR DESCRIPTION
## Description
The default noiseSuppressionLevel of 100 led to some speech being garbled in cases. Manual testing revealed 75 to be a good middleground as a default.


## Changes Made
<!-- List the main changes in this PR. If any changes seem unrelated to the PR title, explain why they're included here or consider moving them to a follow-up PR -->
- 
- 
- 

## Pre-Review Checklist
- [ ] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [ ] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
- [ ] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.