### PR TITLE
fix(voice): preserve pre-set input.audio and output.transcription in RoomIO

### DIFF
--- a/.changeset/witty-pandas-refuse.md
+++ b/.changeset/witty-pandas-refuse.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+RoomIO now preserves a pre-set `session.input.audio` and `session.output.transcription` instead of silently replacing them, matching the existing behavior for `session.output.audio` and the python implementation.

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -873,7 +873,7 @@ export class AgentSession<
       // Check for existing input/output configuration and warn if needed
       if (this.input.audio && inputOptions?.audioEnabled !== false) {
         this.logger.warn(
-          'RoomIO audio input is enabled but input.audio is already set, ignoring..',
+          'RoomIO audio input is enabled; preserving and using the existing input.audio',
         );
       }
 
@@ -885,7 +885,7 @@ export class AgentSession<
 
       if (this.output.transcription && outputOptions?.transcriptionEnabled !== false) {
         this.logger.warn(
-          'RoomIO transcription output is enabled but output.transcription is already set, ignoring..',
+          'RoomIO transcription output is enabled; preserving and using the existing output.transcription',
         );
       }
 

--- a/agents/src/voice/room_io/room_io.test.ts
+++ b/agents/src/voice/room_io/room_io.test.ts
@@ -9,7 +9,8 @@ import { RealtimeModel } from '../../llm/index.js';
 import { IdentityTransform } from '../../stream/identity_transform.js';
 import { DEFAULT_API_CONNECT_OPTIONS } from '../../types.js';
 import { AgentSessionEventTypes, CloseReason, createCloseEvent } from '../events.js';
-import { AudioOutput } from '../io.js';
+import { AudioInput, AudioOutput, TextOutput } from '../io.js';
+import type { TimedString } from '../io.js';
 import { RoomIO } from './room_io.js';
 
 type RoomIOArgs = ConstructorParameters<typeof RoomIO>[0];
@@ -69,8 +70,8 @@ function createFakeRoom() {
 }
 
 type FakeSession = {
-  input: { audio: null };
-  output: { audio: AudioOutput | null; transcription: null };
+  input: { audio: AudioInput | null };
+  output: { audio: AudioOutput | null; transcription: TextOutput | null };
   currentAgent?: { llm?: RealtimeModel };
   llm?: RealtimeModel;
   on: ReturnType<typeof vi.fn>;
@@ -166,6 +167,67 @@ describe('RoomIO external audio output', () => {
       expect(externalOutput.close).not.toHaveBeenCalled();
     },
   );
+});
+
+class ExternalAudioInput extends AudioInput {
+  override close = vi.fn(async () => {});
+}
+
+class ExternalTextOutput extends TextOutput {
+  readonly captured: (string | TimedString)[] = [];
+
+  async captureText(text: string | TimedString): Promise<void> {
+    this.captured.push(text);
+  }
+
+  flush(): void {}
+}
+
+describe('RoomIO external audio input', () => {
+  it('preserves a pre-set input.audio without creating a participant input', async () => {
+    const room = createFakeRoom();
+    const session = createFakeSession();
+    const externalInput = new ExternalAudioInput();
+    session.input.audio = externalInput;
+    const roomIO = new RoomIO({
+      agentSession: session as unknown as RoomIOArgs['agentSession'],
+      room: room as unknown as RoomIOArgs['room'],
+      inputOptions: { textEnabled: false },
+      outputOptions: { audioEnabled: false, transcriptionEnabled: false },
+    });
+
+    roomIO.start();
+
+    expect(Reflect.get(roomIO, 'audioInput')).toBeUndefined();
+    expect(session.input.audio).toBe(externalInput);
+
+    await roomIO.close();
+    expect(externalInput.close).not.toHaveBeenCalled();
+  });
+});
+
+describe('RoomIO external transcription output', () => {
+  it('preserves a pre-set output.transcription and skips the room transcription outputs', async () => {
+    const room = createFakeRoom();
+    const session = createFakeSession();
+    const externalText = new ExternalTextOutput();
+    session.output.transcription = externalText;
+    const roomIO = new RoomIO({
+      agentSession: session as unknown as RoomIOArgs['agentSession'],
+      room: room as unknown as RoomIOArgs['room'],
+      inputOptions: { audioEnabled: false, textEnabled: false },
+      outputOptions: { audioEnabled: false },
+    });
+
+    roomIO.start();
+
+    expect(session.output.transcription).toBe(externalText);
+    expect(Reflect.get(roomIO, 'userTranscriptOutput')).toBeUndefined();
+    expect(Reflect.get(roomIO, 'agentTranscriptOutput')).toBeUndefined();
+    expect(Reflect.get(roomIO, 'transcriptionSynchronizer')).toBeUndefined();
+
+    await roomIO.close();
+  });
 });
 
 class FakeRealtimeModel extends RealtimeModel {

--- a/agents/src/voice/room_io/room_io.ts
+++ b/agents/src/voice/room_io/room_io.ts
@@ -521,7 +521,9 @@ export class RoomIO {
       }
     }
 
-    if (this.inputOptions.audioEnabled) {
+    // if the user pre-set an input, keep it instead of creating (and later attaching) our own
+    const externalAudioInput = this.agentSession.input.audio ?? undefined;
+    if (this.inputOptions.audioEnabled && !externalAudioInput) {
       this.audioInput = new ParticipantAudioInputStream({
         room: this.room,
         sampleRate: this.inputOptions.audioSampleRate,
@@ -540,7 +542,11 @@ export class RoomIO {
         queueSizeMs: this.outputOptions.queueSizeMs,
       });
     }
-    if (this.outputOptions.transcriptionEnabled) {
+    // if the user pre-set a transcription output, keep it: skip the room transcription
+    // outputs and the transcript synchronizer entirely (matches the python implementation,
+    // where a pre-set output disables RoomIO's text output)
+    const externalTranscriptionOutput = this.agentSession.output.transcription ?? undefined;
+    if (this.outputOptions.transcriptionEnabled && !externalTranscriptionOutput) {
       this.userTranscriptOutput = this.createTranscriptionOutput({
         isDeltaStream: false,
         participant: this.participantIdentity,


### PR DESCRIPTION
## Summary

`RoomIO` preserves a pre-set `session.output.audio` since #2103 (`externalAudioOutput`). This PR applies the same check to the other two IO ports, which are still silently replaced today:

- a pre-set `session.input.audio` was replaced by `ParticipantAudioInputStream`
- a pre-set `session.output.transcription` was replaced by RoomIO's transcription outputs

This matches the python implementation, where `agent_session.start()` disables the corresponding RoomIO port (`room_options.audio_input = False` / `room_options.text_output = False`) whenever the user already set one.

The two remaining `"... is already set, ignoring.."` warnings were misleading — nothing was ignored, the pre-set IO was replaced. They are reworded to the same "preserving and using the existing ..." wording #2103 introduced for audio output.

## Background

Found while investigating an avatar (Beyond Presence) session with no lip sync on agents 1.4.x: before #2103, RoomIO replaced the avatar plugin's `DataStreamAudioOutput`, so the agent published its own audio track while the avatar received zero bytes over `lk.audio_stream` — with no error anywhere, because `ParticipantAudioOutput` self-reports playback events. #2103 fixed the audio-output port; this PR completes the pattern for input and transcription, which have the same silent-replacement behavior.

## Changes

- `agents/src/voice/room_io/room_io.ts`
  - skip creating `ParticipantAudioInputStream` when `session.input.audio` is already set
  - skip creating the room transcription outputs and the `TranscriptionSynchronizer` when `session.output.transcription` is already set (python parity: a pre-set text output disables RoomIO's text output entirely)
- `agents/src/voice/agent_session.ts` — reword the two warnings to reflect the preserve behavior
- `agents/src/voice/room_io/room_io.test.ts` — two new tests mirroring the existing `RoomIO external audio output` suite

## Testing

- `vitest run agents/src/voice/room_io/room_io.test.ts` — 17 passed (15 existing + 2 new)
- full `agents/src` suite — 2138 passed, 5 skipped
- `pnpm build`, `pnpm lint`, `pnpm format:check` pass (`pnpm api:check` fails identically on pristine `main` — pre-existing `export * as` limitation in api-extractor, unrelated)
- end-to-end: a real `AgentSession` with `session.output.audio = new DataStreamAudioOutput(...)` set **before** `session.start()`, against a local avatar worker running the released python `DataStreamAudioReceiver` — audio segments arrive, `lk.playback_finished` round-trips, and transcription sync stays enabled

## Notes

Follow-up candidate (not in this PR, larger change): port python's `output.replace_audio_tail()` and use it in the `DataStreamAudioOutput`-based avatar plugins, so an avatar started **after** `session.start()` composes with the transcript synchronizer instead of replacing it (today that order disables transcription sync with a warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
