### PR TITLE
fix: respect agent endpointing delay during reply hold-off

### DIFF
--- a/.changeset/calm-replies-wait.md
+++ b/.changeset/calm-replies-wait.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Use the active agent endpointing delay while holding pending replies during user speech.

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1520,11 +1520,7 @@ export class AgentActivity implements RecognitionHooks {
       this.interruptByAudioActivity();
     }
 
-    if (
-      ev.speaking &&
-      ev.rawAccumulatedSilence <=
-        this.agentSession.sessionOptions.turnHandling.endpointing.minDelay / 2
-    ) {
+    if (ev.speaking && ev.rawAccumulatedSilence <= this.endpointingOpts.minDelay / 2) {
       this.userSilenceEvent.clear();
     } else {
       this.userSilenceEvent.set();

--- a/agents/src/voice/agent_session_endpointing.test.ts
+++ b/agents/src/voice/agent_session_endpointing.test.ts
@@ -21,7 +21,7 @@
 import { describe, expect, it } from 'vitest';
 import { TurnDetector } from '../inference/eot/detector.js';
 import type { VADStream } from '../vad.js';
-import { VAD as BaseVAD } from '../vad.js';
+import { VAD as BaseVAD, VADEventType } from '../vad.js';
 import { Agent } from './agent.js';
 import { AgentActivity } from './agent_activity.js';
 import { AgentSession } from './agent_session.js';
@@ -110,6 +110,53 @@ describe('AgentSession endpointing defaults', () => {
       await session.close().catch(() => {});
     }
   });
+
+  it.each([
+    { sessionMinDelay: 200, agentMinDelay: 1000, replyHeld: true },
+    { sessionMinDelay: 1000, agentMinDelay: 200, replyHeld: false },
+  ])(
+    'reply hold-off uses agent minDelay: $agentMinDelay',
+    async ({ sessionMinDelay, agentMinDelay, replyHeld }) => {
+      const session = new AgentSession({
+        vad: new FakeVAD(),
+        turnHandling: {
+          turnDetection: 'vad',
+          endpointing: { minDelay: sessionMinDelay },
+        },
+      });
+      try {
+        const activity = new AgentActivity(
+          new Agent({
+            instructions: 'test',
+            turnHandling: { endpointing: { minDelay: agentMinDelay } },
+          }),
+          session,
+        );
+        const activityInternals = activity as unknown as {
+          userSilenceEvent: { isSet: boolean };
+        };
+        expect(activity.endpointingOpts.minDelay).toBe(agentMinDelay);
+
+        activity.onVADInferenceDone({
+          type: VADEventType.INFERENCE_DONE,
+          samplesIndex: 0,
+          timestamp: 0,
+          speechDuration: 0,
+          silenceDuration: 250,
+          frames: [],
+          probability: 0,
+          inferenceDuration: 0,
+          speaking: true,
+          rawAccumulatedSilence: 250,
+          rawAccumulatedSpeech: 0,
+        });
+
+        expect(activityInternals.userSilenceEvent.isSet).toBe(!replyHeld);
+      } finally {
+        await session.close().catch(() => {});
+      }
+    },
+  );
 
   it('runtime updateOptions changes survive a handoff via overrides', async () => {
     const session = new AgentSession({ vad: new FakeVAD() });


### PR DESCRIPTION
Pending reply hold-off from #2263 used the session endpointing delay even when the active agent overrides it. This could release speech too early or keep it blocked too long.

Use the activity-resolved minimum delay and cover both override directions.

Stacked on #2263.
Addresses AGT-3281

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> Reply hold-off during user speech ignores per-agent endpointing settings
>
> The silence threshold that decides whether a pending reply keeps waiting is read from the session-wide setting (this.agentSession.sessionOptions.turnHandling.endpointing.minDelay at agents/src/voice/agent_activity.ts:1526) instead of the value actually in effect for the current agent, so replies can be released too early or held too long when an agent customizes it.
> Impact: Agents that configure their own end-of-turn timing can start talking over the user, or wait longer than configured, because the hold-off uses a different delay than the turn detection actually uses.
>
> create a PR. and create a Node-js PR too.
>
> the node PR should be stacked on top of https://github.com/livekit/agents-js/pull/2263/changes

</details>