### PR TITLE
allow initial instructions/tools to be passed in, avoids dupe connection

### DIFF
--- a/.changeset/google-realtime-single-connect.md
+++ b/.changeset/google-realtime-single-connect.md
@@ -1,0 +1,9 @@
+---
+'@livekit/agents': patch
+'@livekit/agents-plugin-google': patch
+'@livekit/agents-plugin-openai': patch
+'@livekit/agents-plugin-phonic': patch
+'@livekit/agents-plugin-xai': patch
+---
+
+Realtime: `RealtimeModel.session()` now accepts the initial instructions, chat context, and tools, and the framework passes them at creation. Gemini realtime sessions with tools (or agent instructions) previously established a first connection only to tear it down and reconnect once the configuration arrived; they now connect once. The OpenAI, xAI, and Phonic realtime plugins honor the same options so a directly created session starts configured.

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -531,7 +531,7 @@ export class AgentSession<UserData = UnknownUserData> extends AgentSession_base 
         force?: boolean;
     }): Future<void, Error>;
     // (undocumented)
-    get interruptionDetection(): "adaptive" | "vad" | undefined;
+    get interruptionDetection(): "vad" | "adaptive" | undefined;
     // @internal (undocumented)
     readonly _keytermDetector: KeytermDetector;
     get keyterms(): string[];
@@ -4751,6 +4751,7 @@ declare namespace llm {
         MessageGeneration,
         RealtimeCapabilities,
         RealtimeModelError,
+        RealtimeSessionOptions,
         RealtimeSessionReconnectedEvent,
         RemoteChatContext,
         computeChatCtxDiff,
@@ -5661,7 +5662,7 @@ export abstract class RealtimeModel {
     // (undocumented)
     get provider(): string;
     // (undocumented)
-    abstract session(): RealtimeSession;
+    abstract session(options?: RealtimeSessionOptions): RealtimeSession;
 }
 
 // Warning: (ae-missing-release-tag) "RealtimeModelError" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5748,6 +5749,15 @@ export abstract class RealtimeSession extends EventEmitter {
     _updateSession(instructions?: string, chatCtx?: ChatContext, tools?: ToolContext): Promise<void>;
     // (undocumented)
     abstract updateTools(tools: ToolContext): Promise<void>;
+}
+
+// Warning: (ae-missing-release-tag) "RealtimeSessionOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface RealtimeSessionOptions {
+    chatCtx?: ChatContext;
+    instructions?: string;
+    tools?: ToolContext;
 }
 
 // Warning: (ae-missing-release-tag) "RealtimeSessionReconnectedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5929,7 +5939,7 @@ export function resolveExpressiveOptions(expr: ExpressiveOptions, options: {
 // Warning: (ae-missing-release-tag) "RimeModels" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-type RimeModels = 'rime/arcana' | 'rime/coda' | 'rime/mistv2' | 'rime/mistv3' | 'rime/mist';
+type RimeModels = 'rime/coda' | 'rime/mistv2' | 'rime/mistv3' | 'rime/mist';
 
 // Warning: (ae-missing-release-tag) "RimeOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -9031,9 +9041,9 @@ export const zipFunctionCallsAndOutputs: (event: FunctionToolsExecutedEvent) => 
 // src/utils.ts:501:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "cancelled"
 // src/voice/agent_session.ts:380:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/voice/agent_session.ts:988:5 - (ae-forgotten-export) The symbol "RecordingOptions" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1626:5 - (ae-forgotten-export) The symbol "STTError" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1626:5 - (ae-forgotten-export) The symbol "TTSError" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1626:5 - (ae-forgotten-export) The symbol "LLMError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1631:5 - (ae-forgotten-export) The symbol "STTError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1631:5 - (ae-forgotten-export) The symbol "TTSError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1631:5 - (ae-forgotten-export) The symbol "LLMError" needs to be exported by the entry point index.d.ts
 // src/voice/amd.ts:314:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "waitForTrackPublication" has more than one declaration; you need to add a TSDoc member reference selector
 // src/voice/amd.ts:314:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
 // src/voice/amd.ts:322:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "aclose"

--- a/agents/src/llm/index.ts
+++ b/agents/src/llm/index.ts
@@ -84,6 +84,7 @@ export {
   type MessageGeneration,
   type RealtimeCapabilities,
   type RealtimeModelError,
+  type RealtimeSessionOptions,
   type RealtimeSessionReconnectedEvent,
 } from './realtime.js';
 

--- a/agents/src/llm/realtime.ts
+++ b/agents/src/llm/realtime.ts
@@ -99,6 +99,23 @@ export interface InputTranscriptionCompleted {
 
 export interface RealtimeSessionReconnectedEvent {}
 
+/**
+ * Initial configuration for a {@link RealtimeSession}.
+ *
+ * The framework passes these when creating a session so that providers whose
+ * configuration is fixed at connect time (e.g. tools serialized into the
+ * connection setup frame) can apply it to the very first connection instead of
+ * reconnecting once the same values arrive through `_updateSession`.
+ */
+export interface RealtimeSessionOptions {
+  /** Initial system instructions. */
+  instructions?: string;
+  /** Initial chat context. */
+  chatCtx?: ChatContext;
+  /** Initial tool context. */
+  tools?: ToolContext;
+}
+
 export abstract class RealtimeModel {
   private _capabilities: RealtimeCapabilities;
 
@@ -121,7 +138,7 @@ export abstract class RealtimeModel {
     return 'RealtimeModel';
   }
 
-  abstract session(): RealtimeSession;
+  abstract session(options?: RealtimeSessionOptions): RealtimeSession;
 
   abstract close(): Promise<void>;
 }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -588,6 +588,8 @@ export class AgentActivity implements RecognitionHooks {
     if (this.llm instanceof RealtimeModel) {
       const rtReused = reuseResources?.rtSession !== undefined;
 
+      removeInstructions(this.agent._chatCtx);
+
       if (rtReused) {
         this.logger.debug('reusing realtime session from previous activity');
         this.realtimeSession = reuseResources!.rtSession;
@@ -597,7 +599,15 @@ export class AgentActivity implements RecognitionHooks {
         await this.realtimeSession!.interrupt();
         await this.realtimeSession!.clearAudio();
       } else {
-        this.realtimeSession = this.llm.session();
+        // pass the initial configuration at creation so providers that can only
+        // apply it in their connection handshake (e.g. tools ride in the setup
+        // frame on Gemini Live) don't reconnect when _updateSession applies the
+        // same values below
+        this.realtimeSession = this.llm.session({
+          instructions: renderInstructions(this.agent.instructions),
+          chatCtx: this.agent.chatCtx,
+          tools: this.tools,
+        });
       }
 
       this.realtimeSpans = new Map<string, Span>();
@@ -610,8 +620,6 @@ export class AgentActivity implements RecognitionHooks {
       );
       this.realtimeSession!.on('metrics_collected', this.onMetricsCollected);
       this.realtimeSession!.on('error', this.onModelError);
-
-      removeInstructions(this.agent._chatCtx);
 
       // skip the update if the session is reused and no mid-session update is supported
       // this means the content is the same as the previous session

--- a/plugins/google/etc/agents-plugin-google.api.md
+++ b/plugins/google/etc/agents-plugin-google.api.md
@@ -397,7 +397,7 @@ class RealtimeModel_2 extends llm.RealtimeModel {
     // @internal (undocumented)
     _options: RealtimeOptions;
     // Warning: (ae-forgotten-export) The symbol "RealtimeSession_2" needs to be exported by the entry point index.d.ts
-    session(): RealtimeSession_2;
+    session(options?: llm.RealtimeSessionOptions): RealtimeSession_2;
     updateOptions(options: {
         voice?: Voice | string;
         temperature?: number;

--- a/plugins/google/src/realtime/realtime_api.test.ts
+++ b/plugins/google/src/realtime/realtime_api.test.ts
@@ -252,6 +252,63 @@ describe('Google Realtime model text parts', () => {
   });
 });
 
+type SeededSessionInternals = {
+  options: { instructions?: string };
+  sessionShouldClose: { isSet: boolean };
+};
+
+describe('Google Realtime initial session options', () => {
+  // These tests never yield to the event loop between session() and close():
+  // #mainTask is parked behind its first await the whole time, so no
+  // connection attempt is made, and close() makes it exit before connecting.
+  const lookup = llm.tool({
+    name: 'lookup',
+    description: 'look something up',
+    execute: async () => 'ok',
+  });
+
+  it('seeds tools, instructions, and chat context from session options', async () => {
+    const tools = new llm.ToolContext([lookup]);
+    const chatCtx = llm.ChatContext.empty();
+    chatCtx.addMessage({ role: 'user', content: 'hi there' });
+
+    const session = new RealtimeModel({ apiKey: 'test-key' }).session({
+      instructions: 'be brief',
+      chatCtx,
+      tools,
+    });
+    const internals = session as unknown as SeededSessionInternals;
+
+    try {
+      expect(session.tools.equals(tools)).toBe(true);
+      expect(session.chatCtx.items.map((item) => item.id)).toEqual(
+        chatCtx.items.map((item) => item.id),
+      );
+      expect(internals.options.instructions).toBe('be brief');
+
+      // the framework re-applies the same config via _updateSession right after
+      // creating the session; that must not schedule a reconnect
+      void session.updateTools(tools.copy());
+      void session.updateInstructions('be brief');
+      expect(internals.sessionShouldClose.isSet).toBe(false);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('still restarts when tools actually change after an unseeded start', async () => {
+    const session = new RealtimeModel({ apiKey: 'test-key' }).session();
+    const internals = session as unknown as SeededSessionInternals;
+
+    try {
+      void session.updateTools(new llm.ToolContext([lookup]));
+      expect(internals.sessionShouldClose.isSet).toBe(true);
+    } finally {
+      await session.close();
+    }
+  });
+});
+
 describe('Google Realtime initial history seeding', () => {
   function historyConfigFor(model: string) {
     const { capabilities } = new RealtimeModel({ model, apiKey: 'test-key' });

--- a/plugins/google/src/realtime/realtime_api.ts
+++ b/plugins/google/src/realtime/realtime_api.ts
@@ -414,8 +414,8 @@ export class RealtimeModel extends llm.RealtimeModel {
   /**
    * Create a new realtime session
    */
-  session() {
-    return new RealtimeSession(this);
+  session(options?: llm.RealtimeSessionOptions) {
+    return new RealtimeSession(this, options);
   }
 
   /**
@@ -499,10 +499,24 @@ export class RealtimeSession extends llm.RealtimeSession {
   #logger = log();
   #closed = false;
 
-  constructor(realtimeModel: RealtimeModel) {
+  constructor(realtimeModel: RealtimeModel, sessionOptions?: llm.RealtimeSessionOptions) {
     super(realtimeModel);
 
     this.options = realtimeModel._options;
+
+    // Seed the initial configuration before #mainTask starts: tools and
+    // instructions are serialized into the setup frame of the first connection,
+    // and the same values arriving later through updateTools/updateInstructions
+    // would force a reconnect (tools cannot be updated mid-session at all).
+    if (sessionOptions?.instructions !== undefined) {
+      this.options.instructions = sessionOptions.instructions;
+    }
+    if (sessionOptions?.tools !== undefined) {
+      this._tools = sessionOptions.tools.copy();
+    }
+    if (sessionOptions?.chatCtx !== undefined) {
+      this._chatCtx = sessionOptions.chatCtx.copy();
+    }
     this.bstream = new AudioByteStream(
       INPUT_AUDIO_SAMPLE_RATE,
       INPUT_AUDIO_CHANNELS,
@@ -1015,6 +1029,9 @@ export class RealtimeSession extends llm.RealtimeSession {
     while (!this.#closed) {
       // previous session might not be closed yet, we'll do it here.
       await this.closeActiveSession();
+
+      // close() may have run while we were waiting on the session lock
+      if (this.#closed) break;
 
       this.sessionShouldClose.clear();
       const config = this.buildConnectConfig();

--- a/plugins/openai/etc/agents-plugin-openai.api.md
+++ b/plugins/openai/etc/agents-plugin-openai.api.md
@@ -1135,7 +1135,7 @@ class RealtimeModel_2 extends llm.RealtimeModel {
     // (undocumented)
     sampleRate: number;
     // (undocumented)
-    session(): RealtimeSession_2;
+    session(options?: llm.RealtimeSessionOptions): RealtimeSession_2;
     static withAzure(input: {
         azureDeployment: string;
         azureEndpoint?: string;
@@ -1157,7 +1157,7 @@ class RealtimeModel_2 extends llm.RealtimeModel {
 //
 // @public
 class RealtimeSession_2 extends llm.RealtimeSession {
-    constructor(realtimeModel: RealtimeModel_2);
+    constructor(realtimeModel: RealtimeModel_2, sessionOptions?: llm.RealtimeSessionOptions);
     // (undocumented)
     get chatCtx(): llm.ChatContext;
     // (undocumented)

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -1098,6 +1098,48 @@ describe('RealtimeSession chat context update events', () => {
   });
 });
 
+describe('RealtimeSession initial session options', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('seeds instructions and tools into the pre-connect event queue', () => {
+    stubTaskRuntime();
+
+    const tools = new llm.ToolContext([
+      llm.tool({ name: 'lookup', description: 'look something up', execute: async () => 'ok' }),
+    ]);
+    const model = new RealtimeModel({ apiKey: 'test-key' });
+    const session = model.session({ instructions: 'be brief', tools });
+    const queued = (session as unknown as { messageChannel: { items: api_proto.ClientEvent[] } })
+      .messageChannel.items;
+
+    const sessionUpdates = queued.filter(
+      (ev): ev is api_proto.SessionUpdateEvent => ev.type === 'session.update',
+    );
+    expect(sessionUpdates).toHaveLength(2);
+    expect((sessionUpdates[0]!.session as { instructions?: string }).instructions).toBe('be brief');
+    expect(sessionUpdates[1]!.session.tools?.map((tool) => tool.name)).toEqual(['lookup']);
+    expect(session.tools.equals(tools)).toBe(true);
+  });
+
+  it('queues the initial chat context through the standard update path', async () => {
+    stubTaskRuntime();
+
+    const chatCtx = llm.ChatContext.empty();
+    chatCtx.addMessage({ role: 'user', content: 'hi there' });
+
+    const model = new RealtimeModel({ apiKey: 'test-key' });
+    const session = model.session({ chatCtx });
+    const queued = (session as unknown as { messageChannel: { items: api_proto.ClientEvent[] } })
+      .messageChannel.items;
+
+    await vi.waitFor(() =>
+      expect(queued.some((ev) => ev.type === 'conversation.item.create')).toBe(true),
+    );
+  });
+});
+
 describe('RealtimeSession.updateOptions', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -348,8 +348,8 @@ export class RealtimeModel extends llm.RealtimeModel {
     });
   }
 
-  session() {
-    return new RealtimeSession(this);
+  session(options?: llm.RealtimeSessionOptions) {
+    return new RealtimeSession(this, options);
   }
 
   async close() {
@@ -486,7 +486,7 @@ export class RealtimeSession extends llm.RealtimeSession {
   #task: Task<void>;
   #closed = false;
 
-  constructor(realtimeModel: RealtimeModel) {
+  constructor(realtimeModel: RealtimeModel, sessionOptions?: llm.RealtimeSessionOptions) {
     super(realtimeModel);
 
     this.oaiRealtimeModel = realtimeModel;
@@ -497,9 +497,29 @@ export class RealtimeSession extends llm.RealtimeSession {
     // diff to always see "no change" and never send session.update.
     this._options = { ...realtimeModel._options };
 
+    // seed before the initial session.update below so instructions ride the
+    // first frame and tools are configured before any generation can start
+    if (sessionOptions?.instructions !== undefined) {
+      this.instructions = sessionOptions.instructions;
+    }
+    if (sessionOptions?.tools !== undefined) {
+      this._tools = sessionOptions.tools.copy();
+    }
+
     this.#task = Task.from(({ signal }) => this.#mainTask(signal));
 
     this.sendEvent(this.createSessionUpdateEvent());
+
+    if (sessionOptions?.tools !== undefined && Object.keys(this._tools.functionTools).length > 0) {
+      this.sendEvent(this.createToolsUpdateEvent(this._tools));
+    }
+    if (sessionOptions?.chatCtx !== undefined && sessionOptions.chatCtx.items.length > 0) {
+      // the standard update path queues the item events ahead of the socket
+      // connecting; a later updateChatCtx with the same context diffs to empty
+      void this.updateChatCtx(sessionOptions.chatCtx).catch((error) => {
+        this.#logger.error(error, 'failed to apply the initial chat context');
+      });
+    }
   }
 
   private hasInflightResponse(): boolean {

--- a/plugins/phonic/etc/agents-plugin-phonic.api.md
+++ b/plugins/phonic/etc/agents-plugin-phonic.api.md
@@ -117,7 +117,7 @@ class RealtimeModel extends llm.RealtimeModel {
     // (undocumented)
     get provider(): string;
     // Warning: (ae-forgotten-export) The symbol "RealtimeSession_2" needs to be exported by the entry point index.d.ts
-    session(): RealtimeSession_2;
+    session(options?: llm.RealtimeSessionOptions): RealtimeSession_2;
 }
 
 // Warning: (ae-missing-release-tag) "RealtimeModelOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -368,8 +368,8 @@ export class RealtimeModel extends llm.RealtimeModel {
   /**
    * Create a new realtime session
    */
-  session(): RealtimeSession {
-    return new RealtimeSession(this);
+  session(options?: llm.RealtimeSessionOptions): RealtimeSession {
+    return new RealtimeSession(this, options);
   }
 
   async close(): Promise<void> {}
@@ -418,7 +418,7 @@ export class RealtimeSession extends llm.RealtimeSession {
   private systemPromptPostfix = '';
   private pendingUserText?: string;
 
-  constructor(realtimeModel: RealtimeModel) {
+  constructor(realtimeModel: RealtimeModel, sessionOptions?: llm.RealtimeSessionOptions) {
     super(realtimeModel);
     this.options = realtimeModel._options;
 
@@ -432,6 +432,19 @@ export class RealtimeSession extends llm.RealtimeSession {
       PHONIC_NUM_CHANNELS,
       (PHONIC_INPUT_SAMPLE_RATE * PHONIC_INPUT_FRAME_MS) / 1000,
     );
+
+    // Seed before connect() starts: the config frame waits on instructionsReady
+    // and toolsReady, and the pre-config update paths apply synchronously.
+    if (sessionOptions?.instructions !== undefined) {
+      void this.updateInstructions(sessionOptions.instructions);
+    }
+    if (sessionOptions?.chatCtx !== undefined) {
+      void this.updateChatCtx(sessionOptions.chatCtx);
+    }
+    if (sessionOptions?.tools !== undefined) {
+      void this.updateTools(sessionOptions.tools);
+    }
+
     this.connectTask = this.connect().catch((error: unknown) => {
       const normalizedError = asError(error);
       this.emitError(normalizedError, false);

--- a/plugins/rime/etc/agents-plugin-rime.api.md
+++ b/plugins/rime/etc/agents-plugin-rime.api.md
@@ -60,7 +60,7 @@ export class TTS extends tts.TTS {
 // Warning: (ae-missing-release-tag) "TTSModels" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export type TTSModels = 'arcana' | 'coda' | 'mistv2' | 'mistv3';
+export type TTSModels = 'coda' | 'mistv2' | 'mistv3';
 
 // Warning: (ae-missing-release-tag) "TTSOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/xai/etc/agents-plugin-xai.api.md
+++ b/plugins/xai/etc/agents-plugin-xai.api.md
@@ -75,8 +75,10 @@ class RealtimeModel_3 extends OpenAIRealtimeModel {
     constructor(options?: RealtimeModelOptions);
     // (undocumented)
     label(): string;
+    // Warning: (ae-forgotten-export) The symbol "llm" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    session(): RealtimeSession_3;
+    session(options?: llm.RealtimeSessionOptions): RealtimeSession_3;
 }
 
 // Warning: (ae-forgotten-export) The symbol "OpenAIRealtimeModelOptions" needs to be exported by the entry point index.d.ts
@@ -99,7 +101,6 @@ interface RealtimeModelOptions extends Omit<OpenAIRealtimeModelOptions, 'model'>
 class RealtimeSession_3 extends OpenAIRealtimeSession {
     // (undocumented)
     close(): Promise<void>;
-    // Warning: (ae-forgotten-export) The symbol "llm" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "realtime_2" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/plugins/xai/src/realtime/realtime_model.ts
+++ b/plugins/xai/src/realtime/realtime_model.ts
@@ -56,8 +56,8 @@ export class RealtimeModel extends OpenAIRealtimeModel {
     });
   }
 
-  override session(): RealtimeSession {
-    return new RealtimeSession(this);
+  override session(options?: llm.RealtimeSessionOptions): RealtimeSession {
+    return new RealtimeSession(this, options);
   }
 }
 


### PR DESCRIPTION
Google Realtime requires instructions/tools to be passed in during initial connection. if they are not passed in, setting them for the first time would cause WS to be re-established, wasting time in the beginning.

updating realtime session establishment to include these parameters when available.

fixes: #2324
