### PR TITLE
fix(vad): copy speech buffer when emitting frames instead of aliasing it

### DIFF
--- a/.changeset/eighty-planets-argue.md
+++ b/.changeset/eighty-planets-argue.md
@@ -1,0 +1,6 @@
+---
+'@livekit/agents': patch
+'@livekit/agents-plugin-silero': patch
+---
+
+fix(vad): copy the speech buffer when emitting START_OF_SPEECH/END_OF_SPEECH frames instead of aliasing it — the pre-roll slide that runs right after END_OF_SPEECH was overwriting the head of the just-emitted frame with the segment's tail, so batch STT (via StreamAdapter) received the end of the utterance prepended to it and transcribed duplicated speech (e.g. "Hello?" → "Hello? Hello?")

--- a/agents/src/inference/vad.test.ts
+++ b/agents/src/inference/vad.test.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { initializeLogger } from '../log.js';
-import type { VADStream } from '../vad.js';
+import { VADEventType, type VADStream } from '../vad.js';
 import { VAD, type VADOptions } from './vad.js';
 
 beforeAll(() => {
@@ -56,6 +57,65 @@ describe('inference.VAD updateOptions propagation', () => {
       expect(s._speechBuffer?.length).toBe(
         Math.trunc((20_000 * sampleRate) / 1000) + expectedPrefix,
       );
+    } finally {
+      stream.close();
+    }
+  });
+});
+
+describe('inference.VAD speech buffer ownership', () => {
+  it('does not mutate an emitted END_OF_SPEECH frame when sliding the next pre-roll', async () => {
+    const sampleRate = 16000; // matches the model rate, so no resampler in the path
+    const windowSamples = 512; // one inference window (32ms) per pushed frame
+
+    const vad = new VAD({
+      minSpeechDuration: 32, // 1 window of speech triggers START_OF_SPEECH
+      minSilenceDuration: 64, // 2 windows of silence trigger END_OF_SPEECH
+      prefixPaddingDuration: 64, // 1024-sample pre-roll — smaller than the segment
+      maxBufferedSpeech: 2000,
+    });
+    const stream = vad.stream();
+
+    // Deterministic stand-in for the native silero model: scripted
+    // probabilities, one per inference window. 2 silence windows (pre-roll),
+    // 10 speech windows, then 2 silence windows to end the segment.
+    const probs = [0, 0, ...Array(10).fill(1), 0, 0];
+    let call = 0;
+    Object.assign(stream as unknown as Record<string, unknown>, {
+      _nativeVad: {
+        predict: async () => probs[call++] ?? 0,
+        reset: () => {},
+      },
+      _windowSamples: windowSamples,
+    });
+
+    try {
+      // Push a monotonically increasing ramp so any later mutation of the
+      // emitted frame's underlying buffer is detectable.
+      for (let w = 0; w < probs.length; w++) {
+        const data = new Int16Array(windowSamples);
+        for (let i = 0; i < windowSamples; i++) data[i] = w * windowSamples + i;
+        stream.pushFrame(new AudioFrame(data, sampleRate, 1, windowSamples));
+      }
+
+      let endFrame: AudioFrame | undefined;
+      for await (const ev of stream) {
+        if (ev.type === VADEventType.END_OF_SPEECH) {
+          endFrame = ev.frames[0];
+          break;
+        }
+      }
+
+      // By the time the consumer observes the event, the pump has already run
+      // resetWriteCursor(), sliding the last pre-roll window to the head of
+      // the speech buffer. If the emitted frame aliases that buffer, its
+      // first samples now hold the segment's tail — the audio corruption
+      // behind duplicated STT transcripts ("Hello? Hello?").
+      expect(endFrame).toBeDefined();
+      const samples = endFrame!.data;
+      expect(samples.length).toBe(probs.length * windowSamples);
+      expect(Array.from(samples.slice(0, 4))).toEqual([0, 1, 2, 3]);
+      expect(samples.every((v, i) => v === i)).toBe(true);
     } finally {
       stream.close();
     }

--- a/agents/src/inference/vad.ts
+++ b/agents/src/inference/vad.ts
@@ -239,8 +239,12 @@ class InferenceVADStream extends BaseVADStream {
       if (this._speechBuffer === null) {
         return new AudioFrame(new Int16Array(0), this._inputSampleRate, 1, 0);
       }
+      // slice() (a copy), not subarray() (a view): the emitted frame must not
+      // alias `_speechBuffer`, which resetWriteCursor() mutates right after
+      // END_OF_SPEECH — sliding the segment tail over the head of the buffer
+      // and corrupting any frame that still points into it.
       return new AudioFrame(
-        this._speechBuffer.subarray(0, speechBufferIndex),
+        this._speechBuffer.slice(0, speechBufferIndex),
         this._inputSampleRate,
         1,
         speechBufferIndex,

--- a/plugins/silero/src/vad.ts
+++ b/plugins/silero/src/vad.ts
@@ -340,8 +340,13 @@ export class VADStream extends baseStream {
 
           const copySpeechBuffer = (): AudioFrame => {
             if (!this.#speechBuffer) throw new Error('speechBuffer is empty');
+            // slice() (a copy), not subarray() (a view): the emitted frame
+            // must not alias `#speechBuffer`, which resetWriteCursor()
+            // mutates right after END_OF_SPEECH — sliding the segment tail
+            // over the head of the buffer and corrupting any frame that
+            // still points into it.
             return new AudioFrame(
-              this.#speechBuffer.subarray(0, speechBufferIndex),
+              this.#speechBuffer.slice(0, speechBufferIndex),
               this.#inputSampleRate,
               1,
               speechBufferIndex,


### PR DESCRIPTION
## Summary

`copySpeechBuffer()` in both the inference VAD and the silero plugin builds the `START_OF_SPEECH` / `END_OF_SPEECH` event frame with `subarray()`, which returns a **view** into the VAD's internal speech buffer rather than a copy.

Immediately after `END_OF_SPEECH` is emitted, `resetWriteCursor()` slides the last `prefixPaddingDuration` of samples to the head of that same buffer to seed the next segment's pre-roll. Because this runs synchronously in the pump loop — before any consumer can observe the event — it overwrites the first samples of the frame that was just emitted.

The audible symptom: any non-streaming STT wrapped in `StreamAdapter` receives the utterance with its own tail prepended, and transcribes duplicated speech. We hit this in production with ElevenLabs `scribe_v1`: the user says "Hello?" and the final transcript is "Hello? Hello?" (the tail of a short utterance is the whole utterance). Longer utterances get their last ~500ms duplicated onto the front, e.g. "Take your time. Jeez" → "Jeez. Take your time. Jeez".

The Python implementation copies the buffer at this point (`bytes.tobytes()`), so this is a porting bug specific to agents-js.

## Fix

Use `slice()` (copy) instead of `subarray()` (view) in `copySpeechBuffer()`, in `agents/src/inference/vad.ts` and `plugins/silero/src/vad.ts`.

## Test

Adds a regression test that drives the real inference-VAD pump with a scripted fake native VAD and a monotonic ramp signal, and asserts the `END_OF_SPEECH` frame still holds the pushed samples after the pump has performed the pre-roll slide. Fails before the fix with the frame's head holding the segment's tail:

```
AssertionError: expected [ 6144, 6145, 6146, 6147 ] to deeply equal [ +0, 1, 2, 3 ]
```

Made with [Cursor](https://cursor.com)