### PR TITLE
feat: add cancellation to warm transfers

### DIFF
--- a/.changeset/warm-transfer-cooperative-cancellation.md
+++ b/.changeset/warm-transfer-cooperative-cancellation.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Add an optional `abortSignal` to `WarmTransferTask`. Aborting stops waiting for a pending dial or ends an active consultation, and `run()` rejects with the signal reason.

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -8770,6 +8770,7 @@ class WarmTransferTask extends AgentTask<WarmTransferResult> {
 //
 // @public (undocumented)
 interface WarmTransferTaskOptions {
+    abortSignal?: AbortSignal;
     // (undocumented)
     allowInterruptions?: boolean;
     callerHangupInstruction?: string | null;

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -273,4 +273,25 @@ describe('createWarmTransferTask', () => {
 
     expect(complete).toHaveBeenCalledWith(reason);
   });
+
+  it('observes aborts after a participant move fails', async () => {
+    const controller = new AbortController();
+    const reason = new Error('application shutdown');
+    mockDial();
+    vi.spyOn(RoomServiceClient.prototype, 'moveParticipant').mockRejectedValue(
+      new Error('move failed'),
+    );
+    const { complete, create } = setupTransfer(controller.signal);
+
+    const options = create.mock.calls[0]![0];
+    await options.onEnter!({} as never);
+    const connect = (options.tools as FunctionTool[]).find(
+      (entry) => entry.name === 'connect_to_caller',
+    )!;
+
+    await expect(connect.execute({}, {} as never)).rejects.toThrow('move failed');
+    controller.abort(reason);
+
+    expect(complete).toHaveBeenCalledWith(reason);
+  });
 });

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -286,8 +286,12 @@ describe('createWarmTransferTask', () => {
     'waits until caller-hangup notice playout %s before exiting and shutting down an answered agent',
     async (outcome) => {
       const controller = new AbortController();
-      const timeoutController = new AbortController();
-      const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+      const playoutTimeoutController = new AbortController();
+      const removalTimeoutController = new AbortController();
+      const timeout = vi
+        .spyOn(AbortSignal, 'timeout')
+        .mockReturnValueOnce(playoutTimeoutController.signal)
+        .mockReturnValueOnce(removalTimeoutController.signal);
       let completePlayout!: () => void;
       let failPlayout!: (error: Error) => void;
       const playout = new Promise<void>((resolve, reject) => {
@@ -335,7 +339,7 @@ describe('createWarmTransferTask', () => {
         failPlayout(new Error('playout failed'));
       } else {
         expect(timeout).toHaveBeenCalledWith(30_000);
-        timeoutController.abort();
+        playoutTimeoutController.abort();
       }
 
       await vi.waitFor(
@@ -354,6 +358,60 @@ describe('createWarmTransferTask', () => {
       expect(exitFinished).toBe(true);
     },
   );
+
+  it('stops waiting when removing the human agent after caller hangup times out', async () => {
+    const controller = new AbortController();
+    const playoutTimeoutController = new AbortController();
+    const removalTimeoutController = new AbortController();
+    const timeout = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValueOnce(playoutTimeoutController.signal)
+      .mockReturnValueOnce(removalTimeoutController.signal);
+    vi.spyOn(AgentSession.prototype, 'interrupt').mockReturnValue({} as never);
+    vi.spyOn(AgentSession.prototype, 'generateReply').mockReturnValue({
+      waitForPlayout: vi.fn().mockResolvedValue(undefined),
+    } as never);
+    const removeParticipant = vi
+      .spyOn(RoomServiceClient.prototype, 'removeParticipant')
+      .mockReturnValue(new Promise<never>(() => {}) as never);
+    const { shutdown } = mockDial();
+    const {
+      callerRoom,
+      create,
+      setInputAudioEnabled,
+      setOutputAudioEnabled,
+      setOutputTranscriptionEnabled,
+    } = setupTransfer(controller.signal);
+
+    const options = create.mock.calls[0]![0];
+    await options.onEnter!({} as never);
+    const onCallerLeft = vi
+      .mocked(callerRoom.on)
+      .mock.calls.find(([event]) => event === RoomEvent.ParticipantDisconnected)?.[1];
+    expect(onCallerLeft).toBeDefined();
+    (onCallerLeft as (participant: { identity: string; kind: ParticipantKind }) => void)({
+      identity: 'caller',
+      kind: ParticipantKind.STANDARD,
+    });
+
+    let exitFinished = false;
+    const exiting = Promise.resolve(options.onExit!({} as never)).then(() => {
+      exitFinished = true;
+    });
+    await vi.waitFor(() => expect(removeParticipant).toHaveBeenCalledOnce());
+    expect(timeout).toHaveBeenNthCalledWith(1, 30_000);
+    await vi.waitFor(() => expect(timeout).toHaveBeenNthCalledWith(2, 10_000), { timeout: 200 });
+    expect(exitFinished).toBe(false);
+    expect(shutdown).not.toHaveBeenCalled();
+
+    removalTimeoutController.abort();
+    await exiting;
+
+    expect(shutdown).toHaveBeenCalledOnce();
+    expect(setInputAudioEnabled).toHaveBeenLastCalledWith(true);
+    expect(setOutputAudioEnabled).toHaveBeenLastCalledWith(true);
+    expect(setOutputTranscriptionEnabled).toHaveBeenLastCalledWith(true);
+  });
 
   it('lets a successful participant move win over an abort', async () => {
     const controller = new AbortController();

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -172,6 +172,23 @@ describe('createWarmTransferTask', () => {
     expect(shutdown).toHaveBeenCalledOnce();
   });
 
+  it('removes the abort listener when the framework exits the task', async () => {
+    const controller = new AbortController();
+    const addEventListener = vi.spyOn(controller.signal, 'addEventListener');
+    const removeEventListener = vi.spyOn(controller.signal, 'removeEventListener');
+    mockDial();
+    const { create } = setupTransfer(controller.signal);
+
+    const options = create.mock.calls[0]![0];
+    await options.onEnter!({} as never);
+    const listener = addEventListener.mock.calls.find(([event]) => event === 'abort')?.[1];
+    expect(listener).toBeDefined();
+    expect(options.onExit).toBeDefined();
+    await options.onExit!({} as never);
+
+    expect(removeEventListener).toHaveBeenCalledWith('abort', listener);
+  });
+
   it.each(['completes', 'fails', 'times out'] as const)(
     'waits until caller-hangup notice playout %s before shutting down an answered agent',
     async (outcome) => {

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -26,6 +26,9 @@ const createFakeTask = () => {
   const complete = vi.fn(() => {
     done = true;
   });
+  const setInputAudioEnabled = vi.fn();
+  const setOutputAudioEnabled = vi.fn();
+  const setOutputTranscriptionEnabled = vi.fn();
   const task = {
     get done() {
       return done;
@@ -47,20 +50,26 @@ const createFakeTask = () => {
       input: {
         audio: {},
         audioEnabled: true,
-        setAudioEnabled: vi.fn(),
+        setAudioEnabled: setInputAudioEnabled,
       },
       output: {
         audio: {},
         audioEnabled: true,
         transcription: {},
         transcriptionEnabled: true,
-        setAudioEnabled: vi.fn(),
-        setTranscriptionEnabled: vi.fn(),
+        setAudioEnabled: setOutputAudioEnabled,
+        setTranscriptionEnabled: setOutputTranscriptionEnabled,
       },
     },
   } as unknown as AgentTask<WarmTransferResult>;
   const create = vi.spyOn(AgentTask, 'create').mockReturnValue(task);
-  return { complete, create };
+  return {
+    complete,
+    create,
+    setInputAudioEnabled,
+    setOutputAudioEnabled,
+    setOutputTranscriptionEnabled,
+  };
 };
 
 const createCallerRoom = (): Room =>
@@ -142,11 +151,26 @@ describe('createWarmTransferTask', () => {
     ).toThrow(/must not be empty/);
   });
 
+  it('aborts before dialing when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    const reason = new Error('application shutdown');
+    controller.abort(reason);
+    const { close, createSipParticipant, disconnect } = mockDial();
+    const { complete, create } = setupTransfer(controller.signal);
+
+    await create.mock.calls[0]![0].onEnter!({} as never);
+
+    expect(complete).toHaveBeenCalledWith(reason);
+    expect(createSipParticipant).not.toHaveBeenCalled();
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
   it('aborts a pending dial with the signal reason', async () => {
     const controller = new AbortController();
     const reason = new Error('application shutdown');
     const dial = new Promise<never>(() => {});
-    const { close, createSipParticipant, disconnect } = mockDial(dial);
+    const { close, createSipParticipant, disconnect, shutdown } = mockDial(dial);
     const { complete, create } = setupTransfer(controller.signal);
 
     const entering = create.mock.calls[0]![0].onEnter!({} as never);
@@ -156,7 +180,76 @@ describe('createWarmTransferTask', () => {
 
     expect(complete).toHaveBeenCalledWith(reason);
     expect(disconnect).toHaveBeenCalledOnce();
-    expect(close).toHaveBeenCalledOnce();
+    expect(shutdown).toHaveBeenCalledWith({ drain: false });
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('does not block cancellation on transfer session teardown', async () => {
+    const controller = new AbortController();
+    const reason = new Error('application shutdown');
+    const dial = new Promise<never>(() => {});
+    const { close, createSipParticipant, disconnect, shutdown } = mockDial(dial);
+    close.mockReturnValue(new Promise<void>(() => {}));
+    const { complete, create } = setupTransfer(controller.signal);
+
+    const entering = create.mock.calls[0]![0].onEnter!({} as never);
+    await vi.waitFor(() => expect(createSipParticipant).toHaveBeenCalled());
+    controller.abort(reason);
+    await vi.waitFor(() => expect(complete).toHaveBeenCalledWith(reason));
+
+    const outcome = await Promise.race([
+      entering.then(() => 'completed' as const),
+      new Promise<'timed out'>((resolve) => {
+        setTimeout(() => resolve('timed out'), 100);
+      }),
+    ]);
+
+    expect(outcome).toBe('completed');
+    expect(shutdown).toHaveBeenCalledWith({ drain: false });
+    expect(close).not.toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(shutdown.mock.invocationCallOrder[0]).toBeLessThan(
+      disconnect.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('keeps caller I/O disabled until cancellation cleanup exits the task', async () => {
+    const controller = new AbortController();
+    const reason = new Error('application shutdown');
+    const dial = new Promise<never>(() => {});
+    let finishDisconnect!: () => void;
+    const disconnecting = new Promise<void>((resolve) => {
+      finishDisconnect = resolve;
+    });
+    const { createSipParticipant, disconnect } = mockDial(dial);
+    disconnect.mockReturnValue(disconnecting);
+    const {
+      complete,
+      create,
+      setInputAudioEnabled,
+      setOutputAudioEnabled,
+      setOutputTranscriptionEnabled,
+    } = setupTransfer(controller.signal);
+    const options = create.mock.calls[0]![0];
+
+    const entering = options.onEnter!({} as never);
+    await vi.waitFor(() => expect(createSipParticipant).toHaveBeenCalled());
+    controller.abort(reason);
+    await vi.waitFor(() => expect(complete).toHaveBeenCalledWith(reason));
+
+    const ioStateBeforeExit = [
+      setInputAudioEnabled.mock.lastCall?.[0],
+      setOutputAudioEnabled.mock.lastCall?.[0],
+      setOutputTranscriptionEnabled.mock.lastCall?.[0],
+    ];
+    finishDisconnect();
+    await entering;
+    await options.onExit!({} as never);
+
+    expect(ioStateBeforeExit).toEqual([false, false, false]);
+    expect(setInputAudioEnabled).toHaveBeenLastCalledWith(true);
+    expect(setOutputAudioEnabled).toHaveBeenLastCalledWith(true);
+    expect(setOutputTranscriptionEnabled).toHaveBeenLastCalledWith(true);
   });
 
   it('aborts an active consultation with the signal reason', async () => {
@@ -190,7 +283,7 @@ describe('createWarmTransferTask', () => {
   });
 
   it.each(['completes', 'fails', 'times out'] as const)(
-    'waits until caller-hangup notice playout %s before shutting down an answered agent',
+    'waits until caller-hangup notice playout %s before exiting and shutting down an answered agent',
     async (outcome) => {
       const controller = new AbortController();
       const timeoutController = new AbortController();
@@ -206,10 +299,18 @@ describe('createWarmTransferTask', () => {
       vi.spyOn(AgentSession.prototype, 'generateReply').mockReturnValue({
         waitForPlayout,
       } as never);
+      let finishRemoval!: () => void;
+      const removal = new Promise<void>((resolve) => {
+        finishRemoval = resolve;
+      });
+      const removeParticipant = vi
+        .spyOn(RoomServiceClient.prototype, 'removeParticipant')
+        .mockReturnValue(removal as never);
       const { shutdown } = mockDial();
       const { callerRoom, create } = setupTransfer(controller.signal);
 
-      await create.mock.calls[0]![0].onEnter!({} as never);
+      const options = create.mock.calls[0]![0];
+      await options.onEnter!({} as never);
       const onCallerLeft = vi
         .mocked(callerRoom.on)
         .mock.calls.find(([event]) => event === RoomEvent.ParticipantDisconnected)?.[1];
@@ -221,17 +322,36 @@ describe('createWarmTransferTask', () => {
 
       await vi.waitFor(() => expect(waitForPlayout).toHaveBeenCalledOnce());
       expect(shutdown).not.toHaveBeenCalled();
+      let exitFinished = false;
+      const exiting = Promise.resolve(options.onExit!({} as never)).then(() => {
+        exitFinished = true;
+      });
+      await Promise.resolve();
+      expect(exitFinished).toBe(false);
 
       if (outcome === 'completes') {
         completePlayout();
       } else if (outcome === 'fails') {
         failPlayout(new Error('playout failed'));
       } else {
-        expect(timeout).toHaveBeenCalledWith(10_000);
+        expect(timeout).toHaveBeenCalledWith(30_000);
         timeoutController.abort();
       }
 
+      await vi.waitFor(
+        () =>
+          expect(removeParticipant).toHaveBeenCalledWith(
+            'caller-room-human-agent',
+            'human-agent-sip',
+          ),
+        { timeout: 200 },
+      );
+      expect(exitFinished).toBe(false);
+      expect(shutdown).not.toHaveBeenCalled();
+      finishRemoval();
       await vi.waitFor(() => expect(shutdown).toHaveBeenCalledOnce());
+      await exiting;
+      expect(exitFinished).toBe(true);
     },
   );
 

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -1,8 +1,119 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { describe, expect, it } from 'vitest';
-import { createWarmTransferTask, resolveHumanAgentRoomName } from './warm_transfer.js';
+import { ParticipantKind, Room } from '@livekit/rtc-node';
+import { AccessToken, RoomServiceClient, SipClient } from 'livekit-server-sdk';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as job from '../job.js';
+import type { JobContext } from '../job.js';
+import { ChatContext, type FunctionTool } from '../llm/index.js';
+import { AgentTask } from '../voice/agent.js';
+import { AgentSession } from '../voice/agent_session.js';
+import { BackgroundAudioPlayer } from '../voice/background_audio.js';
+import {
+  type WarmTransferResult,
+  createWarmTransferTask,
+  resolveHumanAgentRoomName,
+} from './warm_transfer.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+const createFakeTask = () => {
+  let done = false;
+  const complete = vi.fn(() => {
+    done = true;
+  });
+  const task = {
+    get done() {
+      return done;
+    },
+    complete,
+    instructions: '',
+    stt: undefined,
+    vad: undefined,
+    llm: undefined,
+    tts: undefined,
+    toolCtx: { tools: [] },
+    chatCtx: ChatContext.empty(),
+    session: {
+      stt: undefined,
+      vad: undefined,
+      llm: undefined,
+      tts: undefined,
+      turnDetection: undefined,
+      input: {
+        audio: {},
+        audioEnabled: true,
+        setAudioEnabled: vi.fn(),
+      },
+      output: {
+        audio: {},
+        audioEnabled: true,
+        transcription: {},
+        transcriptionEnabled: true,
+        setAudioEnabled: vi.fn(),
+        setTranscriptionEnabled: vi.fn(),
+      },
+    },
+  } as unknown as AgentTask<WarmTransferResult>;
+  const create = vi.spyOn(AgentTask, 'create').mockReturnValue(task);
+  return { complete, create };
+};
+
+const createCallerRoom = (): Room =>
+  ({
+    name: 'caller-room',
+    localParticipant: { identity: 'transfer-agent' },
+    remoteParticipants: new Map([
+      ['caller', { identity: 'caller', kind: ParticipantKind.STANDARD }],
+    ]),
+    on: vi.fn(),
+    off: vi.fn(),
+  }) as unknown as Room;
+
+const mockDial = (sipParticipant: Promise<unknown> = Promise.resolve({})) => {
+  vi.stubEnv('LIVEKIT_API_KEY', 'api-key');
+  vi.stubEnv('LIVEKIT_API_SECRET', 'api-secret');
+  vi.spyOn(AccessToken.prototype, 'toJwt').mockResolvedValue('token');
+  vi.spyOn(Room.prototype, 'connect').mockImplementation(async function () {
+    Object.defineProperty(this, 'name', {
+      configurable: true,
+      value: 'caller-room-human-agent',
+    });
+  });
+  const disconnect = vi.spyOn(Room.prototype, 'disconnect').mockResolvedValue();
+  vi.spyOn(AgentSession.prototype, 'start').mockResolvedValue();
+  const close = vi.spyOn(AgentSession.prototype, 'close').mockResolvedValue();
+  const shutdown = vi.spyOn(AgentSession.prototype, 'shutdown').mockImplementation(() => {});
+  const createSipParticipant = vi
+    .spyOn(SipClient.prototype, 'createSipParticipant')
+    .mockReturnValue(sipParticipant as never);
+  vi.spyOn(BackgroundAudioPlayer.prototype, 'close').mockResolvedValue();
+  return { close, createSipParticipant, disconnect, shutdown };
+};
+
+const setupTransfer = (abortSignal: AbortSignal) => {
+  const callerRoom = createCallerRoom();
+  vi.spyOn(job, 'getJobContext').mockReturnValue({
+    room: callerRoom,
+    info: {
+      url: 'ws://localhost:7880',
+      apiKey: 'api-key',
+      apiSecret: 'api-secret',
+    },
+  } as JobContext);
+  const fakeTask = createFakeTask();
+  createWarmTransferTask({
+    abortSignal,
+    sipCallTo: '+15551234567',
+    sipTrunkId: 'ST_dummy',
+    holdAudio: null,
+  });
+  return { callerRoom, ...fakeTask };
+};
 
 describe('resolveHumanAgentRoomName', () => {
   it('defaults to `<callerRoom>-human-agent` when no override is given', () => {
@@ -29,5 +140,91 @@ describe('createWarmTransferTask', () => {
         roomName: '',
       }),
     ).toThrow(/must not be empty/);
+  });
+
+  it('aborts a pending dial with the signal reason', async () => {
+    const controller = new AbortController();
+    const reason = new Error('application shutdown');
+    const dial = new Promise<never>(() => {});
+    const { close, createSipParticipant, disconnect } = mockDial(dial);
+    const { complete, create } = setupTransfer(controller.signal);
+
+    const entering = create.mock.calls[0]![0].onEnter!({} as never);
+    await vi.waitFor(() => expect(createSipParticipant).toHaveBeenCalled());
+    controller.abort(reason);
+    await entering;
+
+    expect(complete).toHaveBeenCalledWith(reason);
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('aborts an active consultation with the signal reason', async () => {
+    const controller = new AbortController();
+    const reason = new Error('consult deadline expired');
+    const { shutdown } = mockDial();
+    const { complete, create } = setupTransfer(controller.signal);
+
+    await create.mock.calls[0]![0].onEnter!({} as never);
+    controller.abort(reason);
+
+    expect(complete).toHaveBeenCalledWith(reason);
+    expect(shutdown).toHaveBeenCalledOnce();
+  });
+
+  it('lets a successful participant move win over an abort', async () => {
+    const controller = new AbortController();
+    mockDial();
+    let finishMove!: () => void;
+    const move = new Promise<void>((resolve) => {
+      finishMove = resolve;
+    });
+    const moveParticipant = vi
+      .spyOn(RoomServiceClient.prototype, 'moveParticipant')
+      .mockReturnValue(move as never);
+    const { complete, create } = setupTransfer(controller.signal);
+
+    const options = create.mock.calls[0]![0];
+    await options.onEnter!({} as never);
+    const connect = (options.tools as FunctionTool[]).find(
+      (entry) => entry.name === 'connect_to_caller',
+    )!;
+    const merging = connect.execute({}, {} as never);
+    await vi.waitFor(() => expect(moveParticipant).toHaveBeenCalled());
+
+    controller.abort(new Error('application shutdown'));
+    expect(complete).not.toHaveBeenCalled();
+    finishMove();
+    await merging;
+
+    expect(complete).toHaveBeenCalledWith({ humanAgentIdentity: 'human-agent-sip' });
+  });
+
+  it('uses the abort reason when the concurrent participant move fails', async () => {
+    const controller = new AbortController();
+    const reason = new Error('application shutdown');
+    mockDial();
+    let failMove!: (error: Error) => void;
+    const move = new Promise<void>((_resolve, reject) => {
+      failMove = reject;
+    });
+    const moveParticipant = vi
+      .spyOn(RoomServiceClient.prototype, 'moveParticipant')
+      .mockReturnValue(move as never);
+    const { complete, create } = setupTransfer(controller.signal);
+
+    const options = create.mock.calls[0]![0];
+    await options.onEnter!({} as never);
+    const connect = (options.tools as FunctionTool[]).find(
+      (entry) => entry.name === 'connect_to_caller',
+    )!;
+    const merging = connect.execute({}, {} as never);
+    await vi.waitFor(() => expect(moveParticipant).toHaveBeenCalled());
+
+    controller.abort(reason);
+    failMove(new Error('move failed'));
+    await merging;
+
+    expect(complete).toHaveBeenCalledWith(reason);
   });
 });

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { ParticipantKind, Room } from '@livekit/rtc-node';
+import { ParticipantKind, Room, RoomEvent } from '@livekit/rtc-node';
 import { AccessToken, RoomServiceClient, SipClient } from 'livekit-server-sdk';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as job from '../job.js';
@@ -171,6 +171,52 @@ describe('createWarmTransferTask', () => {
     expect(complete).toHaveBeenCalledWith(reason);
     expect(shutdown).toHaveBeenCalledOnce();
   });
+
+  it.each(['completes', 'fails', 'times out'] as const)(
+    'waits until caller-hangup notice playout %s before shutting down an answered agent',
+    async (outcome) => {
+      const controller = new AbortController();
+      const timeoutController = new AbortController();
+      const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+      let completePlayout!: () => void;
+      let failPlayout!: (error: Error) => void;
+      const playout = new Promise<void>((resolve, reject) => {
+        completePlayout = resolve;
+        failPlayout = reject;
+      });
+      const waitForPlayout = vi.fn().mockReturnValue(playout);
+      vi.spyOn(AgentSession.prototype, 'interrupt').mockReturnValue({} as never);
+      vi.spyOn(AgentSession.prototype, 'generateReply').mockReturnValue({
+        waitForPlayout,
+      } as never);
+      const { shutdown } = mockDial();
+      const { callerRoom, create } = setupTransfer(controller.signal);
+
+      await create.mock.calls[0]![0].onEnter!({} as never);
+      const onCallerLeft = vi
+        .mocked(callerRoom.on)
+        .mock.calls.find(([event]) => event === RoomEvent.ParticipantDisconnected)?.[1];
+      expect(onCallerLeft).toBeDefined();
+      (onCallerLeft as (participant: { identity: string; kind: ParticipantKind }) => void)({
+        identity: 'caller',
+        kind: ParticipantKind.STANDARD,
+      });
+
+      await vi.waitFor(() => expect(waitForPlayout).toHaveBeenCalledOnce());
+      expect(shutdown).not.toHaveBeenCalled();
+
+      if (outcome === 'completes') {
+        completePlayout();
+      } else if (outcome === 'fails') {
+        failPlayout(new Error('playout failed'));
+      } else {
+        expect(timeout).toHaveBeenCalledWith(10_000);
+        timeoutController.abort();
+      }
+
+      await vi.waitFor(() => expect(shutdown).toHaveBeenCalledOnce());
+    },
+  );
 
   it('lets a successful participant move win over an abort', async () => {
     const controller = new AbortController();

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -193,6 +193,8 @@ export function createWarmTransferTask({
   // Session handed off to the caller-hangup notification flow, which owns its
   // teardown from that point on — no other cleanup path may close it.
   let hangupNotifySession: AgentSession | null = null;
+  // Task exit keeps the caller job alive until the notification finishes.
+  let hangupNotifyPromise: Promise<void> | null = null;
   let holdAudioHandle: PlayHandle | null = null;
   let originalIoState: IoState | null = null;
 
@@ -244,7 +246,6 @@ export function createWarmTransferTask({
       logger.warn({ error }, 'failed to close background audio');
     });
 
-    setIoEnabled(true);
     task.complete(result);
   };
 
@@ -266,7 +267,10 @@ export function createWarmTransferTask({
 
   // Announces the caller hangup to the human agent, then hangs up on them by
   // shutting the session down (deleteRoomOnClose ends the SIP call).
-  const notifyHumanAgentOfHangup = async (session: AgentSession): Promise<void> => {
+  const notifyHumanAgentOfHangup = async (
+    session: AgentSession,
+    room: Room | null,
+  ): Promise<void> => {
     try {
       session.interrupt();
       const handle = session.generateReply({
@@ -277,11 +281,27 @@ export function createWarmTransferTask({
         toolChoice: 'none',
       });
       // Cap the wait so teardown can't hang on a stuck playout.
-      await waitUntilAborted(handle.waitForPlayout(), AbortSignal.timeout(10_000));
+      const playout = await waitUntilAborted(
+        handle.waitForPlayout(),
+        AbortSignal.timeout(CALLER_HANGUP_NOTICE_TIMEOUT_MS),
+      );
+      if (playout.isAborted) {
+        logger.warn(
+          { timeoutMs: CALLER_HANGUP_NOTICE_TIMEOUT_MS },
+          'caller hangup notification timed out',
+        );
+      }
     } catch (error) {
       logger.warn({ error }, 'failed to notify human agent of caller hangup');
     } finally {
-      session.shutdown();
+      if (room?.name && jobCtx) {
+        const info = jobCtx.info;
+        const rooms = new RoomServiceClient(info.url, info.apiKey, info.apiSecret);
+        await rooms.removeParticipant(room.name, humanAgentIdentity).catch((error) => {
+          logger.warn({ error }, 'failed to remove human agent after caller hangup');
+        });
+      }
+      session.shutdown({ drain: false });
     }
   };
 
@@ -298,10 +318,11 @@ export function createWarmTransferTask({
     // on them mid-briefing.
     const session = transferAgentSession;
     if (session) {
+      const room = humanAgentRoom;
       transferAgentSession = null;
       humanAgentRoom = null;
       hangupNotifySession = session;
-      void notifyHumanAgentOfHangup(session);
+      hangupNotifyPromise = notifyHumanAgentOfHangup(session, room);
     }
     setResult(new ToolError('caller hung up before the transfer completed'));
   };
@@ -364,11 +385,11 @@ export function createWarmTransferTask({
     session?: AgentSession | null,
     room?: Room | null,
   ): Promise<void> => {
+    // Start shutdown before disconnect so closeOnDisconnect cannot start a
+    // second close. Internal session teardown continues after the room is gone.
+    session?.shutdown({ drain: false });
     await room?.disconnect().catch((error) => {
       logger.warn({ error }, 'failed to disconnect human agent room');
-    });
-    await session?.close().catch((error) => {
-      logger.warn({ error }, 'failed to close transfer agent session');
     });
   };
 
@@ -570,8 +591,14 @@ export function createWarmTransferTask({
     llm: llm ?? undefined,
     tts: tts ?? undefined,
     allowInterruptions,
-    onExit: () => {
+    onExit: async () => {
       abortSignal?.removeEventListener('abort', onAbort);
+      if (hangupNotifyPromise) {
+        await hangupNotifyPromise;
+      }
+      // Keep the transfer activity deaf to the caller until dial cleanup has
+      // finished and the framework is ready to resume the original agent.
+      setIoEnabled(true);
     },
     onEnter: async () => {
       jobCtx = getJobContext();
@@ -731,6 +758,8 @@ export function resolveHumanAgentRoomName(callerRoomName: string, override?: str
 
 const CALLER_HANGUP_INSTRUCTION = `The caller has hung up before the transfer could be completed.
 Briefly inform the human agent that the caller has left and that you are ending the call now.`;
+
+const CALLER_HANGUP_NOTICE_TIMEOUT_MS = 30_000;
 
 const PERSONA = `# Identity
 

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -199,8 +199,6 @@ export function createWarmTransferTask({
 
   // Resolves when the human agent room/session fails, so onEnter stops waiting.
   const humanAgentFailedFut = new Future<void>();
-  // Resolves when the transfer is cancelled before the merge, so onEnter stops
-  // a still-pending dial (e.g. while the human agent's phone is ringing).
   const cancellationFut = new Future<void>();
 
   // `task` is created at the end of this function. The helpers and tools below
@@ -604,9 +602,6 @@ export function createWarmTransferTask({
 
       setIoEnabled(false);
 
-      // Race the dial against a human-agent-room failure or cancellation.
-      // AbortController lets the `finally` cancel a still-pending dial when
-      // either of those wins the race.
       const abortController = new AbortController();
       const dialPromise = dialHumanAgent(abortController.signal);
       try {
@@ -617,8 +612,7 @@ export function createWarmTransferTask({
         ]);
 
         if (result.cancelled) {
-          // The cancellation handler already completed the task; the `finally`
-          // below aborts the pending dial and tears down the half-built room.
+          // The cancellation handler already completed the task.
           return;
         }
         if (!result.session) {

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -297,9 +297,19 @@ export function createWarmTransferTask({
       if (room?.name && jobCtx) {
         const info = jobCtx.info;
         const rooms = new RoomServiceClient(info.url, info.apiKey, info.apiSecret);
-        await rooms.removeParticipant(room.name, humanAgentIdentity).catch((error) => {
+        const removal = await waitUntilAborted(
+          rooms.removeParticipant(room.name, humanAgentIdentity),
+          AbortSignal.timeout(CALLER_HANGUP_CLEANUP_TIMEOUT_MS),
+        ).catch((error) => {
           logger.warn({ error }, 'failed to remove human agent after caller hangup');
+          return null;
         });
+        if (removal?.isAborted) {
+          logger.warn(
+            { timeoutMs: CALLER_HANGUP_CLEANUP_TIMEOUT_MS },
+            'timed out removing human agent after caller hangup',
+          );
+        }
       }
       session.shutdown({ drain: false });
     }
@@ -760,6 +770,7 @@ const CALLER_HANGUP_INSTRUCTION = `The caller has hung up before the transfer co
 Briefly inform the human agent that the caller has left and that you are ending the call now.`;
 
 const CALLER_HANGUP_NOTICE_TIMEOUT_MS = 30_000;
+const CALLER_HANGUP_CLEANUP_TIMEOUT_MS = 10_000;
 
 const PERSONA = `# Identity
 

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -195,7 +195,6 @@ export function createWarmTransferTask({
   let hangupNotifySession: AgentSession | null = null;
   let holdAudioHandle: PlayHandle | null = null;
   let originalIoState: IoState | null = null;
-  let mergeInProgress = false;
 
   // Resolves when the human agent room/session fails, so onEnter stops waiting.
   const humanAgentFailedFut = new Future<void>();
@@ -309,7 +308,7 @@ export function createWarmTransferTask({
   };
 
   const onAbort = (): void => {
-    if (task.done || mergeInProgress) return;
+    if (task.done) return;
 
     const error = asError(abortSignal?.reason ?? new Error('warm transfer aborted'));
     logger.info({ error }, 'warm transfer aborted');
@@ -523,7 +522,7 @@ export function createWarmTransferTask({
           throw new ToolError('the transfer was already cancelled');
         }
 
-        mergeInProgress = true;
+        abortSignal?.removeEventListener('abort', onAbort);
         try {
           await mergeCalls();
           setResult({ humanAgentIdentity });
@@ -532,9 +531,8 @@ export function createWarmTransferTask({
             setResult(asError(abortSignal.reason ?? new Error('warm transfer aborted')));
             return;
           }
+          abortSignal?.addEventListener('abort', onAbort, { once: true });
           throw error;
-        } finally {
-          mergeInProgress = false;
         }
         callerRoom.on(RoomEvent.ParticipantDisconnected, onCallerParticipantDisconnected);
       },

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -18,7 +18,7 @@ import { ToolError, ToolFlag, tool } from '../llm/index.js';
 import { log } from '../log.js';
 import type { STT } from '../stt/index.js';
 import type { TTS } from '../tts/index.js';
-import { Future, waitUntilAborted } from '../utils.js';
+import { Future, asError, waitUntilAborted } from '../utils.js';
 import type { VAD } from '../vad.js';
 import { Agent, AgentTask } from '../voice/agent.js';
 import { AgentSession, type TurnDetectionMode } from '../voice/agent_session.js';
@@ -37,6 +37,11 @@ export interface WarmTransferResult {
 }
 
 export interface WarmTransferTaskOptions {
+  /**
+   * Signal used to cancel the transfer. A successful participant move wins if it completes after
+   * the signal aborts. The task stops waiting for a pending SIP request but cannot cancel it.
+   */
+  abortSignal?: AbortSignal;
   /** The phone number or SIP URI to dial for the human agent. */
   sipCallTo?: string;
   /**
@@ -121,6 +126,7 @@ type IoState = {
  * This is the functional core; {@link WarmTransferTask} is a thin class wrapper over it.
  */
 export function createWarmTransferTask({
+  abortSignal,
   sipCallTo,
   sipTrunkId: rawSipTrunkId,
   sipConnection,
@@ -184,12 +190,13 @@ export function createWarmTransferTask({
   let hangupNotifySession: AgentSession | null = null;
   let holdAudioHandle: PlayHandle | null = null;
   let originalIoState: IoState | null = null;
+  let mergeInProgress = false;
 
   // Resolves when the human agent room/session fails, so onEnter stops waiting.
   const humanAgentFailedFut = new Future<void>();
-  // Resolves when the caller hangs up before the merge, so onEnter cancels a
-  // still-pending dial (e.g. while the human agent's phone is ringing).
-  const callerHangupFut = new Future<void>();
+  // Resolves when the transfer is cancelled before the merge, so onEnter stops
+  // a still-pending dial (e.g. while the human agent's phone is ringing).
+  const cancellationFut = new Future<void>();
 
   // `task` is created at the end of this function. The helpers and tools below
   // only read it at runtime (inside their bodies), long after it's assigned, so
@@ -217,6 +224,7 @@ export function createWarmTransferTask({
     // the pre-merge hangup watch; connect_to_caller re-attaches its own
     // post-merge cleanup listener.
     callerRoom?.off(RoomEvent.ParticipantDisconnected, onCallerLeftBeforeMerge);
+    abortSignal?.removeEventListener('abort', onAbort);
 
     if (transferAgentSession) {
       // shutdown() triggers deleteRoomOnClose, which disconnects the human agent
@@ -282,7 +290,7 @@ export function createWarmTransferTask({
       { participantIdentity },
       'caller hung up before the transfer completed, cancelling transfer',
     );
-    callerHangupFut.resolve();
+    cancellationFut.resolve();
 
     // If the human agent already answered, take the session out of setResult's
     // reach and let them know before hanging up, instead of dropping the call
@@ -295,6 +303,15 @@ export function createWarmTransferTask({
       void notifyHumanAgentOfHangup(session);
     }
     setResult(new ToolError('caller hung up before the transfer completed'));
+  };
+
+  const onAbort = (): void => {
+    if (task.done || mergeInProgress) return;
+
+    const error = asError(abortSignal?.reason ?? new Error('warm transfer aborted'));
+    logger.info({ error }, 'warm transfer aborted');
+    cancellationFut.resolve();
+    setResult(error);
   };
 
   // Pre-merge watch: cancels the transfer if the caller leaves while the human
@@ -503,8 +520,19 @@ export function createWarmTransferTask({
           throw new ToolError('the transfer was already cancelled');
         }
 
-        await mergeCalls();
-        setResult({ humanAgentIdentity });
+        mergeInProgress = true;
+        try {
+          await mergeCalls();
+          setResult({ humanAgentIdentity });
+        } catch (error) {
+          if (abortSignal?.aborted) {
+            setResult(asError(abortSignal.reason ?? new Error('warm transfer aborted')));
+            return;
+          }
+          throw error;
+        } finally {
+          mergeInProgress = false;
+        }
         callerRoom.on(RoomEvent.ParticipantDisconnected, onCallerParticipantDisconnected);
       },
     }),
@@ -546,6 +574,12 @@ export function createWarmTransferTask({
       jobCtx = getJobContext();
       callerRoom = jobCtx.room;
 
+      abortSignal?.addEventListener('abort', onAbort, { once: true });
+      if (abortSignal?.aborted) {
+        onAbort();
+        return;
+      }
+
       callerRoom.on(RoomEvent.ParticipantDisconnected, onCallerLeftBeforeMerge);
       if (!hasCallerParticipant()) {
         // The caller was already gone before the listener could attach.
@@ -565,20 +599,20 @@ export function createWarmTransferTask({
 
       setIoEnabled(false);
 
-      // Race the dial against a human-agent-room failure or a caller hangup.
+      // Race the dial against a human-agent-room failure or cancellation.
       // AbortController lets the `finally` cancel a still-pending dial when
       // either of those wins the race.
       const abortController = new AbortController();
       const dialPromise = dialHumanAgent(abortController.signal);
       try {
         const result = await Promise.race([
-          dialPromise.then((session) => ({ session, callerHungUp: false })),
-          humanAgentFailedFut.await.then(() => ({ session: null, callerHungUp: false })),
-          callerHangupFut.await.then(() => ({ session: null, callerHungUp: true })),
+          dialPromise.then((session) => ({ session, cancelled: false })),
+          humanAgentFailedFut.await.then(() => ({ session: null, cancelled: false })),
+          cancellationFut.await.then(() => ({ session: null, cancelled: true })),
         ]);
 
-        if (result.callerHungUp) {
-          // cancelForCallerHangup already completed the task; the `finally`
+        if (result.cancelled) {
+          // The cancellation handler already completed the task; the `finally`
           // below aborts the pending dial and tears down the half-built room.
           return;
         }

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -226,7 +226,6 @@ export function createWarmTransferTask({
     // the pre-merge hangup watch; connect_to_caller re-attaches its own
     // post-merge cleanup listener.
     callerRoom?.off(RoomEvent.ParticipantDisconnected, onCallerLeftBeforeMerge);
-    abortSignal?.removeEventListener('abort', onAbort);
 
     if (transferAgentSession) {
       // shutdown() triggers deleteRoomOnClose, which disconnects the human agent
@@ -571,6 +570,9 @@ export function createWarmTransferTask({
     llm: llm ?? undefined,
     tts: tts ?? undefined,
     allowInterruptions,
+    onExit: () => {
+      abortSignal?.removeEventListener('abort', onAbort);
+    },
     onEnter: async () => {
       jobCtx = getJobContext();
       callerRoom = jobCtx.room;

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -38,8 +38,13 @@ export interface WarmTransferResult {
 
 export interface WarmTransferTaskOptions {
   /**
-   * Signal used to cancel the transfer. A successful participant move wins if it completes after
-   * the signal aborts. The task stops waiting for a pending SIP request but cannot cancel it.
+   * Signal for application cancellation, such as a consult deadline or application shutdown.
+   *
+   * Do not abort this signal when the caller disconnects. The task handles caller disconnects so
+   * it can play `callerHangupInstruction` before it ends an answered consultation.
+   *
+   * A successful participant move wins if it completes after the signal aborts. The task stops
+   * waiting for a pending SIP request but cannot cancel it.
    */
   abortSignal?: AbortSignal;
   /** The phone number or SIP URI to dial for the human agent. */

--- a/examples/src/basic_agent.ts
+++ b/examples/src/basic_agent.ts
@@ -13,7 +13,6 @@ import {
   log,
   logMetrics,
   tool,
-  workflows,
 } from '@livekit/agents';
 import * as krisp from '@livekit/agents-plugin-krisp';
 import { fileURLToPath } from 'node:url';
@@ -24,11 +23,9 @@ import { z } from 'zod';
 // lazy-loads on first stream.
 export default defineAgent({
   entry: async (ctx: JobContext) => {
-    const logger = log();
     const agent = Agent.create({
       instructions:
-        "You are a helpful assistant, you can hear the user's message and respond to it. " +
-        'Use the warm transfer cancellation tool when the user asks to test a cancelled transfer.',
+        "You are a helpful assistant, you can hear the user's message and respond to it.",
       tools: [
         tool({
           name: 'getWeather',
@@ -40,60 +37,10 @@ export default defineAgent({
             return `The weather in ${location} is sunny.`;
           },
         }),
-        tool({
-          name: 'testWarmTransferCancellation',
-          description:
-            'Dial a human agent, then cancel the warm transfer after a specified delay to test cancellation.',
-          parameters: z.object({
-            abortAfterSeconds: z
-              .number()
-              .int()
-              .min(1)
-              .max(120)
-              .default(20)
-              .describe('How many seconds to wait before cancelling the warm transfer'),
-          }),
-          execute: async ({ abortAfterSeconds }, { ctx: toolCtx }) => {
-            const sipTrunkId = process.env.LIVEKIT_SIP_OUTBOUND_TRUNK;
-            const supervisorPhoneNumber = process.env.LIVEKIT_SUPERVISOR_PHONE_NUMBER;
-            if (!sipTrunkId || !supervisorPhoneNumber) {
-              throw new Error(
-                'LIVEKIT_SIP_OUTBOUND_TRUNK and LIVEKIT_SUPERVISOR_PHONE_NUMBER must be set',
-              );
-            }
-
-            const abortController = new AbortController();
-            const abortReason = new Error(
-              `warm transfer test cancelled after ${abortAfterSeconds} seconds`,
-            );
-            const abortTimeout = setTimeout(() => {
-              logger.info({ abortAfterSeconds }, 'aborting warm transfer test');
-              abortController.abort(abortReason);
-            }, abortAfterSeconds * 1000);
-
-            try {
-              const result = await new workflows.WarmTransferTask({
-                abortSignal: abortController.signal,
-                sipCallTo: supervisorPhoneNumber,
-                sipTrunkId,
-                sipNumber: process.env.LIVEKIT_SIP_NUMBER,
-                ringingTimeout: 120_000,
-                chatCtx: toolCtx.session.history,
-              }).run();
-
-              return `Warm transfer completed before cancellation for ${result.humanAgentIdentity}.`;
-            } catch (error) {
-              if (error === abortReason) {
-                logger.info({ error }, 'warm transfer rejected with the expected abort reason');
-              }
-              throw error;
-            } finally {
-              clearTimeout(abortTimeout);
-            }
-          },
-        }),
       ],
     });
+
+    const logger = log();
 
     const session = new AgentSession({
       // Speech-to-text (STT) is your agent's ears, turning the user's speech into text that the LLM can understand
@@ -196,4 +143,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url), agentName: 'basic-agent' }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));

--- a/examples/src/basic_agent.ts
+++ b/examples/src/basic_agent.ts
@@ -13,6 +13,7 @@ import {
   log,
   logMetrics,
   tool,
+  workflows,
 } from '@livekit/agents';
 import * as krisp from '@livekit/agents-plugin-krisp';
 import { fileURLToPath } from 'node:url';
@@ -23,9 +24,11 @@ import { z } from 'zod';
 // lazy-loads on first stream.
 export default defineAgent({
   entry: async (ctx: JobContext) => {
+    const logger = log();
     const agent = Agent.create({
       instructions:
-        "You are a helpful assistant, you can hear the user's message and respond to it.",
+        "You are a helpful assistant, you can hear the user's message and respond to it. " +
+        'Use the warm transfer cancellation tool when the user asks to test a cancelled transfer.',
       tools: [
         tool({
           name: 'getWeather',
@@ -37,10 +40,60 @@ export default defineAgent({
             return `The weather in ${location} is sunny.`;
           },
         }),
+        tool({
+          name: 'testWarmTransferCancellation',
+          description:
+            'Dial a human agent, then cancel the warm transfer after a specified delay to test cancellation.',
+          parameters: z.object({
+            abortAfterSeconds: z
+              .number()
+              .int()
+              .min(1)
+              .max(120)
+              .default(20)
+              .describe('How many seconds to wait before cancelling the warm transfer'),
+          }),
+          execute: async ({ abortAfterSeconds }, { ctx: toolCtx }) => {
+            const sipTrunkId = process.env.LIVEKIT_SIP_OUTBOUND_TRUNK;
+            const supervisorPhoneNumber = process.env.LIVEKIT_SUPERVISOR_PHONE_NUMBER;
+            if (!sipTrunkId || !supervisorPhoneNumber) {
+              throw new Error(
+                'LIVEKIT_SIP_OUTBOUND_TRUNK and LIVEKIT_SUPERVISOR_PHONE_NUMBER must be set',
+              );
+            }
+
+            const abortController = new AbortController();
+            const abortReason = new Error(
+              `warm transfer test cancelled after ${abortAfterSeconds} seconds`,
+            );
+            const abortTimeout = setTimeout(() => {
+              logger.info({ abortAfterSeconds }, 'aborting warm transfer test');
+              abortController.abort(abortReason);
+            }, abortAfterSeconds * 1000);
+
+            try {
+              const result = await new workflows.WarmTransferTask({
+                abortSignal: abortController.signal,
+                sipCallTo: supervisorPhoneNumber,
+                sipTrunkId,
+                sipNumber: process.env.LIVEKIT_SIP_NUMBER,
+                ringingTimeout: 120_000,
+                chatCtx: toolCtx.session.history,
+              }).run();
+
+              return `Warm transfer completed before cancellation for ${result.humanAgentIdentity}.`;
+            } catch (error) {
+              if (error === abortReason) {
+                logger.info({ error }, 'warm transfer rejected with the expected abort reason');
+              }
+              throw error;
+            } finally {
+              clearTimeout(abortTimeout);
+            }
+          },
+        }),
       ],
     });
-
-    const logger = log();
 
     const session = new AgentSession({
       // Speech-to-text (STT) is your agent's ears, turning the user's speech into text that the LLM can understand
@@ -143,4 +196,4 @@ export default defineAgent({
   },
 });
 
-cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
+cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url), agentName: 'basic-agent' }));


### PR DESCRIPTION
Warm transfers need a supported cancellation input. Add constructor-level `abortSignal`. Aborting stops waiting for a pending SIP request or ends an active consultation, and `run()` rejects with the signal reason. The SIP API request itself is not cancellable.

A successful participant move wins a concurrent abort.

Addresses AJS-482
Fixes #2288

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> Can you take a look at https://github.com/livekit/agents-js/issues/2288 and the comments and create a draft PR for this based on the conclusion?
>
> can you compare yours and this PR: dtran26:feat/warm-transfer-abort-signal
>
> https://github.com/livekit/agents-js/pull/2292/changes
>
> okay, port the fixes, and add the original author as a co-author for credit.
>
> can you run a subagent with $thermo-nuclear-code-quality-review ?
>
> yeah, I asked only for an abort signal, now we are tracking states with 100+ lines of code.

</details>