### PR TITLE
fix(voice): resume empty false interruptions after timeout

### DIFF
--- a/.changeset/false-interruption-timeout-resume.md
+++ b/.changeset/false-interruption-timeout-resume.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Resume false-interrupted speech at the configured timeout when no user speech or transcript is present.

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -514,11 +514,13 @@ type FalseInterruptionActivity = {
   audioRecognition?: {
     endOfTurnTask?: Task<void>;
     isClosed: boolean;
+    hasPendingUserSpeech: boolean;
     onStartOfAgentSpeech: ReturnType<typeof vi.fn>;
     onEndOfAgentSpeech: ReturnType<typeof vi.fn>;
   };
   agentSession: {
     agentState: 'speaking';
+    userState: 'speaking' | 'listening';
     sessionOptions: {
       turnHandling: {
         interruption: { resumeFalseInterruption: boolean; falseInterruptionTimeout: number };
@@ -536,7 +538,11 @@ type FalseInterruptionActivity = {
   cancelSpeechPause: (options?: { interrupt?: boolean }) => Promise<void>;
 };
 
-function falseInterruptionActivity(endOfTurnTask?: Task<void>): FalseInterruptionActivity {
+function falseInterruptionActivity(
+  endOfTurnTask?: Task<void>,
+  options: { hasPendingUserSpeech?: boolean; userState?: 'speaking' | 'listening' } = {},
+): FalseInterruptionActivity {
+  const { hasPendingUserSpeech = false, userState = 'listening' } = options;
   const handle = SpeechHandle.create({ allowInterruptions: true });
   const activity = Object.create(AgentActivity.prototype) as FalseInterruptionActivity;
   Object.assign(activity, {
@@ -548,11 +554,13 @@ function falseInterruptionActivity(endOfTurnTask?: Task<void>): FalseInterruptio
     audioRecognition: {
       endOfTurnTask,
       isClosed: false,
+      hasPendingUserSpeech,
       onStartOfAgentSpeech: vi.fn(),
       onEndOfAgentSpeech: vi.fn(async () => {}),
     },
     agentSession: {
       agentState: 'speaking',
+      userState,
       sessionOptions: {
         turnHandling: {
           interruption: { resumeFalseInterruption: true, falseInterruptionTimeout: 300 },
@@ -646,10 +654,29 @@ describe('AgentActivity - false interruption resume', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it('waits for a dropped turn before resuming', async () => {
+  it('resumes when an empty turn decision remains pending', async () => {
     const decision = new Future<void>();
     const task = Task.from(async () => decision.await);
     const activity = falseInterruptionActivity(task);
+
+    activity.startFalseInterruptionTimer(300);
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(activity.agentSession.output.audio.resume).toHaveBeenCalledOnce();
+    expect(activity.falseInterruptionPending).toBe(false);
+    expect(activity.pausedSpeech).toBeUndefined();
+
+    decision.resolve();
+    await task.result;
+  });
+
+  it.each([
+    { signal: 'recognized speech', options: { hasPendingUserSpeech: true } },
+    { signal: 'the speaking state', options: { userState: 'speaking' as const } },
+  ])('waits for a dropped turn with $signal before resuming', async ({ options }) => {
+    const decision = new Future<void>();
+    const task = Task.from(async () => decision.await);
+    const activity = falseInterruptionActivity(task, options);
 
     activity.startFalseInterruptionTimer(300);
     await vi.advanceTimersByTimeAsync(300);
@@ -666,7 +693,7 @@ describe('AgentActivity - false interruption resume', () => {
   it('suppresses the resume when the turn commits', async () => {
     const decision = new Future<void>();
     const task = Task.from(async () => decision.await);
-    const activity = falseInterruptionActivity(task);
+    const activity = falseInterruptionActivity(task, { hasPendingUserSpeech: true });
 
     activity.startFalseInterruptionTimer(300);
     await vi.advanceTimersByTimeAsync(300);
@@ -681,7 +708,7 @@ describe('AgentActivity - false interruption resume', () => {
   it('does not resume a deferred pause during teardown', async () => {
     const decision = new Future<void>();
     const task = Task.from(async () => decision.await);
-    const activity = falseInterruptionActivity(task);
+    const activity = falseInterruptionActivity(task, { hasPendingUserSpeech: true });
 
     activity.startFalseInterruptionTimer(300);
     await vi.advanceTimersByTimeAsync(300);
@@ -700,7 +727,7 @@ describe('AgentActivity - false interruption resume', () => {
       await decision.await;
       if (controller.signal.aborted) return;
     });
-    const activity = falseInterruptionActivity(task);
+    const activity = falseInterruptionActivity(task, { hasPendingUserSpeech: true });
 
     activity.startFalseInterruptionTimer(300);
     await vi.advanceTimersByTimeAsync(300);
@@ -721,7 +748,7 @@ describe('AgentActivity - false interruption resume', () => {
   it('resumes when the turn decision fails', async () => {
     const decision = new Future<void>();
     const task = Task.from(async () => decision.await);
-    const activity = falseInterruptionActivity(task);
+    const activity = falseInterruptionActivity(task, { hasPendingUserSpeech: true });
 
     activity.startFalseInterruptionTimer(300);
     await vi.advanceTimersByTimeAsync(300);

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -5239,10 +5239,14 @@ export class AgentActivity implements RecognitionHooks {
     this.falseInterruptionTimer = setTimeout(() => {
       this.falseInterruptionTimer = undefined;
 
-      // An open turn decision owns the paused speech. It either commits and interrupts it or
-      // drops it, and only then is the interruption known to be false.
-      const endOfTurnTask = this.audioRecognition?.endOfTurnTask;
-      if (endOfTurnTask && !endOfTurnTask.done) {
+      // A pending turn with speech or transcript evidence owns the pause until its decision
+      // settles. An empty task may outlive the timeout and must not hold playout indefinitely.
+      const audioRecognition = this.audioRecognition;
+      const endOfTurnTask = audioRecognition?.endOfTurnTask;
+      const hasUserActivity =
+        this.agentSession.userState === 'speaking' ||
+        Boolean(audioRecognition?.hasPendingUserSpeech);
+      if (endOfTurnTask && !endOfTurnTask.done && hasUserActivity) {
         this.falseInterruptionPending = true;
         endOfTurnTask.addDoneCallback(() => onTurnSettled(endOfTurnTask));
         return;

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -544,6 +544,11 @@ export class AudioRecognition {
   }
 
   /** @internal */
+  get hasPendingUserSpeech(): boolean {
+    return this.turnTranscriptReceived || Boolean(this.currentTranscript.trim());
+  }
+
+  /** @internal */
   get inputStartedAt() {
     return this.sttPipeline?.inputStartedAt;
   }

--- a/agents/src/voice/audio_recognition_transcription_timeout.test.ts
+++ b/agents/src/voice/audio_recognition_transcription_timeout.test.ts
@@ -108,7 +108,7 @@ describe('AudioRecognition transcription timeout', () => {
   });
 
   it('held final transcript cancels the timeout', async () => {
-    const { hooks, internals } = createRecognition({ transcriptionTimeout: 2000 });
+    const { hooks, recognition, internals } = createRecognition({ transcriptionTimeout: 2000 });
     internals.userTurnStart = Date.now();
     internals.armTranscriptionTimeout(1000, 0);
     internals.isInterruptionEnabled = true;
@@ -121,6 +121,7 @@ describe('AudioRecognition transcription timeout', () => {
     expect(internals.transcriptionTimeoutTimer).toBeUndefined();
     expect(internals.turnTranscriptReceived).toBe(true);
     expect(internals.transcriptBuffer).toEqual([event]);
+    expect(recognition.hasPendingUserSpeech).toBe(true);
     expect(hooks.onFinalTranscript).not.toHaveBeenCalled();
     expect(hooks.onTranscriptionTimeout).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- Resume paused agent speech at `falseInterruptionTimeout` when the pending end-of-turn task has no user activity.
- Keep the pause owned by turns with speaking or recognition evidence, including final transcripts still held by interruption detection.
- Cover empty pending decisions, speaking state, recognized speech, held finals, cancellation, teardown, and failed turn decisions.

---

## Behavior

| Case | Result |
| --- | --- |
| Pending task, no speech or transcript | Resume at the configured false-interruption timeout |
| User is speaking | Wait for the turn decision |
| Final/interim transcript exists | Wait for the turn decision |
| Final transcript is buffered by interruption detection | Wait for the turn decision |

## Verification

- `pnpm exec vitest run agents/src/voice/agent_activity.test.ts agents/src/voice/audio_recognition_transcription_timeout.test.ts` — 70 passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed with the repository's existing warnings