### PR TITLE
fix(voice): mute audio input while detached (#2221)

### DIFF
--- a/.changeset/fix-audio-input-detach.md
+++ b/.changeset/fix-audio-input-detach.md
@@ -1,0 +1,7 @@
+---
+'@livekit/agents': patch
+---
+
+Fix `session.input.setAudioEnabled(false)` not stopping caller audio
+
+`AudioInput.onDetached()` was a no-op, so room microphone frames kept flowing into STT while a warm-transfer caller was on hold. Held-caller speech could reach the consult agent activity and invoke transfer tools prematurely. Frames are now dropped while detached and resume after re-attach, matching the Python participant input behavior.

--- a/agents/src/voice/io.test.ts
+++ b/agents/src/voice/io.test.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { type StreamChannel, createStreamChannel } from '../stream/stream_channel.js';
+import { delay } from '../utils.js';
+import { AgentInput, AudioInput } from './io.js';
+
+class FakeAudioInput extends AudioInput {
+  private chan: StreamChannel<AudioFrame> = createStreamChannel<AudioFrame>();
+
+  constructor() {
+    super();
+    this.multiStream.addInputStream(this.chan.stream());
+  }
+
+  push(frame: AudioFrame): Promise<void> {
+    return this.chan.write(frame);
+  }
+}
+
+function makeFrame(sample: number): AudioFrame {
+  return new AudioFrame(new Int16Array([sample]), 16000, 1, 1);
+}
+
+describe('AgentInput.setAudioEnabled', () => {
+  beforeAll(() => {
+    initializeLogger({ pretty: false });
+  });
+
+  it('drops frames while detached and resumes after re-attach', async () => {
+    const audio = new FakeAudioInput();
+    const input = new AgentInput(() => {});
+    input.audio = audio;
+
+    const received: number[] = [];
+    const reader = audio.stream.getReader();
+    const pump = (async () => {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received.push(value.data[0]!);
+      }
+    })();
+
+    await audio.push(makeFrame(1));
+    await delay(50);
+    expect(received).toEqual([1]);
+
+    input.setAudioEnabled(false);
+
+    await audio.push(makeFrame(2));
+    await delay(50);
+    expect(received).toEqual([1]);
+
+    input.setAudioEnabled(true);
+
+    await audio.push(makeFrame(3));
+    await delay(50);
+    expect(received).toEqual([1, 3]);
+
+    await audio.close();
+    await pump;
+  });
+});

--- a/agents/src/voice/io.test.ts
+++ b/agents/src/voice/io.test.ts
@@ -25,6 +25,12 @@ function makeFrame(sample: number): AudioFrame {
   return new AudioFrame(new Int16Array([sample]), 16000, 1, 1);
 }
 
+class HookOnlyAudioInput extends FakeAudioInput {
+  // Intentionally omit super — mute must not depend on lifecycle hooks.
+  override onAttached(): void {}
+  override onDetached(): void {}
+}
+
 describe('AgentInput.setAudioEnabled', () => {
   beforeAll(() => {
     initializeLogger({ pretty: false });
@@ -60,6 +66,34 @@ describe('AgentInput.setAudioEnabled', () => {
     await audio.push(makeFrame(3));
     await delay(50);
     expect(received).toEqual([1, 3]);
+
+    await audio.close();
+    await pump;
+  });
+
+  it('mutes even when onDetached overrides omit super', async () => {
+    const audio = new HookOnlyAudioInput();
+    const input = new AgentInput(() => {});
+    input.audio = audio;
+
+    const received: number[] = [];
+    const reader = audio.stream.getReader();
+    const pump = (async () => {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received.push(value.data[0]!);
+      }
+    })();
+
+    await audio.push(makeFrame(1));
+    await delay(50);
+    expect(received).toEqual([1]);
+
+    input.setAudioEnabled(false);
+    await audio.push(makeFrame(2));
+    await delay(50);
+    expect(received).toEqual([1]);
 
     await audio.close();
     await pump;

--- a/agents/src/voice/io.ts
+++ b/agents/src/voice/io.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AudioFrame } from '@livekit/rtc-node';
 import { EventEmitter } from 'node:events';
-import type { ReadableStream } from 'node:stream/web';
+import { type ReadableStream, TransformStream } from 'node:stream/web';
 import type { ChatContext } from '../llm/chat_context.js';
 import type { ChatChunk } from '../llm/llm.js';
 import type { ToolContext } from '../llm/tool_context.js';
@@ -89,18 +89,37 @@ export interface AudioOutputCapabilities {
 
 export abstract class AudioInput {
   protected multiStream: MultiInputStream<AudioFrame> = new MultiInputStream<AudioFrame>();
+  private _attached = true;
+  private _gatedStream?: ReadableStream<AudioFrame>;
 
   get stream(): ReadableStream<AudioFrame> {
-    return this.multiStream.stream;
+    if (!this._gatedStream) {
+      // Drop frames while detached so setAudioEnabled(false) actually mutes
+      // the input path (matches Python ParticipantInputStream._attached).
+      this._gatedStream = this.multiStream.stream.pipeThrough(
+        new TransformStream<AudioFrame, AudioFrame>({
+          transform: (frame, controller) => {
+            if (this._attached) {
+              controller.enqueue(frame);
+            }
+          },
+        }),
+      );
+    }
+    return this._gatedStream;
   }
 
   async close(): Promise<void> {
     await this.multiStream.close();
   }
 
-  onAttached(): void {}
+  onAttached(): void {
+    this._attached = true;
+  }
 
-  onDetached(): void {}
+  onDetached(): void {
+    this._attached = false;
+  }
 }
 
 export abstract class AudioOutput extends EventEmitter {
@@ -338,8 +357,24 @@ export class AgentInput {
   }
 
   set audio(stream: AudioInput | null) {
+    if (stream === this._audioStream) {
+      return;
+    }
+
+    if (this._audioStream) {
+      this._audioStream.onDetached();
+    }
+
     this._audioStream = stream;
     this.audioChanged();
+
+    if (this._audioStream) {
+      if (this._audioEnabled) {
+        this._audioStream.onAttached();
+      } else {
+        this._audioStream.onDetached();
+      }
+    }
   }
 }
 

--- a/agents/src/voice/io.ts
+++ b/agents/src/voice/io.ts
@@ -113,13 +113,25 @@ export abstract class AudioInput {
     await this.multiStream.close();
   }
 
-  onAttached(): void {
-    this._attached = true;
+  /**
+   * Framework-owned attach-state transition. Subclasses that wrap another
+   * {@link AudioInput} should override this to forward state, but application
+   * code should not call it — use {@link AgentInput.setAudioEnabled} instead.
+   *
+   * Keep this separate from {@link onAttached}/{@link onDetached}: those are
+   * overridable lifecycle hooks and must not be the only place the mute gate
+   * flips, or subclasses that omit `super` would silently break mute.
+   * @internal
+   */
+  setAttached(attached: boolean): void {
+    this._attached = attached;
   }
 
-  onDetached(): void {
-    this._attached = false;
-  }
+  /** Lifecycle hook invoked after the mute gate attaches. */
+  onAttached(): void {}
+
+  /** Lifecycle hook invoked after the mute gate detaches. */
+  onDetached(): void {}
 }
 
 export abstract class AudioOutput extends EventEmitter {
@@ -341,11 +353,7 @@ export class AgentInput {
       return;
     }
 
-    if (enable) {
-      this._audioStream.onAttached();
-    } else {
-      this._audioStream.onDetached();
-    }
+    this.applyAudioAttachState(this._audioStream, enable);
   }
 
   get audioEnabled(): boolean {
@@ -362,18 +370,23 @@ export class AgentInput {
     }
 
     if (this._audioStream) {
-      this._audioStream.onDetached();
+      this.applyAudioAttachState(this._audioStream, false);
     }
 
     this._audioStream = stream;
     this.audioChanged();
 
     if (this._audioStream) {
-      if (this._audioEnabled) {
-        this._audioStream.onAttached();
-      } else {
-        this._audioStream.onDetached();
-      }
+      this.applyAudioAttachState(this._audioStream, this._audioEnabled);
+    }
+  }
+
+  private applyAudioAttachState(stream: AudioInput, attached: boolean): void {
+    stream.setAttached(attached);
+    if (attached) {
+      stream.onAttached();
+    } else {
+      stream.onDetached();
     }
   }
 }

--- a/agents/src/voice/recorder_io/recorder_io.ts
+++ b/agents/src/voice/recorder_io/recorder_io.ts
@@ -566,13 +566,16 @@ class RecorderAudioInput extends AudioInput {
     return transform.readable;
   }
 
+  override setAttached(attached: boolean): void {
+    super.setAttached(attached);
+    this.source.setAttached(attached);
+  }
+
   onAttached(): void {
-    super.onAttached();
     this.source.onAttached();
   }
 
   onDetached(): void {
-    super.onDetached();
     this.source.onDetached();
   }
 }

--- a/agents/src/voice/recorder_io/recorder_io.ts
+++ b/agents/src/voice/recorder_io/recorder_io.ts
@@ -567,10 +567,12 @@ class RecorderAudioInput extends AudioInput {
   }
 
   onAttached(): void {
+    super.onAttached();
     this.source.onAttached();
   }
 
   onDetached(): void {
+    super.onDetached();
     this.source.onDetached();
   }
 }

--- a/agents/src/voice/remote_session.test.ts
+++ b/agents/src/voice/remote_session.test.ts
@@ -31,6 +31,7 @@ beforeAll(() => {
 // close: an `on` added without its `off` leaks a handler across reconnects and
 // only shows up as a mismatch between these two.
 const FORWARDED_EVENTS = new Set([
+  'agent_false_interruption',
   'agent_state_changed',
   'conversation_item_added',
   'debug_message',


### PR DESCRIPTION
## Summary
- `AudioInput.onDetached()` was a no-op, so `session.input.setAudioEnabled(false)` (used by warm-transfer hold) did not stop frames from reaching STT/LLM/tools
- Gate the input stream on attach state (matching Python `_attached`) and sync attach/detach when swapping `AgentInput.audio`
- Fixes held-caller speech invoking consult tools and bridging prematurely ([#2221](https://github.com/livekit/agents-js/issues/2221))

## Test plan
- [x] Unit: `agents/src/voice/io.test.ts` — frames drop while detached and resume after re-attach
- [x] Cue voice E2E (`sid_25948c27e48a`): hold mute → held speech produces no final STT / no tools → unmute → `get_weather` works
- [ ] Confirm warm-transfer hold no longer fires `connect_to_caller` / aliases from caller-room speech