### PR TITLE
fix(agents): anchor transcript sync to reported playback

### DIFF
--- a/.changeset/transcript-sync-remote-playback-anchor.md
+++ b/.changeset/transcript-sync-remote-playback-anchor.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Anchor transcript synchronization to reported playback for audio outputs that render remotely, so captions do not run ahead of the voice.

--- a/agents/src/voice/transcription/synchronizer.test.ts
+++ b/agents/src/voice/transcription/synchronizer.test.ts
@@ -313,6 +313,54 @@ describe('TranscriptionSynchronizer attachment warnings', () => {
   });
 });
 
+class RemotePlaybackAudioOutput extends AudioOutput {
+  constructor() {
+    super(8000);
+  }
+
+  async captureFrame(frame: AudioFrame): Promise<void> {
+    await super.captureFrame(frame);
+  }
+
+  /** A remote renderer reports playback well after the frame was handed over. */
+  startPlayback(): void {
+    this.onPlaybackStarted(Date.now());
+  }
+
+  clearBuffer(): void {}
+}
+
+describe('TranscriptionSynchronizer remote playback anchor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('anchors a rotated segment to reported playback, not the first pushed frame', async () => {
+    const warn = vi.fn();
+    vi.spyOn(logModule, 'log').mockReturnValue({
+      warn,
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    } as unknown as ReturnType<typeof logModule.log>);
+
+    const audio = new RemotePlaybackAudioOutput();
+    const synchronizer = new TranscriptionSynchronizer(audio, new MockTextOutput());
+    const frame = new AudioFrame(new Int16Array(160), 8000, 1, 160);
+
+    synchronizer.rotateSegment();
+    await synchronizer.audioOutput.captureFrame(frame);
+    audio.startPlayback();
+
+    expect(
+      warn.mock.calls.filter(
+        (c) => c[0] === 'SegmentSynchronizerImpl.onPlaybackStarted called after startFuture is set',
+      ),
+    ).toHaveLength(0);
+    await synchronizer.close();
+  });
+});
+
 class DroppingAudioOutput extends AudioOutput {
   constructor() {
     super(8000);

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -707,7 +707,7 @@ export class TranscriptionSynchronizer {
     }
 
     await this._impl.close();
-    this._impl = new SegmentSynchronizerImpl(this.options, this.textOutput.nextInChain, true);
+    this._impl = new SegmentSynchronizerImpl(this.options, this.textOutput.nextInChain);
 
     if (this._paused) {
       this._impl.pause();


### PR DESCRIPTION
## Issue

`SegmentSynchronizerImpl` times word emission from `startWallTime`, which is set by whichever comes first: `pushAudio` or `onPlaybackStarted`.

`rotateSegment` passes `seedFromPushAudio = true`, so every segment after the first anchors to the moment a frame is handed to the audio output. The real playback signal is then rejected when it arrives:

```
SegmentSynchronizerImpl.onPlaybackStarted called after startFuture is set
```

For local sinks those two moments are the same instant, since `ParticipantAudioOutput` calls `onPlaybackStarted` on its own first frame. The seed is redundant there.

For an output that renders remotely they are seconds apart, so captions lead the audio for the whole turn and that warning fires on every turn. I see a consistent 1.5 to 2s lead with a custom `AudioOutput` streaming to a lip sync renderer. `DataStreamAudioOutput` is in the same position, which is presumably why it has `waitPlaybackStart`.

## Fix

Drop the seed so rotated segments behave like the first one.

Text cannot be stranded if an output never reports playback, since `close()` already resolves the clock.

## Test

Added `RemotePlaybackAudioOutput` to `synchronizer.test.ts`. It reports playback after the frame has been handed over, and asserts the rejection warning is not emitted for a rotated segment. Fails on main, passes with the fix.

`vitest run src/voice/`: 620 tests across 58 files, all passing.