### PR TITLE
fix: restore Changesets with js-yaml 4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ overrides:
   protobufjs@<7.6.5: ^7.6.5
   ws@>=8.0.0 <8.21.0: ^8.21.0
   read-yaml-file@<2.0.0: ^2.1.0
-  js-yaml@<3.15.0: ^4.3.1
-  js-yaml@>=4.0.0 <4.3.0: ^4.3.0
+  js-yaml@<3.15.1: ^4.3.1
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   minimatch@<3.1.3: ^3.1.3
   minimatch@>=9.0.0 <9.0.7: ^9.0.7
   brace-expansion@<1.1.16: ^1.1.16
@@ -4303,10 +4303,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
-    hasBin: true
-
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
@@ -5723,7 +5719,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -5933,7 +5929,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.1
       import-fresh: 3.3.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -7838,7 +7834,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -8401,10 +8397,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   lodash@<4.18.0: ^4.18.0
   protobufjs@<7.6.5: ^7.6.5
   ws@>=8.0.0 <8.21.0: ^8.21.0
+  read-yaml-file@<2.0.0: ^2.1.0
   js-yaml@<3.15.0: ^4.3.1
   js-yaml@>=4.0.0 <4.3.0: ^4.3.0
   minimatch@<3.1.3: ^3.1.3
@@ -4725,10 +4726,6 @@ packages:
     resolution: {integrity: sha512-yCH2dtLHfEBnzlHUJymR/Z1nN2ePG3m392Mv8TFlTP1B0xkpMQNHAnfkY0n2tAi6ceKO6YWhxYfZ96V4vVkh/g==}
     engines: {node: '>=18'}
 
-  pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
-
   pino-abstract-transport@1.2.0:
     resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
 
@@ -4848,9 +4845,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  read-yaml-file@1.1.0:
-    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
-    engines: {node: '>=6'}
+  read-yaml-file@2.1.0:
+    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
+    engines: {node: '>=10.13'}
 
   readable-stream@4.5.2:
     resolution: {integrity: sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==}
@@ -5098,6 +5095,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -6301,7 +6302,7 @@ snapshots:
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
-      read-yaml-file: 1.1.0
+      read-yaml-file: 2.1.0
 
   '@microsoft/api-extractor-model@7.33.10(@types/node@22.19.1)':
     dependencies:
@@ -8806,8 +8807,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  pify@4.0.1: {}
-
   pino-abstract-transport@1.2.0:
     dependencies:
       readable-stream: 4.5.2
@@ -8954,12 +8953,10 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  read-yaml-file@1.1.0:
+  read-yaml-file@2.1.0:
     dependencies:
-      graceful-fs: 4.2.11
       js-yaml: 4.3.1
-      pify: 4.0.1
-      strip-bom: 3.0.0
+      strip-bom: 4.0.0
 
   readable-stream@4.5.2:
     dependencies:
@@ -9311,6 +9308,8 @@ snapshots:
       ansi-regex: 6.0.1
 
   strip-bom@3.0.0: {}
+
+  strip-bom@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,8 +41,8 @@ overrides:
   'ws@>=8.0.0 <8.21.0': ^8.21.0
   # js-yaml 4 removed safeLoad; use the compatible read-yaml-file release.
   'read-yaml-file@<2.0.0': ^2.1.0
-  'js-yaml@<3.15.0': ^4.3.1
-  'js-yaml@>=4.0.0 <4.3.0': ^4.3.0
+  'js-yaml@<3.15.1': ^4.3.1
+  'js-yaml@>=4.0.0 <4.3.1': ^4.3.1
   'minimatch@<3.1.3': ^3.1.3
   'minimatch@>=9.0.0 <9.0.7': ^9.0.7
   'brace-expansion@<1.1.16': ^1.1.16

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,8 @@ overrides:
   'lodash@<4.18.0': ^4.18.0
   'protobufjs@<7.6.5': ^7.6.5
   'ws@>=8.0.0 <8.21.0': ^8.21.0
+  # js-yaml 4 removed safeLoad; use the compatible read-yaml-file release.
+  'read-yaml-file@<2.0.0': ^2.1.0
   'js-yaml@<3.15.0': ^4.3.1
   'js-yaml@>=4.0.0 <4.3.0': ^4.3.0
   'minimatch@<3.1.3': ^3.1.3


### PR DESCRIPTION
The js-yaml security update broke the local Changesets CLI. Use its compatible YAML reader and resolve every affected js-yaml 3.x and 4.x path to patched version 4.3.1.

Validated with a frozen install, no js-yaml audit findings, Changesets status, and an isolated Changesets version run.

Addresses AGT-3345

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> > Separate issue: the current js-yaml override breaks the unshimmed local Changesets CLI. Since the release workflow invokes that CLI, this should be fixed before release.
>
> what do you mean?
>
> okay, can you create a PR to fix that?
>
> wouldn't 2309 re-introduce the security issue?
>
> yeah, please do that

</details>