### PR TITLE
chore(changeset): downgrade Cartesia turn-detection typing to patch

### DIFF
--- a/.changeset/type-cartesia-turn-detection.md
+++ b/.changeset/type-cartesia-turn-detection.md
@@ -1,5 +1,5 @@
 ---
-'@livekit/agents': minor
+'@livekit/agents': patch
 ---
 
 Type Cartesia turn-detection parameters in inference STT model options.


### PR DESCRIPTION
## Problem

The open release PR ([#2140](https://github.com/livekit/agents-js/pull/2140)) is cutting `1.7.0` instead of `1.6.1`. Every package in `agents/` and `plugins/` releases together under the `fixed` group in `.changeset/config.json`, so one `minor` entry takes the whole workspace up a minor version.

`.changeset/type-cartesia-turn-detection.md` (from [#2173](https://github.com/livekit/agents-js/pull/2173)) is the only non-`patch` changeset on `main` — the other 19 are all `patch`. It adds type declarations for Cartesia turn-detection parameters that callers could already pass through, which is not a feature.

## Fix

Change that changeset to `patch`.

## Testing

`changeset status` on this branch: all 40 packages at `patch`, none at `minor` or `major`, `@livekit/agents` `1.6.0 -> 1.6.1`. For comparison, the release bot regenerated `changeset-release/main` from the current `main` tip and wrote `1.7.0` into every `package.json`.