### PR TITLE
Add MiniMax LLM support

### DIFF
--- a/.changeset/minimax-llm-support.md
+++ b/.changeset/minimax-llm-support.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-minimax': minor
+---
+
+Add MiniMax chat completion support with regional compatible APIs and current model metadata.

--- a/plugins/minimax/README.md
+++ b/plugins/minimax/README.md
@@ -3,14 +3,16 @@ SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 
 SPDX-License-Identifier: Apache-2.0
 -->
+
 # MiniMax plugin for LiveKit Agents
 
 The Agents Framework is designed for building realtime, programmable
 participants that run on servers. Use it to create conversational, multi-modal
 voice agents that can see, hear, and understand.
 
-This package contains the MiniMax plugin, which provides text-to-speech via
-MiniMax's `t2a_v2` APIs (both HTTP streaming and WebSocket streaming).
+This package contains the MiniMax plugin, which provides chat completion and
+text-to-speech integrations. Chat completion supports the global and China
+OpenAI-compatible and Anthropic-compatible APIs.
 
 Refer to the [documentation](https://docs.livekit.io/agents/overview/) for
 information on how to use it. See the
@@ -26,5 +28,22 @@ pnpm add @livekit/agents-plugin-minimax
 ## Pre-requisites
 
 You'll need an API key from MiniMax. It can be set as an environment variable:
-`MINIMAX_API_KEY`. You can also override the API endpoint via `MINIMAX_BASE_URL`
-(defaults to `https://api-uw.minimax.io`).
+`MINIMAX_API_KEY`. For text-to-speech, you can also override the API endpoint via
+`MINIMAX_BASE_URL` (defaults to `https://api-uw.minimax.io`). Chat completion
+endpoints are selected with the `region` or `baseURL` option.
+
+## Chat completion
+
+The OpenAI-compatible API is used by default:
+
+```ts
+import { LLM } from '@livekit/agents-plugin-minimax';
+
+const model = new LLM({
+  region: 'global_en',
+  thinking: 'adaptive',
+});
+```
+
+Use `AnthropicLLM` for the Anthropic-compatible API, and set `region: 'cn_zh'`
+to select the China endpoint.

--- a/plugins/minimax/package.json
+++ b/plugins/minimax/package.json
@@ -35,6 +35,8 @@
   },
   "devDependencies": {
     "@livekit/agents": "workspace:*",
+    "@livekit/agents-plugin-anthropic": "workspace:*",
+    "@livekit/agents-plugin-openai": "workspace:*",
     "@livekit/agents-plugins-test": "workspace:*",
     "@livekit/rtc-node": "catalog:",
     "@microsoft/api-extractor": "^7.35.0",
@@ -47,6 +49,8 @@
   },
   "peerDependencies": {
     "@livekit/agents": "workspace:*",
+    "@livekit/agents-plugin-anthropic": "workspace:*",
+    "@livekit/agents-plugin-openai": "workspace:*",
     "@livekit/rtc-node": "catalog:"
   }
 }

--- a/plugins/minimax/src/index.ts
+++ b/plugins/minimax/src/index.ts
@@ -4,6 +4,7 @@
 import { Plugin } from '@livekit/agents';
 
 export * from './models.js';
+export * from './llm.js';
 export * from './tts.js';
 
 class MiniMaxPlugin extends Plugin {

--- a/plugins/minimax/src/llm.test.ts
+++ b/plugins/minimax/src/llm.test.ts
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { llm } from '@livekit/agents';
+import { describe, expect, it } from 'vitest';
+import { AnthropicLLM, type AnthropicLLMOptions, LLM, type LLMOptions } from './llm.js';
+import {
+  CHAT_MODEL_INFO,
+  type ChatThinkingMode,
+  DEFAULT_CHAT_MODEL,
+  REGIONAL_ENDPOINTS,
+} from './models.js';
+
+const drain = async (stream: AsyncIterable<unknown>): Promise<void> => {
+  for await (const chunk of stream) {
+    void chunk;
+  }
+};
+
+describe('MiniMax LLM', () => {
+  it('exports the current model metadata', () => {
+    expect(DEFAULT_CHAT_MODEL).toBe('MiniMax-M3');
+    expect(CHAT_MODEL_INFO).toEqual({
+      'MiniMax-M3': {
+        contextWindow: 1_000_000,
+        pricingUSDPerMillionTokens: {
+          input: 0.6,
+          output: 2.4,
+          cacheRead: 0.12,
+          cacheWrite: null,
+        },
+        inputModalities: ['text', 'image', 'video'],
+        thinking: ['adaptive', 'disabled'],
+      },
+      'MiniMax-M2.7': {
+        contextWindow: 204_800,
+        pricingUSDPerMillionTokens: {
+          input: 0.3,
+          output: 1.2,
+          cacheRead: 0.06,
+          cacheWrite: 0.375,
+        },
+        inputModalities: ['text'],
+        thinking: ['always_on'],
+      },
+    });
+  });
+
+  it('selects global and China compatible endpoints', () => {
+    const globalOpenAI = new LLM({ apiKey: 'test-key' });
+    const chinaOpenAI = new LLM({ apiKey: 'test-key', region: 'cn_zh' });
+    const globalAnthropic = new AnthropicLLM({ apiKey: 'test-key' });
+    const chinaAnthropic = new AnthropicLLM({ apiKey: 'test-key', region: 'cn_zh' });
+
+    expect(globalOpenAI.baseURL).toBe(REGIONAL_ENDPOINTS.global_en.openAIBaseURL);
+    expect(chinaOpenAI.baseURL).toBe(REGIONAL_ENDPOINTS.cn_zh.openAIBaseURL);
+    expect(globalAnthropic.baseURL).toBe(REGIONAL_ENDPOINTS.global_en.anthropicBaseURL);
+    expect(chinaAnthropic.baseURL).toBe(REGIONAL_ENDPOINTS.cn_zh.anthropicBaseURL);
+  });
+
+  it('passes adaptive thinking to the OpenAI-compatible request', async () => {
+    let capturedRequest: Record<string, unknown> | undefined;
+    const client = {
+      baseURL: 'https://unused.invalid',
+      chat: {
+        completions: {
+          create: async (request: Record<string, unknown>) => {
+            capturedRequest = request;
+            return (async function* (): AsyncGenerator<never> {})();
+          },
+        },
+      },
+    } as unknown as NonNullable<LLMOptions['client']>;
+    const model = new LLM({ client, thinking: 'adaptive' });
+    const chatCtx = new llm.ChatContext();
+    chatCtx.addMessage({ role: 'user', content: 'Hello' });
+
+    await drain(model.chat({ chatCtx }));
+
+    expect(capturedRequest?.thinking).toEqual({ type: 'adaptive' });
+  });
+
+  it('passes disabled thinking to the Anthropic-compatible request', async () => {
+    let capturedRequest: Record<string, unknown> | undefined;
+    const client = {
+      baseURL: 'https://unused.invalid',
+      messages: {
+        create: async (request: Record<string, unknown>) => {
+          capturedRequest = request;
+          return (async function* (): AsyncGenerator<never> {})();
+        },
+      },
+    } as unknown as NonNullable<AnthropicLLMOptions['client']>;
+    const model = new AnthropicLLM({ client, thinking: 'disabled' });
+    const chatCtx = new llm.ChatContext();
+    chatCtx.addMessage({ role: 'user', content: 'Hello' });
+
+    await drain(model.chat({ chatCtx }));
+
+    expect(capturedRequest?.thinking).toEqual({ type: 'disabled' });
+  });
+
+  it('keeps always-on thinking implicit for MiniMax-M2.7', async () => {
+    let capturedRequest: Record<string, unknown> | undefined;
+    const client = {
+      baseURL: 'https://unused.invalid',
+      chat: {
+        completions: {
+          create: async (request: Record<string, unknown>) => {
+            capturedRequest = request;
+            return (async function* (): AsyncGenerator<never> {})();
+          },
+        },
+      },
+    } as unknown as NonNullable<LLMOptions['client']>;
+    const model = new LLM({ client, model: 'MiniMax-M2.7' });
+    const chatCtx = new llm.ChatContext();
+    chatCtx.addMessage({ role: 'user', content: 'Hello' });
+
+    await drain(model.chat({ chatCtx }));
+
+    expect(model.thinking).toBe('always_on');
+    expect(capturedRequest).not.toHaveProperty('thinking');
+  });
+
+  it.each<ChatThinkingMode>(['adaptive', 'disabled'])(
+    'rejects %s thinking for MiniMax-M2.7',
+    (thinking) => {
+      expect(() => new LLM({ apiKey: 'test-key', model: 'MiniMax-M2.7', thinking })).toThrow(
+        `Thinking mode "${thinking}" is not supported by MiniMax model "MiniMax-M2.7"`,
+      );
+    },
+  );
+
+  it('rejects always-on thinking for MiniMax-M3', () => {
+    expect(
+      () => new LLM({ apiKey: 'test-key', model: 'MiniMax-M3', thinking: 'always_on' }),
+    ).toThrow('Thinking mode "always_on" is not supported by MiniMax model "MiniMax-M3"');
+  });
+});

--- a/plugins/minimax/src/llm.ts
+++ b/plugins/minimax/src/llm.ts
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  LLM as CompatibleAnthropicLLM,
+  type LLMOptions as CompatibleAnthropicLLMOptions,
+} from '@livekit/agents-plugin-anthropic';
+import {
+  LLM as CompatibleOpenAILLM,
+  type LLMOptions as CompatibleOpenAILLMOptions,
+} from '@livekit/agents-plugin-openai';
+import {
+  CHAT_MODEL_INFO,
+  type ChatModels,
+  type ChatThinkingMode,
+  DEFAULT_CHAT_MODEL,
+  DEFAULT_REGION,
+  REGIONAL_ENDPOINTS,
+  type Region,
+} from './models.js';
+
+/** Shared configuration options for MiniMax LLM compatibility APIs. */
+export interface MiniMaxLLMOptions {
+  /** MiniMax model identifier. Defaults to {@link DEFAULT_CHAT_MODEL}. */
+  model?: string | ChatModels;
+  /** API key. Falls back to `$MINIMAX_API_KEY`. */
+  apiKey?: string;
+  /** API region. Defaults to {@link DEFAULT_REGION}. */
+  region?: Region;
+  /** Custom compatible API base URL. Overrides the selected region. */
+  baseURL?: string;
+  /** Model thinking behavior. */
+  thinking?: ChatThinkingMode;
+}
+
+/** Configuration options for the OpenAI-compatible MiniMax LLM. */
+export interface LLMOptions
+  extends MiniMaxLLMOptions,
+    Pick<
+      CompatibleOpenAILLMOptions,
+      | 'client'
+      | 'maxCompletionTokens'
+      | 'parallelToolCalls'
+      | 'strictToolSchema'
+      | 'temperature'
+      | 'toolChoice'
+      | 'topP'
+      | 'user'
+    > {}
+
+/** Configuration options for the Anthropic-compatible MiniMax LLM. */
+export interface AnthropicLLMOptions
+  extends MiniMaxLLMOptions,
+    Pick<
+      CompatibleAnthropicLLMOptions,
+      'client' | 'maxTokens' | 'parallelToolCalls' | 'temperature' | 'toolChoice'
+    > {}
+
+const resolveRegion = (region: Region): (typeof REGIONAL_ENDPOINTS)[Region] => {
+  const endpoints = REGIONAL_ENDPOINTS[region];
+  if (!endpoints) {
+    throw new Error(`Unsupported MiniMax region: ${region}`);
+  }
+  return endpoints;
+};
+
+const resolveThinking = (
+  model: string,
+  thinking: ChatThinkingMode | undefined,
+): ChatThinkingMode | undefined => {
+  const modelInfo = CHAT_MODEL_INFO[model as ChatModels];
+  const resolved =
+    thinking ?? (modelInfo?.thinking.length === 1 ? modelInfo.thinking[0] : undefined);
+
+  if (
+    modelInfo &&
+    resolved &&
+    !(modelInfo.thinking as readonly ChatThinkingMode[]).includes(resolved)
+  ) {
+    throw new Error(`Thinking mode "${resolved}" is not supported by MiniMax model "${model}"`);
+  }
+
+  return resolved;
+};
+
+const withThinking = (
+  extraKwargs: Record<string, unknown> | undefined,
+  thinking: ChatThinkingMode | undefined,
+): Record<string, unknown> => {
+  const extras = { ...extraKwargs };
+  if (thinking === 'adaptive' || thinking === 'disabled') {
+    extras.thinking = { type: thinking };
+  }
+  return extras;
+};
+
+/** MiniMax LLM using the OpenAI-compatible API. */
+export class LLM extends CompatibleOpenAILLM {
+  readonly #baseURL: string;
+  readonly #region: Region;
+  readonly #thinking: ChatThinkingMode | undefined;
+
+  constructor(opts: LLMOptions = {}) {
+    const { region = DEFAULT_REGION, thinking, ...compatibleOpts } = opts;
+    const endpoints = resolveRegion(region);
+    const model = compatibleOpts.model ?? DEFAULT_CHAT_MODEL;
+    const apiKey = compatibleOpts.apiKey ?? process.env.MINIMAX_API_KEY;
+    const baseURL = compatibleOpts.baseURL ?? endpoints.openAIBaseURL;
+    const resolvedThinking = resolveThinking(model, thinking);
+
+    if (!apiKey && !compatibleOpts.client) {
+      throw new Error('MiniMax API key is required, either as an argument or as $MINIMAX_API_KEY');
+    }
+
+    super({
+      ...compatibleOpts,
+      apiKey,
+      baseURL,
+      model,
+      strictToolSchema: compatibleOpts.strictToolSchema ?? false,
+    });
+
+    this.#baseURL = baseURL;
+    this.#region = region;
+    this.#thinking = resolvedThinking;
+  }
+
+  override label(): string {
+    return 'minimax.LLM';
+  }
+
+  override get provider(): string {
+    return 'MiniMax';
+  }
+
+  /** Resolved compatible API base URL. */
+  get baseURL(): string {
+    return this.#baseURL;
+  }
+
+  /** Resolved MiniMax API region. */
+  get region(): Region {
+    return this.#region;
+  }
+
+  /** Resolved model thinking behavior. */
+  get thinking(): ChatThinkingMode | undefined {
+    return this.#thinking;
+  }
+
+  override chat(
+    args: Parameters<CompatibleOpenAILLM['chat']>[0],
+  ): ReturnType<CompatibleOpenAILLM['chat']> {
+    return super.chat({
+      ...args,
+      extraKwargs: withThinking(args.extraKwargs, this.#thinking),
+    });
+  }
+}
+
+/** MiniMax LLM using the Anthropic-compatible API. */
+export class AnthropicLLM extends CompatibleAnthropicLLM {
+  readonly #baseURL: string;
+  readonly #region: Region;
+  readonly #thinking: ChatThinkingMode | undefined;
+
+  constructor(opts: AnthropicLLMOptions = {}) {
+    const { region = DEFAULT_REGION, thinking, ...compatibleOpts } = opts;
+    const endpoints = resolveRegion(region);
+    const model = compatibleOpts.model ?? DEFAULT_CHAT_MODEL;
+    const apiKey = compatibleOpts.apiKey ?? process.env.MINIMAX_API_KEY;
+    const baseURL = compatibleOpts.baseURL ?? endpoints.anthropicBaseURL;
+    const resolvedThinking = resolveThinking(model, thinking);
+
+    if (!apiKey && !compatibleOpts.client) {
+      throw new Error('MiniMax API key is required, either as an argument or as $MINIMAX_API_KEY');
+    }
+
+    super({
+      ...compatibleOpts,
+      apiKey,
+      baseURL,
+      model,
+    });
+
+    this.#baseURL = baseURL;
+    this.#region = region;
+    this.#thinking = resolvedThinking;
+  }
+
+  override label(): string {
+    return 'minimax.AnthropicLLM';
+  }
+
+  override get provider(): string {
+    return 'MiniMax';
+  }
+
+  /** Resolved compatible API base URL. */
+  get baseURL(): string {
+    return this.#baseURL;
+  }
+
+  /** Resolved MiniMax API region. */
+  get region(): Region {
+    return this.#region;
+  }
+
+  /** Resolved model thinking behavior. */
+  get thinking(): ChatThinkingMode | undefined {
+    return this.#thinking;
+  }
+
+  override chat(
+    args: Parameters<CompatibleAnthropicLLM['chat']>[0],
+  ): ReturnType<CompatibleAnthropicLLM['chat']> {
+    return super.chat({
+      ...args,
+      extraKwargs: withThinking(args.extraKwargs, this.#thinking),
+    });
+  }
+}

--- a/plugins/minimax/src/models.ts
+++ b/plugins/minimax/src/models.ts
@@ -2,6 +2,80 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+/** Input modalities accepted by a MiniMax chat model. */
+export type ChatInputModality = 'text' | 'image' | 'video';
+
+/** Thinking behavior supported by a MiniMax chat model. */
+export type ChatThinkingMode = 'adaptive' | 'disabled' | 'always_on';
+
+/** Per-token pricing in USD per million tokens. */
+export interface ChatModelPricing {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number | null;
+}
+
+/** Metadata for a supported MiniMax chat model. */
+export interface ChatModelInfo {
+  contextWindow: number;
+  pricingUSDPerMillionTokens: ChatModelPricing;
+  inputModalities: readonly ChatInputModality[];
+  thinking: readonly ChatThinkingMode[];
+}
+
+/** Supported MiniMax chat models and their current capabilities. */
+export const CHAT_MODEL_INFO = {
+  'MiniMax-M3': {
+    contextWindow: 1_000_000,
+    pricingUSDPerMillionTokens: {
+      input: 0.6,
+      output: 2.4,
+      cacheRead: 0.12,
+      cacheWrite: null,
+    },
+    inputModalities: ['text', 'image', 'video'],
+    thinking: ['adaptive', 'disabled'],
+  },
+  'MiniMax-M2.7': {
+    contextWindow: 204_800,
+    pricingUSDPerMillionTokens: {
+      input: 0.3,
+      output: 1.2,
+      cacheRead: 0.06,
+      cacheWrite: 0.375,
+    },
+    inputModalities: ['text'],
+    thinking: ['always_on'],
+  },
+} as const satisfies Record<string, ChatModelInfo>;
+
+/** Supported MiniMax chat model identifiers. */
+export type ChatModels = keyof typeof CHAT_MODEL_INFO;
+
+/** Default MiniMax chat model. */
+export const DEFAULT_CHAT_MODEL: ChatModels = 'MiniMax-M3';
+
+/** Regional MiniMax compatible API endpoints. */
+export const REGIONAL_ENDPOINTS = {
+  global_en: {
+    openAIBaseURL: 'https://api.minimax.io/v1',
+    anthropicBaseURL: 'https://api.minimax.io/anthropic',
+    docsRoot: 'https://platform.minimax.io/docs',
+  },
+  cn_zh: {
+    openAIBaseURL: 'https://api.minimaxi.com/v1',
+    anthropicBaseURL: 'https://api.minimaxi.com/anthropic',
+    docsRoot: 'https://platform.minimaxi.com/docs',
+  },
+} as const;
+
+/** MiniMax API region. */
+export type Region = keyof typeof REGIONAL_ENDPOINTS;
+
+/** Default MiniMax API region. */
+export const DEFAULT_REGION: Region = 'global_en';
+
 // Ref: python livekit-plugins/livekit-plugins-minimax/livekit/plugins/minimax/tts.py - 27-38 lines
 /** Supported MiniMax TTS models. */
 export type TTSModel =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1041,6 +1041,12 @@ importers:
       '@livekit/agents':
         specifier: workspace:*
         version: link:../../agents
+      '@livekit/agents-plugin-anthropic':
+        specifier: workspace:*
+        version: link:../anthropic
+      '@livekit/agents-plugin-openai':
+        specifier: workspace:*
+        version: link:../openai
       '@livekit/agents-plugins-test':
         specifier: workspace:*
         version: link:../test


### PR DESCRIPTION
Reason: Add first-class MiniMax chat support with current models and regional compatible endpoints.

## Changes

- Add MiniMax chat clients for both compatible API protocols with global and China endpoint selection and API-key detection.
- Export current chat model metadata for context limits, pricing, cache costs, input modalities, and thinking modes.
- Validate model-specific thinking behavior and cover endpoint and request construction with focused tests.

## Checks

- `pnpm --filter @livekit/agents-plugin-minimax lint`
- `pnpm vitest run plugins/minimax/src/llm.test.ts plugins/minimax/src/tts.test.ts`
- `pnpm exec prettier --check plugins/minimax/src/llm.ts plugins/minimax/src/llm.test.ts plugins/minimax/src/models.ts plugins/minimax/src/index.ts plugins/minimax/package.json plugins/minimax/README.md .changeset/minimax-llm-support.md`
- `pnpm turbo run build --filter=@livekit/agents-plugin-minimax`
- `git diff --check`
