### PR TITLE
fix(phonic): reconnect after abnormal disconnects

### DIFF
--- a/.changeset/phonic-abnormal-disconnect-reconnect.md
+++ b/.changeset/phonic-abnormal-disconnect-reconnect.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-phonic': patch
+---
+
+Reconnect Phonic conversations after abnormal WebSocket disconnects

--- a/plugins/phonic/package.json
+++ b/plugins/phonic/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "phonic": "^0.32.9"
+    "phonic": "^0.32.14"
   },
   "peerDependencies": {
     "@livekit/agents": "workspace:*",

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -414,6 +414,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     this.client = new PhonicClient({
       apiKey: this.options.apiKey,
       baseUrl: this.options.baseUrl,
+      reconnectConversationOnAbnormalDisconnect: true,
     });
     this.bstream = new AudioByteStream(
       PHONIC_INPUT_SAMPLE_RATE,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1215,8 +1215,8 @@ importers:
   plugins/phonic:
     dependencies:
       phonic:
-        specifier: ^0.32.9
-        version: 0.32.9
+        specifier: ^0.32.14
+        version: 0.32.14
     devDependencies:
       '@livekit/agents':
         specifier: workspace:*
@@ -4732,8 +4732,8 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  phonic@0.32.9:
-    resolution: {integrity: sha512-eYY7CY9PULChjxxs0xqS7qawDksu2tq4vW9raWC+gNOQi6iwvI+ibIcnKinp0HEP9nDgTNyil8/J+xodHERwPg==}
+  phonic@0.32.14:
+    resolution: {integrity: sha512-e2RafSya3oVjB09HJ4uGTHY2EwEwNtYGYNo17oa66V3iydMNZX+tX2H2wkyVlyPxZ2anszKrtwmztkcyVXG0rQ==}
     engines: {node: '>=18.0.0'}
 
   picocolors@1.1.1:
@@ -8854,7 +8854,7 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  phonic@0.32.9:
+  phonic@0.32.14:
     dependencies:
       ws: 8.21.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ packages:
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   - '@livekit/*'
+  # Reconnectable conversation close handling fix
+  - phonic@0.32.14
   # Renovate security update: vite@7.3.2 || 7.3.5
   - vite@7.3.2 || 7.3.5
   # Renovate security update: ws@8.20.1


### PR DESCRIPTION
## Summary
- opt Phonic realtime sessions into automatic conversation reconnection after abnormal WebSocket disconnects
- add a patch changeset for the Phonic plugin

## Test plan
- [x] `corepack pnpm --filter @livekit/agents-plugin-phonic lint`
- [x] Prettier check for the modified source and changeset
- [x] Build `@livekit/agents`, then run the Phonic plugin declaration build
- [x] Validate the changeset

Made with [Cursor](https://cursor.com)