### PR TITLE
fix(voice): preserve held STT turn boundaries

### DIFF
--- a/.changeset/quiet-turns-close.md
+++ b/.changeset/quiet-turns-close.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Preserve accepted STT turn boundaries when agent speech overlaps the end sentinel.

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -1026,8 +1026,20 @@ export class AudioRecognition {
       }
     }
 
+    // A final can be accepted just before agent speech; its held END_OF_SPEECH must still
+    // close that pending STT turn even though the sentinel has no transcript alternatives.
+    const hasPendingAcceptedTurnBoundary =
+      this.turnDetectionMode === 'stt' &&
+      !this.userTurnCommitted &&
+      this.audioTranscript.length > 0 &&
+      emitFromIndex !== null &&
+      this.transcriptBuffer
+        .slice(emitFromIndex)
+        .some((event) => event.type === SpeechEventType.END_OF_SPEECH);
     const eventsToEmit =
-      emitFromIndex !== null && shouldFlush ? this.transcriptBuffer.slice(emitFromIndex) : [];
+      emitFromIndex !== null && (shouldFlush || hasPendingAcceptedTurnBoundary)
+        ? this.transcriptBuffer.slice(emitFromIndex)
+        : [];
 
     // Snapshot the ignore-until before resetting so the added-delay diagnostic below mirrors
     // the value the holding decision was made against.

--- a/agents/src/voice/audio_recognition_interruption.test.ts
+++ b/agents/src/voice/audio_recognition_interruption.test.ts
@@ -88,6 +88,40 @@ describe('AudioRecognition interruption buffering', () => {
     expect(internals.transcriptBuffer).toHaveLength(0);
   });
 
+  it('commits an accepted final when agent speech starts before its end sentinel', async () => {
+    const now = Date.now();
+    const recognition = new AudioRecognition({
+      recognitionHooks: createHooks(),
+      turnDetectionMode: 'stt',
+      minEndpointingDelay: 0,
+      maxEndpointingDelay: 0,
+    });
+    const internals = recognition as unknown as {
+      isInterruptionEnabled: boolean;
+      sttPipeline: { inputStartedAt: number };
+      trySendInterruptionSentinel: () => Promise<boolean>;
+      onSTTEvent: (event: SpeechEvent) => Promise<void>;
+      transcriptBuffer: SpeechEvent[];
+      runEOUDetection: ReturnType<typeof vi.fn>;
+      userTurnCommitted: boolean;
+    };
+    internals.isInterruptionEnabled = true;
+    internals.sttPipeline = { inputStartedAt: now - 2_000 };
+    internals.trySendInterruptionSentinel = vi.fn(async () => true);
+    internals.runEOUDetection = vi.fn();
+
+    await internals.onSTTEvent(finalTranscript(0.5, 1));
+    await recognition.onStartOfAgentSpeech(now);
+    await internals.onSTTEvent({ type: SpeechEventType.END_OF_SPEECH });
+
+    expect(internals.transcriptBuffer).toHaveLength(1);
+
+    await recognition.onEndOfAgentSpeech(now + 1_000);
+
+    expect(internals.userTurnCommitted).toBe(true);
+    expect(internals.runEOUDetection).toHaveBeenCalledOnce();
+  });
+
   it('holds transcripts inside the bounded ignore window', () => {
     const recognition = createRecognitionInternals({
       ignoreUntil: 1_010_000,


### PR DESCRIPTION
## Description

Preserve an accepted STT turn boundary when agent speech starts between the final transcript and its `END_OF_SPEECH` sentinel.

The final transcript is accepted before agent speech, but the following sentinel is buffered while the agent is speaking. During the later flush, the sentinel has no transcript alternatives, so it cannot set `shouldFlush` and is discarded. The user turn remains uncommitted and can be merged with later speech.

## Changes Made

- Re-emit a held `END_OF_SPEECH` when STT has accepted transcript text for an uncommitted turn.
- Keep the exception scoped to STT turn detection and buffers that actually contain the pending boundary.
- Add a regression covering the exact final → agent speech → end sentinel → agent speech end ordering.
- Add a patch changeset for `@livekit/agents`.

## Pre-Review Checklist

- [x] **Build passes**: Full monorepo build and typecheck pass locally
- [x] **AI-generated code reviewed**: Comments and test setup were reviewed and kept to the state-machine invariant
- [x] **Changes explained**: The failed transition and bounded exception are documented above
- [x] **Scope appropriate**: Only held STT turn-boundary handling and its regression are changed
- [x] **Video demo**: Not applicable; this is an internal event-ordering race covered by a deterministic regression

## Testing

- [x] Regression fails on `main` with `userTurnCommitted === false`
- [x] Regression passes with the fix
- [x] `pnpm test agents/src` — 136 files passed; 2,248 tests passed; 5 skipped
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [x] `pnpm -w lint:fix`

## Additional Notes

The unscoped test command also runs provider/example integration tests. Locally those reported unrelated missing `OPENAI_API_KEY`/`CEREBRAS_API_KEY`, Hugging Face download timeouts, and one FishAudio assertion. The complete `agents/src` suite passes.