### PR TITLE
fix(ipc): continue job teardown after disconnect errors

### DIFF
--- a/.changeset/graceful-rooms-rest.md
+++ b/.changeset/graceful-rooms-rest.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Continue job shutdown callbacks and completion signaling when room disconnect fails during teardown.

--- a/agents/src/ipc/job_proc_lazy_main.ts
+++ b/agents/src/ipc/job_proc_lazy_main.ts
@@ -13,6 +13,7 @@ import type { SimulationContext } from '../simulation.js';
 import { Future, IdleTimeoutError, shortuuid, waitUntilTimeout } from '../utils.js';
 import { defaultInitializeProcessFunc } from '../worker.js';
 import type { InferenceExecutor } from './inference_executor.js';
+import { finalizeJobShutdown } from './job_proc_shutdown.js';
 import type { IPCMessage } from './message.js';
 
 const ORPHANED_TIMEOUT = 15 * 1000;
@@ -199,19 +200,15 @@ const startJob = (
       logger.error({ error }, 'error in ctx._onSessionEnd');
     }
 
-    await room.disconnect();
-    logger.debug('disconnected from room');
-
-    const shutdownTasks = [];
-    for (const callback of ctx.shutdownCallbacks) {
-      shutdownTasks.push(callback());
-    }
-    await ThrowsPromise.all(shutdownTasks).catch((error) =>
-      logger.error({ error }, 'error while shutting down the job'),
-    );
-
-    safeSend({ case: 'done', value: undefined });
-    joinFuture.resolve();
+    await finalizeJobShutdown({
+      room,
+      shutdownCallbacks: ctx.shutdownCallbacks,
+      logger,
+      onDone: () => {
+        safeSend({ case: 'done', value: undefined });
+        joinFuture.resolve();
+      },
+    });
   })();
 
   return { ctx, task };

--- a/agents/src/ipc/job_proc_shutdown.test.ts
+++ b/agents/src/ipc/job_proc_shutdown.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { Logger } from 'pino';
+import { describe, expect, it, vi } from 'vitest';
+import { finalizeJobShutdown } from './job_proc_shutdown.js';
+
+describe('finalizeJobShutdown', () => {
+  it('continues shutdown when room disconnect rejects', async () => {
+    const steps: string[] = [];
+    const disconnectError = new Error('handle not found');
+    const room = {
+      disconnect: vi.fn(async () => {
+        steps.push('disconnect');
+        throw disconnectError;
+      }),
+    };
+    const shutdownCallback = vi.fn(async () => {
+      steps.push('callback');
+    });
+    const onDone = vi.fn(() => {
+      steps.push('done');
+    });
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger;
+
+    await expect(
+      finalizeJobShutdown({
+        room,
+        shutdownCallbacks: [shutdownCallback],
+        logger,
+        onDone,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(steps).toEqual(['disconnect', 'callback', 'done']);
+    expect(logger.error).toHaveBeenCalledWith(
+      { error: disconnectError },
+      'error in room.disconnect',
+    );
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+});

--- a/agents/src/ipc/job_proc_shutdown.ts
+++ b/agents/src/ipc/job_proc_shutdown.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { ThrowsPromise } from '@livekit/throws-transformer/throws';
+import type { Logger } from 'pino';
+
+type DisconnectableRoom = {
+  disconnect(): Promise<void>;
+};
+
+/** @internal Exported for testing; not re-exported from the package index. */
+export async function finalizeJobShutdown({
+  room,
+  shutdownCallbacks,
+  logger,
+  onDone,
+}: {
+  room: DisconnectableRoom;
+  shutdownCallbacks: (() => Promise<void>)[];
+  logger: Logger;
+  onDone: () => void;
+}): Promise<void> {
+  try {
+    await room.disconnect();
+    logger.debug('disconnected from room');
+  } catch (error) {
+    logger.error({ error }, 'error in room.disconnect');
+  }
+
+  const shutdownTasks = [];
+  for (const callback of shutdownCallbacks) {
+    shutdownTasks.push(callback());
+  }
+  await ThrowsPromise.all(shutdownTasks).catch((error) =>
+    logger.error({ error }, 'error while shutting down the job'),
+  );
+
+  onDone();
+}


### PR DESCRIPTION
## Problem

Job teardown calls `room.disconnect()` after the room may already have been disconnected. When that call rejects, teardown stops before registered shutdown callbacks run and before the worker sends its `done` IPC message.

## Fix

- Guard and log room disconnect failures during job teardown.
- Continue running shutdown callbacks and completion signaling after a disconnect failure.
- Add a regression test covering the already-disconnected failure path and teardown ordering.
- Add a patch changeset for `@livekit/agents`.

## Testing

- `npx -y node@24 node_modules/vitest/vitest.mjs run agents --silent` (113 files, 1,559 passed, 5 skipped)
- `pnpm build` (40 packages passed)
- `pnpm lint`
- `pnpm format:check`
- `pnpm throws:check`
- `pnpm typecheck`
- `reuse lint`

Fixes #2157
