### PR TITLE
ci: report changeset version bumps on pull requests

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -9,59 +9,35 @@ on:
     branches: [next, main, 0.x]
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
-  version-bump:
-    name: Report version bump
+  calculate:
+    name: Calculate version bump
     runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.status.outputs.status }}
     steps:
-      - name: Find Changesets Bot comment
-        id: changeset-comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              ...context.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-            const changesetComment = comments.find(
-              ({ user }) => user?.login === 'changeset-bot[bot]',
-            );
-            const reportComment = comments.find(
-              ({ user, body }) =>
-                user?.login === 'github-actions[bot]' &&
-                body?.includes('<!-- changeset-version-bump -->'),
-            );
-            core.setOutput('changeset-comment-id', changesetComment?.id ?? '');
-            core.setOutput('report-comment-id', reportComment?.id ?? '');
-            if (!changesetComment) {
-              core.notice('Changesets Bot has not commented yet; waiting for the next pull request event.');
-            }
-      # Install the trusted base revision before checking out the PR. This workflow has a
-      # write token, so it must not install or execute dependencies supplied by the PR.
+      # Install dependencies from the trusted base before inspecting the pull request.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-        if: steps.changeset-comment.outputs.changeset-comment-id != ''
       - name: Setup node
-        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: pnpm
       - name: Install trusted dependencies
-        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check out pull request
-        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -70,25 +46,33 @@ jobs:
           git checkout --detach FETCH_HEAD
           git checkout "$BASE_SHA" -- .changeset/config.json
       - name: Calculate version bump
-        if: steps.changeset-comment.outputs.changeset-comment-id != ''
+        id: status
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           if ! ./node_modules/.bin/changeset status --since="$BASE_SHA" --output=changeset-status.json; then
             echo '{"releases":[]}' > changeset-status.json
           fi
+          echo "status=$(base64 < changeset-status.json | tr -d '\n')" >> "$GITHUB_OUTPUT"
+
+  report:
+    name: Report version bump
+    needs: calculate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
       - name: Comment on pull request
-        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          STATUS_FILE: changeset-status.json
-          COMMENT_ID: ${{ steps.changeset-comment.outputs.report-comment-id }}
+          STATUS: ${{ needs.calculate.outputs.status }}
         with:
           script: |
-            const fs = require('node:fs');
             const marker = '<!-- changeset-version-bump -->';
-            const { releases } = JSON.parse(fs.readFileSync(process.env.STATUS_FILE, 'utf8'));
+            const { releases } = JSON.parse(Buffer.from(process.env.STATUS, 'base64').toString());
             const rank = { patch: 1, minor: 2, major: 3 };
+            const versionedReleases = releases.filter(({ type }) => Object.hasOwn(rank, type));
             const escape = (value) => String(value).replace(
               /[&<>"'|]/g,
               (character) => ({
@@ -101,25 +85,24 @@ jobs:
               })[character],
             );
             const code = (value) => `<code>${escape(value)}</code>`;
-            const typeLabel = (type) => Object.hasOwn(rank, type) ? type : 'unknown';
 
             let body;
-            if (releases.length === 0) {
+            if (versionedReleases.length === 0) {
               body = `${marker}\n> [!WARNING]\n> **No version bump detected.** This PR does not include a changeset that releases a package.`;
             } else {
-              const level = releases.reduce(
+              const level = versionedReleases.reduce(
                 (highest, release) => rank[release.type] > rank[highest] ? release.type : highest,
                 'patch',
               );
-              const rows = releases
+              const rows = versionedReleases
                 .sort((a, b) => a.name.localeCompare(b.name))
                 .map(({ name, type, oldVersion, newVersion }) =>
-                  `| ${code(name)} | **${typeLabel(type)}** | ${code(oldVersion)} → ${code(newVersion)} |`,
+                  `| ${code(name)} | **${type}** | ${code(oldVersion)} → ${code(newVersion)} |`,
                 )
                 .join('\n');
-              const core = releases.find(({ name }) => name === '@livekit/agents');
-              const coreBump = core
-                ? `> **Core package:** <code>@livekit/agents</code> **${typeLabel(core.type)}** bump, ${code(core.oldVersion)} → ${code(core.newVersion)}`
+              const coreRelease = versionedReleases.find(({ name }) => name === '@livekit/agents');
+              const coreBump = coreRelease
+                ? `> **Core package:** <code>@livekit/agents</code> **${coreRelease.type}** bump, ${code(coreRelease.oldVersion)} → ${code(coreRelease.newVersion)}`
                 : '> **Core package:** `@livekit/agents` is not affected.';
               body = [
                 marker,
@@ -133,10 +116,29 @@ jobs:
               ].join('\n');
             }
 
-            if (process.env.COMMENT_ID) {
+            let comments;
+            let reportComment;
+            for (let attempt = 0; attempt < 6; attempt++) {
+              comments = await github.paginate(github.rest.issues.listComments, {
+                ...context.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              });
+              reportComment = comments.find(
+                ({ user, body }) =>
+                  user?.login === 'github-actions[bot]' && body?.includes(marker),
+              );
+              const changesetComment = comments.find(
+                ({ user }) => user?.login === 'changeset-bot[bot]',
+              );
+              if (reportComment || changesetComment) break;
+              await new Promise((resolve) => setTimeout(resolve, 5_000));
+            }
+
+            if (reportComment) {
               await github.rest.issues.updateComment({
                 ...context.repo,
-                comment_id: Number(process.env.COMMENT_ID),
+                comment_id: reportComment.id,
                 body,
               });
             } else {

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Changeset
+
+on:
+  pull_request_target:
+    branches: [next, main, 0.x]
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  version-bump:
+    name: Report version bump
+    runs-on: ubuntu-latest
+    steps:
+      # Install the trusted base revision before checking out the PR. This workflow has a
+      # write token, so it must not install or execute dependencies supplied by the PR.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - name: Setup node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install trusted dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Check out pull request
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch origin "pull/${PR_NUMBER}/head"
+          git checkout --detach FETCH_HEAD
+          git checkout "$BASE_SHA" -- .changeset/config.json
+      - name: Calculate version bump
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: ./node_modules/.bin/changeset status --since="$BASE_SHA" --output=changeset-status.json
+      - name: Comment on pull request
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          STATUS_FILE: changeset-status.json
+        with:
+          script: |
+            const fs = require('node:fs');
+            const marker = '<!-- changeset-version-bump -->';
+            const { releases } = JSON.parse(fs.readFileSync(process.env.STATUS_FILE, 'utf8'));
+            const rank = { patch: 1, minor: 2, major: 3 };
+
+            let body;
+            if (releases.length === 0) {
+              body = `${marker}\n> [!WARNING]\n> **No version bump detected.** This PR does not include a changeset that releases a package.`;
+            } else {
+              const level = releases.reduce(
+                (highest, release) => rank[release.type] > rank[highest] ? release.type : highest,
+                'patch',
+              );
+              const rows = releases
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map(({ name, type, oldVersion, newVersion }) =>
+                  `| \`${name}\` | **${type}** | \`${oldVersion}\` → \`${newVersion}\` |`,
+                )
+                .join('\n');
+              const core = releases.find(({ name }) => name === '@livekit/agents');
+              const coreBump = core
+                ? `> **Core package:** \`@livekit/agents\` **${core.type}** bump, \`${core.oldVersion}\` → \`${core.newVersion}\``
+                : '> **Core package:** `@livekit/agents` is not affected.';
+              body = [
+                marker,
+                '> [!WARNING]',
+                `> **${level.toUpperCase()} version bump detected.** Review the bump level and resulting versions before merging.`,
+                coreBump,
+                '',
+                '| Package | Level | Version bump |',
+                '| --- | --- | --- |',
+                rows,
+              ].join('\n');
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (comment) => comment.user.type === 'Bot' && comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -18,21 +18,44 @@ jobs:
     name: Report version bump
     runs-on: ubuntu-latest
     steps:
+      - name: Find Changesets Bot comment
+        id: changeset-comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const comment = comments.find(
+              ({ user }) => user?.login === 'changeset-bot[bot]',
+            );
+            core.setOutput('comment-id', comment?.id ?? '');
+            if (!comment) {
+              core.notice('Changesets Bot has not commented yet; waiting for the next pull request event.');
+            }
       # Install the trusted base revision before checking out the PR. This workflow has a
       # write token, so it must not install or execute dependencies supplied by the PR.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        if: steps.changeset-comment.outputs.comment-id != ''
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+          persist-credentials: false
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        if: steps.changeset-comment.outputs.comment-id != ''
       - name: Setup node
+        if: steps.changeset-comment.outputs.comment-id != ''
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: pnpm
       - name: Install trusted dependencies
+        if: steps.changeset-comment.outputs.comment-id != ''
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check out pull request
+        if: steps.changeset-comment.outputs.comment-id != ''
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -41,13 +64,19 @@ jobs:
           git checkout --detach FETCH_HEAD
           git checkout "$BASE_SHA" -- .changeset/config.json
       - name: Calculate version bump
+        if: steps.changeset-comment.outputs.comment-id != ''
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: ./node_modules/.bin/changeset status --since="$BASE_SHA" --output=changeset-status.json
+        run: |
+          if ! ./node_modules/.bin/changeset status --since="$BASE_SHA" --output=changeset-status.json; then
+            echo '{"releases":[]}' > changeset-status.json
+          fi
       - name: Comment on pull request
+        if: steps.changeset-comment.outputs.comment-id != ''
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           STATUS_FILE: changeset-status.json
+          COMMENT_ID: ${{ steps.changeset-comment.outputs.comment-id }}
         with:
           script: |
             const fs = require('node:fs');
@@ -85,20 +114,8 @@ jobs:
               ].join('\n');
             }
 
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
+            await github.rest.issues.updateComment({
+              ...context.repo,
+              comment_id: Number(process.env.COMMENT_ID),
+              body,
             });
-            const existing = comments.find(
-              (comment) => comment.user.type === 'Bot' && comment.body?.includes(marker),
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -13,13 +13,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   calculate:
     name: Calculate version bump
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       status: ${{ steps.status.outputs.status }}
     steps:
@@ -37,30 +37,35 @@ jobs:
           cache: pnpm
       - name: Install trusted dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Check out pull request
+      - name: Prepare pull request worktree
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git fetch origin "pull/${PR_NUMBER}/head"
-          git checkout --detach FETCH_HEAD
-          git checkout "$BASE_SHA" -- .changeset/config.json
+          git worktree add --detach pr FETCH_HEAD
+          git -C pr checkout "$BASE_SHA" -- .changeset/config.json
       - name: Calculate version bump
         id: status
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          if ! ./node_modules/.bin/changeset status --since="$BASE_SHA" --output=changeset-status.json; then
-            echo '{"releases":[]}' > changeset-status.json
+          if (cd pr && ../node_modules/.bin/changeset status --since="$BASE_SHA" --output=changeset-status.json) 2>changeset-error.log; then
+            :
+          elif grep -Fq 'Some packages have been changed but no changesets were found.' changeset-error.log; then
+            cat changeset-error.log >&2
+            echo '{"releases":[]}' > pr/changeset-status.json
+          else
+            cat changeset-error.log >&2
+            exit 1
           fi
-          echo "status=$(base64 < changeset-status.json | tr -d '\n')" >> "$GITHUB_OUTPUT"
+          echo "status=$(base64 < pr/changeset-status.json | tr -d '\n')" >> "$GITHUB_OUTPUT"
 
   report:
     name: Report version bump
     needs: calculate
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: write
     steps:
       - name: Comment on pull request
@@ -72,7 +77,6 @@ jobs:
             const marker = '<!-- changeset-version-bump -->';
             const { releases } = JSON.parse(Buffer.from(process.env.STATUS, 'base64').toString());
             const rank = { patch: 1, minor: 2, major: 3 };
-            const versionedReleases = releases.filter(({ type }) => Object.hasOwn(rank, type));
             const escape = (value) => String(value).replace(
               /[&<>"'|]/g,
               (character) => ({
@@ -86,10 +90,14 @@ jobs:
             );
             const code = (value) => `<code>${escape(value)}</code>`;
 
-            let body;
-            if (versionedReleases.length === 0) {
-              body = `${marker}\n> [!WARNING]\n> **No version bump detected.** This PR does not include a changeset that releases a package.`;
-            } else {
+            const renderReport = (allReleases) => {
+              const versionedReleases = allReleases.filter(
+                ({ type }) => Object.hasOwn(rank, type),
+              );
+              if (versionedReleases.length === 0) {
+                return `${marker}\n> [!WARNING]\n> **No version bump detected.** This PR does not include a changeset that releases a package.`;
+              }
+
               const level = versionedReleases.reduce(
                 (highest, release) => rank[release.type] > rank[highest] ? release.type : highest,
                 'patch',
@@ -104,7 +112,7 @@ jobs:
               const coreBump = coreRelease
                 ? `> **Core package:** <code>@livekit/agents</code> **${coreRelease.type}** bump, ${code(coreRelease.oldVersion)} → ${code(coreRelease.newVersion)}`
                 : '> **Core package:** `@livekit/agents` is not affected.';
-              body = [
+              return [
                 marker,
                 '> [!WARNING]',
                 `> **${level.toUpperCase()} version bump detected.** Review the bump level and resulting versions before merging.`,
@@ -114,12 +122,12 @@ jobs:
                 '| --- | --- | --- |',
                 rows,
               ].join('\n');
-            }
+            };
+            const body = renderReport(releases);
 
-            let comments;
             let reportComment;
             for (let attempt = 0; attempt < 6; attempt++) {
-              comments = await github.paginate(github.rest.issues.listComments, {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 ...context.repo,
                 issue_number: context.issue.number,
                 per_page: 100,
@@ -132,7 +140,9 @@ jobs:
                 ({ user }) => user?.login === 'changeset-bot[bot]',
               );
               if (reportComment || changesetComment) break;
-              await new Promise((resolve) => setTimeout(resolve, 5_000));
+              if (attempt < 5) {
+                await new Promise((resolve) => setTimeout(resolve, 5_000));
+              }
             }
 
             if (reportComment) {

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -28,34 +28,40 @@ jobs:
               issue_number: context.issue.number,
               per_page: 100,
             });
-            const comment = comments.find(
+            const changesetComment = comments.find(
               ({ user }) => user?.login === 'changeset-bot[bot]',
             );
-            core.setOutput('comment-id', comment?.id ?? '');
-            if (!comment) {
+            const reportComment = comments.find(
+              ({ user, body }) =>
+                user?.login === 'github-actions[bot]' &&
+                body?.includes('<!-- changeset-version-bump -->'),
+            );
+            core.setOutput('changeset-comment-id', changesetComment?.id ?? '');
+            core.setOutput('report-comment-id', reportComment?.id ?? '');
+            if (!changesetComment) {
               core.notice('Changesets Bot has not commented yet; waiting for the next pull request event.');
             }
       # Install the trusted base revision before checking out the PR. This workflow has a
       # write token, so it must not install or execute dependencies supplied by the PR.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        if: steps.changeset-comment.outputs.comment-id != ''
+        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-        if: steps.changeset-comment.outputs.comment-id != ''
+        if: steps.changeset-comment.outputs.changeset-comment-id != ''
       - name: Setup node
-        if: steps.changeset-comment.outputs.comment-id != ''
+        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: pnpm
       - name: Install trusted dependencies
-        if: steps.changeset-comment.outputs.comment-id != ''
+        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check out pull request
-        if: steps.changeset-comment.outputs.comment-id != ''
+        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -64,7 +70,7 @@ jobs:
           git checkout --detach FETCH_HEAD
           git checkout "$BASE_SHA" -- .changeset/config.json
       - name: Calculate version bump
-        if: steps.changeset-comment.outputs.comment-id != ''
+        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
@@ -72,17 +78,30 @@ jobs:
             echo '{"releases":[]}' > changeset-status.json
           fi
       - name: Comment on pull request
-        if: steps.changeset-comment.outputs.comment-id != ''
+        if: steps.changeset-comment.outputs.changeset-comment-id != ''
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           STATUS_FILE: changeset-status.json
-          COMMENT_ID: ${{ steps.changeset-comment.outputs.comment-id }}
+          COMMENT_ID: ${{ steps.changeset-comment.outputs.report-comment-id }}
         with:
           script: |
             const fs = require('node:fs');
             const marker = '<!-- changeset-version-bump -->';
             const { releases } = JSON.parse(fs.readFileSync(process.env.STATUS_FILE, 'utf8'));
             const rank = { patch: 1, minor: 2, major: 3 };
+            const escape = (value) => String(value).replace(
+              /[&<>"'|]/g,
+              (character) => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;',
+                '|': '&#124;',
+              })[character],
+            );
+            const code = (value) => `<code>${escape(value)}</code>`;
+            const typeLabel = (type) => Object.hasOwn(rank, type) ? type : 'unknown';
 
             let body;
             if (releases.length === 0) {
@@ -95,12 +114,12 @@ jobs:
               const rows = releases
                 .sort((a, b) => a.name.localeCompare(b.name))
                 .map(({ name, type, oldVersion, newVersion }) =>
-                  `| \`${name}\` | **${type}** | \`${oldVersion}\` → \`${newVersion}\` |`,
+                  `| ${code(name)} | **${typeLabel(type)}** | ${code(oldVersion)} → ${code(newVersion)} |`,
                 )
                 .join('\n');
               const core = releases.find(({ name }) => name === '@livekit/agents');
               const coreBump = core
-                ? `> **Core package:** \`@livekit/agents\` **${core.type}** bump, \`${core.oldVersion}\` → \`${core.newVersion}\``
+                ? `> **Core package:** <code>@livekit/agents</code> **${typeLabel(core.type)}** bump, ${code(core.oldVersion)} → ${code(core.newVersion)}`
                 : '> **Core package:** `@livekit/agents` is not affected.';
               body = [
                 marker,
@@ -114,8 +133,16 @@ jobs:
               ].join('\n');
             }
 
-            await github.rest.issues.updateComment({
-              ...context.repo,
-              comment_id: Number(process.env.COMMENT_ID),
-              body,
-            });
+            if (process.env.COMMENT_ID) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: Number(process.env.COMMENT_ID),
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Description

Add a pull request workflow that calculates and reports package version bumps from changesets.

## Changes Made

- Add a `pull_request_target` workflow for pull requests targeting `next`, `main`, and `0.x`.
- Calculate changeset releases from the pull request and report the highest bump level, package versions, and core package impact.
- Create or update a bot comment on the pull request, including a warning when no version bump is detected.
- Use trusted base dependencies and pinned GitHub Actions to safely run with pull request write permissions.

## Pre-Review Checklist
- [ ] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [ ] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing

- [ ] Automated tests added/updated (if applicable)
- [ ] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes

The workflow updates an existing changeset report comment instead of creating duplicates. It checks out trusted base configuration and installs dependencies with scripts disabled before evaluating the pull request.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.

Base branch: main
Head branch: t3code/changeset-version-warning