### PR TITLE
fix(openai): filter internal items from realtime chat context updates

### DIFF
--- a/.changeset/calm-contexts-sync.md
+++ b/.changeset/calm-contexts-sync.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+Ignore internal agent handoff and configuration records when synchronizing realtime chat contexts.

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -919,6 +919,25 @@ describe('RealtimeSession chat context update events', () => {
     expect((events[0] as api_proto.ConversationItemDeleteEvent).item_id).toBe('item_1');
     expect((events[1] as api_proto.ConversationItemCreateEvent).item.id).toBe('item_1');
   });
+
+  it('ignores internal agent items', async () => {
+    const remoteMessage = llm.ChatMessage.create({
+      id: 'item_1',
+      role: 'assistant',
+      content: ['hello'],
+    });
+    const session = createChatCtxUpdateSession(remoteMessage);
+
+    const events = await session.createChatCtxUpdateEvents(
+      new llm.ChatContext([
+        remoteMessage,
+        llm.AgentConfigUpdate.create({ instructions: 'updated instructions' }),
+        llm.AgentHandoffItem.create({ oldAgentId: 'agent_1', newAgentId: 'agent_2' }),
+      ]),
+    );
+
+    expect(events).toEqual([]);
+  });
 });
 
 describe('RealtimeSession.updateOptions', () => {

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -684,7 +684,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     chatCtx: llm.ChatContext,
     addMockAudio: boolean = false,
   ): Promise<(api_proto.ConversationItemCreateEvent | api_proto.ConversationItemDeleteEvent)[]> {
-    const newChatCtx = chatCtx.copy();
+    const newChatCtx = chatCtx.copy({ excludeHandoff: true, excludeConfigUpdate: true });
     if (addMockAudio) {
       newChatCtx.items.push(createMockAudioItem());
     } else {


### PR DESCRIPTION
## Summary

- filter internal agent configuration and handoff records at the OpenAI Realtime chat-context synchronization boundary
- prevent interrupted turns with skipped outputs from failing their never-played-message cleanup
- add regression coverage for both internal item types while preserving ordinary message synchronization

Closes #2115

## Testing

- `pnpm test plugins/openai/src --silent` (70 passed, 7 skipped)
- `pnpm build` (40 packages passed)
- `pnpm lint`
- `pnpm format:check`
- `pnpm exec changeset status`
- `git diff --check`
