### PR TITLE
plugins/phonic: preserve tool call outputs across mid-session reset

### DIFF
--- a/.changeset/phonic-preserve-tool-outputs.md
+++ b/.changeset/phonic-preserve-tool-outputs.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-phonic': patch
+---
+
+Preserve tool call outputs across mid-session resets. livekit core commits realtime `function_call` items to the agent chat context but not their `function_call_output`, so on a handoff/reset the Phonic plugin rebuilt the conversation history with tool calls but no outputs. The plugin now remembers the outputs it observes and re-injects them into the reset history.

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -401,6 +401,11 @@ export class RealtimeSession extends llm.RealtimeSession {
   private toolDefinitions: Phonic.InlineWebSocketTool[] = [];
   private configsForTools = new Map<string, PhonicToolConfig>();
   private pendingToolCallIds = new Set<string>();
+  // Tool outputs observed during the session, keyed by call id. livekit core commits realtime
+  // function_call items to the agent chat context but not their function_call_output, so on a
+  // mid-session reset the outputs would be lost from the rebuilt history; we re-inject them in
+  // buildTurnHistory.
+  private observedToolOutputs = new Map<string, llm.FunctionCallOutput>();
   private readyToStart = new Future<void>();
   private pendingGenerateReplyFut?: Future<llm.GenerationCreatedEvent>;
   private generateReplyRequestId = 0;
@@ -472,6 +477,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       const item = chatCtx.getById(itemId);
       if (item?.type === 'function_call_output' && this.pendingToolCallIds.has(item.callId)) {
         this.pendingToolCallIds.delete(item.callId);
+        this.observedToolOutputs.set(item.callId, item);
         this.#logger.info(`Sending tool call output for ${item.name} (call_id: ${item.callId})`);
         this.socket?.sendToolCallOutput({
           type: 'tool_call_output',
@@ -1113,9 +1119,24 @@ export class RealtimeSession extends llm.RealtimeSession {
 
   private buildTurnHistory(chatCtx: llm.ChatContext): string | undefined {
     const lines: string[] = [];
+    const presentOutputCallIds = new Set(
+      chatCtx.items
+        .filter((i): i is llm.FunctionCallOutput => i.type === 'function_call_output')
+        .map((i) => i.callId),
+    );
     for (const item of chatCtx.items) {
       const text = chatItemToText(item);
       if (text) lines.push(text);
+      // Re-inject the tool output right after its call: livekit core doesn't commit realtime
+      // function_call_output to the agent chat context, so it's absent from the reset history
+      // unless we add back the output we observed. Skip if the ctx already carries it.
+      if (item.type === 'function_call' && !presentOutputCallIds.has(item.callId)) {
+        const output = this.observedToolOutputs.get(item.callId);
+        if (output) {
+          const outputText = chatItemToText(output);
+          if (outputText) lines.push(outputText);
+        }
+      }
     }
     if (lines.length === 0) return undefined;
     return lines.join('\n');


### PR DESCRIPTION
## What
When the Phonic realtime session is reset mid-session (e.g. an agent handoff), the plugin rebuilds the conversation history from the agent chat context via `buildTurnHistory`. That history included tool **calls** (`<tool_call>`) but not their **outputs** (`<tool_output>`).

The plugin now remembers the tool outputs it observes and re-injects them (right after their call) when rebuilding the reset history — skipping any output the chat context already carries.

## Why
`onToolExecutionCompleted` in the realtime generation path commits the `function_call` to the agent chat context but not the `function_call_output` (that only happens on the interrupted path). Providers whose server keeps its own context across the session are unaffected, but Phonic rebuilds the server context from the agent chat context on reset — so the un-persisted output was lost, leaving the model with a tool call and no result after a handoff.

## Notes
- `chatItemToText` already renders `<tool_output>`, so this only adds the capture + re-inject (~12 lines).
- Bounded (one entry per call), lives on the reused session, and dedupes against outputs already present — so it's a no-op if the framework ever starts persisting them.