### PR TITLE
fix(voice): align session.say transcripts with TTS

### DIFF
--- a/.changeset/fair-voices-align.md
+++ b/.changeset/fair-voices-align.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Use TTS-aligned transcripts for speech created with `session.say()`.

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2698,25 +2698,25 @@ export class AgentActivity implements RecognitionHooks {
         .catch(() => this.logger.debug('firstFrameFut cancelled before first frame'));
     }
 
-    const trNode = await this.agent.transcriptionNode(transcriptionInput, {});
-    let textOut: _TextOut | null = null;
-    if (trNode) {
-      const [textForwardTask, _textOut] = performTextForwarding(
-        trNode,
-        replyAbortController,
-        transcriptionOutput,
-      );
-      textOut = _textOut;
-      tasks.push(textForwardTask);
-    }
-
-    if (!audioOutput && textOut) {
-      textOut.firstTextFut.await
-        .then(() => onFirstFrame(null))
-        .catch(() => this.logger.debug('firstTextFut cancelled before first frame'));
-    }
-
     try {
+      const trNode = await this.agent.transcriptionNode(transcriptionInput, {});
+      let textOut: _TextOut | null = null;
+      if (trNode) {
+        const [textForwardTask, _textOut] = performTextForwarding(
+          trNode,
+          replyAbortController,
+          transcriptionOutput,
+        );
+        textOut = _textOut;
+        tasks.push(textForwardTask);
+      }
+
+      if (!audioOutput && textOut) {
+        textOut.firstTextFut.await
+          .then(() => onFirstFrame(null))
+          .catch(() => this.logger.debug('firstTextFut cancelled before first frame'));
+      }
+
       await speechHandle.waitIfNotInterrupted(tasks.map((task) => task.result));
 
       if (audioOutput) {
@@ -2765,6 +2765,13 @@ export class AgentActivity implements RecognitionHooks {
         }
         this.restoreInterruptionByAudioActivity();
       }
+    } catch (error) {
+      replyAbortController.abort();
+      await cancelAndWait(tasks, REPLY_TASK_CANCEL_TIMEOUT);
+      if (audioOutput && audioOutput.pendingPlayoutSegments > 0) {
+        audioOutput.clearBuffer();
+      }
+      throw error;
     } finally {
       // In a finally so the listener is dropped even if an await above throws —
       // otherwise it would leak on the shared audioOutput.

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2620,20 +2620,9 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     const [textSource, audioSource] = baseStream.tee();
+    let transcriptionInput: ReadableStream<string | TimedString> = textSource;
 
     const tasks: Array<Task<void>> = [];
-
-    const trNode = await this.agent.transcriptionNode(textSource, {});
-    let textOut: _TextOut | null = null;
-    if (trNode) {
-      const [textForwardTask, _textOut] = performTextForwarding(
-        trNode,
-        replyAbortController,
-        transcriptionOutput,
-      );
-      textOut = _textOut;
-      tasks.push(textForwardTask);
-    }
 
     let replyStartedSpeakingAt: number | undefined;
     let replyStartedForwardingAt: number | undefined;
@@ -2655,13 +2644,7 @@ export class AgentActivity implements RecognitionHooks {
     };
 
     let audioOut: _AudioOut | null = null;
-    if (!audioOutput) {
-      if (textOut) {
-        textOut.firstTextFut.await
-          .then(() => onFirstFrame(null))
-          .catch(() => this.logger.debug('firstTextFut cancelled before first frame'));
-      }
-    } else {
+    if (audioOutput) {
       if (!audio) {
         // generate audio using TTS
         const [ttsTask, ttsGenData] = performTTSInference(
@@ -2676,6 +2659,19 @@ export class AgentActivity implements RecognitionHooks {
         );
         tasks.push(ttsTask);
         replyTtsGenData = ttsGenData;
+
+        if (this.useTtsAlignedTranscript && this.tts?.capabilities.alignedTranscript) {
+          const timedTextsStream = await ThrowsPromise.race([
+            ttsGenData.timedTextsFut.await,
+            ttsTask.result.catch(() =>
+              this.logger.warn('TTS task failed before resolving timedTextsFut'),
+            ),
+          ]);
+          if (timedTextsStream) {
+            this.logger.debug('Using TTS aligned transcripts for transcription node input');
+            transcriptionInput = timedTextsStream;
+          }
+        }
 
         const [forwardTask, _audioOut] = performAudioForwarding(
           ttsGenData.audioStream,
@@ -2700,6 +2696,24 @@ export class AgentActivity implements RecognitionHooks {
       audioOut.firstFrameFut.await
         .then((ts) => onFirstFrame(audioOutForCb, ts))
         .catch(() => this.logger.debug('firstFrameFut cancelled before first frame'));
+    }
+
+    const trNode = await this.agent.transcriptionNode(transcriptionInput, {});
+    let textOut: _TextOut | null = null;
+    if (trNode) {
+      const [textForwardTask, _textOut] = performTextForwarding(
+        trNode,
+        replyAbortController,
+        transcriptionOutput,
+      );
+      textOut = _textOut;
+      tasks.push(textForwardTask);
+    }
+
+    if (!audioOutput && textOut) {
+      textOut.firstTextFut.await
+        .then(() => onFirstFrame(null))
+        .catch(() => this.logger.debug('firstTextFut cancelled before first frame'));
     }
 
     try {

--- a/agents/src/voice/agent_activity_say_aligned_transcript.test.ts
+++ b/agents/src/voice/agent_activity_say_aligned_transcript.test.ts
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { AudioFrame } from '@livekit/rtc-node';
 import { ReadableStream } from 'node:stream/web';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { initializeLogger } from '../log.js';
 import { TTS } from '../tts/tts.js';
 import { USERDATA_TIMED_TRANSCRIPT } from '../types.js';
-import { Agent } from './agent.js';
+import { Future } from '../utils.js';
+import { Agent, type ModelSettings } from './agent.js';
 import { AgentSession } from './agent_session.js';
 import {
   AudioOutput,
@@ -16,6 +17,7 @@ import {
   createTimedString,
   isTimedString,
 } from './io.js';
+import { SpeechHandle } from './speech_handle.js';
 
 function frame(durationMs = 20, sampleRate = 24000): AudioFrame {
   const samples = Math.floor((sampleRate * durationMs) / 1000);
@@ -97,6 +99,55 @@ class ImmediateAudioOutput extends AudioOutput {
       this.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
     }
   }
+}
+
+class CleanupTrackingAudioOutput extends AudioOutput {
+  readonly frameCaptured = new Future<void>();
+  clearBufferCalls = 0;
+
+  constructor() {
+    super(24000);
+  }
+
+  async captureFrame(audio: AudioFrame): Promise<void> {
+    await super.captureFrame(audio);
+    if (!this.frameCaptured.done) {
+      this.frameCaptured.resolve();
+    }
+  }
+
+  flush(): void {
+    super.flush();
+  }
+
+  clearBuffer(): void {
+    this.clearBufferCalls += 1;
+    if (this.pendingPlayoutSegments > 0) {
+      this.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
+    }
+  }
+}
+
+class ThrowingTranscriptionAgent extends AlignedAgent {
+  constructor(private readonly audioOutput: CleanupTrackingAudioOutput) {
+    super([createTimedString({ text: 'Aligned', startTime: 0, endTime: 0.2 })]);
+  }
+
+  async transcriptionNode(): Promise<never> {
+    await this.audioOutput.frameCaptured.await;
+    throw new Error('simulated transcription hook failure');
+  }
+}
+
+interface TtsTaskInvoker {
+  ttsTask(
+    speechHandle: SpeechHandle,
+    text: string | ReadableStream<string>,
+    addToChatCtx: boolean,
+    modelSettings: ModelSettings,
+    replyAbortController: AbortController,
+    audio?: ReadableStream<AudioFrame> | null,
+  ): Promise<void>;
 }
 
 class CollectingTextOutput extends TextOutput {
@@ -214,6 +265,34 @@ describe('AgentActivity session.say aligned transcript', () => {
       expect(agent.ttsCalls).toBe(0);
       expect(transcriptionOutput.chunks).toEqual(['Raw scripted greeting.']);
     } finally {
+      await session.close();
+    }
+  });
+
+  it('cleans up audio forwarding when a custom transcription node throws', async () => {
+    const session = new AgentSession();
+    const audioOutput = new CleanupTrackingAudioOutput();
+    session.output.audio = audioOutput;
+
+    await session.start({ agent: new ThrowingTranscriptionAgent(audioOutput) });
+    const replyAbortController = new AbortController();
+    try {
+      const speechHandle = SpeechHandle.create();
+      speechHandle._authorizeGeneration();
+      const activity = session._activity as unknown as TtsTaskInvoker;
+
+      await expect(
+        activity.ttsTask(speechHandle, 'Raw scripted greeting.', false, {}, replyAbortController),
+      ).rejects.toThrow('simulated transcription hook failure');
+      await vi.waitFor(() => expect(audioOutput.capturedPlayoutSegments).toBe(1));
+
+      expect(replyAbortController.signal.aborted).toBe(true);
+      expect(audioOutput.clearBufferCalls).toBe(1);
+      expect(audioOutput.pendingPlayoutSegments).toBe(0);
+      expect(audioOutput.listenerCount(AudioOutput.EVENT_PLAYBACK_STARTED)).toBe(0);
+    } finally {
+      replyAbortController.abort();
+      audioOutput.removeAllListeners();
       await session.close();
     }
   });

--- a/agents/src/voice/agent_activity_say_aligned_transcript.test.ts
+++ b/agents/src/voice/agent_activity_say_aligned_transcript.test.ts
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream } from 'node:stream/web';
+import { describe, expect, it } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { TTS } from '../tts/tts.js';
+import { USERDATA_TIMED_TRANSCRIPT } from '../types.js';
+import { Agent } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import {
+  AudioOutput,
+  TextOutput,
+  type TimedString,
+  createTimedString,
+  isTimedString,
+} from './io.js';
+
+function frame(durationMs = 20, sampleRate = 24000): AudioFrame {
+  const samples = Math.floor((sampleRate * durationMs) / 1000);
+  return new AudioFrame(new Int16Array(samples), sampleRate, 1, samples);
+}
+
+class AlignedTestTTS extends TTS {
+  label = 'aligned-test-tts';
+
+  constructor(alignedTranscript = true) {
+    super(24000, 1, { streaming: true, alignedTranscript });
+  }
+
+  synthesize(): never {
+    throw new Error('not used');
+  }
+
+  stream(): never {
+    throw new Error('not used');
+  }
+}
+
+class AlignedAgent extends Agent {
+  ttsCalls = 0;
+
+  constructor(
+    private readonly alignedTranscript: TimedString[],
+    useTtsAlignedTranscript = true,
+    supportsAlignedTranscript = true,
+  ) {
+    super({
+      instructions: 'test',
+      tts: new AlignedTestTTS(supportsAlignedTranscript),
+      useTtsAlignedTranscript,
+    });
+  }
+
+  async ttsNode(text: ReadableStream<string>): Promise<ReadableStream<AudioFrame>> {
+    this.ttsCalls += 1;
+    for await (const _chunk of text) {
+      // Consume the scripted text just like a streaming TTS provider.
+    }
+
+    const audio = frame();
+    audio.userdata[USERDATA_TIMED_TRANSCRIPT] = this.alignedTranscript;
+    return new ReadableStream<AudioFrame>({
+      start(controller) {
+        controller.enqueue(audio);
+        controller.close();
+      },
+    });
+  }
+}
+
+class ImmediateAudioOutput extends AudioOutput {
+  private started = false;
+
+  constructor() {
+    super(24000);
+  }
+
+  async captureFrame(audio: AudioFrame): Promise<void> {
+    await super.captureFrame(audio);
+    if (!this.started) {
+      this.started = true;
+      this.onPlaybackStarted(Date.now());
+    }
+  }
+
+  flush(): void {
+    super.flush();
+    if (this.pendingPlayoutSegments > 0) {
+      this.onPlaybackFinished({ playbackPosition: 0.02, interrupted: false });
+    }
+  }
+
+  clearBuffer(): void {
+    if (this.pendingPlayoutSegments > 0) {
+      this.onPlaybackFinished({ playbackPosition: 0, interrupted: true });
+    }
+  }
+}
+
+class CollectingTextOutput extends TextOutput {
+  readonly chunks: Array<string | TimedString> = [];
+
+  async captureText(text: string | TimedString): Promise<void> {
+    this.chunks.push(text);
+  }
+
+  flush(): void {}
+}
+
+function audioStream(): ReadableStream<AudioFrame> {
+  return new ReadableStream<AudioFrame>({
+    start(controller) {
+      controller.enqueue(frame());
+      controller.close();
+    },
+  });
+}
+
+describe('AgentActivity session.say aligned transcript', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('forwards TTS-aligned text instead of the raw scripted text', async () => {
+    const alignedTranscript = [
+      createTimedString({ text: 'Aligned ', startTime: 0, endTime: 0.2 }),
+      createTimedString({ text: 'speech', startTime: 0.2, endTime: 0.4 }),
+    ];
+    const session = new AgentSession();
+    const transcriptionOutput = new CollectingTextOutput();
+    session.output.audio = new ImmediateAudioOutput();
+    session.output.transcription = transcriptionOutput;
+
+    await session.start({ agent: new AlignedAgent(alignedTranscript) });
+    try {
+      await session.say('Raw scripted greeting.').waitForPlayout();
+
+      expect(transcriptionOutput.chunks).toHaveLength(2);
+      expect(transcriptionOutput.chunks.every(isTimedString)).toBe(true);
+      expect(
+        transcriptionOutput.chunks.map((chunk) => (isTimedString(chunk) ? chunk.text : chunk)),
+      ).toEqual(['Aligned ', 'speech']);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('forwards the raw scripted text when TTS-aligned transcripts are disabled', async () => {
+    const alignedTranscript = [
+      createTimedString({ text: 'Aligned ', startTime: 0, endTime: 0.2 }),
+      createTimedString({ text: 'speech', startTime: 0.2, endTime: 0.4 }),
+    ];
+    const session = new AgentSession();
+    const transcriptionOutput = new CollectingTextOutput();
+    session.output.audio = new ImmediateAudioOutput();
+    session.output.transcription = transcriptionOutput;
+
+    await session.start({ agent: new AlignedAgent(alignedTranscript, false) });
+    try {
+      await session.say('Raw scripted greeting.').waitForPlayout();
+
+      expect(transcriptionOutput.chunks).toEqual(['Raw scripted greeting.']);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('forwards the raw scripted text when the TTS does not support alignment', async () => {
+    const session = new AgentSession();
+    const transcriptionOutput = new CollectingTextOutput();
+    session.output.audio = new ImmediateAudioOutput();
+    session.output.transcription = transcriptionOutput;
+    const agent = new AlignedAgent([], true, false);
+
+    await session.start({ agent });
+    try {
+      await session.say('Raw scripted greeting.').waitForPlayout();
+
+      expect(agent.ttsCalls).toBe(1);
+      expect(transcriptionOutput.chunks).toEqual(['Raw scripted greeting.']);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('forwards the raw scripted text when the caller provides audio', async () => {
+    const session = new AgentSession();
+    const transcriptionOutput = new CollectingTextOutput();
+    session.output.audio = new ImmediateAudioOutput();
+    session.output.transcription = transcriptionOutput;
+    const agent = new AlignedAgent([]);
+
+    await session.start({ agent });
+    try {
+      await session.say('Raw scripted greeting.', { audio: audioStream() }).waitForPlayout();
+
+      expect(agent.ttsCalls).toBe(0);
+      expect(transcriptionOutput.chunks).toEqual(['Raw scripted greeting.']);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('forwards the raw scripted text when audio output is disabled', async () => {
+    const session = new AgentSession();
+    const transcriptionOutput = new CollectingTextOutput();
+    session.output.transcription = transcriptionOutput;
+    const agent = new AlignedAgent([]);
+
+    await session.start({ agent });
+    try {
+      await session.say('Raw scripted greeting.').waitForPlayout();
+
+      expect(agent.ttsCalls).toBe(0);
+      expect(transcriptionOutput.chunks).toEqual(['Raw scripted greeting.']);
+    } finally {
+      await session.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- use TTS-provided timed transcripts for `session.say()` when aligned transcripts are enabled and supported
- preserve raw scripted text when alignment is disabled, unsupported, bypassed by caller-provided audio, or audio output is disabled
- add regression coverage for the aligned path and each direct fallback path

Fixes #2067

## Testing

- `pnpm test agents/src/voice/agent_activity_say_aligned_transcript.test.ts agents/src/voice/agent_activity_close_commit.test.ts agents/src/voice/agent_activity_interrupted_commit.test.ts agents/src/voice/generation_tts_timeout.test.ts --silent` (20 passed)
- `pnpm test agents/src --exclude agents/src/voice/remote_session.test.ts --silent` (1,561 passed, 5 skipped; the excluded file has an unrelated current-main event assertion mismatch)
- `pnpm build:agents`
- `pnpm format:check`
- targeted ESLint for the changed voice files
- `pnpm exec changeset status --since=origin/main`
