### PR TITLE
fix: downgrade RemoteSession changeset to patch

### DIFF
--- a/.changeset/bright-taxis-listen.md
+++ b/.changeset/bright-taxis-listen.md
@@ -1,5 +1,5 @@
 ---
-'@livekit/agents': minor
+'@livekit/agents': patch
 ---
 
 Forward agent false interruption events through remote sessions.


### PR DESCRIPTION
Forwarding an existing RemoteSession event is a patch-level behavior correction, not a new minor API feature. Downgrade its changeset so the fixed package group releases as 1.6.2 instead of 1.7.0.

Fixes AGT-3222