### PR TITLE
fix(voice): one ChatItem serializer that carries every declared field

### DIFF
--- a/.changeset/chat-item-proto-coverage.md
+++ b/.changeset/chat-item-proto-coverage.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Send every field the agent_session wire format declares for chat items, and emit the telemetry chat item log with the same field names and shapes as livekit/agents.

--- a/agents/src/proto.ts
+++ b/agents/src/proto.ts
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Timestamp } from '@bufbuild/protobuf';
 import { AgentSession as pb } from '@livekit/protocol';
-import type { ChatItem } from './llm/chat_context.js';
-import { isInstructions } from './llm/chat_context.js';
+import type { ChatItem, MetricsReport } from './llm/chat_context.js';
+import { isInstructions, renderInstructions } from './llm/chat_context.js';
 
 /**
  * Mapping between the SDK's own types and the agent_session wire format.
@@ -13,24 +13,40 @@ import { isInstructions } from './llm/chat_context.js';
  * on the wire can share one implementation.
  */
 
-export type RemoteChatItem = Exclude<ChatItem, { type: 'agent_config_update' }>;
+const ROLE_MAP: Record<string, pb.ChatRole> = {
+  developer: pb.ChatRole.DEVELOPER,
+  system: pb.ChatRole.SYSTEM,
+  user: pb.ChatRole.USER,
+  assistant: pb.ChatRole.ASSISTANT,
+};
 
 export function msToTimestamp(ms: number): Timestamp {
   return Timestamp.fromDate(new Date(ms));
 }
 
-export function chatItemToProto(item: RemoteChatItem): pb.ChatContext_ChatItem {
+function encodeMetrics(metrics: MetricsReport): pb.MetricsReport {
+  const report = new pb.MetricsReport();
+  // wall-clock metrics are seconds here and Timestamps on the wire
+  if (metrics.startedSpeakingAt !== undefined)
+    report.startedSpeakingAt = msToTimestamp(metrics.startedSpeakingAt * 1000);
+  if (metrics.stoppedSpeakingAt !== undefined)
+    report.stoppedSpeakingAt = msToTimestamp(metrics.stoppedSpeakingAt * 1000);
+  if (metrics.transcriptionDelay !== undefined)
+    report.transcriptionDelay = metrics.transcriptionDelay;
+  if (metrics.endOfTurnDelay !== undefined) report.endOfTurnDelay = metrics.endOfTurnDelay;
+  if (metrics.onUserTurnCompletedDelay !== undefined)
+    report.onUserTurnCompletedDelay = metrics.onUserTurnCompletedDelay;
+  if (metrics.llmNodeTtft !== undefined) report.llmNodeTtft = metrics.llmNodeTtft;
+  if (metrics.ttsNodeTtfb !== undefined) report.ttsNodeTtfb = metrics.ttsNodeTtfb;
+  if (metrics.e2eLatency !== undefined) report.e2eLatency = metrics.e2eLatency;
+  return report;
+}
+
+export function encodeChatItem(item: ChatItem): pb.ChatContext_ChatItem {
   switch (item.type) {
     case 'message': {
-      const msg = item;
-      const roleMap: Record<string, pb.ChatRole> = {
-        developer: pb.ChatRole.DEVELOPER,
-        system: pb.ChatRole.SYSTEM,
-        user: pb.ChatRole.USER,
-        assistant: pb.ChatRole.ASSISTANT,
-      };
       const content: pb.ChatMessage_ChatContent[] = [];
-      for (const c of msg.content) {
+      for (const c of item.content) {
         if (typeof c === 'string') {
           content.push(new pb.ChatMessage_ChatContent({ payload: { case: 'text', value: c } }));
         } else if (isInstructions(c)) {
@@ -40,76 +56,73 @@ export function chatItemToProto(item: RemoteChatItem): pb.ChatContext_ChatItem {
         }
       }
 
-      const metricsReport = new pb.MetricsReport();
-      if (msg.metrics.transcriptionDelay !== undefined)
-        metricsReport.transcriptionDelay = msg.metrics.transcriptionDelay;
-      if (msg.metrics.endOfTurnDelay !== undefined)
-        metricsReport.endOfTurnDelay = msg.metrics.endOfTurnDelay;
-      if (msg.metrics.onUserTurnCompletedDelay !== undefined)
-        metricsReport.onUserTurnCompletedDelay = msg.metrics.onUserTurnCompletedDelay;
-      if (msg.metrics.llmNodeTtft !== undefined)
-        metricsReport.llmNodeTtft = msg.metrics.llmNodeTtft;
-      if (msg.metrics.ttsNodeTtfb !== undefined)
-        metricsReport.ttsNodeTtfb = msg.metrics.ttsNodeTtfb;
-      if (msg.metrics.e2eLatency !== undefined) metricsReport.e2eLatency = msg.metrics.e2eLatency;
-
       const pbMsg = new pb.ChatMessage({
-        id: msg.id,
-        role: roleMap[msg.role] ?? pb.ChatRole.ASSISTANT,
+        id: item.id,
+        role: ROLE_MAP[item.role] ?? pb.ChatRole.ASSISTANT,
         content,
-        interrupted: msg.interrupted,
-        metrics: metricsReport,
-        createdAt: msToTimestamp(msg.createdAt),
+        interrupted: item.interrupted,
+        metrics: encodeMetrics(item.metrics),
+        // the proto map is <string, string>; livekit/agents coerces the same way
+        extra: Object.fromEntries(Object.entries(item.extra).map(([k, v]) => [k, String(v)])),
+        createdAt: msToTimestamp(item.createdAt),
       });
-      if (msg.transcriptConfidence !== undefined) {
-        pbMsg.transcriptConfidence = msg.transcriptConfidence;
+      if (item.transcriptConfidence !== undefined) {
+        pbMsg.transcriptConfidence = item.transcriptConfidence;
       }
       return new pb.ChatContext_ChatItem({ item: { case: 'message', value: pbMsg } });
     }
-    case 'function_call': {
-      const fc = item;
+    case 'function_call':
       return new pb.ChatContext_ChatItem({
         item: {
           case: 'functionCall',
           value: new pb.FunctionCall({
-            id: fc.id,
-            callId: fc.callId,
-            name: fc.name,
-            arguments: fc.args,
-            createdAt: msToTimestamp(fc.createdAt),
+            id: item.id,
+            callId: item.callId,
+            name: item.name,
+            arguments: item.args,
+            createdAt: msToTimestamp(item.createdAt),
           }),
         },
       });
-    }
-    case 'function_call_output': {
-      const fco = item;
+    case 'function_call_output':
       return new pb.ChatContext_ChatItem({
         item: {
           case: 'functionCallOutput',
           value: new pb.FunctionCallOutput({
-            id: fco.id,
-            callId: fco.callId,
-            name: fco.name,
-            output: fco.output,
-            isError: fco.isError,
-            createdAt: msToTimestamp(fco.createdAt),
+            id: item.id,
+            callId: item.callId,
+            name: item.name,
+            output: item.output,
+            isError: item.isError,
+            createdAt: msToTimestamp(item.createdAt),
           }),
         },
       });
-    }
-    case 'agent_handoff': {
-      const ah = item;
+    case 'agent_handoff':
       return new pb.ChatContext_ChatItem({
         item: {
           case: 'agentHandoff',
           value: new pb.AgentHandoff({
-            id: ah.id,
-            oldAgentId: ah.oldAgentId,
-            newAgentId: ah.newAgentId,
-            createdAt: msToTimestamp(ah.createdAt),
+            id: item.id,
+            oldAgentId: item.oldAgentId,
+            newAgentId: item.newAgentId,
+            createdAt: msToTimestamp(item.createdAt),
           }),
         },
       });
-    }
+    case 'agent_config_update':
+      return new pb.ChatContext_ChatItem({
+        item: {
+          case: 'agentConfigUpdate',
+          value: new pb.AgentConfigUpdate({
+            id: item.id,
+            instructions:
+              item.instructions !== undefined ? renderInstructions(item.instructions) : undefined,
+            toolsAdded: item.toolsAdded,
+            toolsRemoved: item.toolsRemoved,
+            createdAt: msToTimestamp(item.createdAt),
+          }),
+        },
+      });
   }
 }

--- a/agents/src/proto.ts
+++ b/agents/src/proto.ts
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { Timestamp } from '@bufbuild/protobuf';
+import { AgentSession as pb } from '@livekit/protocol';
+import type { ChatItem } from './llm/chat_context.js';
+import { isInstructions } from './llm/chat_context.js';
+
+/**
+ * Mapping between the SDK's own types and the agent_session wire format.
+ *
+ * A leaf: nothing here imports voice or telemetry, so every path that puts a ChatItem
+ * on the wire can share one implementation.
+ */
+
+export type RemoteChatItem = Exclude<ChatItem, { type: 'agent_config_update' }>;
+
+export function msToTimestamp(ms: number): Timestamp {
+  return Timestamp.fromDate(new Date(ms));
+}
+
+export function chatItemToProto(item: RemoteChatItem): pb.ChatContext_ChatItem {
+  switch (item.type) {
+    case 'message': {
+      const msg = item;
+      const roleMap: Record<string, pb.ChatRole> = {
+        developer: pb.ChatRole.DEVELOPER,
+        system: pb.ChatRole.SYSTEM,
+        user: pb.ChatRole.USER,
+        assistant: pb.ChatRole.ASSISTANT,
+      };
+      const content: pb.ChatMessage_ChatContent[] = [];
+      for (const c of msg.content) {
+        if (typeof c === 'string') {
+          content.push(new pb.ChatMessage_ChatContent({ payload: { case: 'text', value: c } }));
+        } else if (isInstructions(c)) {
+          content.push(
+            new pb.ChatMessage_ChatContent({ payload: { case: 'text', value: c.value } }),
+          );
+        }
+      }
+
+      const metricsReport = new pb.MetricsReport();
+      if (msg.metrics.transcriptionDelay !== undefined)
+        metricsReport.transcriptionDelay = msg.metrics.transcriptionDelay;
+      if (msg.metrics.endOfTurnDelay !== undefined)
+        metricsReport.endOfTurnDelay = msg.metrics.endOfTurnDelay;
+      if (msg.metrics.onUserTurnCompletedDelay !== undefined)
+        metricsReport.onUserTurnCompletedDelay = msg.metrics.onUserTurnCompletedDelay;
+      if (msg.metrics.llmNodeTtft !== undefined)
+        metricsReport.llmNodeTtft = msg.metrics.llmNodeTtft;
+      if (msg.metrics.ttsNodeTtfb !== undefined)
+        metricsReport.ttsNodeTtfb = msg.metrics.ttsNodeTtfb;
+      if (msg.metrics.e2eLatency !== undefined) metricsReport.e2eLatency = msg.metrics.e2eLatency;
+
+      const pbMsg = new pb.ChatMessage({
+        id: msg.id,
+        role: roleMap[msg.role] ?? pb.ChatRole.ASSISTANT,
+        content,
+        interrupted: msg.interrupted,
+        metrics: metricsReport,
+        createdAt: msToTimestamp(msg.createdAt),
+      });
+      if (msg.transcriptConfidence !== undefined) {
+        pbMsg.transcriptConfidence = msg.transcriptConfidence;
+      }
+      return new pb.ChatContext_ChatItem({ item: { case: 'message', value: pbMsg } });
+    }
+    case 'function_call': {
+      const fc = item;
+      return new pb.ChatContext_ChatItem({
+        item: {
+          case: 'functionCall',
+          value: new pb.FunctionCall({
+            id: fc.id,
+            callId: fc.callId,
+            name: fc.name,
+            arguments: fc.args,
+            createdAt: msToTimestamp(fc.createdAt),
+          }),
+        },
+      });
+    }
+    case 'function_call_output': {
+      const fco = item;
+      return new pb.ChatContext_ChatItem({
+        item: {
+          case: 'functionCallOutput',
+          value: new pb.FunctionCallOutput({
+            id: fco.id,
+            callId: fco.callId,
+            name: fco.name,
+            output: fco.output,
+            isError: fco.isError,
+            createdAt: msToTimestamp(fco.createdAt),
+          }),
+        },
+      });
+    }
+    case 'agent_handoff': {
+      const ah = item;
+      return new pb.ChatContext_ChatItem({
+        item: {
+          case: 'agentHandoff',
+          value: new pb.AgentHandoff({
+            id: ah.id,
+            oldAgentId: ah.oldAgentId,
+            newAgentId: ah.newAgentId,
+            createdAt: msToTimestamp(ah.createdAt),
+          }),
+        },
+      });
+    }
+  }
+}

--- a/agents/src/telemetry/traces.ts
+++ b/agents/src/telemetry/traces.ts
@@ -29,10 +29,10 @@ import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import FormData from 'form-data';
 import { AccessToken } from 'livekit-server-sdk';
 import fs from 'node:fs/promises';
-import { isInstructions, renderInstructions } from '../llm/chat_context.js';
-import type { ChatContent, ChatItem, ChatRole } from '../llm/index.js';
+import type { ChatItem } from '../llm/index.js';
 import { enableOtelLogging } from '../log.js';
 import { filterZeroValues } from '../metrics/model_usage.js';
+import { encodeChatItem } from '../proto.js';
 import {
   ATTRIBUTE_REDACTION_ENABLED,
   ATTRIBUTE_SIMULATION_ENABLED,
@@ -518,217 +518,9 @@ export async function flushOtelLogs(): Promise<void> {
   await flushPinoLogs();
 }
 
-/** Proto-compatible role enum values. */
-type ProtoRole = 'DEVELOPER' | 'SYSTEM' | 'USER' | 'ASSISTANT';
-
-const ROLE_MAP: Record<ChatRole, ProtoRole> = {
-  developer: 'DEVELOPER',
-  system: 'SYSTEM',
-  user: 'USER',
-  assistant: 'ASSISTANT',
-};
-
-interface ProtoMetricsReport {
-  startedSpeakingAt?: string;
-  stoppedSpeakingAt?: string;
-  transcriptionDelay?: number;
-  endOfTurnDelay?: number;
-  onUserTurnCompletedDelay?: number;
-  llmNodeTtft?: number;
-  ttsNodeTtfb?: number;
-  playbackLatency?: number;
-  e2eLatency?: number;
-}
-
-interface ProtoMessage {
-  id: string;
-  role: ProtoRole;
-  content: { text: ChatContent }[];
-  createdAt: string;
-  interrupted?: boolean;
-  extra?: Record<string, unknown>;
-  transcriptConfidence?: number;
-  metrics?: ProtoMetricsReport;
-}
-
-interface ProtoFunctionCall {
-  id: string;
-  callId: string;
-  arguments: string | Record<string, unknown>;
-  name: string;
-  createdAt: string;
-}
-
-interface ProtoFunctionCallOutput {
-  id: string;
-  name: string;
-  callId: string;
-  output: string;
-  isError: boolean;
-  createdAt: string;
-}
-
-interface ProtoAgentHandoff {
-  id: string;
-  newAgentId: string;
-  createdAt: string;
-  oldAgentId?: string;
-}
-
-interface ProtoAgentConfigUpdate {
-  id: string;
-  createdAt: string;
-  instructions?: string;
-  toolsAdded?: string[];
-  toolsRemoved?: string[];
-}
-
-interface ProtoChatItem {
-  message?: ProtoMessage;
-  functionCall?: ProtoFunctionCall;
-  functionCallOutput?: ProtoFunctionCallOutput;
-  agentHandoff?: ProtoAgentHandoff;
-  agentConfigUpdate?: ProtoAgentConfigUpdate;
-}
-
-/**
- * Convert ChatItem to proto-compatible dictionary format.
- * TODO: Use actual agent_session proto types once livekit/protocol v1.43.1+ is published
- */
-function chatItemToProto(item: ChatItem): ProtoChatItem {
-  const itemDict: ProtoChatItem = {};
-
-  if (item.type === 'message') {
-    const msg: ProtoMessage = {
-      id: item.id,
-      role: ROLE_MAP[item.role] ?? (item.role.toUpperCase() as ProtoRole),
-      // Match Python's `_build_proto_chat_item`: only string content is uploaded.
-      // Non-string content (image/audio) must not leak into the wire format —
-      // the ChatContent proto's `text` field is a string, and non-string values
-      // render as garbage in the dashboard.
-      content: item.content
-        .filter((c: ChatContent) => typeof c === 'string' || isInstructions(c))
-        .map((c) => ({
-          text: isInstructions(c) ? c.value : (c as string),
-        })),
-      createdAt: toRFC3339(item.createdAt),
-    };
-
-    if (item.interrupted) {
-      msg.interrupted = item.interrupted;
-    }
-
-    if (item.extra && Object.keys(item.extra).length > 0) {
-      msg.extra = item.extra;
-    }
-
-    if (item.transcriptConfidence !== undefined) {
-      msg.transcriptConfidence = item.transcriptConfidence;
-    }
-
-    const metrics = item.metrics;
-    if (metrics && Object.keys(metrics).length > 0) {
-      const protoMetrics: ProtoMetricsReport = {};
-      if (metrics.startedSpeakingAt !== undefined) {
-        protoMetrics.startedSpeakingAt = toRFC3339(metrics.startedSpeakingAt * 1000);
-      }
-      if (metrics.stoppedSpeakingAt !== undefined) {
-        protoMetrics.stoppedSpeakingAt = toRFC3339(metrics.stoppedSpeakingAt * 1000);
-      }
-      if (metrics.transcriptionDelay !== undefined) {
-        protoMetrics.transcriptionDelay = metrics.transcriptionDelay;
-      }
-      if (metrics.endOfTurnDelay !== undefined) {
-        protoMetrics.endOfTurnDelay = metrics.endOfTurnDelay;
-      }
-      if (metrics.onUserTurnCompletedDelay !== undefined) {
-        protoMetrics.onUserTurnCompletedDelay = metrics.onUserTurnCompletedDelay;
-      }
-      if (metrics.llmNodeTtft !== undefined) {
-        protoMetrics.llmNodeTtft = metrics.llmNodeTtft;
-      }
-      if (metrics.ttsNodeTtfb !== undefined) {
-        protoMetrics.ttsNodeTtfb = metrics.ttsNodeTtfb;
-      }
-      if (metrics.playbackLatency !== undefined) {
-        protoMetrics.playbackLatency = metrics.playbackLatency;
-      }
-      if (metrics.e2eLatency !== undefined) {
-        protoMetrics.e2eLatency = metrics.e2eLatency;
-      }
-      msg.metrics = protoMetrics;
-    }
-
-    itemDict.message = msg;
-  } else if (item.type === 'function_call') {
-    itemDict.functionCall = {
-      id: item.id,
-      callId: item.callId,
-      arguments: item.args,
-      name: item.name,
-      createdAt: toRFC3339(item.createdAt),
-    };
-  } else if (item.type === 'function_call_output') {
-    itemDict.functionCallOutput = {
-      id: item.id,
-      name: item.name,
-      callId: item.callId,
-      output: item.output,
-      isError: item.isError,
-      createdAt: toRFC3339(item.createdAt),
-    };
-  } else if (item.type === 'agent_handoff') {
-    const handoff: ProtoAgentHandoff = {
-      id: item.id,
-      newAgentId: item.newAgentId,
-      createdAt: toRFC3339(item.createdAt),
-    };
-    if (item.oldAgentId !== undefined && item.oldAgentId !== null && item.oldAgentId !== '') {
-      handoff.oldAgentId = item.oldAgentId;
-    }
-    itemDict.agentHandoff = handoff;
-  } else if (item.type === 'agent_config_update') {
-    const configUpdate: ProtoAgentConfigUpdate = {
-      id: item.id,
-      createdAt: toRFC3339(item.createdAt),
-    };
-    if (item.instructions !== undefined) {
-      configUpdate.instructions = renderInstructions(item.instructions);
-    }
-    if (item.toolsAdded !== undefined) {
-      configUpdate.toolsAdded = item.toolsAdded;
-    }
-    if (item.toolsRemoved !== undefined) {
-      configUpdate.toolsRemoved = item.toolsRemoved;
-    }
-    itemDict.agentConfigUpdate = configUpdate;
-  }
-
-  try {
-    if (item.type === 'function_call' && typeof itemDict.functionCall?.arguments === 'string') {
-      itemDict.functionCall.arguments = JSON.parse(itemDict.functionCall.arguments);
-    } else if (
-      item.type === 'function_call_output' &&
-      typeof itemDict.functionCallOutput?.output === 'string'
-    ) {
-      itemDict.functionCallOutput.output = JSON.parse(itemDict.functionCallOutput.output);
-    }
-  } catch {
-    // ignore parsing errors
-  }
-
-  return itemDict;
-}
-
-/**
- * Convert timestamp to RFC3339 format
- */
-function toRFC3339(valueMs: number | Date): string {
-  // valueMs is already in milliseconds (from Date.now())
-  const dt = valueMs instanceof Date ? valueMs : new Date(valueMs);
-  // Truncate sub-millisecond precision
-  const truncated = new Date(Math.floor(dt.getTime()));
-  return truncated.toISOString();
+/** Proto field names and shapes, matching what livekit/agents emits for the same log body. */
+function chatItemSpanAttribute(item: ChatItem): Record<string, unknown> {
+  return encodeChatItem(item).toJson({ useProtoFieldName: true }) as Record<string, unknown>;
 }
 
 /**
@@ -809,7 +601,7 @@ export async function uploadSessionReport(options: {
     }
     lastTimestamp = itemTimestamp;
 
-    const itemProto = chatItemToProto(item);
+    const itemProto = chatItemSpanAttribute(item);
     let severityNumber = SeverityNumber.UNSPECIFIED;
     let severityText = 'unspecified';
 

--- a/agents/src/voice/chat_item_proto_coverage.test.ts
+++ b/agents/src/voice/chat_item_proto_coverage.test.ts
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { Message } from '@bufbuild/protobuf';
+import { AgentSession as pb } from '@livekit/protocol';
+import { describe, expect, it } from 'vitest';
+import {
+  AgentConfigUpdate,
+  AgentHandoffItem,
+  type ChatItem,
+  ChatMessage,
+  FunctionCall,
+  FunctionCallOutput,
+} from '../llm/chat_context.js';
+import { encodeChatItem } from '../proto.js';
+
+const TS = 1_700_000_000_500;
+
+// Fields the wire format declares but this SDK cannot supply yet. An entry here is a
+// deliberate parity gap; anything else missing is an accidental drop.
+const KNOWN_GAPS = new Set([
+  // llm tps/ttfs land in livekit/agents (#6373) but were never ported to this SDK,
+  // so MetricsReport has no field to read them from.
+  'metrics.llm_node_tps',
+  'metrics.llm_node_ttfs',
+]);
+
+// Every field carries a non-default value: a proto3 scalar left at its zero value is
+// indistinguishable from one the serializer never assigned.
+const SATURATED_ITEMS: ChatItem[] = [
+  new ChatMessage({
+    id: 'item_msg',
+    role: 'user',
+    content: ['hello'],
+    interrupted: true,
+    transcriptConfidence: 0.75,
+    extra: { key: 'value' },
+    createdAt: TS,
+    metrics: {
+      startedSpeakingAt: TS / 1000,
+      stoppedSpeakingAt: TS / 1000,
+      transcriptionDelay: 1,
+      endOfTurnDelay: 1,
+      onUserTurnCompletedDelay: 1,
+      llmNodeTtft: 1,
+      ttsNodeTtfb: 1,
+      e2eLatency: 1,
+    },
+  }),
+  new FunctionCall({ id: 'item_fc', callId: 'call-1', name: 'fn', args: '{}', createdAt: TS }),
+  new FunctionCallOutput({
+    id: 'item_fco',
+    callId: 'call-1',
+    name: 'fn',
+    output: 'ok',
+    isError: true,
+    createdAt: TS,
+  }),
+  new AgentHandoffItem({
+    id: 'item_ah',
+    oldAgentId: 'a',
+    newAgentId: 'b',
+    createdAt: TS,
+  }),
+  new AgentConfigUpdate({
+    id: 'item_acu',
+    instructions: 'be brief',
+    toolsAdded: ['x'],
+    toolsRemoved: ['y'],
+    createdAt: TS,
+  }),
+];
+
+function unsetFields(msg: Message, prefix = ''): string[] {
+  const json = msg.toJson() as Record<string, unknown>;
+  const missing: string[] = [];
+  for (const f of msg.getType().fields.list()) {
+    const key = f.jsonName ?? f.localName;
+    if (!(key in json)) {
+      missing.push(prefix + f.name);
+      continue;
+    }
+    // well-known types are leaves; their own fields are legitimately zero
+    if (f.kind === 'message' && !f.repeated && !f.T.typeName.startsWith('google.protobuf.')) {
+      const nested = (msg as unknown as Record<string, Message>)[f.localName];
+      missing.push(...unsetFields(nested, `${prefix}${f.name}.`));
+    }
+  }
+  return missing;
+}
+
+function payloadOf(item: ChatItem): { which: string; message: Message } {
+  const pbItem = encodeChatItem(item);
+  const { case: which, value } = pbItem.item;
+  if (!which) throw new Error('serializer produced an empty oneof');
+  return { which, message: value as Message };
+}
+
+describe('ChatItem proto coverage', () => {
+  it.each(SATURATED_ITEMS.map((item) => [item.type, item] as const))(
+    '%s reaches every proto field',
+    (_type, item) => {
+      const { which, message } = payloadOf(item);
+      const dropped = unsetFields(message).filter((f) => !KNOWN_GAPS.has(f));
+      expect(dropped, `${which} drops: ${dropped.join(', ')}`).toEqual([]);
+    },
+  );
+
+  it('detects a dropped field', () => {
+    const fco = new pb.FunctionCallOutput({
+      callId: 'call-1',
+      name: 'fn',
+      output: 'ok',
+      isError: true,
+    });
+    expect(unsetFields(fco)).toEqual(['id', 'created_at']);
+  });
+
+  it('every known gap names a real proto field', () => {
+    const declared = new Set(pb.MetricsReport.fields.list().map((f) => `metrics.${f.name}`));
+    for (const gap of KNOWN_GAPS) {
+      expect(declared, `${gap} is allowlisted but not in the proto`).toContain(gap);
+    }
+  });
+
+  it('covers every case the oneof declares', () => {
+    const declared = pb.ChatContext_ChatItem.fields.list().map((f) => f.localName);
+    const covered = SATURATED_ITEMS.map((item) => payloadOf(item).which);
+    expect(new Set(covered)).toEqual(new Set(declared));
+  });
+});

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -16,7 +16,7 @@ import type {
   FunctionCall as FCItem,
   FunctionCallOutput as FCOItem,
 } from '../llm/chat_context.js';
-import { isInstructions, renderInstructions } from '../llm/chat_context.js';
+import { renderInstructions } from '../llm/chat_context.js';
 import { type ToolContext, sortedToolNames } from '../llm/tool_context.js';
 import { log } from '../log.js';
 import type {
@@ -26,6 +26,7 @@ import type {
   STTModelUsage,
   TTSModelUsage,
 } from '../metrics/model_usage.js';
+import { type RemoteChatItem, chatItemToProto, msToTimestamp } from '../proto.js';
 import type { SimulationContext } from '../simulation.js';
 import { Future, Task, asError, shortuuid } from '../utils.js';
 import { version } from '../version.js';
@@ -387,10 +388,6 @@ const AMD_CATEGORY_MAP: Record<AMDCategory, pb.AmdCategory> = {
 // ===========================================================================
 // Chat item / timestamp conversion helpers
 // ===========================================================================
-function msToTimestamp(ms: number): Timestamp {
-  return Timestamp.fromDate(new Date(ms));
-}
-
 function nowTimestamp(): Timestamp {
   return Timestamp.fromDate(new Date());
 }
@@ -404,107 +401,10 @@ function msToDuration(ms: number): Duration {
   });
 }
 
-type RemoteChatItem = Exclude<ChatItem, { type: 'agent_config_update' }>;
-
 function chatItemsToProto(items: ChatItem[]): pb.ChatContext_ChatItem[] {
   return items
     .filter((item): item is RemoteChatItem => item.type !== 'agent_config_update')
     .map(chatItemToProto);
-}
-
-function chatItemToProto(item: RemoteChatItem): pb.ChatContext_ChatItem {
-  switch (item.type) {
-    case 'message': {
-      const msg = item;
-      const roleMap: Record<string, pb.ChatRole> = {
-        developer: pb.ChatRole.DEVELOPER,
-        system: pb.ChatRole.SYSTEM,
-        user: pb.ChatRole.USER,
-        assistant: pb.ChatRole.ASSISTANT,
-      };
-      const content: pb.ChatMessage_ChatContent[] = [];
-      for (const c of msg.content) {
-        if (typeof c === 'string') {
-          content.push(new pb.ChatMessage_ChatContent({ payload: { case: 'text', value: c } }));
-        } else if (isInstructions(c)) {
-          content.push(
-            new pb.ChatMessage_ChatContent({ payload: { case: 'text', value: c.value } }),
-          );
-        }
-      }
-
-      const metricsReport = new pb.MetricsReport();
-      if (msg.metrics.transcriptionDelay !== undefined)
-        metricsReport.transcriptionDelay = msg.metrics.transcriptionDelay;
-      if (msg.metrics.endOfTurnDelay !== undefined)
-        metricsReport.endOfTurnDelay = msg.metrics.endOfTurnDelay;
-      if (msg.metrics.onUserTurnCompletedDelay !== undefined)
-        metricsReport.onUserTurnCompletedDelay = msg.metrics.onUserTurnCompletedDelay;
-      if (msg.metrics.llmNodeTtft !== undefined)
-        metricsReport.llmNodeTtft = msg.metrics.llmNodeTtft;
-      if (msg.metrics.ttsNodeTtfb !== undefined)
-        metricsReport.ttsNodeTtfb = msg.metrics.ttsNodeTtfb;
-      if (msg.metrics.e2eLatency !== undefined) metricsReport.e2eLatency = msg.metrics.e2eLatency;
-
-      const pbMsg = new pb.ChatMessage({
-        id: msg.id,
-        role: roleMap[msg.role] ?? pb.ChatRole.ASSISTANT,
-        content,
-        interrupted: msg.interrupted,
-        metrics: metricsReport,
-        createdAt: msToTimestamp(msg.createdAt),
-      });
-      if (msg.transcriptConfidence !== undefined) {
-        pbMsg.transcriptConfidence = msg.transcriptConfidence;
-      }
-      return new pb.ChatContext_ChatItem({ item: { case: 'message', value: pbMsg } });
-    }
-    case 'function_call': {
-      const fc = item;
-      return new pb.ChatContext_ChatItem({
-        item: {
-          case: 'functionCall',
-          value: new pb.FunctionCall({
-            id: fc.id,
-            callId: fc.callId,
-            name: fc.name,
-            arguments: fc.args,
-            createdAt: msToTimestamp(fc.createdAt),
-          }),
-        },
-      });
-    }
-    case 'function_call_output': {
-      const fco = item;
-      return new pb.ChatContext_ChatItem({
-        item: {
-          case: 'functionCallOutput',
-          value: new pb.FunctionCallOutput({
-            id: fco.id,
-            callId: fco.callId,
-            name: fco.name,
-            output: fco.output,
-            isError: fco.isError,
-            createdAt: msToTimestamp(fco.createdAt),
-          }),
-        },
-      });
-    }
-    case 'agent_handoff': {
-      const ah = item;
-      return new pb.ChatContext_ChatItem({
-        item: {
-          case: 'agentHandoff',
-          value: new pb.AgentHandoff({
-            id: ah.id,
-            oldAgentId: ah.oldAgentId,
-            newAgentId: ah.newAgentId,
-            createdAt: msToTimestamp(ah.createdAt),
-          }),
-        },
-      });
-    }
-  }
 }
 
 // ===========================================================================

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -26,7 +26,7 @@ import type {
   STTModelUsage,
   TTSModelUsage,
 } from '../metrics/model_usage.js';
-import { type RemoteChatItem, chatItemToProto, msToTimestamp } from '../proto.js';
+import { encodeChatItem, msToTimestamp } from '../proto.js';
 import type { SimulationContext } from '../simulation.js';
 import { Future, Task, asError, shortuuid } from '../utils.js';
 import { version } from '../version.js';
@@ -401,10 +401,12 @@ function msToDuration(ms: number): Duration {
   });
 }
 
+type RemoteChatItem = Exclude<ChatItem, { type: 'agent_config_update' }>;
+
 function chatItemsToProto(items: ChatItem[]): pb.ChatContext_ChatItem[] {
   return items
     .filter((item): item is RemoteChatItem => item.type !== 'agent_config_update')
-    .map(chatItemToProto);
+    .map(encodeChatItem);
 }
 
 // ===========================================================================
@@ -710,7 +712,7 @@ export class SessionHost {
       {
         case: 'conversationItemAdded',
         value: new pb.AgentSessionEvent_ConversationItemAdded({
-          item: chatItemToProto(event.item),
+          item: encodeChatItem(event.item),
         }),
       },
       event.createdAt,


### PR DESCRIPTION
Companion to livekit/agents#6756, which found the same class of bug in Python: the ChatItem-to-proto mapping was written twice per SDK, and each copy dropped whatever the other one carried.

## What was wrong here

`chatItemToProto` in `voice/remote_session.ts` dropped `extra` and the speaking-at metrics on messages, which the telemetry path and livekit/agents both send.

The telemetry copy was worse. `telemetry/traces.ts` declared its own `ProtoMessage`, `ProtoMetricsReport`, `ProtoChatItem` and four more interfaces instead of the generated types, so nothing tied it to the schema. It carried this:

> `TODO: Use actual agent_session proto types once livekit/protocol v1.43.1+ is published`

`agents/package.json` pins `@livekit/protocol` at `^1.50.4`, so that has been unblocked for a while. With no schema link it emitted `playbackLatency`, which `MetricsReport` does not declare, and camelCase keys where livekit/agents emits proto field names — the same `chat item` log body, structurally different payloads.

## The three commits

**`refactor: move proto serialization into its own module`** — `agents/src/proto.ts`, a leaf that neither voice nor telemetry sits above. Verbatim otherwise.

**`fix(voice): carry every field the wire format declares`** — one encoder for both paths. `chatItemSpanAttribute` becomes a one-liner over it, structurally identical to Python's:

```ts
return encodeChatItem(item).toJson({ useProtoFieldName: true });                  // here
```
```python
return MessageToDict(encode_chat_item(item), preserving_proto_field_name=True)    # livekit/agents
```

**`test(voice): fail when a declared field is dropped`** — the guard, below.

## Telemetry payload changes

The emitted `chat item` log changes in four ways, all of them toward what livekit/agents already sends. **Anything querying these logs on camelCase keys or on nested `arguments` needs updating.**

| | before | after |
|---|---|---|
| keys | `functionCall`, `callId`, `createdAt` | `function_call`, `call_id`, `created_at` |
| `arguments` / `output` | re-parsed into nested objects | JSON strings, as the wire format has them |
| `extra` values | raw (`{n: 1}`) | stringified (`{n: "1"}`), as the proto map requires |
| `playbackLatency` | emitted | gone; not a field on `MetricsReport` |

The re-parse came in with the original upload path in #851 and was never a considered divergence — the hand-written `arguments: string \| Record<string, unknown>` existed to accommodate it. A schema-driven encoder has nowhere to put a parsed object.

I checked the result rather than assuming it: encoding all five saturated item types through both SDKs and diffing produces identical payloads, key sets and values.

## Tests

`chat_item_proto_coverage.test.ts` saturates every ChatItem, encodes it, then walks the result against the message descriptor; anything left unset is a drop, unless allowlisted as a parity gap this SDK cannot fill. Since both paths now share the encoder, the guard covers telemetry too.

Two entries are allowlisted rather than fixed, because neither is an accidental drop:

- `metrics.llm_node_tps` / `metrics.llm_node_ttfs` — livekit/agents#6373 added these in Python and they were never ported, so `MetricsReport` here has no field to read them from. A test asserts every allowlist entry names a real proto field, so the list cannot rot into stale excuses.
- `agent_config_update` is a case on the oneof and the encoder fills it, but `chatItemsToProto` filters those items out of the chat context the RemoteSession sends. livekit/agents sends them.

1593 passing across 116 files; `tsc --noEmit` and eslint clean at each of the three commits.

## Follow-up, not in this PR

`playbackLatency` stops being emitted here and livekit/agents never sent it. Carrying it from either SDK needs a `playback_latency` field in livekit/protocol.
