### PR TITLE
fix(elevenlabs): enforce TTS WebSocket context limit

### DIFF
--- a/.changeset/elevenlabs-context-cap.md
+++ b/.changeset/elevenlabs-context-cap.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-elevenlabs': patch
+---
+
+Prevent rapid TTS interruptions from exceeding ElevenLabs' five-context WebSocket limit.

--- a/plugins/elevenlabs/src/tts.test.ts
+++ b/plugins/elevenlabs/src/tts.test.ts
@@ -5,7 +5,7 @@ import { once } from 'node:events';
 import type { AddressInfo } from 'node:net';
 import { describe, expect, it } from 'vitest';
 import { type WebSocket, WebSocketServer } from 'ws';
-import { TTS } from './tts.js';
+import { type SynthesizeStream, TTS } from './tts.js';
 
 async function startWebSocketServer() {
   const wss = new WebSocketServer({ host: '127.0.0.1', port: 0 });
@@ -174,6 +174,141 @@ describe('ElevenLabs TTS options', () => {
 
 describe('ElevenLabs TTS websocket', () => {
   const audio = Buffer.alloc(4410).toString('base64');
+
+  it('defers new contexts until an interrupted context is finalized', async () => {
+    const { wss, baseURL } = await startWebSocketServer();
+    const messages: Record<string, unknown>[] = [];
+    let socket: WebSocket | undefined;
+
+    wss.on('connection', (ws) => {
+      socket = ws;
+      ws.on('message', (raw) => {
+        messages.push(JSON.parse(raw.toString()) as Record<string, unknown>);
+      });
+    });
+
+    const elevenlabs = new TTS({ apiKey: 'test-key', baseURL });
+    const streams: SynthesizeStream[] = [];
+
+    const isInit = (contextId: string) =>
+      messages.some(
+        (message) =>
+          message.context_id === contextId &&
+          message.text === ' ' &&
+          Object.hasOwn(message, 'voice_settings'),
+      );
+    const isClosed = (contextId: string) =>
+      messages.some(
+        (message) => message.context_id === contextId && message.close_context === true,
+      );
+
+    try {
+      for (let i = 0; i < 5; i++) {
+        const stream = elevenlabs.stream();
+        streams.push(stream);
+        stream.pushText(`reply ${i}.`);
+        stream.flush();
+        await waitUntil(() => isInit(stream.contextId));
+      }
+
+      for (const stream of streams) {
+        stream.close();
+      }
+
+      const replacement = elevenlabs.stream();
+      streams.push(replacement);
+      replacement.pushText('replacement reply.');
+      replacement.flush();
+
+      await waitUntil(() => streams.slice(0, 5).every((stream) => isClosed(stream.contextId)));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(isInit(replacement.contextId)).toBe(false);
+      for (const stream of streams.slice(0, 5)) {
+        const closeIndex = messages.findIndex(
+          (message) => message.context_id === stream.contextId && message.close_context === true,
+        );
+        expect(closeIndex).toBeGreaterThanOrEqual(0);
+        expect(
+          messages
+            .slice(closeIndex + 1)
+            .some((message) => message.context_id === stream.contextId && 'text' in message),
+        ).toBe(false);
+      }
+
+      socket!.send(JSON.stringify({ context_id: streams[0]!.contextId, isFinal: true }));
+      await waitUntil(() => isInit(replacement.contextId));
+
+      const firstCloseIndex = messages.findIndex(
+        (message) => message.context_id === streams[0]!.contextId && message.close_context === true,
+      );
+      const replacementInitIndex = messages.findIndex(
+        (message) =>
+          message.context_id === replacement.contextId &&
+          message.text === ' ' &&
+          Object.hasOwn(message, 'voice_settings'),
+      );
+      expect(firstCloseIndex).toBeGreaterThanOrEqual(0);
+      expect(replacementInitIndex).toBeGreaterThan(firstCloseIndex);
+    } finally {
+      for (const stream of streams) {
+        stream.close();
+      }
+      await elevenlabs.close();
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('does not initialize a stream that was cancelled before startup', async () => {
+    const { wss, baseURL } = await startWebSocketServer();
+    const messages: Record<string, unknown>[] = [];
+
+    wss.on('connection', (ws) => {
+      ws.on('message', (raw) => {
+        messages.push(JSON.parse(raw.toString()) as Record<string, unknown>);
+      });
+    });
+
+    const elevenlabs = new TTS({ apiKey: 'test-key', baseURL });
+    const stream = elevenlabs.stream();
+
+    try {
+      stream.close();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(messages).toEqual([]);
+    } finally {
+      stream.close();
+      await elevenlabs.close();
+      await closeWebSocketServer(wss);
+    }
+  });
+
+  it('flushes graceful streams before closing their context', async () => {
+    let responded = false;
+    const { messages } = await synthesizeWithMessages((ws, receivedMessages) => {
+      const closeMessage = receivedMessages.find((message) => message.close_context === true);
+      if (closeMessage && !responded) {
+        responded = true;
+        ws.send(JSON.stringify({ context_id: closeMessage.context_id, isFinal: true }));
+      }
+    });
+
+    const contextId = messages[0]!.context_id;
+    const flushIndex = messages.findIndex(
+      (message) =>
+        message.context_id === contextId && message.text === '' && message.flush === true,
+    );
+    const closeIndex = messages.findIndex(
+      (message) => message.context_id === contextId && message.close_context === true,
+    );
+
+    expect(flushIndex).toBeGreaterThanOrEqual(0);
+    expect(closeIndex).toBeGreaterThan(flushIndex);
+    expect(
+      messages
+        .slice(closeIndex + 1)
+        .some((message) => message.context_id === contextId && 'text' in message),
+    ).toBe(false);
+  });
 
   it('accepts snake-case context IDs', async () => {
     const { events } = await synthesizeWithMessages((ws, messages) => {

--- a/plugins/elevenlabs/src/tts.ts
+++ b/plugins/elevenlabs/src/tts.ts
@@ -29,6 +29,7 @@ const API_BASE_URL_V1 = 'https://api.elevenlabs.io/v1';
 const AUTHORIZATION_HEADER = 'xi-api-key';
 const WS_INACTIVITY_TIMEOUT = 180;
 const DEFAULT_ENCODING: TTSEncoding = 'pcm_22050';
+const MAX_ACTIVE_CONTEXTS = 5;
 
 export interface VoiceSettings {
   stability: number; // [0.0 - 1.0]
@@ -256,6 +257,8 @@ class Connection {
   #ws: WebSocket | null = null;
   #isCurrent = true;
   #activeContexts = new Set<string>();
+  #closingContexts = new Set<string>();
+  #cancelledContexts = new Set<string>();
   #inputQueue: ConnectionMessage[] = [];
   #contextData = new Map<string, StreamData>();
   #sendTask: Promise<void> | null = null;
@@ -327,6 +330,14 @@ class Connection {
     if (this.#closed || !this.#ws || this.#ws.readyState !== WebSocket.OPEN) {
       throw new APIConnectionError({ message: 'WebSocket connection is closed' });
     }
+
+    if (
+      this.#cancelledContexts.has(content.contextId) ||
+      this.#closingContexts.has(content.contextId)
+    ) {
+      return;
+    }
+
     this.#inputQueue.push(content);
     this.#inputQueueResolver?.();
   }
@@ -335,25 +346,73 @@ class Connection {
     if (this.#closed || !this.#ws || this.#ws.readyState !== WebSocket.OPEN) {
       throw new APIConnectionError({ message: 'WebSocket connection is closed' });
     }
+    if (this.#cancelledContexts.has(contextId) || this.#closingContexts.has(contextId)) {
+      return;
+    }
     this.#inputQueue.push({ contextId });
     this.#inputQueueResolver?.();
+  }
+
+  cancelContext(contextId: string): void {
+    if (this.#closed || !this.#ws || this.#ws.readyState !== WebSocket.OPEN) {
+      throw new APIConnectionError({ message: 'WebSocket connection is closed' });
+    }
+    if (this.#cancelledContexts.has(contextId)) {
+      return;
+    }
+
+    this.#cancelledContexts.add(contextId);
+    this.#inputQueue = this.#inputQueue.filter((message) => message.contextId !== contextId);
+
+    if (this.#activeContexts.has(contextId)) {
+      if (!this.#closingContexts.has(contextId)) {
+        this.#inputQueue.unshift({ contextId });
+      }
+    } else {
+      this.#contextData.delete(contextId);
+    }
+
+    this.#inputQueueResolver?.();
+  }
+
+  finishCancelledContext(contextId: string): void {
+    this.#cancelledContexts.delete(contextId);
+  }
+
+  #takeNextMessage(): ConnectionMessage | undefined {
+    const seenContexts = new Set<string>();
+
+    for (let i = 0; i < this.#inputQueue.length; i++) {
+      const message = this.#inputQueue[i]!;
+      if (seenContexts.has(message.contextId)) {
+        continue;
+      }
+      seenContexts.add(message.contextId);
+
+      const isActive = this.#activeContexts.has(message.contextId);
+      const canProcess =
+        !('text' in message) || isActive || this.#activeContexts.size < MAX_ACTIVE_CONTEXTS;
+      if (canProcess) {
+        return this.#inputQueue.splice(i, 1)[0];
+      }
+    }
+
+    return undefined;
   }
 
   async #sendLoop(): Promise<void> {
     try {
       while (!this.#closed) {
-        // Wait for messages in queue
-        if (this.#inputQueue.length === 0) {
+        const msg = this.#takeNextMessage();
+        if (!msg) {
           await new Promise<void>((resolve) => {
             this.#inputQueueResolver = resolve;
           });
           this.#inputQueueResolver = null;
+          continue;
         }
 
         if (this.#closed) break;
-
-        const msg = this.#inputQueue.shift();
-        if (!msg) continue;
 
         if (!this.#ws || this.#ws.readyState !== WebSocket.OPEN) {
           break;
@@ -364,8 +423,10 @@ class Connection {
           const content = msg as SynthesizeContent;
           const isNewContext = !this.#activeContexts.has(content.contextId);
 
-          // If not current and this is a new context, ignore it
-          if (!this.#isCurrent && isNewContext) {
+          if (
+            this.#cancelledContexts.has(content.contextId) ||
+            this.#closingContexts.has(content.contextId)
+          ) {
             continue;
           }
 
@@ -412,13 +473,17 @@ class Connection {
         } else {
           // CloseContext
           const closeMsg = msg as CloseContext;
-          if (this.#activeContexts.has(closeMsg.contextId)) {
+          if (
+            this.#activeContexts.has(closeMsg.contextId) &&
+            !this.#closingContexts.has(closeMsg.contextId)
+          ) {
             const closePkt = {
               context_id: closeMsg.contextId,
               close_context: true,
             };
             const closePktStr = JSON.stringify(closePkt);
             this.#ws.send(closePktStr);
+            this.#closingContexts.add(closeMsg.contextId);
           }
         }
       }
@@ -627,6 +692,9 @@ class Connection {
   #cleanupContext(contextId: string): void {
     this.#contextData.delete(contextId);
     this.#activeContexts.delete(contextId);
+    this.#closingContexts.delete(contextId);
+    this.#cancelledContexts.delete(contextId);
+    this.#inputQueueResolver?.();
   }
 
   async close(): Promise<void> {
@@ -977,11 +1045,19 @@ export class SynthesizeStream extends tts.SynthesizeStream {
     const segmentId = this.#contextId;
     const bstream = new AudioByteStream(this.#opts.sampleRate, 1);
 
+    if (this.abortController.signal.aborted) {
+      return;
+    }
+
     let connection: Connection;
     try {
       connection = await this.#tts.currentConnection();
     } catch (e) {
       throw new APIConnectionError({ message: 'could not connect to ElevenLabs' });
+    }
+
+    if (this.abortController.signal.aborted) {
+      return;
     }
 
     let waiterReject: ((reason: Error) => void) | undefined;
@@ -990,6 +1066,7 @@ export class SynthesizeStream extends tts.SynthesizeStream {
       connection.registerStream(this, { resolve, reject });
     });
     let contextClosed = false;
+    let contextCancelled = false;
 
     const closeContext = (suppressErrors = false) => {
       if (contextClosed) {
@@ -1010,13 +1087,36 @@ export class SynthesizeStream extends tts.SynthesizeStream {
       contextClosed = true;
     };
 
+    const cancelContext = (suppressErrors = false) => {
+      if (contextCancelled) {
+        return;
+      }
+
+      contextCancelled = true;
+      contextClosed = true;
+      if (suppressErrors) {
+        try {
+          connection.cancelContext(this.#contextId);
+        } catch {
+          // The connection may already be closed during cancellation.
+        }
+        return;
+      }
+
+      connection.cancelContext(this.#contextId);
+    };
+
     // Handle abort - reject the waiter so Promise.all can complete
     const abortHandler = () => {
+      cancelContext(true);
       if (waiterReject) {
         waiterReject(new Error('Stream aborted'));
       }
     };
     this.abortController.signal.addEventListener('abort', abortHandler, { once: true });
+    if (this.abortController.signal.aborted) {
+      abortHandler();
+    }
 
     const inputTask = async () => {
       for await (const data of this.input) {
@@ -1065,6 +1165,10 @@ export class SynthesizeStream extends tts.SynthesizeStream {
           text: formattedText,
           flush: flushOnChunk,
         });
+      }
+
+      if (this.abortController.signal.aborted) {
+        return;
       }
 
       if (xmlContent.length > 0) {
@@ -1134,11 +1238,16 @@ export class SynthesizeStream extends tts.SynthesizeStream {
       sendLastFrame(true);
     };
 
+    const inputPromise = inputTask();
+    const sentenceStreamPromise = sentenceStreamTask();
+    const audioProcessPromise = audioProcessTask();
+
     try {
-      await Promise.all([inputTask(), sentenceStreamTask(), audioProcessTask(), waiterPromise]);
+      await Promise.all([inputPromise, sentenceStreamPromise, audioProcessPromise, waiterPromise]);
     } catch (e) {
       // If aborted, this is a normal termination - don't throw
       if (this.abortController.signal.aborted) {
+        await Promise.allSettled([inputPromise, sentenceStreamPromise, audioProcessPromise]);
         return;
       }
 
@@ -1150,7 +1259,12 @@ export class SynthesizeStream extends tts.SynthesizeStream {
       }
       throw new APIStatusError({ message: 'Could not synthesize' });
     } finally {
-      closeContext(true);
+      if (this.abortController.signal.aborted) {
+        cancelContext(true);
+      } else {
+        closeContext(true);
+      }
+      connection.finishCancelledContext(this.#contextId);
       // Clean up abort listener
       this.abortController.signal.removeEventListener('abort', abortHandler);
     }


### PR DESCRIPTION
## Description

Fixes #1985.

Rapid interruptions could enqueue a replacement ElevenLabs TTS context before the provider finalized an interrupted one. Because ElevenLabs allows [up to five concurrent contexts](https://elevenlabs.io/docs/eleven-api/guides/how-to/websockets/multi-context-web-socket), a sixth context could trigger `max_active_conversations` and reset the shared socket.

## Changes Made

- Track active and closing contexts and defer new-context admission until ElevenLabs finalizes a previous context.
- Prioritize cancellation cleanup, remove queued content for interrupted streams, and prevent text from being sent after `close_context`.
- Preserve per-context ordering and graceful flush-before-close behavior.
- Add regression coverage for rapid interruptions at the five-context limit, cancellation before startup, and graceful stream closure.
- Add a patch changeset for `@livekit/agents-plugin-elevenlabs`.

## Pre-Review Checklist

- [x] **Build passes**: Build, lint, typecheck, formatting, throws, and scoped API checks pass locally on Node 24.
- [x] **AI-generated code reviewed**: Removed unnecessary comments and reviewed the changes for correctness and code quality.
- [x] **Changes explained**: Changes and their purpose are documented above.
- [x] **Scope appropriate**: The three changed files are limited to the ElevenLabs fix, tests, and changeset.
- [x] **Video demo**: Not applicable; this is WebSocket lifecycle logic covered by deterministic local-server tests.

## Testing

- [x] Automated tests added and updated.
- [x] `pnpm test plugins/elevenlabs/src/tts.test.ts --silent` — 10 passed, 1 credential-gated test skipped on Node 24.
- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm throws:check`
- [x] `pnpm format:check`
- [x] `pnpm --filter @livekit/agents-plugin-elevenlabs api:check`
- [x] `restaurant_agent.ts` and `realtime_agent.ts` are not applicable to this internal provider scheduling fix.

## Additional Notes

The full monorepo suite was also exercised: 186 test files passed. The remaining failures were unrelated environment-dependent credential, network, and LFS cases plus an existing FishAudio test; the focused ElevenLabs suite passes.
