### PR TITLE
fix(llm): keep a stream retryable until it emits generation

### DIFF
--- a/.changeset/first-retry-interval-milliseconds.md
+++ b/.changeset/first-retry-interval-milliseconds.md
@@ -1,0 +1,13 @@
+---
+'@livekit/agents': patch
+---
+
+fix: wait 100ms before the first retry, not 0.1ms
+
+`intervalForRetry` returned `0.1` for the first retry — Python's 0.1 _seconds_, carried over
+without converting to the milliseconds every caller passes to `setTimeout`/`delay`. Its other
+branch returns `retryIntervalMs`, so the two return paths were in different units. Measured,
+the first retry waited ~3ms (scheduling overhead alone) against Python's 100ms.
+
+This affects every retrying component — LLM, STT, TTS, avatars, and the turn-detector
+transport — where a first retry reattempted essentially instantly.

--- a/.changeset/llm-retryable-content-only.md
+++ b/.changeset/llm-retryable-content-only.md
@@ -1,0 +1,15 @@
+---
+'@livekit/agents': patch
+---
+
+fix(inference): keep a stream retryable until it emits generation
+
+`retryable` was cleared by any chunk reaching the caller, including ones that carry no
+output: a usage block, or provider metadata such as the LiveKit inference gateway's
+deployment/tier stamp or a Gemini thought signature. The gateway stamps its leading
+(contentless) delta, so every streamed response went unretryable from its first chunk — a
+mid-stream stall then failed the turn outright rather than retrying, with nothing generated
+and nothing for a retry to duplicate. Only failures landing before the very first chunk
+still recovered.
+
+`retryable` is now cleared on text or a tool call, the output a retry would actually repeat.

--- a/.changeset/llm-ttft-measures-generation.md
+++ b/.changeset/llm-ttft-measures-generation.md
@@ -1,0 +1,15 @@
+---
+'@livekit/agents': patch
+---
+
+fix(llm): measure ttft against generation, not the first chunk to arrive
+
+The time-to-first-token clock started on whatever chunk arrived first. That was harmless
+while a stream went unretryable at its first chunk, because a retry then implied nothing had
+arrived. Now that a contentless chunk keeps a stream retryable, the metadata chunk of a
+_failed_ attempt starts the clock, and the turn reports a near-zero ttft for a wait that
+spanned a stall and a retry — so retried turns read as faster than a normal one rather than
+slower.
+
+The clock now starts on generation, in both the metrics monitor and the voice pipeline's
+span. A response that generates nothing continues to report `ttftMs` as -1.

--- a/.changeset/responses-retryable-content-only.md
+++ b/.changeset/responses-retryable-content-only.md
@@ -1,0 +1,15 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+fix(openai): keep a Responses stream retryable until it emits generation
+
+`retryable` was cleared by every event the HTTP stream processed, including events that
+emit no chunk at all. `response.created` opens every stream, so a Responses request went
+unretryable from its first event regardless of provider — a mid-stream stall then failed
+the turn outright with nothing generated and nothing for a retry to duplicate. The
+WebSocket path had the mirror defect: it never cleared `retryable`, so a socket dropping
+after text had already streamed retried and regenerated it.
+
+Both paths now clear `retryable` on text or a tool call, the output a retry would actually
+repeat. The phase marker and the usage-bearing completion event are not.

--- a/.changeset/stream-terminal-failure-rejection.md
+++ b/.changeset/stream-terminal-failure-rejection.md
@@ -1,0 +1,13 @@
+---
+'@livekit/agents': patch
+---
+
+fix(agents): stop a terminally failed stream leaving an unhandled rejection
+
+`LLMStream` and `STTStream` dropped the promise from their fire-and-forget main task, so a
+stream that exhausted its retries rejected with no handler attached — reaching the job
+process's `unhandledRejection` hook as a spurious crash report for a failure already
+delivered through the `error` event, and failing any test run that exercises the path.
+
+The task is now awaited inside a `try`/`finally` that closes the queue either way, matching
+what `TTSStream` already does.

--- a/agents/src/inference/llm.test.ts
+++ b/agents/src/inference/llm.test.ts
@@ -97,6 +97,95 @@ async function collectChatChunks(
   return chunks;
 }
 
+/**
+ * Yields the given completion chunks, then throws as a provider going quiet
+ * would. Returns how many times the request was attempted.
+ */
+async function countAttemptsUntilStall(
+  completionChunks: CompletionChunk[],
+  maxRetry: number,
+): Promise<{ attempts: number }> {
+  const llm = new LLM({
+    model: 'google/gemma-4-31b-it',
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+    baseURL: 'https://example.livekit.cloud',
+  });
+
+  // The stream emits 'error' on every failed attempt; without a listener the
+  // EventEmitter turns it into an unhandled error and fails the run.
+  llm.on('error', () => {});
+
+  let attempts = 0;
+  const stub = async () => {
+    attempts++;
+    return {
+      async *[Symbol.asyncIterator]() {
+        for (const chunk of completionChunks) {
+          yield chunk;
+        }
+        throw new Error('stalled mid-stream');
+      },
+    };
+  };
+
+  const internal = llm as unknown as {
+    client: { chat: { completions: { create: typeof stub } } };
+  };
+  internal.client.chat.completions.create = stub;
+
+  try {
+    const stream = llm.chat({
+      chatCtx: new ChatContext(),
+      connOptions: { maxRetry, retryIntervalMs: 0, timeoutMs: 5000 },
+    });
+    for await (const _chunk of stream) {
+      void _chunk;
+    }
+  } catch {
+    // the stall surfaces through the 'error' event; the iterator just ends
+  }
+
+  return { attempts };
+}
+
+// The gateway stamps its deployment and billing tier onto the leading delta,
+// which carries no content of its own.
+const METADATA_ONLY_CHUNK: CompletionChunk = {
+  id: 'chatcmpl_test',
+  choices: [
+    {
+      index: 0,
+      finish_reason: null,
+      delta: {
+        role: 'assistant',
+        extra_content: {
+          livekit: { inference_deployment: 'd', inference_tier_billed: 'standard' },
+        },
+      },
+    },
+  ],
+};
+
+const TEXT_CHUNK: CompletionChunk = {
+  id: 'chatcmpl_test',
+  choices: [{ index: 0, finish_reason: null, delta: { role: 'assistant', content: 'hello' } }],
+};
+
+describe('inference.LLM retry eligibility', () => {
+  it('retries a stall that follows provider metadata alone', async () => {
+    const { attempts } = await countAttemptsUntilStall([METADATA_ONLY_CHUNK], 2);
+
+    expect(attempts).toBe(3);
+  });
+
+  it('does not retry once generated text has reached the caller', async () => {
+    const { attempts } = await countAttemptsUntilStall([METADATA_ONLY_CHUNK, TEXT_CHUNK], 2);
+
+    expect(attempts).toBe(1);
+  });
+});
+
 describe('inference.LLM X-LiveKit-Inference-Priority header', () => {
   // --- no value anywhere ---
 

--- a/agents/src/inference/llm.test.ts
+++ b/agents/src/inference/llm.test.ts
@@ -5,6 +5,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import * as agents from '../index.js';
 import { ChatContext } from '../llm/index.js';
 import { initializeLogger } from '../log.js';
+import type { LLMMetrics } from '../metrics/base.js';
 import { type InferenceClass, LLM } from './llm.js';
 import { describeLiveKitInference } from './test_utils.js';
 
@@ -246,6 +247,69 @@ describe('inference.LLM reported latency', () => {
     const ttftMs = await ttftAcrossARetry();
 
     expect(ttftMs).toBeGreaterThanOrEqual(STALL_MS);
+  });
+});
+
+const USAGE_CHUNK: CompletionChunk = {
+  id: 'chatcmpl_test',
+  choices: [],
+  usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+};
+
+// A model told to end the call without speaking answers with no content at all.
+async function runResponseThatGeneratesNothing(): Promise<{
+  attempts: number;
+  metrics: LLMMetrics[];
+}> {
+  const llm = new LLM({
+    model: 'google/gemma-4-31b-it',
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+    baseURL: 'https://example.livekit.cloud',
+  });
+  llm.on('error', () => {});
+
+  const metrics: LLMMetrics[] = [];
+  llm.on('metrics_collected', (m) => metrics.push(m));
+
+  let attempts = 0;
+  const stub = async () => {
+    attempts++;
+    return {
+      async *[Symbol.asyncIterator]() {
+        yield METADATA_ONLY_CHUNK;
+        yield USAGE_CHUNK;
+      },
+    };
+  };
+
+  const internal = llm as unknown as {
+    client: { chat: { completions: { create: typeof stub } } };
+  };
+  internal.client.chat.completions.create = stub;
+
+  const stream = llm.chat({
+    chatCtx: new ChatContext(),
+    connOptions: { maxRetry: 2, retryIntervalMs: 0, timeoutMs: 5000 },
+  });
+  for await (const _chunk of stream) {
+    void _chunk;
+  }
+  // metrics are emitted just after the output stream closes
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  return { attempts, metrics };
+}
+
+describe('inference.LLM response that generates nothing', () => {
+  it('completes on the first attempt, reporting no ttft and the tokens it used', async () => {
+    const { attempts, metrics } = await runResponseThatGeneratesNothing();
+
+    expect(attempts).toBe(1);
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0]!.ttftMs).toBe(-1);
+    expect(metrics[0]!.completionTokens).toBe(7);
+    expect(metrics[0]!.totalTokens).toBe(18);
   });
 });
 

--- a/agents/src/inference/llm.test.ts
+++ b/agents/src/inference/llm.test.ts
@@ -186,6 +186,69 @@ describe('inference.LLM retry eligibility', () => {
   });
 });
 
+const STALL_MS = 60;
+
+/**
+ * First attempt yields metadata, waits, then stalls; the retry succeeds. Returns
+ * the ttft the run reported.
+ */
+async function ttftAcrossARetry(): Promise<number> {
+  const llm = new LLM({
+    model: 'google/gemma-4-31b-it',
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+    baseURL: 'https://example.livekit.cloud',
+  });
+  llm.on('error', () => {});
+
+  let reported = -1;
+  llm.on('metrics_collected', (metrics) => {
+    reported = metrics.ttftMs;
+  });
+
+  let attempts = 0;
+  const stub = async () => {
+    attempts++;
+    const failing = attempts === 1;
+    return {
+      async *[Symbol.asyncIterator]() {
+        yield METADATA_ONLY_CHUNK;
+        if (failing) {
+          await new Promise((resolve) => setTimeout(resolve, STALL_MS));
+          throw new Error('stalled mid-stream');
+        }
+        yield TEXT_CHUNK;
+      },
+    };
+  };
+
+  const internal = llm as unknown as {
+    client: { chat: { completions: { create: typeof stub } } };
+  };
+  internal.client.chat.completions.create = stub;
+
+  const stream = llm.chat({
+    chatCtx: new ChatContext(),
+    connOptions: { maxRetry: 2, retryIntervalMs: 0, timeoutMs: 5000 },
+  });
+  for await (const _chunk of stream) {
+    void _chunk;
+  }
+  // metrics are emitted just after the output stream closes
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  expect(attempts).toBe(2);
+  return reported;
+}
+
+describe('inference.LLM reported latency', () => {
+  it('measures ttft to generation, not to a failed attempt metadata chunk', async () => {
+    const ttftMs = await ttftAcrossARetry();
+
+    expect(ttftMs).toBeGreaterThanOrEqual(STALL_MS);
+  });
+});
+
 describe('inference.LLM X-LiveKit-Inference-Priority header', () => {
   // --- no value anywhere ---
 

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -516,7 +516,7 @@ export class LLMStream extends llm.LLMStream {
         for (const choice of chunk.choices) {
           const chatChunk = this.parseChoice(chunk.id, choice, thinkingFilter);
           if (chatChunk) {
-            if (llm.carriesGeneration(chatChunk)) {
+            if (llm.hasResponse(chatChunk)) {
               retryable = false;
             }
             this.queue.put(chatChunk);

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -516,14 +516,18 @@ export class LLMStream extends llm.LLMStream {
         for (const choice of chunk.choices) {
           const chatChunk = this.parseChoice(chunk.id, choice, thinkingFilter);
           if (chatChunk) {
-            retryable = false;
+            // only generation makes a retry duplicate what the caller already saw;
+            // provider metadata (a gateway deployment stamp, a thought signature)
+            // is not output
+            if (chatChunk.delta?.content || chatChunk.delta?.toolCalls?.length) {
+              retryable = false;
+            }
             this.queue.put(chatChunk);
           }
         }
 
         if (chunk.usage) {
           const usage = chunk.usage;
-          retryable = false;
           this.queue.put({
             id: chunk.id,
             usage: {

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -516,10 +516,7 @@ export class LLMStream extends llm.LLMStream {
         for (const choice of chunk.choices) {
           const chatChunk = this.parseChoice(chunk.id, choice, thinkingFilter);
           if (chatChunk) {
-            // only generation makes a retry duplicate what the caller already saw;
-            // provider metadata (a gateway deployment stamp, a thought signature)
-            // is not output
-            if (chatChunk.delta?.content || chatChunk.delta?.toolCalls?.length) {
+            if (llm.carriesGeneration(chatChunk)) {
               retryable = false;
             }
             this.queue.put(chatChunk);

--- a/agents/src/llm/index.ts
+++ b/agents/src/llm/index.ts
@@ -65,6 +65,7 @@ export type { ProviderFormat } from './provider_format/index.js';
 export {
   LLM,
   LLMStream,
+  carriesGeneration,
   type ChatChunk,
   type ChoiceDelta,
   type CollectedResponse,

--- a/agents/src/llm/index.ts
+++ b/agents/src/llm/index.ts
@@ -65,7 +65,7 @@ export type { ProviderFormat } from './provider_format/index.js';
 export {
   LLM,
   LLMStream,
-  carriesGeneration,
+  hasResponse,
   type ChatChunk,
   type ChoiceDelta,
   type CollectedResponse,

--- a/agents/src/llm/llm.ts
+++ b/agents/src/llm/llm.ts
@@ -47,7 +47,7 @@ export interface ChatChunk {
  * signature) reach the caller without being output: they neither start the clock
  * on time-to-first-token nor give a retry anything to duplicate.
  */
-export function carriesGeneration(chunk: ChatChunk): boolean {
+export function hasResponse(chunk: ChatChunk): boolean {
   return Boolean(chunk.delta?.content || chunk.delta?.toolCalls?.length);
 }
 
@@ -290,7 +290,7 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
       }
       // measured against generation, not the first chunk: a retry that follows a
       // contentless chunk would otherwise latch the clock on the failed attempt
-      if (ttft === BigInt(-1) && carriesGeneration(ev)) {
+      if (ttft === BigInt(-1) && hasResponse(ev)) {
         ttft = process.hrtime.bigint() - startTime;
         completionStartTime = new Date().toISOString();
       }

--- a/agents/src/llm/llm.ts
+++ b/agents/src/llm/llm.ts
@@ -40,6 +40,17 @@ export interface ChatChunk {
   usage?: CompletionUsage;
 }
 
+/**
+ * Whether this chunk delivered generation the caller can see.
+ *
+ * Token counts and provider metadata (a gateway deployment stamp, a thought
+ * signature) reach the caller without being output: they neither start the clock
+ * on time-to-first-token nor give a retry anything to duplicate.
+ */
+export function carriesGeneration(chunk: ChatChunk): boolean {
+  return Boolean(chunk.delta?.content || chunk.delta?.toolCalls?.length);
+}
+
 export interface CollectedResponse {
   text: string;
   toolCalls: FunctionCall[];

--- a/agents/src/llm/llm.ts
+++ b/agents/src/llm/llm.ts
@@ -185,7 +185,15 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
     // is run **after** the constructor has finished. Otherwise we get
     // runtime error when trying to access class variables in the
     // `run` method.
-    startSoon(() => this.mainTask().finally(() => this.queue.close()));
+    startSoon(async () => {
+      try {
+        await this.mainTask();
+      } catch {
+        // already surfaced via emitError; swallow to avoid unhandled rejection.
+      } finally {
+        this.queue.close();
+      }
+    });
   }
 
   private _mainTaskImpl = async (span: Span) => {

--- a/agents/src/llm/llm.ts
+++ b/agents/src/llm/llm.ts
@@ -280,7 +280,9 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
       if (requestId && !this.#providerRequestIds.includes(requestId)) {
         this.#providerRequestIds.push(requestId);
       }
-      if (ttft === BigInt(-1)) {
+      // measured against generation, not the first chunk: a retry that follows a
+      // contentless chunk would otherwise latch the clock on the failed attempt
+      if (ttft === BigInt(-1) && carriesGeneration(ev)) {
         ttft = process.hrtime.bigint() - startTime;
         completionStartTime = new Date().toISOString();
       }

--- a/agents/src/stt/stt.ts
+++ b/agents/src/stt/stt.ts
@@ -336,12 +336,20 @@ export abstract class SpeechStream implements AsyncIterableIterator<SpeechEvent>
     // is run **after** the constructor has finished. Otherwise we get
     // runtime error when trying to access class variables in the
     // `run` method.
-    startSoon(() => this.mainTask().finally(() => this.queue.close()));
+    startSoon(async () => {
+      try {
+        await this.mainTask();
+      } catch {
+        // already surfaced via emitError; swallow to avoid unhandled rejection.
+      } finally {
+        this.queue.close();
+      }
+    });
   }
 
   /**
    * Runs the STT with retry logic. Errors are emitted via {@link STT} error events
-   * and then re-thrown to trigger `.finally()` cleanup.
+   * and then re-thrown to end the attempt loop; the caller swallows them.
    *
    * @throws {APIError} When the STT request fails with a non-retryable error
    * @throws {APIConnectionError} When all retry attempts are exhausted

--- a/agents/src/types.test.ts
+++ b/agents/src/types.test.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_API_CONNECT_OPTIONS, intervalForRetry } from './types.js';
+
+describe('intervalForRetry', () => {
+  const connOptions = { ...DEFAULT_API_CONNECT_OPTIONS, retryIntervalMs: 300 };
+
+  it('returns milliseconds for every retry, including the first', () => {
+    // Every caller passes this straight to setTimeout/delay, so both branches
+    // have to be in the same unit. Python's equivalent waits 0.1s here.
+    expect(intervalForRetry(connOptions, 0)).toBe(100);
+    expect(intervalForRetry(connOptions, 1)).toBe(300);
+    expect(intervalForRetry(connOptions, 2)).toBe(300);
+  });
+
+  it('waits noticeably before the first retry rather than reattempting at once', async () => {
+    const started = performance.now();
+    await new Promise((resolve) => setTimeout(resolve, intervalForRetry(connOptions, 0)));
+
+    expect(performance.now() - started).toBeGreaterThanOrEqual(50);
+  });
+});

--- a/agents/src/types.ts
+++ b/agents/src/types.ts
@@ -60,14 +60,17 @@ export const DEFAULT_API_CONNECT_OPTIONS: APIConnectOptions = {
   timeoutMs: 10000,
 };
 
+/** Matches agents (Python), whose _interval_for_retry returns 0.1 seconds here. */
+const FIRST_RETRY_INTERVAL_MS = 100;
+
 /**
- * Return the interval for the given number of retries.
- * The first retry is immediate, and then uses specified retryIntervalMs.
+ * Return the interval before the given retry, in milliseconds.
+ * The first retry comes quickly, and every one after uses retryIntervalMs.
  * @internal
  */
 export function intervalForRetry(connOptions: APIConnectOptions, numRetries: number): number {
   if (numRetries === 0) {
-    return 0.1;
+    return FIRST_RETRY_INTERVAL_MS;
   }
   return connOptions.retryIntervalMs;
 }

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -16,7 +16,7 @@ import {
   isInstructions,
 } from '../llm/chat_context.js';
 import type { ChatChunk } from '../llm/llm.js';
-import { carriesGeneration } from '../llm/llm.js';
+import { hasResponse } from '../llm/llm.js';
 import {
   type JSONObject,
   type ToolChoice,
@@ -604,7 +604,7 @@ export function performLLMInference(
         if (typeof chunk === 'string') {
           generated = chunk.length > 0;
         } else if (!isFlushSentinel(chunk)) {
-          generated = carriesGeneration(chunk);
+          generated = hasResponse(chunk);
         }
 
         // measured against generation, not the first chunk: a retry that follows a

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -16,6 +16,7 @@ import {
   isInstructions,
 } from '../llm/chat_context.js';
 import type { ChatChunk } from '../llm/llm.js';
+import { carriesGeneration } from '../llm/llm.js';
 import {
   type JSONObject,
   type ToolChoice,
@@ -599,7 +600,16 @@ export function performLLMInference(
         const { done, value: chunk } = result;
         if (done) break;
 
-        if (!firstTokenReceived) {
+        let generated = false;
+        if (typeof chunk === 'string') {
+          generated = chunk.length > 0;
+        } else if (!isFlushSentinel(chunk)) {
+          generated = carriesGeneration(chunk);
+        }
+
+        // measured against generation, not the first chunk: a retry that follows a
+        // contentless chunk would otherwise latch the clock on the failed attempt
+        if (!firstTokenReceived && generated) {
           firstTokenReceived = true;
           data.ttft = performance.now() / 1000 - startTime;
         }

--- a/plugins/openai/src/responses/llm.test.ts
+++ b/plugins/openai/src/responses/llm.test.ts
@@ -1,10 +1,14 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { ChatContext, initializeLogger } from '@livekit/agents';
 import { llm, llmStrict } from '@livekit/agents-plugins-test';
+import type OpenAI from 'openai';
 import { describe, expect, it } from 'vitest';
 import { wsServerEventSchema } from '../ws/types.js';
 import { LLM } from './llm.js';
+
+initializeLogger({ level: 'silent', pretty: false });
 
 const hasOpenAIApiKey = Boolean(process.env.OPENAI_API_KEY);
 
@@ -25,6 +29,90 @@ describe('OpenAI Responses WebSocket', () => {
     if (parsed.type !== 'error') throw new Error('expected error event');
     expect(parsed.message).toBe(frame.message);
     expect(parsed.param).toBe('reasoning.mode');
+  });
+});
+
+type ResponsesEvent = Record<string, unknown>;
+
+// opens every stream, on every provider
+const RESPONSE_CREATED: ResponsesEvent = {
+  type: 'response.created',
+  response: { id: 'resp_1' },
+};
+
+// a reasoning phase marker: a message item with no text of its own
+const PHASE_METADATA: ResponsesEvent = {
+  type: 'response.output_item.done',
+  item: { type: 'message', phase: 'thinking' },
+};
+
+const TEXT_DELTA: ResponsesEvent = {
+  type: 'response.output_text.delta',
+  delta: 'hello',
+};
+
+/**
+ * Replays the given events, then dies the way a provider going quiet does.
+ * Returns how many times the request was attempted.
+ */
+async function attemptsUntilStall(events: ResponsesEvent[], maxRetry: number): Promise<number> {
+  let attempts = 0;
+
+  const client = {
+    responses: {
+      create: async () => {
+        attempts++;
+        return {
+          async *[Symbol.asyncIterator]() {
+            for (const event of events) {
+              yield event;
+            }
+            throw new Error('stalled mid-stream');
+          },
+        };
+      },
+    },
+  };
+
+  const model = new LLM({
+    model: 'gpt-4.1',
+    apiKey: 'test-key',
+    useWebSocket: false,
+    client: client as unknown as OpenAI,
+  });
+  // the stream emits 'error' on every failed attempt; without a listener the
+  // EventEmitter turns it into an unhandled error and fails the run
+  model.on('error', () => {});
+
+  const chatCtx = ChatContext.empty();
+  chatCtx.addMessage({ role: 'user', content: 'hi' });
+
+  try {
+    const stream = model.chat({
+      chatCtx,
+      connOptions: { maxRetry, retryIntervalMs: 0, timeoutMs: 5000 },
+    });
+    for await (const _chunk of stream) {
+      void _chunk;
+    }
+  } catch {
+    // the stall surfaces through the 'error' event; the iterator just ends
+  }
+
+  return attempts;
+}
+
+describe('OpenAI Responses HTTP retry eligibility', () => {
+  it('retries a stall that follows the stream-opening event alone', async () => {
+    expect(await attemptsUntilStall([RESPONSE_CREATED], 2)).toBe(3);
+  });
+
+  it('retries a stall that follows a phase marker', async () => {
+    expect(await attemptsUntilStall([RESPONSE_CREATED, PHASE_METADATA], 2)).toBe(3);
+  });
+
+  it('does not retry once generated text has reached the caller', async () => {
+    expect(await attemptsUntilStall([RESPONSE_CREATED, TEXT_DELTA], 2)).toBe(1);
   });
 });
 

--- a/plugins/openai/src/responses/llm.ts
+++ b/plugins/openai/src/responses/llm.ts
@@ -253,7 +253,7 @@ class ResponsesHttpLLMStream extends llm.LLMStream {
           this.queue.put(chunk);
           // a retry only duplicates output the caller has already seen; the
           // stream-opening event and the usage-bearing one are neither
-          if (llm.carriesGeneration(chunk)) {
+          if (llm.hasResponse(chunk)) {
             retryable = false;
           }
         }

--- a/plugins/openai/src/responses/llm.ts
+++ b/plugins/openai/src/responses/llm.ts
@@ -226,7 +226,6 @@ class ResponsesHttpLLMStream extends llm.LLMStream {
       );
 
       for await (const event of stream) {
-        retryable = false;
         let chunk: llm.ChatChunk | undefined;
 
         switch (event.type) {
@@ -252,6 +251,11 @@ class ResponsesHttpLLMStream extends llm.LLMStream {
 
         if (chunk) {
           this.queue.put(chunk);
+          // a retry only duplicates output the caller has already seen; the
+          // stream-opening event and the usage-bearing one are neither
+          if (llm.carriesGeneration(chunk)) {
+            retryable = false;
+          }
         }
       }
     } catch (error) {

--- a/plugins/openai/src/ws/llm.test.ts
+++ b/plugins/openai/src/ws/llm.test.ts
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { initializeLogger } from '@livekit/agents';
+import { ChatContext, ConnectionPool, initializeLogger, stream } from '@livekit/agents';
 import { llm, llmStrict } from '@livekit/agents-plugins-test';
 import { describe, expect, it } from 'vitest';
 import { LLM } from '../responses/llm.js';
-import { buildResponsesWsUrl } from './llm.js';
+import type { ResponsesWebSocket } from './llm.js';
+import { WSLLM, WSLLMStream, buildResponsesWsUrl } from './llm.js';
+import type { WsServerEvent } from './types.js';
 
 initializeLogger({ level: 'silent', pretty: false });
 
@@ -78,6 +80,96 @@ describe('buildResponsesWsUrl', () => {
     expect(url.protocol).toBe('ws:');
     expect(url.pathname).toBe('/v1/responses');
     expect(url.searchParams.get('model')).toBe('gpt-4o-mini');
+  });
+});
+
+// opens every stream, on every provider
+const RESPONSE_CREATED: WsServerEvent = {
+  type: 'response.created',
+  response: { id: 'resp_1' },
+};
+
+// a reasoning phase marker: a message item with no text of its own
+const PHASE_METADATA: WsServerEvent = {
+  type: 'response.output_item.done',
+  item: { type: 'message', phase: 'thinking' },
+};
+
+const TEXT_DELTA: WsServerEvent = {
+  type: 'response.output_text.delta',
+  delta: 'hello',
+};
+
+/** Replays the given frames, then dies the way a socket going quiet does. */
+class StallingConnection {
+  attempts = 0;
+
+  constructor(private readonly frames: WsServerEvent[]) {}
+
+  sendRequest(): stream.StreamChannel<WsServerEvent> {
+    this.attempts++;
+    const channel = stream.createStreamChannel<WsServerEvent>();
+
+    void (async () => {
+      for (const frame of this.frames) {
+        await channel.write(frame);
+      }
+      await channel.abort(new Error('stalled mid-stream'));
+    })();
+
+    return channel;
+  }
+
+  close(): void {}
+}
+
+/** Returns how many times the response was requested before the stream gave up. */
+async function attemptsUntilStall(frames: WsServerEvent[], maxRetry: number): Promise<number> {
+  const wsLLM = new WSLLM({ model: 'gpt-4.1', apiKey: 'test-key' });
+  // the stream emits 'error' on every failed attempt; without a listener the
+  // EventEmitter turns it into an unhandled error and fails the run
+  wsLLM.on('error', () => {});
+
+  const conn = new StallingConnection(frames);
+  const pool = new ConnectionPool<ResponsesWebSocket>({
+    connectCb: async () => conn as unknown as ResponsesWebSocket,
+  });
+
+  const chatCtx = ChatContext.empty();
+  chatCtx.addMessage({ role: 'user', content: 'hi' });
+
+  const llmStream = new WSLLMStream(wsLLM, {
+    pool,
+    model: 'gpt-4.1',
+    chatCtx,
+    fullChatCtx: chatCtx,
+    connOptions: { maxRetry, retryIntervalMs: 0, timeoutMs: 5000 },
+    modelOptions: {},
+    strictToolSchema: true,
+  });
+
+  try {
+    for await (const _chunk of llmStream) {
+      void _chunk;
+    }
+  } catch {
+    // the stall surfaces through the 'error' event; the iterator just ends
+  }
+
+  return conn.attempts;
+}
+
+describe('OpenAI Responses WS retry eligibility', () => {
+  it('retries a stall that follows the stream-opening frame alone', async () => {
+    expect(await attemptsUntilStall([RESPONSE_CREATED], 2)).toBe(3);
+  });
+
+  it('retries a stall that follows a phase marker', async () => {
+    expect(await attemptsUntilStall([RESPONSE_CREATED, PHASE_METADATA], 2)).toBe(3);
+  });
+
+  it('does not retry once generated text has reached the caller', async () => {
+    expect(await attemptsUntilStall([RESPONSE_CREATED, TEXT_DELTA], 2)).toBe(1);
   });
 });
 

--- a/plugins/openai/src/ws/llm.ts
+++ b/plugins/openai/src/ws/llm.ts
@@ -541,7 +541,7 @@ export class WSLLMStream extends llm.LLMStream {
 
         if (chunk) {
           this.queue.put(chunk);
-          if (llm.carriesGeneration(chunk)) {
+          if (llm.hasResponse(chunk)) {
             this.#retryable = false;
           }
         }

--- a/plugins/openai/src/ws/llm.ts
+++ b/plugins/openai/src/ws/llm.ts
@@ -393,6 +393,12 @@ export class WSLLMStream extends llm.LLMStream {
   #fullChatCtx: llm.ChatContext;
   #responseId = '';
   #pendingToolCalls = new Set<string>();
+  /**
+   * Whether this attempt may still be retried. Cleared once generation reaches the
+   * caller, which a retry would duplicate. Held on the instance because the loop
+   * that reads chunks sits in #runWithConn, one call down from run().
+   */
+  #retryable = true;
 
   constructor(
     llm: WSLLM,
@@ -429,7 +435,7 @@ export class WSLLMStream extends llm.LLMStream {
   }
 
   protected async run(): Promise<void> {
-    let retryable = true;
+    this.#retryable = true;
 
     try {
       await this.#pool.withConnection(async (conn: ResponsesWebSocket) => {
@@ -438,7 +444,7 @@ export class WSLLMStream extends llm.LLMStream {
         if (needsRetry) {
           // previous_response_id was evicted from the server-side cache.
           // Retry once on the same connection with the full context and no ID.
-          retryable = true;
+          this.#retryable = true;
           await this.#runWithConn(conn, this.#fullChatCtx, undefined);
         }
       });
@@ -452,7 +458,7 @@ export class WSLLMStream extends llm.LLMStream {
       }
       throw new APIConnectionError({
         message: toError(error).message,
-        options: { retryable },
+        options: { retryable: this.#retryable },
       });
     }
   }
@@ -535,6 +541,9 @@ export class WSLLMStream extends llm.LLMStream {
 
         if (chunk) {
           this.queue.put(chunk);
+          if (llm.carriesGeneration(chunk)) {
+            this.#retryable = false;
+          }
         }
       }
     } finally {
@@ -564,7 +573,7 @@ export class WSLLMStream extends llm.LLMStream {
       this.#pool.invalidate();
       throw new APIConnectionError({
         message: event.error?.message ?? `WebSocket closed (${code})`,
-        options: { retryable: true },
+        options: { retryable: this.#retryable },
       });
     }
 


### PR DESCRIPTION
Port of livekit/agents#6697 — `agents/src/inference/llm.ts` is a line-for-line equivalent of the Python file and carries the identical bug. Porting it surfaced two more that are JS-only.

## Retry eligibility

`retryable` was cleared by any chunk reaching the caller, including chunks that carry no output — a usage block, or provider metadata such as the inference gateway's deployment/tier stamp or a Gemini thought signature.

The gateway stamps `extra_content.livekit` onto every delta it forwards, including the leading contentless one, and `parseChoice` returns a real `ChatChunk` for a delta whose only payload is `extra_content` (the `if (!content && !deltaExtra) return undefined` guard passes on `deltaExtra`). So **every streamed response through the gateway went unretryable from its first chunk.** Only failures landing before that first chunk could still recover.

Diagnosed from a Python simulation run, where a mid-stream stall failed the turn outright with nothing generated and nothing a retry could have duplicated. The JS path has had no reported incident, but the code is the same.

`retryable` is now cleared on text or a tool call — the output a retry would actually repeat. The `retryable = false` on the usage chunk is dropped for the same reason: token counts aren't output either.

The OpenAI Responses plugin has it twice over. Its HTTP path cleared `retryable` after every event it processed, and `response.created` opens every stream, so a Responses request went unretryable from its first event regardless of provider. Its WebSocket path carries the mirror defect: it never cleared `retryable` at all, so a socket dropping after text had already streamed retried and regenerated it. Python shares one event loop between the two transports and fixed both at once; here they are separate files.

## Time to first token

The clock started on whatever chunk arrived first. That was harmless while a stream went unretryable at its first chunk, because a retry then implied nothing had arrived. Now that a contentless chunk keeps a stream retryable, the metadata chunk of a *failed* attempt starts the clock, and the turn reports a near-zero ttft for a wait that spanned a stall and a retry.

The clock now starts on generation, in both the metrics monitor and the voice pipeline's span. A response that generates nothing keeps reporting `ttftMs` as -1, as it already did.

## First retry interval

`intervalForRetry` returned `0.1` for the first retry — Python's 0.1 seconds, carried over without converting to the milliseconds every caller passes to `setTimeout`/`delay`. Its other branch returns `retryIntervalMs`, so the two return paths were in different units; measured, the first retry waited ~3ms, which is scheduling overhead alone, against Python's 100ms.

This reaches every retrying component: LLM, STT, TTS, avatars, and the turn-detector transport all reattempted essentially instantly on their first retry.

## Unhandled rejection on terminal failure

`LLMStream` and `STTStream` dropped the promise from their fire-and-forget main task, so a stream that exhausted its retries rejected with nothing attached to it. Nothing is lost — the failure has already reached the caller through the `error` event, and closing the queue ends the iterator — but the bare rejection still reached the job process's `unhandledRejection` hook as a spurious crash report.

It also turned this branch's Test job red: 116 files passed, 2 unhandled errors, exit 1. `TTSStream` already awaits its task inside a `try`/`finally`; the other two now match it.

## Tests

`agents/src/inference/llm.test.ts`, `agents/src/types.test.ts`, and `plugins/openai/src/{responses,ws}/llm.test.ts`, using the existing client-stubbing pattern with a stub that yields chunks then throws. The metadata chunk in the inference fixtures is the literal `extra_content.livekit` payload observed in production.

- a stall after provider metadata alone retries (3 attempts at `maxRetry: 2`); a stall after generated text does not (1 attempt)
- the same two cases on both Responses transports, plus a phase marker that is metadata rather than output
- ttft measured across a retry
- the first retry interval in milliseconds

Reverting the retry-eligibility fixes fails these with `expected 1 to be 3` (HTTP, under-retry) and `expected 3 to be 1` (WebSocket, over-retry). `pnpm test agents`: 1521 passed across 112 files, exit 0 — it was exit 1 before the rejection fix. `pnpm test plugins/openai`: 74 passed. `pnpm build` (`tsc`) clean.

## Not ported

Python also gained an `httpx.TimeoutException` clause, so a timeout waiting on the stream body is reported as `APITimeoutError` rather than `APIConnectionError`. The same structural gap exists here — `OpenAI.APIConnectionTimeoutError` only catches what the OpenAI client mapped — but I could not establish which concrete error class a mid-stream stall produces in Node, and there is no precedent in this repo to follow. A guessed class name would be a check that silently never matches, so it needs a reproduction first.
