### PR TITLE
fix(voice): honor empty synchronized transcript on interrupted replies

### DIFF
--- a/.changeset/spotty-teeth-hammer.md
+++ b/.changeset/spotty-teeth-hammer.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(voice): don't commit unspoken text when a reply is interrupted before the transcript synchronizer released any words — an empty (but defined) synchronizedTranscript now means nothing was heard, instead of falling back to the full generated text

--- a/agents/src/voice/agent_activity_interrupted_commit.test.ts
+++ b/agents/src/voice/agent_activity_interrupted_commit.test.ts
@@ -43,6 +43,38 @@ class InterruptibleOutput extends AudioOutput {
   }
 }
 
+// Audio sink that mimics a sync-capable output (RoomIO wrapped by a
+// TranscriptSynchronizer): the playback-finished event triggered by the
+// interruption's clearBuffer always carries a synchronizedTranscript STRING —
+// the words actually released downstream so far. It is '' (not undefined) when
+// the caller barged in before the synchronizer released any words.
+class SyncedInterruptibleOutput extends AudioOutput {
+  onFirstFrame?: () => void;
+  synchronizedTranscript = '';
+  private started = false;
+  constructor() {
+    super(24000);
+  }
+  async captureFrame(f: AudioFrame): Promise<void> {
+    await super.captureFrame(f);
+    if (!this.started) {
+      this.started = true;
+      this.onPlaybackStarted(Date.now());
+      this.onFirstFrame?.();
+    }
+  }
+  flush(): void {
+    super.flush();
+  }
+  clearBuffer(): void {
+    this.onPlaybackFinished({
+      playbackPosition: 0.02,
+      interrupted: true,
+      synchronizedTranscript: this.synchronizedTranscript,
+    });
+  }
+}
+
 // Audio sink that mimics a DataStream avatar output (waitPlaybackStart: true):
 // frames are accepted faster than real time and playback-started is only
 // reported LATER, via an out-of-band notification (the `lk.playback_started`
@@ -225,6 +257,77 @@ describe('AgentActivity interrupted-speech commit', () => {
       expect(msg.interrupted).toBe(true);
       expect(msg.content.length).toBeGreaterThan(0);
       expect('A fairly long spoken reply.'.startsWith(msg.content)).toBe(true);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('does not commit an interrupted reply when the synchronizer reports an empty transcript (nothing heard)', async () => {
+    const session = new AgentSession({
+      llm: new FakeLLM([{ input: 'hello', content: 'A fairly long spoken reply.' }]),
+    });
+    const audioOut = new SyncedInterruptibleOutput();
+    audioOut.synchronizedTranscript = '';
+    session.output.audio = audioOut;
+    // Barge in on the very first frame — before the synchronizer has released
+    // any words downstream, so its transcript is '' (defined, but empty).
+    audioOut.onFirstFrame = () => session.interrupt({ force: true });
+
+    const assistantMessages: { content: string; interrupted: boolean }[] = [];
+    session.on(AgentSessionEventTypes.ConversationItemAdded, (ev: ConversationItemAddedEvent) => {
+      if (ev.item.type === 'message' && ev.item.role === 'assistant') {
+        assistantMessages.push({
+          content: ev.item.textContent ?? '',
+          interrupted: !!ev.item.interrupted,
+        });
+      }
+    });
+
+    await session.start({ agent: new FrameAgent() });
+    try {
+      const handle = session.generateReply({ userInput: 'hello' });
+      await handle.waitForPlayout();
+
+      // Close drains the reply task fully — the interrupted-commit block has
+      // fired by the time close resolves. The synchronizer said nothing was
+      // heard: committing the full generated text would fabricate a reply
+      // (phantom utterance) in both chat ctx and the transcript.
+      await session.close();
+      expect(assistantMessages).toHaveLength(0);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('commits exactly the synchronized transcript when the caller heard a partial prefix', async () => {
+    const session = new AgentSession({
+      llm: new FakeLLM([{ input: 'hello', content: 'A fairly long spoken reply.' }]),
+    });
+    const audioOut = new SyncedInterruptibleOutput();
+    audioOut.synchronizedTranscript = 'A fairly';
+    session.output.audio = audioOut;
+    audioOut.onFirstFrame = () => session.interrupt({ force: true });
+
+    const assistantMessages: { content: string; interrupted: boolean }[] = [];
+    session.on(AgentSessionEventTypes.ConversationItemAdded, (ev: ConversationItemAddedEvent) => {
+      if (ev.item.type === 'message' && ev.item.role === 'assistant') {
+        assistantMessages.push({
+          content: ev.item.textContent ?? '',
+          interrupted: !!ev.item.interrupted,
+        });
+      }
+    });
+
+    await session.start({ agent: new FrameAgent() });
+    try {
+      const handle = session.generateReply({ userInput: 'hello' });
+      await handle.waitForPlayout();
+      await vi.waitFor(() => expect(assistantMessages.length).toBeGreaterThan(0));
+
+      // The synchronizer's transcript is authoritative: only the words that
+      // actually played may be committed, never the full generated text.
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0]).toEqual({ content: 'A fairly', interrupted: true });
     } finally {
       await session.close();
     }

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -940,14 +940,18 @@ export interface _AudioOut {
 /**
  * The text that actually reached the user, accounting for interruptions.
  *
- * On a mid-playout interruption (`played === 'partial'`) we prefer the
- * playback-aligned `synchronizedTranscript`, but fall back to the full generated
- * text when no synchronized transcript is available (e.g. avatar outputs) so the
- * heard reply is still committed to chat ctx rather than dropped.
+ * On a mid-playout interruption (`played === 'partial'`) the playback-aligned
+ * `synchronizedTranscript` is authoritative whenever the output reported one.
+ * A sync-capable output (e.g. RoomIO wrapped by a TranscriptSynchronizer)
+ * always attaches a string — `''` means the user barged in before any word
+ * was released, so committing the generated text would fabricate a reply the
+ * user never heard. Only when the transcript is `undefined` (no synchronizer
+ * in the chain, e.g. avatar outputs) do we fall back to the full generated
+ * text so the heard reply is still committed to chat ctx rather than dropped.
  */
 export function forwardedTextFor(output: ForwardOutput): string {
   if (output.played === 'skipped') return '';
-  if (output.played === 'partial' && output.synchronizedTranscript) {
+  if (output.played === 'partial' && output.synchronizedTranscript !== undefined) {
     return output.synchronizedTranscript;
   }
   return output.textOut?.text ?? '';


### PR DESCRIPTION
## What



---

_Downstream deployment (internal, ships this as a pnpm patch until released): pairteam/ai#1169_
