### PR TITLE
plugins/phonic: support built-in tools via phonicTools + configsForTools

### DIFF
--- a/.changeset/phonic-built-in-tools.md
+++ b/.changeset/phonic-built-in-tools.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-phonic': patch
+---
+
+Support Phonic's built-in tools (`choose_not_to_respond`, `keypad_input`, `natural_conversation_ending`) in the realtime model. Enable them by name via `phonicTools` and configure them with a matching `configsForTools` entry (`respond_after_sec` for `choose_not_to_respond`; `speech_before_tool_call` for the other two) — a built-in with a config is sent to Phonic as an inline object, otherwise as a bare name using its defaults.

--- a/plugins/phonic/README.md
+++ b/plugins/phonic/README.md
@@ -1,6 +1,6 @@
 # @livekit/agents-plugin-phonic
 
-Realtime voice AI integration for [Phonic](https://phonic.co/) with LiveKit Agents.
+Realtime voice AI integration for [Phonic](https://phonic.ai/) with LiveKit Agents.
 
 ## Usage
 
@@ -76,7 +76,7 @@ Set the `PHONIC_API_KEY` environment variable, or pass `apiKey` directly to `Rea
 | `additionalLanguages`                | `string[]`                                 | Further ISO 639-1 codes (must not repeat `defaultLanguage`)                                                                                                                                                                                                 |
 | `multilingualMode`                   | `'auto'` \| `'request'`                    | Per-utterance language detection vs. change on user request (recommended: `request`)                                                                                                                                                                        |
 | `audioSpeed`                         | `number`                                   | Audio playback speed                                                                                                                                                                                                                                        |
-| `phonicTools`                        | `string[]`                                 | Names of Phonic-side tools available to the assistant: [Webhook tools](https://docs.phonic.co/docs/using-tools/tools_overview#webhook-tools) and [built-in tools](#built-in-tools) (`choose_not_to_respond`, `keypad_input`, `natural_conversation_ending`) |
+| `phonicTools`                        | `string[]`                                 | Names of Phonic-side tools available to the assistant: [Webhook tools](https://docs.phonic.ai/docs/using-tools/tools_overview#webhook-tools) and [built-in tools](#built-in-tools) (`choose_not_to_respond`, `keypad_input`, `natural_conversation_ending`) |
 | `boostedKeywords`                    | `string[]`                                 | Keywords to boost in speech recognition                                                                                                                                                                                                                     |
 | `minWordsToInterrupt`                | `number`                                   | Minimum number of user words required to interrupt the assistant                                                                                                                                                                                            |
 | `generateNoInputPokeText`            | `boolean`                                  | Auto-generate poke text when user is silent                                                                                                                                                                                                                 |

--- a/plugins/phonic/README.md
+++ b/plugins/phonic/README.md
@@ -57,51 +57,50 @@ export default defineAgent({
 });
 
 cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
-
 ```
 
 ## Configuration
 
 Set the `PHONIC_API_KEY` environment variable, or pass `apiKey` directly to `RealtimeModel`. All other options are optional.
 
-| Option | Type | Description |
-| --- | --- | --- |
-| `apiKey` | `string` | Phonic API key. Falls back to `PHONIC_API_KEY` environment variable |
-| `model` | `string` | Model name (default: `merritt`) |
-| `phonicAgent` | `string` | Phonic agent name. Options set explicitly here override agent settings |
-| `voice` | `string` | Voice ID — `sabrina`, `grant`, `virginia`, `landon`, `eleanor`, `shelby`, `nolan` |
-| `welcomeMessage` | `string` | Message the agent says when the conversation starts. Ignored when `generateWelcomeMessage` is true |
-| `generateWelcomeMessage` | `boolean` | Auto-generate the welcome message (ignores `welcomeMessage`) |
-| `project` | `string` | Project name (default: `main`) |
-| `defaultLanguage` | `string` | ISO 639-1 default language for recognition and speech |
-| `additionalLanguages` | `string[]` | Further ISO 639-1 codes (must not repeat `defaultLanguage`) |
-| `multilingualMode` | `'auto'` \| `'request'` | Per-utterance language detection vs. change on user request (recommended: `request`) |
-| `audioSpeed` | `number` | Audio playback speed |
-| `phonicTools` | `string[]` | [Phonic Webhook tool](https://docs.phonic.co/docs/using-tools/tools_overview#webhook-tools) names available to the assistant |
-| `boostedKeywords` | `string[]` | Keywords to boost in speech recognition |
-| `minWordsToInterrupt` | `number` | Minimum number of user words required to interrupt the assistant |
-| `generateNoInputPokeText` | `boolean` | Auto-generate poke text when user is silent |
-| `noInputPokeSec` | `number` | Seconds of silence before sending poke message |
-| `noInputPokeText` | `string` | Poke message text (ignored when `generateNoInputPokeText` is true) |
-| `noInputEndConversationSec` | `number` | Seconds of silence before ending conversation |
-| `websocketTimeoutSec` | `number` | Seconds of inactivity before the Phonic websocket is closed |
-| `intelligenceLevel` | `'standard'` \| `'high'` | LLM intelligence level |
-| `isWelcomeMessageInterruptible` | `boolean` | When false, the welcome message cannot be interrupted |
-| `vadPrebufferDurationMs` | `number` | Voice-activity-detection prebuffer duration (ms) |
-| `vadMinSpeechDurationMs` | `number` | Minimum speech duration for VAD (ms) |
-| `vadMinSilenceDurationMs` | `number` | Minimum silence duration for VAD (ms) |
-| `vadThreshold` | `number` | Voice-activity-detection threshold |
-| `enableAssistantBackchannel` | `boolean` | When true, the assistant backchannels (e.g. "mm-hmm") while the user speaks |
-| `assistantBackchannelAggressiveness` | `number` | How aggressively the assistant backchannels (needs `enableAssistantBackchannel`) |
-| `pronunciationDictionary` | `{ word, pronunciation }[]` | Pronunciation entries; words must be unique |
-| `templateVariables` | `Record<string, string>` | Variables substituted into the system prompt and welcome message |
-| `enableRedaction` | `boolean` | Redact PII/PHI from transcripts and bleep it from audio after the conversation |
-| `mcpServers` | `string[]` | Names of pre-configured MCP servers to make available (must be unique) |
-| `observabilityIntegrations` | `'braintrust'[]` | Observability integrations to forward traces to |
-| `configurationEndpoint` | `{ url, headers?, timeout_ms? }` \| `null` | Endpoint the agent calls to fetch per-conversation configuration |
-| `additionalParams` | `Record<string, unknown>` | Additional runtime parameters forwarded to Phonic |
-| `configsForTools` | `PhonicToolConfig[]` | Per-tool behavior overrides (see [Per-tool configuration](#per-tool-configuration)) |
-| `onConversationCreated` | `(conversationId: string) => void` | Callback invoked with the Phonic conversation ID when the conversation is created |
+| Option                               | Type                                       | Description                                                                                                                                                                                                                                                 |
+| ------------------------------------ | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiKey`                             | `string`                                   | Phonic API key. Falls back to `PHONIC_API_KEY` environment variable                                                                                                                                                                                         |
+| `model`                              | `string`                                   | Model name (default: `merritt`)                                                                                                                                                                                                                             |
+| `phonicAgent`                        | `string`                                   | Phonic agent name. Options set explicitly here override agent settings                                                                                                                                                                                      |
+| `voice`                              | `string`                                   | Voice ID — `sabrina`, `grant`, `virginia`, `landon`, `eleanor`, `shelby`, `nolan`                                                                                                                                                                           |
+| `welcomeMessage`                     | `string`                                   | Message the agent says when the conversation starts. Ignored when `generateWelcomeMessage` is true                                                                                                                                                          |
+| `generateWelcomeMessage`             | `boolean`                                  | Auto-generate the welcome message (ignores `welcomeMessage`)                                                                                                                                                                                                |
+| `project`                            | `string`                                   | Project name (default: `main`)                                                                                                                                                                                                                              |
+| `defaultLanguage`                    | `string`                                   | ISO 639-1 default language for recognition and speech                                                                                                                                                                                                       |
+| `additionalLanguages`                | `string[]`                                 | Further ISO 639-1 codes (must not repeat `defaultLanguage`)                                                                                                                                                                                                 |
+| `multilingualMode`                   | `'auto'` \| `'request'`                    | Per-utterance language detection vs. change on user request (recommended: `request`)                                                                                                                                                                        |
+| `audioSpeed`                         | `number`                                   | Audio playback speed                                                                                                                                                                                                                                        |
+| `phonicTools`                        | `string[]`                                 | Names of Phonic-side tools available to the assistant: [Webhook tools](https://docs.phonic.co/docs/using-tools/tools_overview#webhook-tools) and [built-in tools](#built-in-tools) (`choose_not_to_respond`, `keypad_input`, `natural_conversation_ending`) |
+| `boostedKeywords`                    | `string[]`                                 | Keywords to boost in speech recognition                                                                                                                                                                                                                     |
+| `minWordsToInterrupt`                | `number`                                   | Minimum number of user words required to interrupt the assistant                                                                                                                                                                                            |
+| `generateNoInputPokeText`            | `boolean`                                  | Auto-generate poke text when user is silent                                                                                                                                                                                                                 |
+| `noInputPokeSec`                     | `number`                                   | Seconds of silence before sending poke message                                                                                                                                                                                                              |
+| `noInputPokeText`                    | `string`                                   | Poke message text (ignored when `generateNoInputPokeText` is true)                                                                                                                                                                                          |
+| `noInputEndConversationSec`          | `number`                                   | Seconds of silence before ending conversation                                                                                                                                                                                                               |
+| `websocketTimeoutSec`                | `number`                                   | Seconds of inactivity before the Phonic websocket is closed                                                                                                                                                                                                 |
+| `intelligenceLevel`                  | `'standard'` \| `'high'`                   | LLM intelligence level                                                                                                                                                                                                                                      |
+| `isWelcomeMessageInterruptible`      | `boolean`                                  | When false, the welcome message cannot be interrupted                                                                                                                                                                                                       |
+| `vadPrebufferDurationMs`             | `number`                                   | Voice-activity-detection prebuffer duration (ms)                                                                                                                                                                                                            |
+| `vadMinSpeechDurationMs`             | `number`                                   | Minimum speech duration for VAD (ms)                                                                                                                                                                                                                        |
+| `vadMinSilenceDurationMs`            | `number`                                   | Minimum silence duration for VAD (ms)                                                                                                                                                                                                                       |
+| `vadThreshold`                       | `number`                                   | Voice-activity-detection threshold                                                                                                                                                                                                                          |
+| `enableAssistantBackchannel`         | `boolean`                                  | When true, the assistant backchannels (e.g. "mm-hmm") while the user speaks                                                                                                                                                                                 |
+| `assistantBackchannelAggressiveness` | `number`                                   | How aggressively the assistant backchannels (needs `enableAssistantBackchannel`)                                                                                                                                                                            |
+| `pronunciationDictionary`            | `{ word, pronunciation }[]`                | Pronunciation entries; words must be unique                                                                                                                                                                                                                 |
+| `templateVariables`                  | `Record<string, string>`                   | Variables substituted into the system prompt and welcome message                                                                                                                                                                                            |
+| `enableRedaction`                    | `boolean`                                  | Redact PII/PHI from transcripts and bleep it from audio after the conversation                                                                                                                                                                              |
+| `mcpServers`                         | `string[]`                                 | Names of pre-configured MCP servers to make available (must be unique)                                                                                                                                                                                      |
+| `observabilityIntegrations`          | `'braintrust'[]`                           | Observability integrations to forward traces to                                                                                                                                                                                                             |
+| `configurationEndpoint`              | `{ url, headers?, timeout_ms? }` \| `null` | Endpoint the agent calls to fetch per-conversation configuration                                                                                                                                                                                            |
+| `additionalParams`                   | `Record<string, unknown>`                  | Additional runtime parameters forwarded to Phonic                                                                                                                                                                                                           |
+| `configsForTools`                    | `PhonicToolConfig[]`                       | Per-tool behavior overrides (see [Per-tool configuration](#per-tool-configuration))                                                                                                                                                                         |
+| `onConversationCreated`              | `(conversationId: string) => void`         | Callback invoked with the Phonic conversation ID when the conversation is created                                                                                                                                                                           |
 
 ### Per-tool configuration
 
@@ -116,17 +115,30 @@ new phonic.realtime.RealtimeModel({
 });
 ```
 
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| `name` | `string` | — | Tool this config applies to (required) |
-| `require_speech_before_tool_call` | `boolean` | `false` | Require the agent to speak before the tool can be called |
-| `forbid_speech_after_tool_call` | `boolean` | `false` | Suppress the auto-generated spoken reply after the tool. Use for tools that always hand off to another agent (a non-handoff tool set here would leave the agent silent) |
-| `forbid_tool_call_after_speech` | `boolean` | `false` | Drop the tool call if the agent already spoke this turn |
+| Field                             | Type      | Default | Description                                                                                                                                                             |
+| --------------------------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                            | `string`  | —       | Tool this config applies to (required)                                                                                                                                  |
+| `require_speech_before_tool_call` | `boolean` | `false` | Require the agent to speak before the tool can be called                                                                                                                |
+| `forbid_speech_after_tool_call`   | `boolean` | `false` | Suppress the auto-generated spoken reply after the tool. Use for tools that always hand off to another agent (a non-handoff tool set here would leave the agent silent) |
+| `forbid_tool_call_after_speech`   | `boolean` | `false` | Drop the tool call if the agent already spoke this turn                                                                                                                 |
+| `respond_after_sec`               | `number`  | —       | **`choose_not_to_respond` only.** Seconds to wait after the tool fires; if the user stays silent, the agent speaks a follow-up. Omit to keep the default (stay silent). |
+| `speech_before_tool_call`         | `string`  | —       | **`keypad_input` / `natural_conversation_ending` only.** `required` \| `optional` \| `suppressed`.                                                                      |
 
 The plugin always sends tool calls with `wait_for_speech_before_tool_call` on and `allow_tool_chaining` off; these are not configurable per tool.
 
 > **Deprecated:** the top-level `forbidSpeechAfterToolCall: string[]` option still works but is deprecated — it now folds each listed tool into `configsForTools` as `forbid_speech_after_tool_call: true` (an explicit `configsForTools` entry wins) and logs a warning. Prefer `configsForTools`.
 
-If you already have an agent set up on the Phonic platform, you can use the `phonicAgent` option to specify the agent name. As a note, configuration options you set in the LiveKit Agents SDK will override the agent settings set on the Phonic platform. This means the system prompt you have set on the Phonic platform will be ignored in favor of the `instructions` field set on the LiveKit `voice.Agent`. Likewise, options explicitly set in the `RealtimeModel` constructor will override the Phonic agent's settings. 
+### Built-in tools
 
-If you have Webhook tools set up on the Phonic platform, you can use `phonicTools` to make them available to your agent. Only [Phonic Webhook tools](https://docs.phonic.co/docs/using-tools/tools_overview#webhook-tools) are supported with LiveKit Agents.
+Phonic's built-in tools — `choose_not_to_respond`, `keypad_input`, `natural_conversation_ending` — are enabled by listing their names in `phonicTools`, alongside any Webhook tools. To configure one, add a `configsForTools` entry keyed by the same name (`respond_after_sec` for `choose_not_to_respond`; `speech_before_tool_call` for the other two). A built-in listed without a config uses its Phonic-side defaults.
+
+```typescript
+new phonic.realtime.RealtimeModel({
+  phonicTools: ['choose_not_to_respond', 'keypad_input'],
+  configsForTools: [{ name: 'choose_not_to_respond', respond_after_sec: 5 }],
+});
+```
+
+If you already have an agent set up on the Phonic platform, you can use the `phonicAgent` option to specify the agent name. As a note, configuration options you set in the LiveKit Agents SDK will override the agent settings set on the Phonic platform. This means the system prompt you have set on the Phonic platform will be ignored in favor of the `instructions` field set on the LiveKit `voice.Agent`. Likewise, options explicitly set in the `RealtimeModel` constructor will override the Phonic agent's settings.
+
+If you have Webhook tools set up on the Phonic platform, you can use `phonicTools` to make them available to your agent, together with Phonic's [built-in tools](#built-in-tools). Custom function tools you define on the LiveKit `voice.Agent` are also supported and run over the websocket.

--- a/plugins/phonic/package.json
+++ b/plugins/phonic/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "phonic": "^0.32.14"
+    "phonic": "^0.32.15"
   },
   "peerDependencies": {
     "@livekit/agents": "workspace:*",

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -593,21 +593,23 @@ export class RealtimeSession extends llm.RealtimeSession {
       const cfg = this.configsForTools.get(name);
       if (name === 'choose_not_to_respond') {
         if (cfg?.respond_after_sec === undefined) return name;
-        // The published Phonic SDK does not yet type choose_not_to_respond / respond_after_sec on
-        // BuiltInToolDefinition (added in Phonic's fern-config); cast until the SDK is regenerated.
         return {
           type: 'built_in',
           name,
           tool_config: { respond_after_sec: cfg.respond_after_sec },
-        } as unknown as Phonic.ToolDefinition;
+        };
       }
-      // keypad_input, natural_conversation_ending
+      // keypad_input, natural_conversation_ending. name is a string here (not narrowed to the
+      // literal union), so cast it to the built-in name type; the config is passed through as-is.
       if (cfg?.speech_before_tool_call === undefined) return name;
       return {
         type: 'built_in',
-        name,
-        tool_config: { speech_before_tool_call: cfg.speech_before_tool_call },
-      } as Phonic.ToolDefinition;
+        name: name as Phonic.BuiltInToolDefinition.Name,
+        tool_config: {
+          speech_before_tool_call:
+            cfg.speech_before_tool_call as Phonic.BuiltInToolConfig['speech_before_tool_call'],
+        },
+      };
     });
   }
 

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -77,6 +77,14 @@ export interface RealtimeModelOptions {
   instructions?: string;
 }
 
+// Phonic's built-in tools, referenced by name in `phonicTools`. A configsForTools entry for one of
+// these carries its built-in config (below) so it is sent to Phonic as an inline object, not a name.
+const BUILT_IN_TOOL_NAMES = new Set([
+  'choose_not_to_respond',
+  'keypad_input',
+  'natural_conversation_ending',
+]);
+
 /**
  * Per-tool behavior overrides for `configsForTools` (see README). `name` is required; every other
  * field is optional and falls back to the plugin default when omitted. Keys are snake_case to match
@@ -87,6 +95,9 @@ export interface PhonicToolConfig {
   require_speech_before_tool_call?: boolean;
   forbid_speech_after_tool_call?: boolean;
   forbid_tool_call_after_speech?: boolean;
+  // Built-in tools only (set on the matching `phonicTools` entry):
+  respond_after_sec?: number; // choose_not_to_respond: seconds to wait before a follow-up (or omit)
+  speech_before_tool_call?: string; // keypad_input / natural_conversation_ending: required|optional|suppressed
 }
 
 export class RealtimeModel extends llm.RealtimeModel {
@@ -573,6 +584,33 @@ export class RealtimeSession extends llm.RealtimeSession {
       });
   }
 
+  // A phonicTools entry: an inline built-in object when it's a built-in with a config in
+  // configsForTools (so respond_after_sec / speech_before_tool_call reach Phonic), else the bare name
+  // (which uses the tool's default config).
+  private serializePhonicTools(): Phonic.ToolDefinition[] {
+    return (this.options.phonicTools ?? []).map((name): Phonic.ToolDefinition => {
+      if (!BUILT_IN_TOOL_NAMES.has(name)) return name;
+      const cfg = this.configsForTools.get(name);
+      if (name === 'choose_not_to_respond') {
+        if (cfg?.respond_after_sec === undefined) return name;
+        // The published Phonic SDK does not yet type choose_not_to_respond / respond_after_sec on
+        // BuiltInToolDefinition (added in Phonic's fern-config); cast until the SDK is regenerated.
+        return {
+          type: 'built_in',
+          name,
+          tool_config: { respond_after_sec: cfg.respond_after_sec },
+        } as unknown as Phonic.ToolDefinition;
+      }
+      // keypad_input, natural_conversation_ending
+      if (cfg?.speech_before_tool_call === undefined) return name;
+      return {
+        type: 'built_in',
+        name,
+        tool_config: { speech_before_tool_call: cfg.speech_before_tool_call },
+      } as Phonic.ToolDefinition;
+    });
+  }
+
   override async _updateSession(
     instructions?: string,
     chatCtx?: llm.ChatContext,
@@ -606,7 +644,7 @@ export class RealtimeSession extends llm.RealtimeSession {
     this.pendingUserText = undefined;
 
     const toolsPayload: Phonic.ToolDefinition[] = [
-      ...(this.options.phonicTools ?? []),
+      ...this.serializePhonicTools(),
       ...this.toolDefinitions,
     ];
 
@@ -796,7 +834,7 @@ export class RealtimeSession extends llm.RealtimeSession {
       model: this.options.model as Phonic.ConfigPayload['model'],
       ...this.buildConfigOptions({
         systemPrompt: this.options.instructions + this.systemPromptPostfix,
-        toolsPayload: [...(this.options.phonicTools ?? []), ...this.toolDefinitions],
+        toolsPayload: [...this.serializePhonicTools(), ...this.toolDefinitions],
       }),
     });
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1215,8 +1215,8 @@ importers:
   plugins/phonic:
     dependencies:
       phonic:
-        specifier: ^0.32.14
-        version: 0.32.14
+        specifier: ^0.32.15
+        version: 0.32.15
     devDependencies:
       '@livekit/agents':
         specifier: workspace:*
@@ -4732,8 +4732,8 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  phonic@0.32.14:
-    resolution: {integrity: sha512-e2RafSya3oVjB09HJ4uGTHY2EwEwNtYGYNo17oa66V3iydMNZX+tX2H2wkyVlyPxZ2anszKrtwmztkcyVXG0rQ==}
+  phonic@0.32.15:
+    resolution: {integrity: sha512-RP2l67N/wSaAkLfwK1OS6q7OvZY51OJAGfqqcISJiec967gOkBQlk1IJGGg9gDMZL9OL5275VNytD7V/VLoRqA==}
     engines: {node: '>=18.0.0'}
 
   picocolors@1.1.1:
@@ -8854,7 +8854,7 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  phonic@0.32.14:
+  phonic@0.32.15:
     dependencies:
       ws: 8.21.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,8 @@ packages:
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   - '@livekit/*'
-  # Reconnectable conversation close handling fix
-  - phonic@0.32.14
+  # choose_not_to_respond respond_after_sec built-in tool config
+  - phonic@0.32.15
   # Renovate security update: vite@7.3.2 || 7.3.5
   - vite@7.3.2 || 7.3.5
   # Renovate security update: ws@8.20.1


### PR DESCRIPTION
Enable Phonic's built-in tools (`choose_not_to_respond`, `keypad_input`, `natural_conversation_ending`) in the realtime model by listing their names in `phonicTools`, and configure them through a matching `configsForTools` entry — `respond_after_sec` for `choose_not_to_respond`, `speech_before_tool_call` for the other two.

A built-in listed with a config is serialized as an inline `{ type: "built_in", name, tool_config }` object; without a config it is sent as a bare name and uses the tool's Phonic-side defaults. No new constructor option — this reuses the existing `phonicTools` / `configsForTools` surface.

Note: the published `phonic` SDK does not yet type `choose_not_to_respond` / `respond_after_sec` on `BuiltInToolDefinition`; that shape is being added to Phonic's API definition and the CNR object is cast until the regenerated SDK ships. Draft until then.

README + changeset updated.