### PR TITLE
feat: add greeting speech to warm transfers

### DIFF
--- a/.changeset/quiet-rivers-greet.md
+++ b/.changeset/quiet-rivers-greet.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Add `greetingSpeech` for optional answer-time speech during warm transfers.

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -1970,9 +1970,6 @@ type BuiltinTextTransform = 'filter_markdown' | 'filter_emoji';
 // @public (undocumented)
 export function calculateAudioDurationSeconds(frame: AudioBuffer_2): number;
 
-// @public
-type CallerHangupSpeech = string | ((session: AgentSession) => SpeechHandle);
-
 // Warning: (ae-missing-release-tag) "cancelAndWait" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -8914,6 +8911,9 @@ interface WarmTransferResult {
     humanAgentIdentity: string;
 }
 
+// @public
+type WarmTransferSpeech = string | ((session: AgentSession) => SpeechHandle);
+
 // Warning: (ae-missing-release-tag) "WarmTransferTask" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "createWarmTransferTask"
 //
@@ -8933,10 +8933,11 @@ interface WarmTransferTaskOptions {
     allowInterruptions?: boolean;
     // @deprecated
     callerHangupInstruction?: string | null;
-    callerHangupSpeech?: CallerHangupSpeech;
+    callerHangupSpeech?: WarmTransferSpeech;
     // (undocumented)
     chatCtx?: ChatContext;
     dtmf?: string | null;
+    greetingSpeech?: WarmTransferSpeech;
     holdAudio?: AudioSourceType | AudioConfig | AudioConfig[] | null;
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "InstructionParts"
     instructions?: InstructionParts | string;
@@ -9071,7 +9072,7 @@ declare namespace workflows {
         TaskGroupResult,
         WarmTransferTask,
         createWarmTransferTask,
-        CallerHangupSpeech,
+        WarmTransferSpeech,
         WarmTransferResult,
         WarmTransferTaskOptions,
         InstructionParts

--- a/agents/src/workflows/index.ts
+++ b/agents/src/workflows/index.ts
@@ -10,7 +10,7 @@ export {
 export {
   WarmTransferTask,
   createWarmTransferTask,
-  type CallerHangupSpeech,
+  type WarmTransferSpeech,
   type WarmTransferResult,
   type WarmTransferTaskOptions,
 } from './warm_transfer.js';

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { SIPParticipantInfo } from '@livekit/protocol';
 import { ParticipantKind, Room, RoomEvent } from '@livekit/rtc-node';
 import { AccessToken, RoomServiceClient, SipClient } from 'livekit-server-sdk';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -14,6 +15,7 @@ import { SpeechHandle } from '../voice/speech_handle.js';
 import {
   type WarmTransferResult,
   createCallerHangupSpeech,
+  createWarmTransferSpeech,
   createWarmTransferTask,
   resolveHumanAgentRoomName,
 } from './warm_transfer.js';
@@ -491,6 +493,74 @@ describe('createWarmTransferTask', () => {
 
     expect(complete).toHaveBeenCalledWith(reason);
   });
+
+  it('starts greeting speech only after the outbound SIP call answers', async () => {
+    vi.stubEnv('LIVEKIT_API_KEY', 'api-key');
+    vi.stubEnv('LIVEKIT_API_SECRET', 'api-secret');
+    let resolveAnswer!: (participant: SIPParticipantInfo) => void;
+    const answer = new Promise<SIPParticipantInfo>((resolve) => {
+      resolveAnswer = resolve;
+    });
+    const createSipParticipant = vi
+      .spyOn(SipClient.prototype, 'createSipParticipant')
+      .mockReturnValue(answer);
+    vi.spyOn(AccessToken.prototype, 'toJwt').mockResolvedValue('token');
+    vi.spyOn(Room.prototype, 'connect').mockResolvedValue();
+    vi.spyOn(AgentSession.prototype, 'start').mockResolvedValue();
+
+    const greetingSpeech = vi.fn(() => completedSpeechHandle());
+    const callerRoom = {
+      name: 'caller-room',
+      localParticipant: { identity: 'transfer-agent' },
+      remoteParticipants: new Map([
+        ['caller', { identity: 'caller', kind: ParticipantKind.STANDARD }],
+      ]),
+      on: vi.fn(),
+      off: vi.fn(),
+    } as unknown as Room;
+    const callerSession = {
+      input: { audioEnabled: true, audio: null },
+      output: {
+        audioEnabled: true,
+        transcriptionEnabled: true,
+        audio: null,
+        transcription: null,
+      },
+      vad: undefined,
+      llm: undefined,
+      stt: undefined,
+      tts: undefined,
+      turnDetection: undefined,
+    } as unknown as AgentSession;
+    const task = createWarmTransferTask({
+      sipCallTo: '+15551234567',
+      sipTrunkId: 'ST_dummy',
+      holdAudio: null,
+      greetingSpeech,
+    });
+    task._agentActivity = { agentSession: callerSession } as never;
+    const jobContext = {
+      room: callerRoom,
+      info: { url: 'wss://example.livekit.cloud' },
+    } as JobContext;
+
+    const onEnter = job.runWithJobContextAsync(jobContext, () => task.onEnter());
+    await vi.waitFor(() => expect(createSipParticipant).toHaveBeenCalledOnce());
+
+    expect(greetingSpeech).not.toHaveBeenCalled();
+
+    resolveAnswer(new SIPParticipantInfo());
+    await onEnter;
+
+    expect(greetingSpeech).toHaveBeenCalledOnce();
+    expect(createSipParticipant).toHaveBeenCalledWith(
+      'ST_dummy',
+      '+15551234567',
+      'caller-room-human-agent',
+      expect.objectContaining({ waitUntilAnswered: true }),
+      undefined,
+    );
+  });
 });
 
 function completedSpeechHandle(): SpeechHandle {
@@ -509,6 +579,37 @@ function createSession() {
   return { session, say, sayHandle, generateReply, generatedHandle };
 }
 
+describe('createWarmTransferSpeech', () => {
+  it('does nothing when no speech is configured', () => {
+    const { session, say, generateReply } = createSession();
+
+    expect(createWarmTransferSpeech(session, undefined)).toBeUndefined();
+    expect(say).not.toHaveBeenCalled();
+    expect(generateReply).not.toHaveBeenCalled();
+  });
+
+  it('speaks literal text with default say options', () => {
+    const { session, say, sayHandle, generateReply } = createSession();
+
+    expect(
+      createWarmTransferSpeech(session, 'Hello, I am calling about a customer transfer.'),
+    ).toBe(sayHandle);
+    expect(say).toHaveBeenCalledWith('Hello, I am calling about a customer transfer.', undefined);
+    expect(generateReply).not.toHaveBeenCalled();
+  });
+
+  it('uses a lazy factory to create any speech handle', () => {
+    const { session, say, generateReply } = createSession();
+    const customHandle = completedSpeechHandle();
+    const factory = vi.fn(() => customHandle);
+
+    expect(createWarmTransferSpeech(session, factory)).toBe(customHandle);
+    expect(factory).toHaveBeenCalledWith(session);
+    expect(say).not.toHaveBeenCalled();
+    expect(generateReply).not.toHaveBeenCalled();
+  });
+});
+
 describe('createCallerHangupSpeech', () => {
   it('speaks literal text without generating a reply', () => {
     const { session, say, sayHandle, generateReply } = createSession();
@@ -520,17 +621,6 @@ describe('createCallerHangupSpeech', () => {
       allowInterruptions: false,
       addToChatCtx: false,
     });
-    expect(generateReply).not.toHaveBeenCalled();
-  });
-
-  it('uses a lazy factory to create any speech handle', () => {
-    const { session, say, generateReply } = createSession();
-    const customHandle = completedSpeechHandle();
-    const factory = vi.fn(() => customHandle);
-
-    expect(createCallerHangupSpeech(session, factory, undefined)).toBe(customHandle);
-    expect(factory).toHaveBeenCalledWith(session);
-    expect(say).not.toHaveBeenCalled();
     expect(generateReply).not.toHaveBeenCalled();
   });
 

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -38,11 +38,11 @@ export interface WarmTransferResult {
 }
 
 /**
- * Speech played to the human agent when the caller hangs up before the transfer completes.
+ * Exact text or a callback that starts speech in the consultation session.
  *
  * @public
  */
-export type CallerHangupSpeech = string | ((session: AgentSession) => SpeechHandle);
+export type WarmTransferSpeech = string | ((session: AgentSession) => SpeechHandle);
 
 export interface WarmTransferTaskOptions {
   /**
@@ -99,13 +99,21 @@ export interface WarmTransferTaskOptions {
   /** Audio played to the caller while they are on hold during the transfer. */
   holdAudio?: AudioSourceType | AudioConfig | AudioConfig[] | null;
   /**
+   * Speech started after the outbound SIP call is answered. A string is spoken with
+   * `session.say()`. A callback runs once after answer with the consultation session and must
+   * return a speech handle. Omit this option to let the destination speak first. The answer signal
+   * does not distinguish a person from voicemail or an IVR, so an enabled greeting can overlap
+   * automated audio.
+   */
+  greetingSpeech?: WarmTransferSpeech;
+  /**
    * Speech played before ending the human agent's call when the caller hangs up after the human
    * agent answers. A string is spoken with `session.say()` and requires a TTS model. For sessions
    * without TTS, use a callback that returns `session.say(text, { audio })` with prerecorded audio.
    * The callback runs only after the caller hangs up, and the task awaits its returned handle.
    * This option takes precedence over `callerHangupInstruction`.
    */
-  callerHangupSpeech?: CallerHangupSpeech;
+  callerHangupSpeech?: WarmTransferSpeech;
   /**
    * Instructions used to generate the reply spoken to the human agent before their call is
    * ended when the caller hangs up mid-transfer (after the human agent answered but before
@@ -160,6 +168,7 @@ export function createWarmTransferTask({
   ringingTimeout,
   roomName: rawRoomName,
   holdAudio = { source: BuiltinAudioClip.HOLD_MUSIC, volume: 0.8 },
+  greetingSpeech,
   callerHangupSpeech,
   callerHangupInstruction,
   instructions,
@@ -681,6 +690,11 @@ export function createWarmTransferTask({
           return;
         }
         transferAgentSession = result.session;
+        try {
+          createWarmTransferSpeech(transferAgentSession, greetingSpeech);
+        } catch (error) {
+          logger.warn({ error }, 'failed to greet human agent');
+        }
       } catch (error) {
         logger.error({ error }, 'could not dial human agent');
         setResult(new ToolError('could not dial human agent'));
@@ -787,20 +801,34 @@ export function resolveHumanAgentRoomName(callerRoomName: string, override?: str
 }
 
 /** @internal */
-export function createCallerHangupSpeech(
+export function createWarmTransferSpeech(
   session: AgentSession,
-  callerHangupSpeech: CallerHangupSpeech | undefined,
-  callerHangupInstruction: string | null | undefined,
-): SpeechHandle {
-  if (typeof callerHangupSpeech === 'function') {
-    return callerHangupSpeech(session);
+  speech: WarmTransferSpeech | undefined,
+  sayOptions?: Parameters<AgentSession['say']>[1],
+): SpeechHandle | undefined {
+  if (typeof speech === 'function') {
+    return speech(session);
   }
 
-  if (callerHangupSpeech !== undefined) {
-    return session.say(callerHangupSpeech, {
-      allowInterruptions: false,
-      addToChatCtx: false,
-    });
+  if (speech !== undefined) {
+    return session.say(speech, sayOptions);
+  }
+
+  return undefined;
+}
+
+/** @internal */
+export function createCallerHangupSpeech(
+  session: AgentSession,
+  callerHangupSpeech: WarmTransferSpeech | undefined,
+  callerHangupInstruction: string | null | undefined,
+): SpeechHandle {
+  const handle = createWarmTransferSpeech(session, callerHangupSpeech, {
+    allowInterruptions: false,
+    addToChatCtx: false,
+  });
+  if (handle) {
+    return handle;
   }
 
   return session.generateReply({

--- a/examples/src/warm_transfer.ts
+++ b/examples/src/warm_transfer.ts
@@ -61,6 +61,7 @@ Examples on when the tool should be called:
                 // Give up if the supervisor doesn't pick up within 25s with
                 // `ringingTimeout: 25000`.
                 instructions: { extra: SUMMARY_INSTRUCTIONS },
+                greetingSpeech: (session) => session.generateReply({ toolChoice: 'none' }),
               }).run();
 
               logger.info(


### PR DESCRIPTION
**Behavior:** Add `greetingSpeech` for opt-in speech when the outbound SIP leg reports answered. Strings use `session.say()`; callbacks can return generated or custom speech.

**Compatibility:** The default remains listen-first for voicemail and IVR support.

**Stack:** Depends on livekit/agents-js#2299.

Addresses livekit/agents-js#2210  <br>Fixes livekit/agents-js#2210

<details><summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> can you review the linear ticket: livekit/agents-js#2210?
>
> then maybe greetingSpeech? Following the 2299 pattern?
>
> we can stack a PR on top of 2299 for the greetingSpeech changes

</details>