### PR TITLE
fix(llm): ensure Google chats end with a user turn

### DIFF
--- a/.changeset/fair-google-turns.md
+++ b/.changeset/fair-google-turns.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Ensure Google chat formatting ends with a user turn when an empty trailing user message is omitted.

--- a/agents/src/llm/provider_format/google.test.ts
+++ b/agents/src/llm/provider_format/google.test.ts
@@ -536,6 +536,31 @@ describe('Google Provider Format - toChatCtx', () => {
     expect(formatData.systemMessages).toBeNull();
   });
 
+  it('should inject dummy user message when trailing user message is empty', async () => {
+    const ctx = ChatContext.empty();
+    ctx.addMessage({ role: 'user', content: 'Hello' });
+    ctx.addMessage({ role: 'assistant', content: 'Partial reply' });
+    ctx.addMessage({ role: 'user', content: '' });
+
+    const [result, formatData] = await toChatCtx(ctx, true);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        parts: [{ text: 'Hello' }],
+      },
+      {
+        role: 'model',
+        parts: [{ text: 'Partial reply' }],
+      },
+      {
+        role: 'user',
+        parts: [{ text: '.' }],
+      },
+    ]);
+    expect(formatData.systemMessages).toBeNull();
+  });
+
   it('should not inject dummy user message when disabled', async () => {
     const ctx = ChatContext.empty();
     ctx.addMessage({ role: 'user', content: 'Hello' });

--- a/agents/src/llm/provider_format/google.ts
+++ b/agents/src/llm/provider_format/google.ts
@@ -101,7 +101,7 @@ export async function toChatCtx(
   }
 
   // Gemini requires the last message to end with user's turn before they can generate
-  if (injectDummyUserMessage && currentRole !== 'user') {
+  if (injectDummyUserMessage && turns[turns.length - 1]?.role !== 'user') {
     turns.push({ role: 'user', parts: [{ text: '.' }] });
   }
 


### PR DESCRIPTION
## Summary

- decide Google dummy-user injection from the final serialized turn instead of the loop's last observed role
- preserve a trailing user turn when an empty interrupted message is omitted from the serialized payload
- add a regression test for the barge-in sequence reported in #2108

This PR only fixes trailing-turn serialization. It does not change Google API error retry classification.

Fixes #2108

## Testing

- `pnpm exec vitest run agents/src/llm/provider_format/google.test.ts` (27 passed)
- `pnpm exec vitest run agents/src --reporter=dot` (1,586 passed, 5 skipped)
- `pnpm --filter @livekit/agents typecheck`
- `pnpm build` (40 packages)
- ESLint and Prettier on changed files
- `pnpm exec changeset status`
