### PR TITLE
fix: correct changeset release levels

### DIFF
--- a/.changeset/fuzzy-taxis-listen.md
+++ b/.changeset/fuzzy-taxis-listen.md
@@ -1,5 +1,5 @@
 ---
-'@livekit/agents-plugin-openai': minor
+'@livekit/agents-plugin-openai': patch
 ---
 
 Support context hints and code-switched language lists in OpenAI STT.

--- a/.changeset/fuzzy-tools-write.md
+++ b/.changeset/fuzzy-tools-write.md
@@ -1,5 +1,5 @@
 ---
-'@livekit/agents': minor
+'@livekit/agents': patch
 '@livekit/agents-plugin-anthropic': patch
 ---
 

--- a/.changeset/xai-final-transcript.md
+++ b/.changeset/xai-final-transcript.md
@@ -1,6 +1,6 @@
 ---
 '@livekit/agents-plugin-openai': patch
-'@livekit/agents-plugin-xai': minor
+'@livekit/agents-plugin-xai': patch
 ---
 
 Emit one final xAI user transcript per turn and settle rejected realtime chat context updates.


### PR DESCRIPTION
Three patch-level fixes were marked as minor releases, which would publish unnecessary minor version bumps. Mark the affected agents, OpenAI, and xAI changesets as patches.

**Validation:** `pnpm exec changeset status` reports no minor or major package bumps.

Addresses AGT-3284

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> .changeset/fuzzy-taxis-listen.md should have been a patch change
>
> same for .changeset/fuzzy-tools-write.md
>
> .changeset/xai-final-transcript.md
>
> creata a PR please

</details>