### PR TITLE
fix(rime): remove Arcana model support

### DIFF
--- a/.changeset/bright-codas-speak.md
+++ b/.changeset/bright-codas-speak.md
@@ -1,6 +1,6 @@
 ---
-'@livekit/agents': minor
-'@livekit/agents-plugin-rime': minor
+'@livekit/agents': patch
+'@livekit/agents-plugin-rime': patch
 ---
 
 ⚠️ Remove Rime Arcana model support before Rime's cloud cutoff on August 15, 2026 at 12:00 UTC. Set `modelId` to `coda` when you upgrade. The default paths keep their established speakers for voice continuity.

--- a/.changeset/bright-codas-speak.md
+++ b/.changeset/bright-codas-speak.md
@@ -1,0 +1,6 @@
+---
+'@livekit/agents': minor
+'@livekit/agents-plugin-rime': minor
+---
+
+Use Rime Coda with the Wawona speaker in defaults and examples, and stop advertising Arcana in model types. Explicit Arcana strings continue to use the existing runtime compatibility path.

--- a/.changeset/bright-codas-speak.md
+++ b/.changeset/bright-codas-speak.md
@@ -3,4 +3,4 @@
 '@livekit/agents-plugin-rime': minor
 ---
 
-Use Rime Coda while preserving the established default speakers, and stop advertising Arcana in model types. Explicit Arcana strings continue to use the existing runtime compatibility path.
+⚠️ Remove Rime Arcana model support before Rime's cloud cutoff on August 15, 2026 at 12:00 UTC. Set `modelId` to `coda` when you upgrade. The default paths keep their established speakers for voice continuity.

--- a/.changeset/bright-codas-speak.md
+++ b/.changeset/bright-codas-speak.md
@@ -3,4 +3,4 @@
 '@livekit/agents-plugin-rime': minor
 ---
 
-Use Rime Coda with the Wawona speaker in defaults and examples, and stop advertising Arcana in model types. Explicit Arcana strings continue to use the existing runtime compatibility path.
+Use Rime Coda while preserving the established default speakers, and stop advertising Arcana in model types. Explicit Arcana strings continue to use the existing runtime compatibility path.

--- a/agents/src/inference/tts.test.ts
+++ b/agents/src/inference/tts.test.ts
@@ -484,7 +484,7 @@ describeLiveKitInference('LiveKit Inference TTS integration', agents, async (har
       voice: 'Xb7hH8MSUJpSbSDYk0k2',
     },
     { model: 'inworld/inworld-tts-2', voice: 'Ashley' },
-    { model: 'rime/coda', voice: 'wawona' },
+    { model: 'rime/coda', voice: 'celeste' },
   ] as const;
 
   for (const options of models) {

--- a/agents/src/inference/tts.test.ts
+++ b/agents/src/inference/tts.test.ts
@@ -484,7 +484,7 @@ describeLiveKitInference('LiveKit Inference TTS integration', agents, async (har
       voice: 'Xb7hH8MSUJpSbSDYk0k2',
     },
     { model: 'inworld/inworld-tts-2', voice: 'Ashley' },
-    { model: 'rime/arcana', voice: 'celeste' },
+    { model: 'rime/coda', voice: 'wawona' },
   ] as const;
 
   for (const options of models) {

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -60,7 +60,7 @@ export type InworldModels =
   | 'inworld/inworld-tts-1-max'
   | 'inworld/inworld-tts-1';
 
-export type RimeModels = 'rime/arcana' | 'rime/coda' | 'rime/mistv2' | 'rime/mistv3' | 'rime/mist';
+export type RimeModels = 'rime/coda' | 'rime/mistv2' | 'rime/mistv3' | 'rime/mist';
 
 export type XaiTTSModels = 'xai/tts-1';
 
@@ -251,7 +251,7 @@ export function hasAlignedTranscript(
 
 /** Inference Fallback Adapter: configuration for a fallback TTS model that runs server-side in LiveKit Inference, providing automatic fallback between providers. */
 export interface TTSFallbackModel {
-  /** Model name (e.g. "cartesia/sonic", "elevenlabs/eleven_flash_v2", "rime/arcana"). */
+  /** Model name (e.g. "cartesia/sonic", "elevenlabs/eleven_flash_v2", "rime/coda"). */
   model: string;
   /** Voice to use for the model. */
   voice: string;

--- a/examples/src/basic_agent.ts
+++ b/examples/src/basic_agent.ts
@@ -61,7 +61,7 @@ export default defineAgent({
         voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc',
         fallback: [
           { model: 'elevenlabs/eleven_flash_v2', voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc' },
-          'rime/arcana',
+          { model: 'rime/coda', voice: 'wawona' },
         ],
       }),
       ttsTextTransforms: ['filter_markdown', 'filter_emoji'],

--- a/examples/src/basic_agent.ts
+++ b/examples/src/basic_agent.ts
@@ -61,7 +61,7 @@ export default defineAgent({
         voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc',
         fallback: [
           { model: 'elevenlabs/eleven_flash_v2', voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc' },
-          { model: 'rime/coda', voice: 'wawona' },
+          { model: 'rime/coda', voice: 'luna' },
         ],
       }),
       ttsTextTransforms: ['filter_markdown', 'filter_emoji'],

--- a/examples/src/otel_trace.ts
+++ b/examples/src/otel_trace.ts
@@ -168,7 +168,7 @@ export default defineAgent({
       tts: new tts.FallbackAdapter({
         ttsInstances: [
           new inference.TTS({ model: 'cartesia/sonic-3' }),
-          new inference.TTS({ model: 'rime/coda', voice: 'wawona' }),
+          new inference.TTS({ model: 'rime/coda', voice: 'luna' }),
         ],
       }),
     });

--- a/examples/src/otel_trace.ts
+++ b/examples/src/otel_trace.ts
@@ -168,7 +168,7 @@ export default defineAgent({
       tts: new tts.FallbackAdapter({
         ttsInstances: [
           new inference.TTS({ model: 'cartesia/sonic-3' }),
-          new inference.TTS({ model: 'rime/arcana' }),
+          new inference.TTS({ model: 'rime/coda', voice: 'wawona' }),
         ],
       }),
     });

--- a/plugins/rime/src/models.ts
+++ b/plugins/rime/src/models.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /** Supported Rime AI TTS models */
-export type TTSModels = 'arcana' | 'coda' | 'mistv2' | 'mistv3';
+export type TTSModels = 'coda' | 'mistv2' | 'mistv3';
 
 /** Supported default languages for Rime AI TTS */
 export type DefaultLanguages = 'eng' | 'spa' | 'fra' | 'ger';

--- a/plugins/rime/src/tts.test.ts
+++ b/plugins/rime/src/tts.test.ts
@@ -35,9 +35,17 @@ describe('Rime TTS streaming', () => {
     vi.restoreAllMocks();
   });
 
-  it('defaults to Coda', () => {
-    const rimeTTS = new TTS({ apiKey: 'test-rime-key' });
-    expect(rimeTTS.model).toBe('coda');
+  it('preserves model-specific default speakers', () => {
+    const defaultTTS = new TTS({ apiKey: 'test-rime-key' });
+    const explicitCodaTTS = new TTS({ apiKey: 'test-rime-key', modelId: 'coda' });
+    const explicitArcanaTTS = new TTS({ apiKey: 'test-rime-key', modelId: 'arcana' });
+
+    expect(defaultTTS).toHaveProperty('opts.modelId', 'coda');
+    expect(defaultTTS).toHaveProperty('opts.speaker', 'luna');
+    expect(explicitCodaTTS).toHaveProperty('opts.modelId', 'coda');
+    expect(explicitCodaTTS).toHaveProperty('opts.speaker', 'lyra');
+    expect(explicitArcanaTTS).toHaveProperty('opts.modelId', 'arcana');
+    expect(explicitArcanaTTS).toHaveProperty('opts.speaker', 'luna');
   });
 
   it('emits audio before the Rime response body closes', async () => {
@@ -79,7 +87,7 @@ describe('Rime TTS streaming', () => {
     const request = fetchSpy.mock.calls[0]?.[1];
     expect(JSON.parse(request?.body as string)).toMatchObject({
       modelId: 'coda',
-      speaker: 'wawona',
+      speaker: 'lyra',
     });
 
     bodyController.close();

--- a/plugins/rime/src/tts.test.ts
+++ b/plugins/rime/src/tts.test.ts
@@ -35,6 +35,11 @@ describe('Rime TTS streaming', () => {
     vi.restoreAllMocks();
   });
 
+  it('defaults to Coda', () => {
+    const rimeTTS = new TTS({ apiKey: 'test-rime-key' });
+    expect(rimeTTS.model).toBe('coda');
+  });
+
   it('emits audio before the Rime response body closes', async () => {
     let bodyController!: ReadableStreamDefaultController<Uint8Array>;
     const body = new ReadableStream<Uint8Array>({
@@ -43,7 +48,7 @@ describe('Rime TTS streaming', () => {
       },
     });
 
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(body, {
         status: 200,
         headers: { 'Content-Type': 'audio/pcm' },
@@ -53,8 +58,7 @@ describe('Rime TTS streaming', () => {
     const rimeTTS = new TTS({
       apiKey: 'test-rime-key',
       baseURL: 'https://rime.test/v1/rime-tts',
-      modelId: 'arcana',
-      speaker: 'luna',
+      modelId: 'coda',
       samplingRate: 16000,
     });
 
@@ -71,6 +75,12 @@ describe('Rime TTS streaming', () => {
     expect(firstResult.done).toBe(false);
     expect(firstResult.value.final).toBe(false);
     expect(firstResult.value.frame.samplesPerChannel).toBe(1600);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const request = fetchSpy.mock.calls[0]?.[1];
+    expect(JSON.parse(request?.body as string)).toMatchObject({
+      modelId: 'coda',
+      speaker: 'wawona',
+    });
 
     bodyController.close();
 

--- a/plugins/rime/src/tts.test.ts
+++ b/plugins/rime/src/tts.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { initializeLogger } from '@livekit/agents';
+import { initializeLogger, log } from '@livekit/agents';
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts } from '@livekit/agents-plugins-test';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -43,6 +43,22 @@ describe('Rime TTS streaming', () => {
     expect(defaultTTS).toHaveProperty('opts.speaker', 'luna');
     expect(explicitCodaTTS).toHaveProperty('opts.modelId', 'coda');
     expect(explicitCodaTTS).toHaveProperty('opts.speaker', 'lyra');
+  });
+
+  it('warns when the Arcana model is selected', () => {
+    const warnSpy = vi.spyOn(log(), 'warn');
+    const rimeTTS = new TTS({ apiKey: 'test-rime-key', modelId: 'arcana' });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Rime Arcana is no longer supported. Use modelId: 'coda' instead.",
+    );
+
+    warnSpy.mockClear();
+    rimeTTS.updateOptions({ modelId: 'arcana' });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Rime Arcana is no longer supported. Use modelId: 'coda' instead.",
+    );
   });
 
   it('emits audio before the Rime response body closes', async () => {

--- a/plugins/rime/src/tts.test.ts
+++ b/plugins/rime/src/tts.test.ts
@@ -38,14 +38,11 @@ describe('Rime TTS streaming', () => {
   it('preserves model-specific default speakers', () => {
     const defaultTTS = new TTS({ apiKey: 'test-rime-key' });
     const explicitCodaTTS = new TTS({ apiKey: 'test-rime-key', modelId: 'coda' });
-    const explicitArcanaTTS = new TTS({ apiKey: 'test-rime-key', modelId: 'arcana' });
 
     expect(defaultTTS).toHaveProperty('opts.modelId', 'coda');
     expect(defaultTTS).toHaveProperty('opts.speaker', 'luna');
     expect(explicitCodaTTS).toHaveProperty('opts.modelId', 'coda');
     expect(explicitCodaTTS).toHaveProperty('opts.speaker', 'lyra');
-    expect(explicitArcanaTTS).toHaveProperty('opts.modelId', 'arcana');
-    expect(explicitArcanaTTS).toHaveProperty('opts.speaker', 'luna');
   });
 
   it('emits audio before the Rime response body closes', async () => {
@@ -68,6 +65,11 @@ describe('Rime TTS streaming', () => {
       baseURL: 'https://rime.test/v1/rime-tts',
       modelId: 'coda',
       samplingRate: 16000,
+      repetition_penalty: 1.1,
+      temperature: 0.5,
+      top_p: 0.9,
+      max_tokens: 200,
+      timeScaleFactor: 1.2,
     });
 
     const stream = rimeTTS.synthesize('This should stream before the response ends.');
@@ -88,6 +90,11 @@ describe('Rime TTS streaming', () => {
     expect(JSON.parse(request?.body as string)).toMatchObject({
       modelId: 'coda',
       speaker: 'lyra',
+      repetition_penalty: 1.1,
+      temperature: 0.5,
+      top_p: 0.9,
+      max_tokens: 200,
+      timeScaleFactor: 1.2,
     });
 
     bodyController.close();

--- a/plugins/rime/src/tts.ts
+++ b/plugins/rime/src/tts.ts
@@ -78,8 +78,8 @@ export interface TTSOptions {
 }
 
 const defaultTTSOptions: TTSOptions = {
-  modelId: 'arcana',
-  speaker: 'luna',
+  modelId: 'coda',
+  speaker: 'wawona',
   apiKey: process.env.RIME_API_KEY,
   baseURL: RIME_BASE_URL,
   useWebsocket: false,
@@ -191,13 +191,11 @@ function resolveOptions(opts: Partial<TTSOptions>): TTSOptions {
   };
 
   if (opts.speaker === undefined && opts.modelId === 'coda') {
-    resolved.speaker = 'lyra';
+    resolved.speaker = 'wawona';
   }
 
   if (resolved.modelId === 'mistv2' && resolved.timeScaleFactor !== undefined) {
-    throw new Error(
-      'timeScaleFactor is not supported by the mistv2 model; use arcana, mistv3, or coda.',
-    );
+    throw new Error('timeScaleFactor is not supported by the mistv2 model; use mistv3 or coda.');
   }
 
   return resolved;

--- a/plugins/rime/src/tts.ts
+++ b/plugins/rime/src/tts.ts
@@ -79,7 +79,7 @@ export interface TTSOptions {
 
 const defaultTTSOptions: TTSOptions = {
   modelId: 'coda',
-  speaker: 'wawona',
+  speaker: 'luna',
   apiKey: process.env.RIME_API_KEY,
   baseURL: RIME_BASE_URL,
   useWebsocket: false,
@@ -191,7 +191,7 @@ function resolveOptions(opts: Partial<TTSOptions>): TTSOptions {
   };
 
   if (opts.speaker === undefined && opts.modelId === 'coda') {
-    resolved.speaker = 'wawona';
+    resolved.speaker = 'lyra';
   }
 
   if (resolved.modelId === 'mistv2' && resolved.timeScaleFactor !== undefined) {

--- a/plugins/rime/src/tts.ts
+++ b/plugins/rime/src/tts.ts
@@ -85,6 +85,12 @@ const defaultTTSOptions: TTSOptions = {
   segment: 'bySentence',
 };
 
+function warnIfArcana(modelId: TTSOptions['modelId'] | undefined): void {
+  if (modelId === 'arcana') {
+    log().warn("Rime Arcana is no longer supported. Use modelId: 'coda' instead.");
+  }
+}
+
 function modelParams(opts: TTSOptions): Record<string, string | number | boolean> {
   const params: Record<string, string | number | boolean> = {};
   if (opts.lang !== undefined) params.lang = opts.lang;
@@ -223,6 +229,7 @@ export class TTS extends tts.TTS {
     if (this.opts.apiKey === undefined) {
       throw new Error('RIME API key is required, whether as an argument or as $RIME_API_KEY');
     }
+    warnIfArcana(opts.modelId);
   }
 
   get model(): string {
@@ -239,6 +246,7 @@ export class TTS extends tts.TTS {
    * @param opts - Partial options to update
    */
   updateOptions(opts: Partial<TTSOptions>) {
+    warnIfArcana(opts.modelId);
     this.opts = resolveOptions({ ...this.opts, ...opts });
   }
 

--- a/plugins/rime/src/tts.ts
+++ b/plugins/rime/src/tts.ts
@@ -32,7 +32,7 @@ const RIME_TTS_CHANNELS = 1;
  *
  * @param opts - Optional TTS configuration options
  * @returns The sample rate in Hz. Returns the explicit samplingRate if provided,
- *          otherwise returns model-specific defaults (24000 for arcana, 16000 for mistv2,
+ *          otherwise returns model-specific defaults (24000 for coda, 16000 for mistv2,
  *          or the default RIME_TTS_SAMPLE_RATE for other models)
  */
 function getSampleRate(opts?: Partial<TTSOptions>): number {
@@ -40,7 +40,6 @@ function getSampleRate(opts?: Partial<TTSOptions>): number {
     return opts.samplingRate;
   }
   switch (opts?.modelId) {
-    case 'arcana':
     case 'coda':
       return 24000;
     case 'mistv2':
@@ -90,13 +89,10 @@ function modelParams(opts: TTSOptions): Record<string, string | number | boolean
   const params: Record<string, string | number | boolean> = {};
   if (opts.lang !== undefined) params.lang = opts.lang;
 
-  if (opts.modelId === 'arcana') {
+  if (opts.modelId === 'coda') {
     if (opts.repetition_penalty !== undefined) params.repetition_penalty = opts.repetition_penalty;
     if (opts.temperature !== undefined) params.temperature = opts.temperature;
     if (opts.top_p !== undefined) params.top_p = opts.top_p;
-    if (opts.max_tokens !== undefined) params.max_tokens = opts.max_tokens;
-    if (opts.timeScaleFactor !== undefined) params.timeScaleFactor = opts.timeScaleFactor;
-  } else if (opts.modelId === 'coda') {
     if (opts.max_tokens !== undefined) params.max_tokens = opts.max_tokens;
     if (opts.timeScaleFactor !== undefined) params.timeScaleFactor = opts.timeScaleFactor;
   } else if (opts.modelId.includes('mist')) {


### PR DESCRIPTION
## Summary

- Remove Arcana from the Rime plugin runtime paths, public model types, examples, and tests.
- Change the no-argument Rime TTS model to Coda while keeping the existing Luna speaker.
- Keep Lyra for callers that explicitly select Coda without a speaker.
- Apply repetition_penalty, temperature, top_p, max_tokens, and other supported request controls to Coda.
- Add a release changeset with the migration deadline.

⚠️ Rime's public cloud cutoff is August 15, 2026 at 12:00 UTC. Set modelId to coda when you upgrade. Luna is available on Coda, so the no-argument path keeps its established speaker for voice continuity.

Migration notice: https://docs.rime.ai/docs/arcana-sunset