### PR TITLE
Fix room audio input detachment

### DIFF
--- a/.changeset/quiet-callers-wait.md
+++ b/.changeset/quiet-callers-wait.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Stop forwarding participant audio while agent input is disabled.

--- a/agents/src/voice/io.test.ts
+++ b/agents/src/voice/io.test.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it, vi } from 'vitest';
+import { AgentInput, AudioInput } from './io.js';
+
+class TestAudioInput extends AudioInput {
+  override onAttached = vi.fn();
+  override onDetached = vi.fn();
+}
+
+describe('AgentInput', () => {
+  it('detaches replaced audio and synchronizes the new stream with the disabled state', () => {
+    const audioChanged = vi.fn();
+    const agentInput = new AgentInput(audioChanged);
+    const original = new TestAudioInput();
+    const replacement = new TestAudioInput();
+
+    agentInput.audio = original;
+    expect(original.onAttached).toHaveBeenCalledOnce();
+
+    agentInput.setAudioEnabled(false);
+    expect(original.onDetached).toHaveBeenCalledOnce();
+
+    agentInput.audio = replacement;
+    expect(original.onDetached).toHaveBeenCalledTimes(2);
+    expect(replacement.onDetached).toHaveBeenCalledOnce();
+    expect(replacement.onAttached).not.toHaveBeenCalled();
+
+    agentInput.audio = replacement;
+    expect(audioChanged).toHaveBeenCalledTimes(2);
+    expect(replacement.onDetached).toHaveBeenCalledOnce();
+  });
+});

--- a/agents/src/voice/io.ts
+++ b/agents/src/voice/io.ts
@@ -338,8 +338,21 @@ export class AgentInput {
   }
 
   set audio(stream: AudioInput | null) {
+    if (stream === this._audioStream) {
+      return;
+    }
+
+    this._audioStream?.onDetached();
     this._audioStream = stream;
     this.audioChanged();
+
+    if (this._audioStream) {
+      if (this._audioEnabled) {
+        this._audioStream.onAttached();
+      } else {
+        this._audioStream.onDetached();
+      }
+    }
   }
 }
 

--- a/agents/src/voice/room_io/_input.test.ts
+++ b/agents/src/voice/room_io/_input.test.ts
@@ -4,6 +4,7 @@
 import { AudioFrame, type Room, TrackSource } from '@livekit/rtc-node';
 import { ReadableStream, type ReadableStreamDefaultController } from 'node:stream/web';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AgentInput } from '../io.js';
 import { ParticipantAudioInputStream } from './_input.js';
 
 const audioStreams = vi.hoisted(() => [] as ReadableStream<AudioFrame>[]);
@@ -38,6 +39,33 @@ function createFrame(value: number): AudioFrame {
   return new AudioFrame(new Int16Array([value]), 24000, 1, 1);
 }
 
+function createParticipantInput() {
+  const source = createAudioStream();
+  audioStreams.push(source.stream);
+
+  const publication = {
+    sid: 'microphone-track',
+    source: TrackSource.SOURCE_MICROPHONE,
+    track: {},
+  };
+  const participant = {
+    identity: 'caller',
+    trackPublications: new Map([[publication.sid, publication]]),
+  };
+  const room = {
+    remoteParticipants: new Map([[participant.identity, participant]]),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+  const input = new ParticipantAudioInputStream({
+    room: room as unknown as Room,
+    sampleRate: 24000,
+    numChannels: 1,
+  });
+
+  return { input, participant, source };
+}
+
 describe('ParticipantAudioInputStream', () => {
   afterEach(() => {
     audioStreams.length = 0;
@@ -45,43 +73,48 @@ describe('ParticipantAudioInputStream', () => {
   });
 
   it('drops frames while detached and resumes forwarding when attached', async () => {
-    const source = createAudioStream();
-    audioStreams.push(source.stream);
-
-    const publication = {
-      sid: 'microphone-track',
-      source: TrackSource.SOURCE_MICROPHONE,
-      track: {},
-    };
-    const participant = {
-      identity: 'caller',
-      trackPublications: new Map([[publication.sid, publication]]),
-    };
-    const room = {
-      remoteParticipants: new Map([[participant.identity, participant]]),
-      on: vi.fn(),
-      off: vi.fn(),
-    };
-    const input = new ParticipantAudioInputStream({
-      room: room as unknown as Room,
-      sampleRate: 24000,
-      numChannels: 1,
-    });
+    const { input, participant, source } = createParticipantInput();
     input.setParticipant(participant.identity);
+    const agentInput = new AgentInput(() => {});
+    agentInput.audio = input;
 
     const reader = input.stream.getReader();
     const initialFrame = createFrame(1);
     source.controller().enqueue(initialFrame);
     await expect(reader.read()).resolves.toMatchObject({ done: false, value: initialFrame });
 
-    input.onDetached();
+    agentInput.setAudioEnabled(false);
     source.controller().enqueue(createFrame(2));
     await nextTick();
 
-    input.onAttached();
+    agentInput.setAudioEnabled(true);
     const resumedFrame = createFrame(3);
     source.controller().enqueue(resumedFrame);
     await expect(reader.read()).resolves.toMatchObject({ done: false, value: resumedFrame });
+
+    source.controller().close();
+    reader.releaseLock();
+    await input.close();
+  });
+
+  it('gates a track subscribed after input is disabled', async () => {
+    const { input, participant, source } = createParticipantInput();
+    const onDetached = vi.spyOn(input, 'onDetached');
+    const agentInput = new AgentInput(() => {});
+    agentInput.setAudioEnabled(false);
+    agentInput.audio = input;
+
+    expect(onDetached).toHaveBeenCalledOnce();
+
+    input.setParticipant(participant.identity);
+    const reader = input.stream.getReader();
+    source.controller().enqueue(createFrame(1));
+    await nextTick();
+
+    agentInput.setAudioEnabled(true);
+    const attachedFrame = createFrame(2);
+    source.controller().enqueue(attachedFrame);
+    await expect(reader.read()).resolves.toMatchObject({ done: false, value: attachedFrame });
 
     source.controller().close();
     reader.releaseLock();

--- a/agents/src/voice/room_io/_input.test.ts
+++ b/agents/src/voice/room_io/_input.test.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame, type Room, TrackSource } from '@livekit/rtc-node';
+import { ReadableStream, type ReadableStreamDefaultController } from 'node:stream/web';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ParticipantAudioInputStream } from './_input.js';
+
+const audioStreams = vi.hoisted(() => [] as ReadableStream<AudioFrame>[]);
+
+vi.mock('@livekit/rtc-node', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    AudioStream: vi.fn(function MockAudioStream() {
+      const stream = audioStreams.shift();
+      if (!stream) {
+        throw new Error('No mock audio stream configured');
+      }
+      return stream;
+    }),
+  };
+});
+
+const nextTick = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+function createAudioStream() {
+  let controller!: ReadableStreamDefaultController<AudioFrame>;
+  const stream = new ReadableStream<AudioFrame>({
+    start(streamController) {
+      controller = streamController;
+    },
+  });
+  return { stream, controller: () => controller };
+}
+
+function createFrame(value: number): AudioFrame {
+  return new AudioFrame(new Int16Array([value]), 24000, 1, 1);
+}
+
+describe('ParticipantAudioInputStream', () => {
+  afterEach(() => {
+    audioStreams.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('drops frames while detached and resumes forwarding when attached', async () => {
+    const source = createAudioStream();
+    audioStreams.push(source.stream);
+
+    const publication = {
+      sid: 'microphone-track',
+      source: TrackSource.SOURCE_MICROPHONE,
+      track: {},
+    };
+    const participant = {
+      identity: 'caller',
+      trackPublications: new Map([[publication.sid, publication]]),
+    };
+    const room = {
+      remoteParticipants: new Map([[participant.identity, participant]]),
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+    const input = new ParticipantAudioInputStream({
+      room: room as unknown as Room,
+      sampleRate: 24000,
+      numChannels: 1,
+    });
+    input.setParticipant(participant.identity);
+
+    const reader = input.stream.getReader();
+    const initialFrame = createFrame(1);
+    source.controller().enqueue(initialFrame);
+    await expect(reader.read()).resolves.toMatchObject({ done: false, value: initialFrame });
+
+    input.onDetached();
+    source.controller().enqueue(createFrame(2));
+    await nextTick();
+
+    input.onAttached();
+    const resumedFrame = createFrame(3);
+    source.controller().enqueue(resumedFrame);
+    await expect(reader.read()).resolves.toMatchObject({ done: false, value: resumedFrame });
+
+    source.controller().close();
+    reader.releaseLock();
+    await input.close();
+  });
+});

--- a/agents/src/voice/room_io/_input.ts
+++ b/agents/src/voice/room_io/_input.ts
@@ -14,7 +14,7 @@ import {
   TrackSource,
   isFrameProcessor,
 } from '@livekit/rtc-node';
-import type { ReadableStream } from 'node:stream/web';
+import { type ReadableStream, TransformStream } from 'node:stream/web';
 import { log } from '../../log.js';
 import { resampleStream } from '../../utils.js';
 import { AudioInput } from '../io.js';
@@ -28,6 +28,7 @@ export class ParticipantAudioInputStream extends AudioInput {
   private publication: RemoteTrackPublication | null = null;
   private participantIdentity: string | null = null;
   private currentInputId: string | null = null;
+  private attached = true;
   private logger = log();
 
   constructor({
@@ -100,6 +101,16 @@ export class ParticipantAudioInputStream extends AudioInput {
     }
   }
 
+  override onAttached(): void {
+    this.logger.debug({ participant: this.participantIdentity }, 'input stream attached');
+    this.attached = true;
+  }
+
+  override onDetached(): void {
+    this.logger.debug({ participant: this.participantIdentity }, 'input stream detached');
+    this.attached = false;
+  }
+
   private onTrackUnpublished = (
     publication: RemoteTrackPublication,
     participant: RemoteParticipant,
@@ -147,12 +158,19 @@ export class ParticipantAudioInputStream extends AudioInput {
     }
     this.closeStream();
     this.publication = publication;
-    this.currentInputId = this.multiStream.addInputStream(
-      resampleStream({
-        stream: this.createStream(track),
-        outputRate: this.sampleRate,
+    const attachedStream = resampleStream({
+      stream: this.createStream(track),
+      outputRate: this.sampleRate,
+    }).pipeThrough(
+      new TransformStream<AudioFrame, AudioFrame>({
+        transform: (frame, controller) => {
+          if (this.attached) {
+            controller.enqueue(frame);
+          }
+        },
       }),
     );
+    this.currentInputId = this.multiStream.addInputStream(attachedStream);
     return true;
   };
 


### PR DESCRIPTION
## What & why

Make disabling room audio input actually stop participant frames from reaching the agent pipeline. `AgentInput.setAudioEnabled(false)` invoked `onDetached()`, but `ParticipantAudioInputStream` inherited the no-op base implementation, so held-caller audio could continue reaching STT and trigger agent turns.

Addresses the input-detachment portion of #2221. Isolating consult tools from the caller-side warm-transfer task remains a separate follow-up.

## Key changes

- track attachment state in `ParticipantAudioInputStream`, dropping frames while detached and resuming when attached
- detach replaced `AgentInput` streams and synchronize incoming streams with the current `audioEnabled` state, matching Python
- continuously drain the underlying RTC stream while detached so dropped frames are not buffered and replayed after reattachment
- add regression coverage for the public `setAudioEnabled` path, stream replacement while disabled, and tracks subscribed while detached

With recording enabled, detached participant audio is omitted from the recording because the recorder consumes the gated stream. This matches the Python implementation.

## Validation

- `pnpm test agents/src/voice/room_io agents/src/voice/io.test.ts` (25 passed)
- `pnpm --filter @livekit/agents typecheck`
- `pnpm --filter @livekit/agents exec eslint -f unix src/voice/io.ts src/voice/io.test.ts src/voice/room_io/_input.ts src/voice/room_io/_input.test.ts`
- `pnpm exec prettier --check agents/src/voice/io.ts agents/src/voice/io.test.ts agents/src/voice/room_io/_input.ts agents/src/voice/room_io/_input.test.ts`
- `pnpm build:agents`

Full `pnpm test` was also attempted; unrelated current-main/plugin-fixture failures remain outside this change (unbuilt plugin packages, missing test assets, and existing remote-session expectations).
