### PR TITLE
fix(llm): treat a null tool argument as absent for optional Zod fields

### DIFF
--- a/.changeset/optional-null-sentinel.md
+++ b/.changeset/optional-null-sentinel.md
@@ -1,0 +1,21 @@
+---
+'@livekit/agents': patch
+---
+
+fix(llm): treat a null tool argument as absent for optional Zod fields
+
+`zodSchemaToJsonSchema` targets `openAi`, which rewrites an `.optional()` property
+into a required nullable one because a strict tool schema must list every property
+in `required`. That leaves null as the only way for a model to say "not provided",
+but tool arguments are validated against the original Zod schema, where
+`.optional()` accepts undefined and rejects null. Any tool with a bare
+`.optional()` field therefore failed with `Arguments parsing failed` as soon as the
+model filled the key in with null — reliably under `strictToolSchema`, since the
+decoder then enforces `required`.
+
+Defaulted fields already round-tripped through the null sentinel resolved in
+`injectSchemaDefaults`. This extends the same inverse mapping to optional fields:
+a null is dropped when the property is absent from `required` and its schema does
+not allow null, so Zod sees undefined. Defaults still win, and a property that is
+required or genuinely nullable keeps its null so real contract violations still
+surface.

--- a/agents/src/llm/utils.test.ts
+++ b/agents/src/llm/utils.test.ts
@@ -482,6 +482,93 @@ describe('executeToolCall', () => {
     expect(result.output).toMatch(/Arguments parsing failed/);
   });
 
+  it('should treat null as absent for an optional argument without a default', async () => {
+    const search = tool({
+      name: 'search',
+      description: 'search',
+      parameters: z.object({ query: z.string(), limit: z.number().optional() }),
+      execute: async (args) => args,
+    });
+
+    const result = await executeToolCall(
+      FunctionCall.create({
+        callId: 'call-optional-1',
+        name: 'search',
+        args: '{"query":"cats","limit":null}',
+      }),
+      new ToolContext([search]),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.output)).toEqual({ query: 'cats' });
+  });
+
+  it('should treat null as absent for optional arguments carrying constraints', async () => {
+    const lookup = tool({
+      name: 'lookup',
+      description: 'lookup',
+      parameters: z.object({ id: z.string().min(1).optional() }),
+      execute: async (args) => args,
+    });
+
+    const result = await executeToolCall(
+      FunctionCall.create({
+        callId: 'call-optional-2',
+        name: 'lookup',
+        args: '{"id":null}',
+      }),
+      new ToolContext([lookup]),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.output)).toEqual({});
+  });
+
+  it('should treat nested null as absent for optional arguments', async () => {
+    const nested = tool({
+      name: 'nested',
+      description: 'nested',
+      parameters: z.object({
+        outer: z.object({ inner: z.string().optional(), kept: z.string() }),
+        list: z.array(z.object({ x: z.number().optional() })),
+      }),
+      execute: async (args) => args,
+    });
+
+    const result = await executeToolCall(
+      FunctionCall.create({
+        callId: 'call-optional-3',
+        name: 'nested',
+        args: JSON.stringify({ outer: { inner: null, kept: 'k' }, list: [{ x: null }] }),
+      }),
+      new ToolContext([nested]),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.output)).toEqual({ outer: { kept: 'k' }, list: [{}] });
+  });
+
+  it('should preserve a genuine null for a nullish argument', async () => {
+    const maybe = tool({
+      name: 'maybe',
+      description: 'maybe',
+      parameters: z.object({ n: z.number().nullish() }),
+      execute: async (args) => args,
+    });
+
+    const result = await executeToolCall(
+      FunctionCall.create({
+        callId: 'call-nullish-1',
+        name: 'maybe',
+        args: '{"n":null}',
+      }),
+      new ToolContext([maybe]),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(JSON.parse(result.output)).toEqual({ n: null });
+  });
+
   it('should preserve a genuine null for a nullable defaulted argument', async () => {
     const maybe = tool({
       name: 'maybe',

--- a/agents/src/llm/utils.ts
+++ b/agents/src/llm/utils.ts
@@ -531,16 +531,27 @@ function injectSchemaDefaults(
     const properties = schema.properties;
     const additional = schema.additionalProperties;
     if (isJsonObject(properties) || isJsonObject(additional)) {
+      const required = Array.isArray(schema.required) ? schema.required : [];
       return Object.fromEntries(
-        Object.entries(value).map(([key, item]) => {
+        Object.entries(value).flatMap<[string, unknown]>(([key, item]) => {
           const prop = isJsonObject(properties) ? properties[key] : undefined;
           if (isJsonObject(prop)) {
-            return [key, injectSchemaDefaults(item, prop, root)];
+            const resolved = injectSchemaDefaults(item, prop, root);
+            // A strict tool schema has no way to spell "absent": every property must be listed in
+            // `required`, so an optional one is emitted as required-and-nullable and the model
+            // signals "not provided" with null. Zod's `.optional()` accepts only undefined, so drop
+            // the key instead of handing validation a null the schema rejects. Defaults were already
+            // substituted above, and a property that is required or genuinely nullable keeps its
+            // null so a real contract violation still surfaces.
+            if (resolved === null && !required.includes(key) && !jsonSchemaAllowsNull(prop, root)) {
+              return [];
+            }
+            return [[key, resolved]];
           }
           if (isJsonObject(additional)) {
-            return [key, injectSchemaDefaults(item, additional, root)];
+            return [[key, injectSchemaDefaults(item, additional, root)]];
           }
-          return [key, item];
+          return [[key, item]];
         }),
       );
     }


### PR DESCRIPTION
## Description

A function tool whose Zod schema has a bare `.optional()` field fails with `Arguments parsing failed` as soon as the model sends `null` for that field. The schema we hand the model and the schema we validate against disagree about how to spell "absent".

`zodSchemaToJsonSchema` uses `target: 'openAi'` (`zod-utils.ts:126`), whose `forceOptionalIntoNullable` rewrites an `.optional()` property into a **required, nullable** one — necessarily, because a strict tool schema must list every property in `required`. So `null` becomes the model's only way to say "not provided". But `executeToolCall` validates against the *original* Zod schema (`utils.ts:612`), where `.optional()` accepts `undefined` and rejects `null`.

Minimal repro:

```ts
const t = tool({
  name: 'search',
  description: 'search',
  parameters: z.object({ query: z.string(), limit: z.number().optional() }),
  execute: async (args) => args,
});
// args: '{"query":"cats","limit":null}'
// -> Arguments parsing failed: [{ expected: 'number', received: 'null', path: ['limit'] }]
```

This is not specific to `strictToolSchema`. The emitted schema for a bare `.optional()` field is byte-identical with `strict` on and off — `forceOptionalIntoNullable` runs off the target, not the strict flag — and validation never consults the flag. Turning `strictToolSchema` on just makes it deterministic rather than occasional, because the decoder then enforces `required` and the model must fill the key in.

The docs already advise ["prefer `.nullable()` over `.optional()`"](https://docs.livekit.io/agents/logic/tools/definition/) for OpenAI strict mode. The problem is that ignoring it fails silently: no error at schema build, no warning, no test-time signal — just a runtime tool failure on a live call. For contrast, OpenAI's own SDK treats this exact shape as unsupported and **throws** at schema construction (`openai/_vendor/zod-to-json-schema/parsers/object.js`), on precisely the predicate `isOptional() && !isNullable() && no defaultValue`.

#2150 already established that null is the wire encoding for "absent" and added the inverse mapping in `injectSchemaDefaults` — but only for fields with a `.default()`. Optional fields get the identical wire encoding with no return path. This extends that same mechanism to cover them.

## Changes Made

- `injectSchemaDefaults` now drops a `null` property value when the property is absent from the parent's `required` list and its schema does not allow null, so Zod sees `undefined` — which is what `.optional()` accepts.
- Tests for the flat, constrained, and nested (object + array element) cases, plus a `.nullish()` regression guard that must keep its null.
- Patch changeset.

Three properties keep it narrow:

- **Defaults still win.** The drop test runs on the *result* of the recursive call, so the existing default branch has already substituted the default and a defaulted field never reaches the drop.
- **Genuine nulls survive.** Gated on the existing `jsonSchemaAllowsNull` helper, so `.nullish()` and `.nullable()` are untouched.
- **Real violations still fail.** A `required` non-nullable field keeps its null and still errors — the existing `should reject null for required arguments without defaults` test still passes unchanged.

No public API change, and no change to schema generation — only the inverse mapping at validation time. `required` is read off the `jsonSchema7`-target schema `injectSchemaDefaults` already receives, where it still reflects true optionality.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title
- [ ] **Video demo**: n/a — no runtime/UX surface, covered by unit tests

## Testing

- [x] Automated tests added/updated
- [x] All tests pass

- `pnpm exec vitest run agents` — **2140 passed**, 5 skipped, 0 failed
- Confirmed the new tests fail without the fix (3 of the 4 fail when the `utils.ts` change is stashed; the `.nullish()` guard passes both ways by design)
- `tsc --noEmit` — clean
- `prettier --check` — clean
- `eslint` — no new findings (one pre-existing `no-explicit-any` warning in `utils.ts`, present at `main` too)
- `api:check` (API Extractor) — passes, no API surface change

## Additional Notes

An alternative fix would be to throw at schema-generation time the way OpenAI's SDK does. I didn't take that route: it would break every existing user who has a bare `.optional()` in a tool schema and is currently getting away with it because their model omits the key rather than nulling it. Resolving the sentinel is backward compatible, and it matches the direction #2150 already set. A dev-time warning could be added on top if you'd want the sharper signal.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
