### PR TITLE
fix(voice): preserve non-delta transcription final text

### DIFF
--- a/.changeset/fix-non-delta-transcription-final-stream.md
+++ b/.changeset/fix-non-delta-transcription-final-stream.md
@@ -1,0 +1,10 @@
+---
+'@livekit/agents': patch
+---
+
+Fix `ParticipantTranscriptionOutput` publishing wrong or empty text on the non-delta
+final stream.
+
+Preserve a segment's first captured text when initializing its state, and snapshot the
+text when queuing a flush so a subsequent segment cannot replace the pending final
+transcription.

--- a/agents/src/voice/room_io/_output.test.ts
+++ b/agents/src/voice/room_io/_output.test.ts
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { LocalAudioTrack, TrackPublishOptions, TrackSource } from '@livekit/rtc-node';
 import { describe, expect, it, vi } from 'vitest';
-import { Future } from '../../utils.js';
-import { ParticipantAudioOutput } from './_output.js';
+import { ATTRIBUTE_TRANSCRIPTION_FINAL } from '../../constants.js';
+import { Future, type Task } from '../../utils.js';
+import { ParticipantAudioOutput, ParticipantTranscriptionOutput } from './_output.js';
 
 type CaptureFrameArg = Parameters<ParticipantAudioOutput['captureFrame']>[0];
 
@@ -276,5 +277,139 @@ describe('ParticipantAudioOutput publishTrack', () => {
 
     expect(publishTrack).toHaveBeenCalledWith(fakeTrack, trackPublishOptions);
     expect(output.startedFuture.done).toBe(true);
+  });
+});
+
+describe('ParticipantTranscriptionOutput non-delta final streams', () => {
+  type Stream = { attributes: Record<string, string>; chunks: string[] };
+  type Deferred = { promise: Promise<void>; resolve: () => void };
+
+  const deferred = (): Deferred => {
+    let resolve!: () => void;
+    const promise = new Promise<void>((resolvePromise) => {
+      resolve = resolvePromise;
+    });
+    return { promise, resolve };
+  };
+
+  const makeOutput = ({ holdFinalWriter = false }: { holdFinalWriter?: boolean } = {}) => {
+    const streams: Stream[] = [];
+    const finalWriterEntered = deferred();
+    const releaseFinalWriter = deferred();
+    const logger = { error: vi.fn() };
+    const output = Object.create(
+      ParticipantTranscriptionOutput.prototype,
+    ) as ParticipantTranscriptionOutput & {
+      writer: unknown;
+      flushTask: Task<void> | null;
+      jsonFormat: boolean;
+      isDeltaStream: boolean;
+      latestText: string;
+      capturing: boolean;
+      currentId: string;
+      participantIdentity: string | null;
+      trackId?: string;
+      logger: { error: () => void };
+      room: unknown;
+      handleFlush: () => void;
+    };
+
+    output.writer = null;
+    output.flushTask = null;
+    output.jsonFormat = false;
+    output.isDeltaStream = false;
+    output.latestText = '';
+    output.capturing = false;
+    output.currentId = 'SG_a';
+    output.participantIdentity = 'user-a';
+    output.trackId = 'TR_a';
+    output.logger = logger;
+    output.room = {
+      isConnected: true,
+      localParticipant: {
+        streamText: async ({ attributes }: { attributes: Record<string, string> }) => {
+          const stream: Stream = { attributes: { ...attributes }, chunks: [] };
+          streams.push(stream);
+
+          if (holdFinalWriter && attributes[ATTRIBUTE_TRANSCRIPTION_FINAL] === 'true') {
+            finalWriterEntered.resolve();
+            await releaseFinalWriter.promise;
+          }
+
+          return {
+            write: async (text: string) => {
+              stream.chunks.push(text);
+            },
+            close: async () => {},
+          };
+        },
+      },
+    };
+
+    return { output, streams, logger, finalWriterEntered, releaseFinalWriter };
+  };
+
+  const finals = (streams: Stream[]) =>
+    streams.filter((stream) => stream.attributes[ATTRIBUTE_TRANSCRIPTION_FINAL] === 'true');
+
+  it('publishes the latest capture from one active segment', async () => {
+    const { output, streams, logger } = makeOutput();
+
+    await output.captureText('interim');
+    await output.captureText('complete sentence');
+    output.flush();
+    await output.flushTask!.result;
+
+    expect(finals(streams)).toHaveLength(1);
+    expect(finals(streams)[0]!.chunks).toEqual(['complete sentence']);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('publishes the captured text when a segment starts with a final (no prior interims)', async () => {
+    const { output, streams, logger } = makeOutput();
+
+    await output.captureText('hello world');
+    output.flush();
+    await output.flushTask!.result;
+
+    expect(finals(streams)).toHaveLength(1);
+    expect(finals(streams)[0]!.chunks).toEqual(['hello world']);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps segment A when it finishes before segment B starts', async () => {
+    const { output, streams, logger } = makeOutput();
+
+    await output.captureText('segment A interim');
+    await output.captureText('segment A');
+    output.flush();
+    await output.flushTask!.result;
+    await output.captureText('B');
+
+    expect(finals(streams)).toHaveLength(1);
+    expect(finals(streams)[0]!.chunks).toEqual(['segment A']);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps segment A when segment B captures while A finalization is blocked', async () => {
+    const { output, streams, logger, finalWriterEntered, releaseFinalWriter } = makeOutput({
+      holdFinalWriter: true,
+    });
+
+    await output.captureText('segment A interim');
+    await output.captureText('segment A full sentence');
+    output.flush();
+    await finalWriterEntered.promise;
+
+    // captureText updates latestText before waiting for the pending flush. The barriers ensure
+    // that update happens while segment A's final writer is blocked, without relying on timing.
+    const nextCapture = output.captureText('segment B fragment');
+    releaseFinalWriter.resolve();
+    await nextCapture;
+    await output.flushTask!.result;
+
+    expect(finals(streams)).toHaveLength(1);
+    expect(finals(streams)[0]!.chunks).toEqual(['segment A full sentence']);
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -190,6 +190,7 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
     if (!this.capturing) {
       this.resetState();
       this.capturing = true;
+      this.latestText = text;
     }
 
     try {
@@ -214,7 +215,10 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
   protected handleFlush() {
     const currWriter = this.writer;
     this.writer = null;
-    this.flushTask = Task.from((controller) => this.flushTaskImpl(currWriter, controller.signal));
+    const textToFlush = this.latestText;
+    this.flushTask = Task.from((controller) =>
+      this.flushTaskImpl(currWriter, textToFlush, controller.signal),
+    );
   }
 
   private async createTextWriter(attributes?: Record<string, string>): Promise<TextStreamWriter> {
@@ -243,7 +247,11 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
     });
   }
 
-  private async flushTaskImpl(writer: TextStreamWriter | null, signal: AbortSignal): Promise<void> {
+  private async flushTaskImpl(
+    writer: TextStreamWriter | null,
+    textToFlush: string,
+    signal: AbortSignal,
+  ): Promise<void> {
     const attributes: Record<string, string> = {
       [ATTRIBUTE_TRANSCRIPTION_FINAL]: 'true',
     };
@@ -266,7 +274,7 @@ export class ParticipantTranscriptionOutput extends BaseParticipantTranscription
           if (signal.aborted || !tmpWriter) {
             return;
           }
-          await Promise.race([tmpWriter.write(this.latestText), abortPromise]);
+          await Promise.race([tmpWriter.write(textToFlush), abortPromise]);
           if (signal.aborted) {
             return;
           }


### PR DESCRIPTION
## Description

Fixes #1759.

Non-delta transcription finalization could publish either an empty string or text from the next
segment. Starting a segment reset `latestText` after `captureText()` populated it, while the async
flush task read that shared field only after creating its final text writer. A subsequent capture
could therefore replace the text belonging to the pending flush.

## Changes Made

- Preserve the first captured payload after initializing a new transcription segment.
- Snapshot the segment text when its flush is queued and pass that value through finalization.
- Add deterministic regression tests for final-only segments and overlapping segment finalization,
  plus sequential and same-segment controls.
- Add a patch changeset for `@livekit/agents`.

## Pre-Review Checklist

- [x] **Build passes**: All repository CI checks pass locally.
- [x] **AI-generated code reviewed**: Removed unnecessary comments and narrowed the change to the
  two reproduced text-state defects.
- [x] **Changes explained**: The state reset and async shared-state race are documented above.
- [x] **Scope appropriate**: Production changes are limited to non-delta transcription text
  finalization.
- [ ] **Video demo**: Not applicable; this is an output-boundary race covered deterministically by
  unit tests.

## Testing

- [x] Automated tests added/updated.
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm throws:check`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test agents --silent` — 1,592 passed, 5 skipped.
- [x] Focused non-delta transcription tests passed in 20 independent Vitest runs.
- [ ] `restaurant_agent.ts` and `realtime_agent.ts`: Not applicable for this focused output-state
  fix.

## Additional Notes

The race test uses explicit promise barriers around final-writer creation. It does not depend on
wall-clock sleeps or scheduler timing.

---

**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.
