### PR TITLE
fix(google): keep unspoken model text out of the realtime transcript

### DIFF
--- a/.changeset/google-realtime-unspoken-text.md
+++ b/.changeset/google-realtime-unspoken-text.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-google': patch
+---
+
+Gemini realtime: keep unspoken model text parts out of the transcript when the session runs with audio output and output transcription enabled.

--- a/plugins/google/src/realtime/realtime_api.test.ts
+++ b/plugins/google/src/realtime/realtime_api.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import type { LiveServerContent } from '@google/genai';
 import { Behavior, FunctionResponseScheduling } from '@google/genai';
 import { llm } from '@livekit/agents';
 import { describe, expect, it, vi } from 'vitest';
@@ -179,6 +180,75 @@ describe('Google Realtime non-blocking tool scheduling', () => {
     session.clearPendingToolCallIdsForResponses(result?.functionResponses ?? []);
 
     expect(session.pendingToolCallIds.has('call_123')).toBe(false);
+  });
+});
+
+type ServerContentSessionInternals = {
+  _realtimeModel: { capabilities: { audioOutput: boolean } };
+  options: { outputAudioTranscription?: Record<string, never> };
+  earlyCompletionPending: boolean;
+  currentGeneration: {
+    outputText: string;
+    textChannel: { write: ReturnType<typeof vi.fn> };
+  };
+  handleServerContent(serverContent: LiveServerContent): void;
+};
+
+function createServerContentSession({
+  audioOutput,
+  outputAudioTranscription,
+}: {
+  audioOutput: boolean;
+  outputAudioTranscription?: Record<string, never>;
+}): ServerContentSessionInternals {
+  const session = Object.create(RealtimeSession.prototype) as ServerContentSessionInternals;
+  session._realtimeModel = { capabilities: { audioOutput } };
+  session.options = { outputAudioTranscription };
+  session.earlyCompletionPending = false;
+  session.currentGeneration = {
+    outputText: '',
+    textChannel: { write: vi.fn() },
+  };
+  return session;
+}
+
+describe('Google Realtime model text parts', () => {
+  const modelTextTurn: LiveServerContent = {
+    modelTurn: { parts: [{ text: 'call:getWeather{location:Seattle' }] },
+    outputTranscription: { text: 'Let me check.' },
+  };
+
+  it('keeps unspoken model text out of the transcript in an audio session', () => {
+    const session = createServerContentSession({
+      audioOutput: true,
+      outputAudioTranscription: {},
+    });
+
+    session.handleServerContent(modelTextTurn);
+
+    expect(session.currentGeneration.textChannel.write.mock.calls).toEqual([['Let me check.']]);
+    expect(session.currentGeneration.outputText).toBe('Let me check.');
+  });
+
+  it('forwards model text when the session runs in text modality', () => {
+    const session = createServerContentSession({
+      audioOutput: false,
+      outputAudioTranscription: {},
+    });
+
+    session.handleServerContent({ modelTurn: { parts: [{ text: 'Hello there.' }] } });
+
+    expect(session.currentGeneration.textChannel.write.mock.calls).toEqual([['Hello there.']]);
+    expect(session.currentGeneration.outputText).toBe('Hello there.');
+  });
+
+  it('forwards model text when output transcription is disabled', () => {
+    const session = createServerContentSession({ audioOutput: true });
+
+    session.handleServerContent({ modelTurn: { parts: [{ text: 'Hello there.' }] } });
+
+    expect(session.currentGeneration.textChannel.write.mock.calls).toEqual([['Hello there.']]);
+    expect(session.currentGeneration.outputText).toBe('Hello there.');
   });
 });
 

--- a/plugins/google/src/realtime/realtime_api.ts
+++ b/plugins/google/src/realtime/realtime_api.ts
@@ -1651,6 +1651,14 @@ export class RealtimeSession extends llm.RealtimeSession {
 
     const discardOutput = this.earlyCompletionPending;
 
+    // With audio output and output transcription on, the spoken words arrive as
+    // outputTranscription; a text part on the model turn is never spoken (an unflagged
+    // thought, or a function call the model wrote out as text) and would leak unspoken
+    // text into the transcript.
+    const forwardModelText =
+      !this._realtimeModel.capabilities.audioOutput ||
+      this.options.outputAudioTranscription === undefined;
+
     if (serverContent.modelTurn && !discardOutput) {
       const turn = serverContent.modelTurn;
 
@@ -1660,7 +1668,7 @@ export class RealtimeSession extends llm.RealtimeSession {
           continue;
         }
 
-        if (part.text) {
+        if (part.text && forwardModelText) {
           gen.outputText += part.text;
           gen.textChannel.write(part.text);
         }

--- a/plugins/google/src/realtime/realtime_transcript.test.ts
+++ b/plugins/google/src/realtime/realtime_transcript.test.ts
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type * as genai from '@google/genai';
+import { Modality } from '@google/genai';
+import type { llm } from '@livekit/agents';
+import { describe, expect, it, vi } from 'vitest';
+import { RealtimeModel } from './realtime_api.js';
+
+/** The fields of a server message the session reads — `LiveServerMessage` itself is a class. */
+type ServerFrame = Pick<genai.LiveServerMessage, 'serverContent' | 'toolCall'>;
+
+type ServerCallbacks = {
+  onopen: () => void;
+  onmessage: (message: ServerFrame) => void;
+};
+
+/**
+ * Captures the callbacks the plugin hands to `live.connect()` so a test can
+ * play server frames into the real `RealtimeSession`. Hoisted because `vi.mock` is.
+ */
+const { live } = vi.hoisted(() => ({
+  live: { callbacks: undefined as ServerCallbacks | undefined },
+}));
+
+vi.mock('@google/genai', async (importOriginal) => {
+  const actual = await importOriginal<typeof genai>();
+  return {
+    ...actual,
+    GoogleGenAI: class {
+      live = {
+        connect: async ({ callbacks }: { callbacks: ServerCallbacks }) => {
+          live.callbacks = callbacks;
+          callbacks.onopen();
+          return {
+            sendClientContent: () => {},
+            sendRealtimeInput: () => {},
+            sendToolResponse: () => {},
+            close: () => {},
+          };
+        },
+      };
+    },
+  };
+});
+
+type SessionOptions = Partial<ConstructorParameters<typeof RealtimeModel>[0]>;
+
+/** Two PCM16 samples — enough for the plugin to build one AudioFrame. */
+const AUDIO_PART: genai.Part = {
+  inlineData: { data: Buffer.from([0, 0, 0, 0]).toString('base64'), mimeType: 'audio/pcm' },
+};
+
+async function openSession(options: SessionOptions = {}) {
+  live.callbacks = undefined;
+  const session = new RealtimeModel({
+    model: 'gemini-2.0-flash-live-001',
+    apiKey: 'test-key',
+    ...options,
+  }).session();
+
+  const generations: llm.GenerationCreatedEvent[] = [];
+  session.on('generation_created', (ev) => generations.push(ev));
+
+  // Frames are only accepted once the main task holds the connected session.
+  const internals = session as unknown as { activeSession?: unknown };
+  await vi.waitFor(() => expect(internals.activeSession).toBeDefined());
+
+  return {
+    generations,
+    serverSends: (message: ServerFrame) => live.callbacks!.onmessage(message),
+  };
+}
+
+/**
+ * Frames are handled asynchronously (the plugin serialises them behind its
+ * session lock), so wait for the generation they open, then drain it the way
+ * AgentActivity would: every message's text and audio, then the tool calls.
+ */
+async function drainFirst(generations: llm.GenerationCreatedEvent[]) {
+  await vi.waitFor(() => expect(generations).toHaveLength(1));
+  const ev = generations[0]!;
+
+  let text = '';
+  let audioFrames = 0;
+  for await (const message of ev.messageStream) {
+    for await (const chunk of message.textStream) {
+      text += typeof chunk === 'string' ? chunk : chunk.text;
+    }
+    for await (const _frame of message.audioStream) {
+      audioFrames += 1;
+    }
+  }
+
+  const functionCalls: string[] = [];
+  for await (const call of ev.functionStream) {
+    functionCalls.push(call.name);
+  }
+
+  return { text, audioFrames, functionCalls };
+}
+
+describe('Gemini realtime transcript', () => {
+  it('carries only the output transcription when audio and transcription are on', async () => {
+    const { generations, serverSends } = await openSession();
+
+    // The exact shape seen in production: the model writes a function call out as
+    // text, then speaks. Only the spoken words belong in the transcript.
+    serverSends({
+      serverContent: { modelTurn: { parts: [{ text: 'call:assetGenerator{context:' }] } },
+    });
+    serverSends({ serverContent: { modelTurn: { parts: [AUDIO_PART] } } });
+    serverSends({ serverContent: { outputTranscription: { text: 'Tako je!' } } });
+    serverSends({ serverContent: { generationComplete: true } });
+    serverSends({ serverContent: { turnComplete: true } });
+
+    await expect(drainFirst(generations)).resolves.toEqual({
+      text: 'Tako je!',
+      audioFrames: 1,
+      functionCalls: [],
+    });
+  });
+
+  it('still delivers the tool call the model makes after writing one out as text', async () => {
+    const { generations, serverSends } = await openSession();
+
+    serverSends({
+      serverContent: { modelTurn: { parts: [{ text: 'call:getWeather{location:' }] } },
+    });
+    serverSends({
+      toolCall: {
+        functionCalls: [{ id: 'fc-1', name: 'getWeather', args: { location: 'Seattle' } }],
+      },
+    });
+
+    await expect(drainFirst(generations)).resolves.toEqual({
+      text: '',
+      audioFrames: 0,
+      functionCalls: ['getWeather'],
+    });
+  });
+
+  it('keeps forwarding model text in text modality', async () => {
+    const { generations, serverSends } = await openSession({ modalities: [Modality.TEXT] });
+
+    serverSends({ serverContent: { modelTurn: { parts: [{ text: 'Hello there.' }] } } });
+    serverSends({ serverContent: { turnComplete: true } });
+
+    await expect(drainFirst(generations)).resolves.toEqual({
+      text: 'Hello there.',
+      audioFrames: 0,
+      functionCalls: [],
+    });
+  });
+
+  it('keeps forwarding model text when output transcription is disabled', async () => {
+    const { generations, serverSends } = await openSession({ outputAudioTranscription: null });
+
+    serverSends({ serverContent: { modelTurn: { parts: [{ text: 'Hello there.' }] } } });
+    serverSends({ serverContent: { turnComplete: true } });
+
+    await expect(drainFirst(generations)).resolves.toEqual({
+      text: 'Hello there.',
+      audioFrames: 0,
+      functionCalls: [],
+    });
+  });
+});


### PR DESCRIPTION
## What

In a Gemini realtime session running with **audio output** and **output transcription** enabled (the plugin default), `RealtimeSession.handleServerContent` no longer forwards `modelTurn.parts[].text` into the generation's text stream. Only `outputTranscription` — the transcription of the audio the model actually speaks — feeds the transcript.

Behaviour is unchanged when the session runs in text modality (`modalities: [Modality.TEXT]`) or when output transcription is disabled (`outputAudioTranscription: null`): there the model's text parts are the response and still flow through.

## Why

Both writers currently land in the same `gen.textChannel`:

```ts
if (part.text) { gen.outputText += part.text; gen.textChannel.write(part.text); }   // modelTurn
…
gen.outputText += text; gen.textChannel.write(text);                                 // outputTranscription
```

That channel is the message's `textStream`, so whatever goes in ends up in the `lk.transcription` streams, in the assistant `ChatMessage` (`ConversationItemAdded`), and in the plugin's own `_chatCtx` replay on reconnect.

In an audio session a text part on the model turn is never spoken. We hit this in production on `gemini-3.1-flash-live-preview` (audio modality, `outputAudioTranscription: {}`, no `thinkingConfig`): the model occasionally *writes out* a function call as text instead of emitting a `toolCall` — the transcript then contains things like

```
call:assetGenerator{context:…,title:…,type:quiz
```

followed, in the same generation, by the words that were actually spoken. In one turn the text was cut off exactly where the real `toolCall` arrived (`handleToolCall` → `markCurrentGenerationDone` closes the channel), so the partial call was persisted as its own assistant message; in another the whole call came through as text, no `toolCall` fired, and the leaked text was the only trace. Nothing was said aloud — the leak was invisible in the audio and very visible in captions and persisted history.

The same failure class is acknowledged by Google for Gemini 3.x (function calls verbalized into the text stream in `call:<name>{…}` / `<call:default_api:…/>` shape): [https://discuss.ai.google.dev/t/gemini-3-5-flash-lite-verbalizes-its-function-call-as-pseudo-xml-in-the-text-stream-instead-of-emitting-a-functioncall-part/176699](<https://discuss.ai.google.dev/t/gemini-3-5-flash-lite-verbalizes-its-function-call-as-pseudo-xml-in-the-text-stream-instead-of-emitting-a-functioncall-part/176699>) — and reported against the Python plugin in livekit/agents#5662. The plugin already skips `part.thought` for the same reason (reasoning is not spoken); an unflagged text part in an audio-with-transcription session is the remaining way unspoken text reaches the transcript.

## Approach

One condition computed once per server message, next to the existing `discardOutput`:

```ts
const forwardModelText =
  !this._realtimeModel.capabilities.audioOutput ||
  this.options.outputAudioTranscription === undefined;
```

and the text-part branch becomes `if (part.text && forwardModelText)`. `inlineData` handling, `outputTranscription`, tool calls, `_firstTokenTimestamp` and the turn-complete bookkeeping are untouched. Text-modality sessions and audio sessions without transcription behave exactly as before.

The Python plugin has the identical merge (`realtime_api.py`, `_handle_server_content`: `current_gen.push_text(part.text)` and `current_gen.push_text(output_transcription.text)`), so the same one-line gate applies there if you want parity — happy to open that too.

## Tests

**Wire replay** — `plugins/google/src/realtime/realtime_transcript.test.ts` drives the real `RealtimeSession` through a mocked `live.connect()` (same harness as `live_setup_wiring.test.ts`), plays server frames in, and asserts on the public output streams (`messageStream` → `textStream`/`audioStream`, `functionStream`) the way `AgentActivity` reads them:

<!-- linear:table-colwidths:266,266,266 -->
| frames in | on `main` | with this PR |
| -- | -- | -- |
| text part `call:assetGenerator{context:` → audio → `outputTranscription: 'Tako je!'` → complete | text `'call:assetGenerator{context:Tako je!'`, 1 audio frame | text `'Tako je!'`, 1 audio frame |
| text part `call:getWeather{location:` → `toolCall getWeather` | text `'call:getWeather{location:'`, tool call delivered | text `''`, tool call delivered |
| `modalities: [TEXT]`, text part `'Hello there.'` | text `'Hello there.'` | unchanged |
| `outputAudioTranscription: null`, text part `'Hello there.'` | text `'Hello there.'` | unchanged |

The first row is the production artifact byte for byte (leaked call glued to the spoken words in one assistant message).

**Unit** — `Google Realtime model text parts` in `realtime_api.test.ts` covers the same three configurations at the `handleServerContent` level (`Object.create(RealtimeSession.prototype)` pattern already used in that file); the audio+transcription case is red on `main`.

**Live probe** (local only, not committed) — real `gemini-3.1-flash-live-preview` through the patched plugin: a spoken reply arrives as `modelTurn.inlineData` (8 frames) + `outputTranscription` (`'smoke ok'`), zero model text parts, and the plugin's transcript equals the transcription; a tool-calling prompt yields the call on `functionStream`. So the frame shapes the replay test assumes are the ones the API sends, and speech/transcription/tool calls still flow.

Checks: `pnpm exec vitest run plugins/google` — 45 passed / 2 skipped (pre-existing); `tsc --noEmit` for the plugin — clean; `eslint` — no new findings (three pre-existing `no-explicit-any` warnings elsewhere in the file); `prettier --check` — clean; changeset added (`@livekit/agents-plugin-google`: patch).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)