### PR TITLE
fix(deepgram): keep streaming audio while an utterance is in progress

### DIFF
--- a/.changeset/deepgram-keep-streaming-until-endpointed.md
+++ b/.changeset/deepgram-keep-streaming-until-endpointed.md
@@ -1,0 +1,7 @@
+---
+'@livekit/agents-plugin-deepgram': patch
+---
+
+Keep streaming audio to Deepgram while an utterance is in progress
+
+`AudioEnergyFilter` could stop forwarding frames after Deepgram had reported speech but before it had endpointed the utterance. Deepgram only fires `endpointing` on silence it actually receives, so once starved it never sent `speech_final`, no final transcript arrived, and the turn was never committed. `SpeechStream` now bypasses the energy gate between start of speech and endpoint, and clears that state when a websocket session starts so a reconnect cannot inherit an unfinished utterance.

--- a/plugins/deepgram/src/stt.test.ts
+++ b/plugins/deepgram/src/stt.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { stt as agentStt } from '@livekit/agents';
 import { VAD } from '@livekit/agents-plugin-silero';
 import { stt } from '@livekit/agents-plugins-test';
 import { AudioFrame } from '@livekit/rtc-node';
@@ -8,6 +9,7 @@ import { once } from 'node:events';
 import type { AddressInfo } from 'node:net';
 import { describe, expect, it } from 'vitest';
 import { WebSocketServer } from 'ws';
+import type { SpeechStream } from './stt.js';
 import { STT } from './stt.js';
 
 const hasDeepgramApiKey = Boolean(process.env.DEEPGRAM_API_KEY);
@@ -94,6 +96,119 @@ describe('Deepgram streaming flush', () => {
       stream.pushFrame(makeFrame(480));
       stream.flush();
       await waitUntil(() => wire.join(',') === 'audio,Finalize');
+    } finally {
+      stream.close();
+      await closeWebSocketServer(wss);
+    }
+  });
+});
+
+describe('Deepgram energy gating', () => {
+  // 100ms at 16kHz, exactly one JS repack chunk. makeFrame is far below the energy
+  // filter's RMS threshold, so these only pass the gate while the cooldown lasts.
+  const FRAME_SAMPLES = 1600;
+  // Longer than the filter's one second cooldown, so the gate closes partway through.
+  const QUIET_FRAMES = 15;
+
+  const countAudio = (wire: string[]) => wire.filter((entry) => entry === 'audio').length;
+
+  function collectEvents(stream: SpeechStream): agentStt.SpeechEventType[] {
+    const types: agentStt.SpeechEventType[] = [];
+    void (async () => {
+      try {
+        for await (const event of stream) types.push(event.type);
+      } catch {
+        // the stream throws on close, which every test does in its finally block
+      }
+    })();
+    return types;
+  }
+
+  it('stops sending low-energy audio once the cooldown elapses', async () => {
+    const { wss, baseUrl } = await startWebSocketServer();
+    const wire: string[] = [];
+    wss.on('connection', (ws) => {
+      ws.on('message', (data, isBinary) => {
+        wire.push(isBinary ? 'audio' : (JSON.parse(data.toString()) as { type: string }).type);
+      });
+    });
+
+    const stream = new STT({ apiKey: 'test-key', baseUrl }).stream();
+    try {
+      for (let i = 0; i < QUIET_FRAMES; i++) stream.pushFrame(makeFrame(FRAME_SAMPLES));
+      // Finalize is ordered behind every frame already sent, so it is a barrier.
+      stream.flush();
+      await waitUntil(() => wire.includes('Finalize'));
+
+      expect(countAudio(wire)).toBeLessThan(QUIET_FRAMES);
+    } finally {
+      stream.close();
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('keeps sending low-energy audio while an utterance is in progress', async () => {
+    const { wss, baseUrl } = await startWebSocketServer();
+    const wire: string[] = [];
+    wss.on('connection', (ws) => {
+      ws.on('message', (data, isBinary) => {
+        wire.push(isBinary ? 'audio' : (JSON.parse(data.toString()) as { type: string }).type);
+        // Announced on the first frame rather than on connection: the plugin only
+        // attaches its message listener once the socket is open, so anything sent
+        // before it has sent audio is dropped.
+        if (countAudio(wire) === 1) ws.send(JSON.stringify({ type: 'SpeechStarted' }));
+      });
+    });
+
+    const stream = new STT({ apiKey: 'test-key', baseUrl }).stream();
+    const events = collectEvents(stream);
+    try {
+      stream.pushFrame(makeFrame(FRAME_SAMPLES));
+      await waitUntil(() => events.includes(agentStt.SpeechEventType.START_OF_SPEECH));
+
+      for (let i = 0; i < QUIET_FRAMES; i++) stream.pushFrame(makeFrame(FRAME_SAMPLES));
+      stream.flush();
+      await waitUntil(() => wire.includes('Finalize'));
+
+      expect(countAudio(wire)).toBe(QUIET_FRAMES + 1);
+    } finally {
+      stream.close();
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('does not carry an unfinished utterance into a reconnected websocket', async () => {
+    const { wss, baseUrl } = await startWebSocketServer();
+    const wires: string[][] = [];
+    wss.on('connection', (ws) => {
+      const wire: string[] = [];
+      wires.push(wire);
+      // Only the first connection reports speech; the reconnect never hears about it.
+      const announcesSpeech = wires.length === 1;
+      ws.on('message', (data, isBinary) => {
+        wire.push(isBinary ? 'audio' : (JSON.parse(data.toString()) as { type: string }).type);
+        if (announcesSpeech && countAudio(wire) === 1) {
+          ws.send(JSON.stringify({ type: 'SpeechStarted' }));
+        }
+      });
+    });
+
+    const stream = new STT({ apiKey: 'test-key', baseUrl }).stream();
+    const events = collectEvents(stream);
+    try {
+      stream.pushFrame(makeFrame(FRAME_SAMPLES));
+      await waitUntil(() => events.includes(agentStt.SpeechEventType.START_OF_SPEECH));
+
+      // Reconnects mid-utterance, without Deepgram ever endpointing it.
+      stream.updateOptions({ keyterm: ['livekit'] });
+      await waitUntil(() => wires.length === 2);
+
+      // Finalize on the new socket proves its send loop is running.
+      stream.pushFrame(makeFrame(FRAME_SAMPLES));
+      stream.flush();
+      await waitUntil(() => wires[1]!.includes('Finalize'));
+
+      expect(stream._speaking).toBe(false);
     } finally {
       stream.close();
       await closeWebSocketServer(wss);

--- a/plugins/deepgram/src/stt.ts
+++ b/plugins/deepgram/src/stt.ts
@@ -375,6 +375,7 @@ export class SpeechStream extends stt.SpeechStream {
 
   async #runWS(ws: WebSocket) {
     this.#resetWS = new Future();
+    this.#speaking = false;
     let closing = false;
 
     const keepalive = setInterval(() => {
@@ -438,7 +439,8 @@ export class SpeechStream extends stt.SpeechStream {
           }
 
           for await (const frame of frames) {
-            if (this.#audioEnergyFilter.pushFrame(frame)) {
+            const energyGateOpen = this.#audioEnergyFilter.pushFrame(frame);
+            if (this.#speaking || energyGateOpen) {
               const frameDuration = frame.samplesPerChannel / frame.sampleRate;
               this.#audioDurationCollector.push(frameDuration);
               ws.send(frame.data.buffer);


### PR DESCRIPTION
## Description

Fixes #2242.

`AudioEnergyFilter` stops forwarding frames once its cooldown elapses with no audio above the RMS threshold. Deepgram only fires `endpointing` on silence it actually receives, so when the gate closed after Deepgram had reported speech but before it had endpointed the utterance, `speech_final` never arrived. The pending final was only flushed when the speaker started talking again, and until then `audio_recognition` had no transcript to commit the turn with - `runEOUDetection` skips on an empty `audioTranscript`, so the agent sat silent until `userAwayTimeout` fired 15s later.

## Changes Made

- `plugins/deepgram/src/stt.ts` - bypass the energy gate while an utterance is in flight, using the existing `#speaking` flag (set on `SpeechStarted` or the first non-empty result, cleared on `speech_final`/`UtteranceEnd`).
- `plugins/deepgram/src/stt.ts` - reset `#speaking` at the start of `#runWS`. This is a pre-existing leak (`updateOptions()` resolves `#resetWS` and forces a reconnect, e.g. via deferred keyterm updates), but the bypass above raises its cost from a stale flag to the gate being bypassed for the rest of the session. `plugins/sarvam/src/stt.ts` already resets its equivalent flag per session; this matches it.
- `plugins/deepgram/src/stt.test.ts` - three regression tests on the existing local-websocket harness.

## Pre-Review Checklist
- [x] **Build passes**: `build`, `lint` and the deepgram test file pass.
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**:  no user-facing surface to demo. The failure is a timing race on the STT socket; the regression tests below capture it deterministically instead.

## Testing

- [x] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

Three tests added to `plugins/deepgram/src/stt.test.ts`, using the existing `WebSocketServer` harness.

1. `stops sending low-energy audio once the cooldown elapses` - pins the existing gating behaviour, so the fix can't silently disable the filter.
2. `keeps sending low-energy audio while an utterance is in progress` - the fix itself.
3. `does not carry an unfinished utterance into a reconnected websocket` -  the `#runWS` reset. Asserts `_speaking` is false after a reconnect triggered mid-utterance by `updateOptions`.

## Additional Notes

**Test 3 asserts on `_speaking`, which is `@internal`.** It's the most direct deterministic signal for the reconnect case. I first tried asserting on forwarded-frame counts, but reconnection drops frames on its own, so the signal was 4 vs 7 frames rather than 4 vs 15 — too timing-dependent to assert on without flake. Happy to change the approach if you'd rather not have a test reach for that getter.

**Billing.** More audio is forwarded between gate-close and endpoint - normally a few hundred milliseconds per utterance. The duration collector only counts sent frames, so reported recognition usage reflects it. The `#runWS` reset is what bounds this: without it a stuck `#speaking` would forward audio indefinitely.

I marked the changeset `patch`. It is a bugfix, but it does change audio-forwarding behaviour for every Deepgram streaming user, so say the word if you'd rather it were a minor.
