### PR TITLE
feat: add caller hangup speech to warm transfers

### DIFF
--- a/.changeset/calm-spoons-speak.md
+++ b/.changeset/calm-spoons-speak.md
@@ -1,0 +1,6 @@
+---
+'@livekit/agents': patch
+---
+
+Add `callerHangupSpeech` for deterministic text or custom speech handles during warm transfers.
+Deprecate `callerHangupInstruction`.

--- a/.changeset/calm-spoons-speak.md
+++ b/.changeset/calm-spoons-speak.md
@@ -3,4 +3,4 @@
 ---
 
 Add `callerHangupSpeech` for deterministic text or custom speech handles during warm transfers.
-Deprecate `callerHangupInstruction`.
+Export `SpeechHandle` and deprecate `callerHangupInstruction`.

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -1972,6 +1972,11 @@ type BuiltinTextTransform = 'filter_markdown' | 'filter_emoji';
 // @public (undocumented)
 export function calculateAudioDurationSeconds(frame: AudioBuffer_2): number;
 
+// Warning: (ae-missing-release-tag) "CallerHangupSpeech" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+type CallerHangupSpeech = string | ((session: AgentSession) => SpeechHandle);
+
 // Warning: (ae-missing-release-tag) "cancelAndWait" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -2758,7 +2763,6 @@ export const createUserTurnExceededEvent: (input: {
 }) => UserTurnExceededEvent;
 
 // Warning: (ae-missing-release-tag) "createWarmTransferTask" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "WarmTransferTaskOptions"
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "WarmTransferTask"
 //
 // @public
@@ -8831,7 +8835,9 @@ interface WarmTransferTaskOptions {
     abortSignal?: AbortSignal;
     // (undocumented)
     allowInterruptions?: boolean;
+    // @deprecated
     callerHangupInstruction?: string | null;
+    callerHangupSpeech?: CallerHangupSpeech;
     // (undocumented)
     chatCtx?: ChatContext;
     dtmf?: string | null;
@@ -8969,6 +8975,7 @@ declare namespace workflows {
         TaskGroupResult,
         WarmTransferTask,
         createWarmTransferTask,
+        CallerHangupSpeech,
         WarmTransferResult,
         WarmTransferTaskOptions,
         InstructionParts

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -573,8 +573,6 @@ export class AgentSession<UserData = UnknownUserData> extends AgentSession_base 
         outputType?: z.ZodType<T>;
         outputOptions?: RunOutputOptions | null;
     }): RunResult<T>;
-    // Warning: (ae-forgotten-export) The symbol "SpeechHandle" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     say(text: string | ReadableStream_2<string>, options?: {
         audio?: ReadableStream_2<AudioFrame>;
@@ -1972,8 +1970,6 @@ type BuiltinTextTransform = 'filter_markdown' | 'filter_emoji';
 // @public (undocumented)
 export function calculateAudioDurationSeconds(frame: AudioBuffer_2): number;
 
-// Warning: (ae-missing-release-tag) "CallerHangupSpeech" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 type CallerHangupSpeech = string | ((session: AgentSession) => SpeechHandle);
 
@@ -4223,6 +4219,12 @@ export const initializeLogger: (input: LoggerOptions) => void;
 // @public (undocumented)
 function initPinoCloudExporter(config: PinoCloudExporterConfig): void;
 
+// @public
+export interface InputDetails {
+    // (undocumented)
+    modality: 'audio' | 'text';
+}
+
 // Warning: (ae-missing-release-tag) "InputSpeechStartedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -5917,6 +5919,9 @@ export interface ResolvedSessionConnectOptions {
     ttsConnOptions: APIConnectOptions;
 }
 
+// @public
+export type ResolvedSpeechHandle = Omit<SpeechHandle, 'then'>;
+
 // Warning: (ae-missing-release-tag) "resolveEnvVar" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
@@ -6116,7 +6121,6 @@ export class RunContext<UserData = UnknownUserData> {
     get updates(): readonly [FunctionCall, FunctionCallOutput][];
     // (undocumented)
     get userData(): UserData;
-    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "SpeechHandle"
     waitForPlayout(): Promise<void>;
 }
 
@@ -6665,6 +6669,94 @@ enum SpeechEventType {
     PREFLIGHT_TRANSCRIPT = 5,
     RECOGNITION_USAGE = 4,
     START_OF_SPEECH = 0
+}
+
+// @public
+export class SpeechHandle {
+    // @internal
+    readonly [SPEECH_HANDLE_SYMBOL] = true;
+    constructor(_id: string, _allowInterruptions: boolean,
+    _stepIndex: number, _inputDetails?: InputDetails, parent?: SpeechHandle | undefined);
+    // (undocumented)
+    addDoneCallback(callback: (sh: SpeechHandle) => void): void;
+    // @internal (undocumented)
+    _addItemAddedCallback(callback: (item: ChatItem) => void): void;
+    // @internal
+    _agentTurnContext?: Context;
+    // (undocumented)
+    get allowInterruptions(): boolean;
+    set allowInterruptions(value: boolean);
+    // @internal (undocumented)
+    _authorizeGeneration(): void;
+    // @internal (undocumented)
+    _cancel(): SpeechHandle;
+    // (undocumented)
+    get chatItems(): ChatItem[];
+    // @internal (undocumented)
+    _clearAuthorization(): void;
+    // (undocumented)
+    static create(options?: {
+        allowInterruptions?: boolean;
+        stepIndex?: number;
+        inputDetails?: InputDetails;
+        parent?: SpeechHandle;
+    }): SpeechHandle;
+    // (undocumented)
+    done(): boolean;
+    exception(): unknown;
+    // @internal (undocumented)
+    get _hasGenerations(): boolean;
+    // (undocumented)
+    get id(): string;
+    // (undocumented)
+    get inputDetails(): InputDetails;
+    interrupt(force?: boolean): SpeechHandle;
+    // (undocumented)
+    get interrupted(): boolean;
+    // @internal (undocumented)
+    _itemAdded(items: ChatItem[]): void;
+    // @internal (undocumented)
+    _markDone(error?: unknown): void;
+    // @internal (undocumented)
+    _markGenerationDone(): void;
+    // @internal (undocumented)
+    _markScheduled(): void;
+    // @internal
+    _maybeRunFinalOutput?: unknown;
+    // (undocumented)
+    get numSteps(): number;
+    // @internal (undocumented)
+    _numSteps: number;
+    // (undocumented)
+    readonly parent?: SpeechHandle | undefined;
+    // (undocumented)
+    removeDoneCallback(callback: (sh: SpeechHandle) => void): void;
+    // @internal (undocumented)
+    _removeItemAddedCallback(callback: (item: ChatItem) => void): void;
+    // (undocumented)
+    get scheduled(): boolean;
+    static SPEECH_PRIORITY_HIGH: number;
+    static SPEECH_PRIORITY_LOW: number;
+    static SPEECH_PRIORITY_NORMAL: number;
+    // @internal (undocumented)
+    _stepIndex: number;
+    // @internal (undocumented)
+    _tasks: Task<void>[];
+    then<R1 = ResolvedSpeechHandle, R2 = never>(onFulfilled?: ((value: ResolvedSpeechHandle) => R1 | PromiseLike<R1>) | null, onRejected?: ((reason: unknown) => R2 | PromiseLike<R2>) | null): Promise<R1 | R2>;
+    // @internal (undocumented)
+    _waitForAuthorization(): Promise<void>;
+    // @internal (undocumented)
+    _waitForGeneration(stepIdx?: number): Promise<void>;
+    waitForPlayout(): Promise<void>;
+    // @internal (undocumented)
+    _waitForScheduled(): Promise<void>;
+    // (undocumented)
+    waitIfNotInterrupted(aw: Promise<unknown>[]): Promise<void>;
+}
+
+// @public
+export class SpeechHandleCircularWaitError extends Error {
+    constructor(functionCallName: string);
 }
 
 // Warning: (ae-missing-release-tag) "SpeechmaticsModels" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -8629,6 +8721,10 @@ declare namespace voice {
         createTimedString,
         isTimedString,
         RunContext,
+        SpeechHandle,
+        SpeechHandleCircularWaitError,
+        InputDetails,
+        ResolvedSpeechHandle,
         testing,
         RunOutputOptions,
         textTransforms,

--- a/agents/src/index.test.ts
+++ b/agents/src/index.test.ts
@@ -7,6 +7,8 @@ import {
   AgentSession,
   ChatContext,
   ModelUsageCollector,
+  SpeechHandle,
+  SpeechHandleCircularWaitError,
   logMetrics,
   tool,
 } from './index.js';
@@ -19,5 +21,7 @@ describe('index exports', () => {
     expect(tool).toBeDefined();
     expect(ModelUsageCollector).toBeDefined();
     expect(logMetrics).toBeDefined();
+    expect(SpeechHandle).toBeDefined();
+    expect(SpeechHandleCircularWaitError).toBeDefined();
   });
 });

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -64,6 +64,12 @@ export {
 export * from './report.js';
 export * from './room_io/index.js';
 export { RunContext } from './run_context.js';
+export {
+  SpeechHandle,
+  SpeechHandleCircularWaitError,
+  type InputDetails,
+  type ResolvedSpeechHandle,
+} from './speech_handle.js';
 export * from './turn_config/endpointing.js';
 export * from './turn_config/user_turn_limit.js';
 export * as testing from './testing/index.js';

--- a/agents/src/voice/speech_handle.ts
+++ b/agents/src/voice/speech_handle.ts
@@ -75,6 +75,8 @@ export function isSpeechHandle(value: unknown): value is SpeechHandle {
  * Omitting `then` terminates the unwrap because the pattern
  * `object & { then(...) }` no longer matches. In practice, calling `.then`
  * on an already-awaited handle has no meaningful use.
+ *
+ * @public
  */
 export type ResolvedSpeechHandle = Omit<SpeechHandle, 'then'>;
 
@@ -84,6 +86,8 @@ export type ResolvedSpeechHandle = Omit<SpeechHandle, 'then'>;
  * currently-running tool creates a real circular wait — the handle's playout
  * cannot finish until the tool returns, but the tool is blocked waiting for
  * the playout.
+ *
+ * @public
  */
 export class SpeechHandleCircularWaitError extends Error {
   constructor(functionCallName: string) {
@@ -99,6 +103,8 @@ export class SpeechHandleCircularWaitError extends Error {
 /**
  * Describes how the user provided input that triggered the current turn.
  * Used by modality-aware Instructions to pick the correct variant.
+ *
+ * @public
  */
 export interface InputDetails {
   modality: 'audio' | 'text';
@@ -107,6 +113,11 @@ export interface InputDetails {
 /** Default {@link InputDetails} used when no explicit value is provided. */
 export const DEFAULT_INPUT_DETAILS: InputDetails = { modality: 'audio' };
 
+/**
+ * Controls and observes one agent speech turn.
+ *
+ * @public
+ */
 export class SpeechHandle {
   /** Priority for messages that should be played after all other messages in the queue */
   static SPEECH_PRIORITY_LOW = 0;

--- a/agents/src/workflows/index.ts
+++ b/agents/src/workflows/index.ts
@@ -10,6 +10,7 @@ export {
 export {
   WarmTransferTask,
   createWarmTransferTask,
+  type CallerHangupSpeech,
   type WarmTransferResult,
   type WarmTransferTaskOptions,
 } from './warm_transfer.js';

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -10,8 +10,10 @@ import { ChatContext, type FunctionTool } from '../llm/index.js';
 import { AgentTask } from '../voice/agent.js';
 import { AgentSession } from '../voice/agent_session.js';
 import { BackgroundAudioPlayer } from '../voice/background_audio.js';
+import { SpeechHandle } from '../voice/speech_handle.js';
 import {
   type WarmTransferResult,
+  createCallerHangupSpeech,
   createWarmTransferTask,
   resolveHumanAgentRoomName,
 } from './warm_transfer.js';
@@ -488,5 +490,61 @@ describe('createWarmTransferTask', () => {
     controller.abort(reason);
 
     expect(complete).toHaveBeenCalledWith(reason);
+  });
+});
+
+function completedSpeechHandle(): SpeechHandle {
+  const handle = SpeechHandle.create();
+  handle._markDone();
+  return handle;
+}
+
+function createSession() {
+  const sayHandle = completedSpeechHandle();
+  const generatedHandle = completedSpeechHandle();
+  const say = vi.fn(() => sayHandle);
+  const generateReply = vi.fn(() => generatedHandle);
+  const session = { say, generateReply } as unknown as AgentSession;
+
+  return { session, say, sayHandle, generateReply, generatedHandle };
+}
+
+describe('createCallerHangupSpeech', () => {
+  it('speaks literal text without generating a reply', () => {
+    const { session, say, sayHandle, generateReply } = createSession();
+
+    expect(
+      createCallerHangupSpeech(session, 'The caller disconnected. Hanging up now.', undefined),
+    ).toBe(sayHandle);
+    expect(say).toHaveBeenCalledWith('The caller disconnected. Hanging up now.', {
+      allowInterruptions: false,
+      addToChatCtx: false,
+    });
+    expect(generateReply).not.toHaveBeenCalled();
+  });
+
+  it('uses a lazy factory to create any speech handle', () => {
+    const { session, say, generateReply } = createSession();
+    const customHandle = completedSpeechHandle();
+    const factory = vi.fn(() => customHandle);
+
+    expect(createCallerHangupSpeech(session, factory, undefined)).toBe(customHandle);
+    expect(factory).toHaveBeenCalledWith(session);
+    expect(say).not.toHaveBeenCalled();
+    expect(generateReply).not.toHaveBeenCalled();
+  });
+
+  it('preserves the deprecated generated-reply path when no speech is configured', () => {
+    const { session, say, generateReply, generatedHandle } = createSession();
+
+    expect(
+      createCallerHangupSpeech(session, undefined, 'Generate a short caller hangup message.'),
+    ).toBe(generatedHandle);
+    expect(generateReply).toHaveBeenCalledWith({
+      instructions: 'Generate a short caller hangup message.',
+      allowInterruptions: false,
+      toolChoice: 'none',
+    });
+    expect(say).not.toHaveBeenCalled();
   });
 });

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -37,7 +37,11 @@ export interface WarmTransferResult {
   humanAgentIdentity: string;
 }
 
-/** Speech played to the human agent when the caller hangs up before the transfer completes. */
+/**
+ * Speech played to the human agent when the caller hangs up before the transfer completes.
+ *
+ * @public
+ */
 export type CallerHangupSpeech = string | ((session: AgentSession) => SpeechHandle);
 
 export interface WarmTransferTaskOptions {

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -100,9 +100,10 @@ export interface WarmTransferTaskOptions {
   holdAudio?: AudioSourceType | AudioConfig | AudioConfig[] | null;
   /**
    * Speech played before ending the human agent's call when the caller hangs up after the human
-   * agent answers. A string is spoken with `session.say()`. A callback runs only after the caller
-   * hangs up and must return the speech handle that the task will await. This option takes
-   * precedence over `callerHangupInstruction`.
+   * agent answers. A string is spoken with `session.say()` and requires a TTS model. For sessions
+   * without TTS, use a callback that returns `session.say(text, { audio })` with prerecorded audio.
+   * The callback runs only after the caller hangs up, and the task awaits its returned handle.
+   * This option takes precedence over `callerHangupInstruction`.
    */
   callerHangupSpeech?: CallerHangupSpeech;
   /**

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -30,11 +30,15 @@ import {
   type PlayHandle,
 } from '../voice/background_audio.js';
 import { DEFAULT_PARTICIPANT_KINDS } from '../voice/room_io/index.js';
+import type { SpeechHandle } from '../voice/speech_handle.js';
 import type { InstructionParts } from './utils.js';
 
 export interface WarmTransferResult {
   humanAgentIdentity: string;
 }
+
+/** Speech played to the human agent when the caller hangs up before the transfer completes. */
+export type CallerHangupSpeech = string | ((session: AgentSession) => SpeechHandle);
 
 export interface WarmTransferTaskOptions {
   /**
@@ -91,9 +95,19 @@ export interface WarmTransferTaskOptions {
   /** Audio played to the caller while they are on hold during the transfer. */
   holdAudio?: AudioSourceType | AudioConfig | AudioConfig[] | null;
   /**
+   * Speech played before ending the human agent's call when the caller hangs up after the human
+   * agent answers. A string is spoken with `session.say()`. A callback runs only after the caller
+   * hangs up and must return the speech handle that the task will await. This option takes
+   * precedence over `callerHangupInstruction`.
+   */
+  callerHangupSpeech?: CallerHangupSpeech;
+  /**
    * Instructions used to generate the reply spoken to the human agent before their call is
    * ended when the caller hangs up mid-transfer (after the human agent answered but before
    * the merge). Falls back to a built-in instruction when not provided.
+   *
+   * @deprecated Use `callerHangupSpeech`. Return `session.generateReply()` from its callback to
+   * keep generated speech.
    */
   callerHangupInstruction?: string | null;
   /**
@@ -125,8 +139,8 @@ type IoState = {
  * If the caller hangs up before the merge — including while the human agent's phone is
  * still ringing — the transfer is cancelled: the pending dial is aborted, the human agent
  * room is torn down (ending the SIP call), and the task completes with a {@link ToolError}.
- * A human agent who already answered is told the caller left (a reply generated from
- * {@link WarmTransferTaskOptions.callerHangupInstruction}) before their call is ended.
+ * A human agent who already answered is told the caller left using `callerHangupSpeech`, or a
+ * reply generated from the deprecated `callerHangupInstruction`, before their call is ended.
  *
  * This is the functional core; {@link WarmTransferTask} is a thin class wrapper over it.
  */
@@ -141,6 +155,7 @@ export function createWarmTransferTask({
   ringingTimeout,
   roomName: rawRoomName,
   holdAudio = { source: BuiltinAudioClip.HOLD_MUSIC, volume: 0.8 },
+  callerHangupSpeech,
   callerHangupInstruction,
   instructions,
   chatCtx,
@@ -273,13 +288,7 @@ export function createWarmTransferTask({
   ): Promise<void> => {
     try {
       session.interrupt();
-      const handle = session.generateReply({
-        instructions: callerHangupInstruction ?? CALLER_HANGUP_INSTRUCTION,
-        allowInterruptions: false,
-        // The transfer is already cancelled; the reply must speak, not call
-        // connect_to_caller/decline_transfer.
-        toolChoice: 'none',
-      });
+      const handle = createCallerHangupSpeech(session, callerHangupSpeech, callerHangupInstruction);
       // Cap the wait so teardown can't hang on a stuck playout.
       const playout = await waitUntilAborted(
         handle.waitForPlayout(),
@@ -770,6 +779,32 @@ export function resolveHumanAgentRoomName(callerRoomName: string, override?: str
     throw new Error('`roomName` must differ from the caller room name');
   }
   return override;
+}
+
+/** @internal */
+export function createCallerHangupSpeech(
+  session: AgentSession,
+  callerHangupSpeech: CallerHangupSpeech | undefined,
+  callerHangupInstruction: string | null | undefined,
+): SpeechHandle {
+  if (typeof callerHangupSpeech === 'function') {
+    return callerHangupSpeech(session);
+  }
+
+  if (callerHangupSpeech !== undefined) {
+    return session.say(callerHangupSpeech, {
+      allowInterruptions: false,
+      addToChatCtx: false,
+    });
+  }
+
+  return session.generateReply({
+    instructions: callerHangupInstruction ?? CALLER_HANGUP_INSTRUCTION,
+    allowInterruptions: false,
+    // The transfer is already cancelled; the reply must speak, not call
+    // connect_to_caller/decline_transfer.
+    toolChoice: 'none',
+  });
 }
 
 const CALLER_HANGUP_INSTRUCTION = `The caller has hung up before the transfer could be completed.


### PR DESCRIPTION
The warm-transfer consultation model can repeat an interrupted briefing when it generates the caller-hangup message.

Add `callerHangupSpeech` for deterministic text or a lazy `SpeechHandle` factory. Deprecate `callerHangupInstruction` while retaining it as the fallback, so existing applications keep their behavior.

Addresses livekit/agents-js#2167  <br>Fixes livekit/agents-js#2167  <br>Supersedes [#2168](<https://github.com/livekit/agents-js/issues/2168>)

<details><summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> can you take a look at [https://github.com/livekit/agents-js/issues/2167](<https://github.com/livekit/agents-js/issues/2167>)? I think we have something very similar to this in agents filler generation (python)? where we take a callback to generate any speech handle?
>
> is it backward compatible?
>
> I don't know about "Notice", it feels unclear. Yeah, we should deprecate that parameter.
>
> okay, let's create a PR for that. Add the original PR's author as co-author ([#2168](<https://github.com/livekit/agents-js/issues/2168>))

</details>