### PR TITLE
fix(voice): harden input detach mute

### DIFF
--- a/.changeset/input-detach-setAttached.md
+++ b/.changeset/input-detach-setAttached.md
@@ -1,0 +1,7 @@
+---
+'@livekit/agents': patch
+---
+
+Keep audio input mute independent of overridable attach hooks
+
+`AgentInput` now flips mute via `AudioInput.setAttached()` before calling `onAttached`/`onDetached`, and `ParticipantAudioInputStream` gates on that state. Subclasses that override lifecycle hooks without `super` no longer silently break hold mute.

--- a/agents/src/voice/io.test.ts
+++ b/agents/src/voice/io.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { AgentInput, AudioInput } from './io.js';
 
 class TestAudioInput extends AudioInput {
+  override setAttached = vi.fn();
   override onAttached = vi.fn();
   override onDetached = vi.fn();
 }
@@ -17,18 +18,44 @@ describe('AgentInput', () => {
     const replacement = new TestAudioInput();
 
     agentInput.audio = original;
+    expect(original.setAttached).toHaveBeenCalledWith(true);
     expect(original.onAttached).toHaveBeenCalledOnce();
 
     agentInput.setAudioEnabled(false);
+    expect(original.setAttached).toHaveBeenCalledWith(false);
     expect(original.onDetached).toHaveBeenCalledOnce();
 
     agentInput.audio = replacement;
+    expect(original.setAttached).toHaveBeenCalledWith(false);
     expect(original.onDetached).toHaveBeenCalledTimes(2);
+    expect(replacement.setAttached).toHaveBeenCalledWith(false);
     expect(replacement.onDetached).toHaveBeenCalledOnce();
     expect(replacement.onAttached).not.toHaveBeenCalled();
 
     agentInput.audio = replacement;
     expect(audioChanged).toHaveBeenCalledTimes(2);
     expect(replacement.onDetached).toHaveBeenCalledOnce();
+  });
+
+  it('flips attach state before lifecycle hooks', () => {
+    const order: string[] = [];
+    class OrderedAudioInput extends AudioInput {
+      override setAttached(attached: boolean): void {
+        order.push(`setAttached:${attached}`);
+      }
+      override onAttached(): void {
+        order.push('onAttached');
+      }
+      override onDetached(): void {
+        order.push('onDetached');
+      }
+    }
+
+    const agentInput = new AgentInput(() => {});
+    const audio = new OrderedAudioInput();
+    agentInput.audio = audio;
+    agentInput.setAudioEnabled(false);
+
+    expect(order).toEqual(['setAttached:true', 'onAttached', 'setAttached:false', 'onDetached']);
   });
 });

--- a/agents/src/voice/io.ts
+++ b/agents/src/voice/io.ts
@@ -98,8 +98,19 @@ export abstract class AudioInput {
     await this.multiStream.close();
   }
 
+  /**
+   * Framework-owned attach-state transition used by {@link AgentInput.setAudioEnabled}.
+   * Subclasses that gate frames (or wrap another {@link AudioInput}) should override
+   * this — not only {@link onAttached}/{@link onDetached} — so mute still works when
+   * lifecycle hooks omit `super`.
+   * @internal
+   */
+  setAttached(_attached: boolean): void {}
+
+  /** Lifecycle hook invoked after {@link setAttached}(true). */
   onAttached(): void {}
 
+  /** Lifecycle hook invoked after {@link setAttached}(false). */
   onDetached(): void {}
 }
 
@@ -322,11 +333,7 @@ export class AgentInput {
       return;
     }
 
-    if (enable) {
-      this._audioStream.onAttached();
-    } else {
-      this._audioStream.onDetached();
-    }
+    this.applyAudioAttachState(this._audioStream, enable);
   }
 
   get audioEnabled(): boolean {
@@ -342,16 +349,24 @@ export class AgentInput {
       return;
     }
 
-    this._audioStream?.onDetached();
+    if (this._audioStream) {
+      this.applyAudioAttachState(this._audioStream, false);
+    }
+
     this._audioStream = stream;
     this.audioChanged();
 
     if (this._audioStream) {
-      if (this._audioEnabled) {
-        this._audioStream.onAttached();
-      } else {
-        this._audioStream.onDetached();
-      }
+      this.applyAudioAttachState(this._audioStream, this._audioEnabled);
+    }
+  }
+
+  private applyAudioAttachState(stream: AudioInput, attached: boolean): void {
+    stream.setAttached(attached);
+    if (attached) {
+      stream.onAttached();
+    } else {
+      stream.onDetached();
     }
   }
 }

--- a/agents/src/voice/recorder_io/recorder_io.ts
+++ b/agents/src/voice/recorder_io/recorder_io.ts
@@ -566,6 +566,11 @@ class RecorderAudioInput extends AudioInput {
     return transform.readable;
   }
 
+  override setAttached(attached: boolean): void {
+    super.setAttached(attached);
+    this.source.setAttached(attached);
+  }
+
   onAttached(): void {
     this.source.onAttached();
   }

--- a/agents/src/voice/remote_session.test.ts
+++ b/agents/src/voice/remote_session.test.ts
@@ -31,6 +31,7 @@ beforeAll(() => {
 // close: an `on` added without its `off` leaks a handler across reconnects and
 // only shows up as a mismatch between these two.
 const FORWARDED_EVENTS = new Set([
+  'agent_false_interruption',
   'agent_state_changed',
   'conversation_item_added',
   'debug_message',

--- a/agents/src/voice/room_io/_input.test.ts
+++ b/agents/src/voice/room_io/_input.test.ts
@@ -120,4 +120,32 @@ describe('ParticipantAudioInputStream', () => {
     reader.releaseLock();
     await input.close();
   });
+
+  it('keeps mute when onDetached override omits attach-state updates', async () => {
+    const { input, participant, source } = createParticipantInput();
+    input.setParticipant(participant.identity);
+    // Simulate a subclass/wrapper that overrides the hook without updating gate state.
+    input.onDetached = () => {};
+
+    const agentInput = new AgentInput(() => {});
+    agentInput.audio = input;
+
+    const reader = input.stream.getReader();
+    const initialFrame = createFrame(1);
+    source.controller().enqueue(initialFrame);
+    await expect(reader.read()).resolves.toMatchObject({ done: false, value: initialFrame });
+
+    agentInput.setAudioEnabled(false);
+    source.controller().enqueue(createFrame(2));
+    await nextTick();
+
+    agentInput.setAudioEnabled(true);
+    const resumedFrame = createFrame(3);
+    source.controller().enqueue(resumedFrame);
+    await expect(reader.read()).resolves.toMatchObject({ done: false, value: resumedFrame });
+
+    source.controller().close();
+    reader.releaseLock();
+    await input.close();
+  });
 });

--- a/agents/src/voice/room_io/_input.ts
+++ b/agents/src/voice/room_io/_input.ts
@@ -101,14 +101,16 @@ export class ParticipantAudioInputStream extends AudioInput {
     }
   }
 
+  override setAttached(attached: boolean): void {
+    this.attached = attached;
+  }
+
   override onAttached(): void {
     this.logger.debug({ participant: this.participantIdentity }, 'input stream attached');
-    this.attached = true;
   }
 
   override onDetached(): void {
     this.logger.debug({ participant: this.participantIdentity }, 'input stream detached');
-    this.attached = false;
   }
 
   private onTrackUnpublished = (


### PR DESCRIPTION
## Summary
- Follow-up to [#2222](https://github.com/livekit/agents-js/pull/2222) / [#2221](https://github.com/livekit/agents-js/issues/2221)
- `AgentInput` now calls `AudioInput.setAttached()` before `onAttached`/`onDetached`
- `ParticipantAudioInputStream` gates on `setAttached` so hook overrides that omit attach-state updates still mute
- `RecorderAudioInput` forwards `setAttached` to its source
- Fix CI: add `agent_false_interruption` to `FORWARDED_EVENTS` in `remote_session.test.ts` (main drift from #2214, unrelated to mute but blocked #2222 CI)

## Test plan
- [x] `pnpm exec vitest run --project nodejs agents/src/voice/io.test.ts agents/src/voice/room_io/_input.test.ts agents/src/voice/remote_session.test.ts agents/src/voice/recorder_io/recorder_io.test.ts`
- [x] CI green on this PR

Closes duplicate work from #2231.