### PR TITLE
fix(minimax): refresh TTS endpoint and add region selection

### DIFF
--- a/.changeset/minimax-tts-regional-endpoints.md
+++ b/.changeset/minimax-tts-regional-endpoints.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-minimax': patch
+---
+
+fix(minimax): default TTS to the current global endpoint and add explicit region selection

--- a/plugins/minimax/README.md
+++ b/plugins/minimax/README.md
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 
 SPDX-License-Identifier: Apache-2.0
 -->
+
 # MiniMax plugin for LiveKit Agents
 
 The Agents Framework is designed for building realtime, programmable
@@ -26,5 +27,18 @@ pnpm add @livekit/agents-plugin-minimax
 ## Pre-requisites
 
 You'll need an API key from MiniMax. It can be set as an environment variable:
-`MINIMAX_API_KEY`. You can also override the API endpoint via `MINIMAX_BASE_URL`
-(defaults to `https://api-uw.minimax.io`).
+`MINIMAX_API_KEY`.
+
+The plugin talks to the global endpoint (`https://api.minimax.io`) by default.
+Pass `region: 'cn_zh'` to target the mainland China endpoint
+(`https://api.minimaxi.com`) instead, and note that an API key is only valid for
+the region it was created in:
+
+```ts
+import { TTS } from '@livekit/agents-plugin-minimax';
+
+const tts = new TTS({ region: 'cn_zh' });
+```
+
+You can also override the endpoint entirely via the `baseUrl` option or the
+`MINIMAX_BASE_URL` environment variable.

--- a/plugins/minimax/etc/agents-plugin-minimax.api.md
+++ b/plugins/minimax/etc/agents-plugin-minimax.api.md
@@ -25,13 +25,18 @@ export class ChunkedStream extends tts.ChunkedStream {
 
 // Warning: (ae-missing-release-tag) "DEFAULT_BASE_URL" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
-export const DEFAULT_BASE_URL = "https://api-uw.minimax.io";
+// @public
+export const DEFAULT_BASE_URL: string;
 
 // Warning: (ae-missing-release-tag) "DEFAULT_MODEL" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const DEFAULT_MODEL: TTSModel;
+
+// Warning: (ae-missing-release-tag) "DEFAULT_TTS_REGION" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const DEFAULT_TTS_REGION: TTSRegion;
 
 // Warning: (ae-missing-release-tag) "DEFAULT_VOICE_ID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -56,6 +61,7 @@ export class SynthesizeStream extends tts.SynthesizeStream {
 // @public (undocumented)
 export class TTS extends tts.TTS {
     constructor(opts?: TTSOptions);
+    get baseUrl(): string;
     // (undocumented)
     label: string;
     // (undocumented)
@@ -71,6 +77,14 @@ export class TTS extends tts.TTS {
     // (undocumented)
     updateOptions(opts: Partial<Pick<TTSOptions, 'model' | 'voice' | 'emotion' | 'speed' | 'vol' | 'pitch' | 'textNormalization' | 'pronunciationDict' | 'intensity' | 'timbre' | 'languageBoost'>>): void;
 }
+
+// Warning: (ae-missing-release-tag) "TTS_REGIONAL_BASE_URLS" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export const TTS_REGIONAL_BASE_URLS: {
+    readonly global_en: "https://api.minimax.io";
+    readonly cn_zh: "https://api.minimaxi.com";
+};
 
 // Warning: (ae-missing-release-tag) "TTSEmotion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -100,6 +114,7 @@ export interface TTSOptions {
     model?: TTSModel | string;
     pitch?: number;
     pronunciationDict?: Record<string, string[]>;
+    region?: TTSRegion;
     sampleRate?: TTSSampleRate;
     speed?: number;
     textNormalization?: boolean;
@@ -109,6 +124,11 @@ export interface TTSOptions {
     voice?: TTSVoice | string;
     vol?: number;
 }
+
+// Warning: (ae-missing-release-tag) "TTSRegion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type TTSRegion = 'global_en' | 'cn_zh';
 
 // Warning: (ae-missing-release-tag) "TTSSampleRate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/minimax/src/models.ts
+++ b/plugins/minimax/src/models.ts
@@ -133,5 +133,30 @@ export type TTSSampleRate = 8000 | 16000 | 22050 | 24000 | 32000 | 44100;
 // Ref: python livekit-plugins/livekit-plugins-minimax/livekit/plugins/minimax/tts.py - 85-86 lines
 export const DEFAULT_MODEL: TTSModel = 'speech-02-turbo';
 export const DEFAULT_VOICE_ID: TTSVoice = 'socialmedia_female_2_v1';
+
+/**
+ * MiniMax API region.
+ *
+ * @remarks `global_en` targets the international platform and `cn_zh` targets
+ * the mainland China platform. Both regions expose the same `t2a_v2` routes,
+ * but an API key is only valid for the region it was created in.
+ */
+export type TTSRegion = 'global_en' | 'cn_zh';
+
+/**
+ * Base URL of the MiniMax API per region.
+ *
+ * @remarks Endpoint reference: `https://platform.minimax.io/docs` for
+ * `global_en` and `https://platform.minimaxi.com/docs` for `cn_zh`.
+ */
+export const TTS_REGIONAL_BASE_URLS = {
+  global_en: 'https://api.minimax.io',
+  cn_zh: 'https://api.minimaxi.com',
+} as const satisfies Record<TTSRegion, string>;
+
+/** Region used when {@link TTSOptions.region} is not set. */
+export const DEFAULT_TTS_REGION: TTSRegion = 'global_en';
+
 // Ref: python livekit-plugins/livekit-plugins-minimax/livekit/plugins/minimax/tts.py - 142-144 lines
-export const DEFAULT_BASE_URL = 'https://api-uw.minimax.io';
+/** Base URL used when neither a base URL nor a region is given. */
+export const DEFAULT_BASE_URL: string = TTS_REGIONAL_BASE_URLS[DEFAULT_TTS_REGION];

--- a/plugins/minimax/src/tts.test.ts
+++ b/plugins/minimax/src/tts.test.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { describe, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_BASE_URL, DEFAULT_TTS_REGION, TTS_REGIONAL_BASE_URLS } from './models.js';
 import { TTS } from './tts.js';
 
 const hasMinimaxConfig = Boolean(process.env.MINIMAX_API_KEY);
@@ -17,3 +18,44 @@ if (hasMinimaxConfig) {
     it.skip('requires MINIMAX_API_KEY', () => {});
   });
 }
+
+describe('MiniMax TTS endpoint selection', () => {
+  const apiKey = 'key';
+  const savedBaseUrl = process.env.MINIMAX_BASE_URL;
+
+  beforeEach(() => {
+    delete process.env.MINIMAX_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (savedBaseUrl === undefined) {
+      delete process.env.MINIMAX_BASE_URL;
+    } else {
+      process.env.MINIMAX_BASE_URL = savedBaseUrl;
+    }
+  });
+
+  it('defaults to the endpoint of the default region', () => {
+    expect(DEFAULT_BASE_URL).toBe(TTS_REGIONAL_BASE_URLS[DEFAULT_TTS_REGION]);
+    expect(new TTS({ apiKey }).baseUrl).toBe(TTS_REGIONAL_BASE_URLS.global_en);
+  });
+
+  it('uses the endpoint of the requested region', () => {
+    expect(new TTS({ apiKey, region: 'global_en' }).baseUrl).toBe(TTS_REGIONAL_BASE_URLS.global_en);
+    expect(new TTS({ apiKey, region: 'cn_zh' }).baseUrl).toBe(TTS_REGIONAL_BASE_URLS.cn_zh);
+  });
+
+  it('keeps distinct hosts per region', () => {
+    expect(TTS_REGIONAL_BASE_URLS.global_en).not.toBe(TTS_REGIONAL_BASE_URLS.cn_zh);
+  });
+
+  it('prefers an explicit base URL over the region', () => {
+    const baseUrl = 'https://tts.example.invalid';
+    expect(new TTS({ apiKey, region: 'cn_zh', baseUrl }).baseUrl).toBe(baseUrl);
+  });
+
+  it('falls back to $MINIMAX_BASE_URL when no region is requested', () => {
+    process.env.MINIMAX_BASE_URL = 'https://tts.example.invalid';
+    expect(new TTS({ apiKey }).baseUrl).toBe('https://tts.example.invalid');
+  });
+});

--- a/plugins/minimax/src/tts.ts
+++ b/plugins/minimax/src/tts.ts
@@ -23,8 +23,10 @@ import {
   type TTSEmotion,
   type TTSLanguageBoost,
   type TTSModel,
+  type TTSRegion,
   type TTSSampleRate,
   type TTSVoice,
+  TTS_REGIONAL_BASE_URLS,
 } from './models.js';
 
 const NUM_CHANNELS = 1;
@@ -72,7 +74,13 @@ export interface TTSOptions {
   /** API key. Falls back to `$MINIMAX_API_KEY`. */
   apiKey?: string;
   /**
-   * Base URL of the MiniMax API. Falls back to `$MINIMAX_BASE_URL`, otherwise
+   * MiniMax API region used to pick the endpoint. Ignored when
+   * {@link TTSOptions.baseUrl} is set. Defaults to `global_en`.
+   */
+  region?: TTSRegion;
+  /**
+   * Base URL of the MiniMax API. Defaults to the endpoint of
+   * {@link TTSOptions.region}, then to `$MINIMAX_BASE_URL`, then to
    * {@link DEFAULT_BASE_URL}.
    */
   baseUrl?: string;
@@ -128,6 +136,15 @@ const validateOptions = (opts: {
   }
 };
 
+// Ref: python livekit-plugins/livekit-plugins-minimax/livekit/plugins/minimax/tts.py - 142-144 lines
+const resolveBaseUrl = (opts: TTSOptions): string => {
+  if (opts.baseUrl) return opts.baseUrl;
+  // An explicitly requested region wins over the environment so a single
+  // process can talk to both regions.
+  if (opts.region) return TTS_REGIONAL_BASE_URLS[opts.region];
+  return process.env.MINIMAX_BASE_URL || DEFAULT_BASE_URL;
+};
+
 // Ref: python livekit-plugins/livekit-plugins-minimax/livekit/plugins/minimax/tts.py - 221-252 lines
 const resolveOptions = (opts: TTSOptions): ResolvedTTSOptions => {
   const apiKey = opts.apiKey ?? process.env.MINIMAX_API_KEY;
@@ -161,7 +178,7 @@ const resolveOptions = (opts: TTSOptions): ResolvedTTSOptions => {
     sampleRate: opts.sampleRate ?? DEFAULT_SAMPLE_RATE,
     bitrate: opts.bitrate ?? DEFAULT_BITRATE,
     apiKey,
-    baseUrl: opts.baseUrl ?? process.env.MINIMAX_BASE_URL ?? DEFAULT_BASE_URL,
+    baseUrl: resolveBaseUrl(opts),
     tokenizer: opts.tokenizer ?? new tokenize.basic.SentenceTokenizer(),
   };
 };
@@ -214,6 +231,11 @@ export class TTS extends tts.TTS {
 
   get model(): string {
     return this.#opts.model;
+  }
+
+  /** Resolved base URL of the MiniMax API this instance talks to. */
+  get baseUrl(): string {
+    return this.#opts.baseUrl;
   }
 
   get provider(): string {


### PR DESCRIPTION
Reason: The MiniMax TTS client still defaulted to the legacy endpoint host and offered no explicit global/China endpoint selection.

## Changes

- Default the TTS base URL to the current global API host and export the per-region base URLs together with the default region.
- Add a `region` option that selects the endpoint, keep an explicit `baseUrl` and `$MINIMAX_BASE_URL` as overrides, and expose the resolved base URL through a `baseUrl` getter.
- Cover endpoint resolution with tests, document region selection in the plugin README, and refresh the API Extractor report and changeset.

## Checks

- `pnpm exec prettier --check plugins/minimax/src/models.ts plugins/minimax/src/tts.ts plugins/minimax/src/tts.test.ts plugins/minimax/README.md .changeset/minimax-tts-regional-endpoints.md`
- `pnpm --filter @livekit/agents-plugin-minimax lint`
- `pnpm exec turbo run build --filter=@livekit/agents-plugin-minimax`
- `pnpm vitest run plugins/minimax/src/tts.test.ts`
- `pnpm --filter @livekit/agents-plugin-minimax api:check`
- `git diff --check`
