### PR TITLE
fix(ipc): prune completed inference tasks

### DIFF
--- a/.changeset/clean-inference-tasks.md
+++ b/.changeset/clean-inference-tasks.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Stop retaining completed IPC inference tasks for the lifetime of job processes.

--- a/agents/src/ipc/job_proc_executor.ts
+++ b/agents/src/ipc/job_proc_executor.ts
@@ -20,7 +20,7 @@ export class JobProcExecutor extends SupervisedProc implements JobExecutor {
   #runningJob?: RunningJobInfo;
   #agent: string;
   #inferenceExecutor?: InferenceExecutor;
-  #inferenceTasks: Promise<void>[] = [];
+  #inferenceTasks = new Set<Promise<void>>();
   #logger = log();
 
   constructor(
@@ -84,8 +84,12 @@ export class JobProcExecutor extends SupervisedProc implements JobExecutor {
   async mainTask(proc: ChildProcess) {
     proc.on('message', (msg: IPCMessage) => {
       switch (msg.case) {
-        case 'inferenceRequest':
-          this.#inferenceTasks.push(this.#doInferenceTask(proc, msg.value));
+        case 'inferenceRequest': {
+          const task = this.#doInferenceTask(proc, msg.value);
+          this.#inferenceTasks.add(task);
+          void task.finally(() => this.#inferenceTasks.delete(task));
+          break;
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary

- replace the unbounded inference task array with an active-task set
- remove each inference task after it settles so completed promises are not retained for the job process lifetime
- add a patch changeset for `@livekit/agents`

Fixes #1996

## Testing

- `pnpm test agents/src/ipc/proc_pool.test.ts agents/src/ipc/supervised_proc.test.ts`
- `pnpm test agents --silent`
- `pnpm lint`
- `pnpm format:check`
- `pnpm throws:check`
- `pnpm typecheck`
- `pnpm build:agents`
- `uvx --from 'reuse[charset-normalizer]' reuse lint`