### PR TITLE
fix(voice): place recorded audio where it actually played

### DIFF
--- a/.changeset/recorder-playback-progress.md
+++ b/.changeset/recorder-playback-progress.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Place recorded audio where the sink reports it actually played, instead of inferring it from the moment playback finished.

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -1602,6 +1602,8 @@ export abstract class AudioOutput extends EventEmitter_2 {
     // (undocumented)
     static readonly EVENT_PLAYBACK_FINISHED = "playbackFinished";
     // (undocumented)
+    static readonly EVENT_PLAYBACK_PROGRESSED = "playbackProgressed";
+    // (undocumented)
     static readonly EVENT_PLAYBACK_STARTED = "playbackStarted";
     // (undocumented)
     flush(): void;
@@ -1614,6 +1616,7 @@ export abstract class AudioOutput extends EventEmitter_2 {
     // (undocumented)
     onDetached(): void;
     onPlaybackFinished(options: PlaybackFinishedEvent): void;
+    onPlaybackProgressed(ev: PlaybackProgressedEvent): void;
     onPlaybackStarted(createdAt: number): void;
     pause(): void;
     // @internal
@@ -5481,6 +5484,15 @@ export interface PlaybackFinishedEvent {
     synchronizedTranscript?: string;
 }
 
+// Warning: (ae-missing-release-tag) "PlaybackProgressedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface PlaybackProgressedEvent {
+    duration: number;
+    offset: number;
+    startedAt: number;
+}
+
 // Warning: (ae-missing-release-tag) "PlaybackStartedEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -8620,6 +8632,7 @@ declare namespace voice {
         AudioOutput,
         AudioOutputCapabilities,
         PlaybackFinishedEvent,
+        PlaybackProgressedEvent,
         PlaybackStartedEvent,
         TimedString,
         createTimedString,

--- a/agents/src/voice/index.ts
+++ b/agents/src/voice/index.ts
@@ -56,6 +56,7 @@ export {
   AudioOutput,
   type AudioOutputCapabilities,
   type PlaybackFinishedEvent,
+  type PlaybackProgressedEvent,
   type PlaybackStartedEvent,
   type TimedString,
   createTimedString,

--- a/agents/src/voice/io.ts
+++ b/agents/src/voice/io.ts
@@ -117,6 +117,7 @@ export abstract class AudioInput {
 export abstract class AudioOutput extends EventEmitter {
   static readonly EVENT_PLAYBACK_STARTED = 'playbackStarted';
   static readonly EVENT_PLAYBACK_FINISHED = 'playbackFinished';
+  static readonly EVENT_PLAYBACK_PROGRESSED = 'playbackProgressed';
 
   private playbackFinishedFuture: Future<void> = new Future();
   private _capturing: boolean = false;
@@ -143,6 +144,9 @@ export abstract class AudioOutput extends EventEmitter {
       );
       this.nextInChain.on(AudioOutput.EVENT_PLAYBACK_FINISHED, (ev: PlaybackFinishedEvent) =>
         this.onPlaybackFinished(ev),
+      );
+      this.nextInChain.on(AudioOutput.EVENT_PLAYBACK_PROGRESSED, (ev: PlaybackProgressedEvent) =>
+        this.onPlaybackProgressed(ev),
       );
     }
   }
@@ -204,6 +208,16 @@ export abstract class AudioOutput extends EventEmitter {
    */
   onPlaybackStarted(createdAt: number): void {
     this.emit(AudioOutput.EVENT_PLAYBACK_STARTED, { createdAt } as PlaybackStartedEvent);
+  }
+
+  /**
+   * Report a stretch of the current segment that has played.
+   *
+   * Sinks that own their playback device report one run at a time; one that reports nothing is
+   * described by its segment endpoints instead.
+   */
+  onPlaybackProgressed(ev: PlaybackProgressedEvent): void {
+    this.emit(AudioOutput.EVENT_PLAYBACK_PROGRESSED, ev);
   }
 
   /**
@@ -290,6 +304,20 @@ export interface PlaybackFinishedEvent {
 export interface PlaybackStartedEvent {
   /** The timestamp (Date.now()) when the playback started */
   createdAt: number;
+}
+
+/**
+ * A stretch of the current segment that has played.
+ *
+ * Reported once the audio can no longer be discarded, so it is never revised.
+ */
+export interface PlaybackProgressedEvent {
+  /** The timestamp (Date.now()) at which this stretch began to play */
+  startedAt: number;
+  /** Where it starts in the audio captured for the current segment, in milliseconds */
+  offset: number;
+  /** How much of it played, in milliseconds */
+  duration: number;
 }
 
 export abstract class TextOutput {

--- a/agents/src/voice/recorder_io/recorder_io.test.ts
+++ b/agents/src/voice/recorder_io/recorder_io.test.ts
@@ -15,7 +15,7 @@ import type { AgentSession } from '../agent_session.js';
 import { AudioInput, AudioOutput, type PlaybackFinishedEvent, TextOutput } from '../io.js';
 import { ParticipantAudioOutput } from '../room_io/_output.js';
 import { TranscriptionSynchronizer } from '../transcription/synchronizer.js';
-import { RecorderIO, Track } from './recorder_io.js';
+import { INPUT_STALL_TIMEOUT_MS, RecorderIO, Track, WRITE_INTERVAL_MS } from './recorder_io.js';
 
 class FakeAudioInput extends AudioInput {
   private chan: StreamChannel<AudioFrame> = createStreamChannel<AudioFrame>();
@@ -1394,4 +1394,95 @@ describe('RecorderIO end to end', () => {
       vi.useRealTimers();
     }
   }, 30000);
+});
+
+describe('RecorderAudioOutput event forwarding', () => {
+  /** The device at the end of the chain: the only output that knows where its audio went. */
+  class LeafAudioOutput extends AudioOutput {
+    constructor() {
+      super(RECORDING_RATE);
+    }
+
+    clearBuffer(): void {}
+  }
+
+  /** A wrapper that forwards audio, the way the transcription synchronizer sits in the chain. */
+  class PassthroughAudioOutput extends AudioOutput {
+    constructor(nextInChain: AudioOutput) {
+      super(nextInChain.sampleRate, nextInChain);
+    }
+
+    override async captureFrame(frame: AudioFrame): Promise<void> {
+      await super.captureFrame(frame);
+      await this.nextInChain!.captureFrame(frame);
+    }
+
+    clearBuffer(): void {}
+  }
+
+  it('carries a report from two levels down up to the recorder', async () => {
+    // Nothing else covers the listener the base class registers on `nextInChain`. Without it
+    // every recorder silently falls back to the segment endpoints, and the rest of the suite
+    // still passes because it calls `onPlaybackProgressed` directly.
+    const leaf = new LeafAudioOutput();
+    const { recorder, output, placed, state } = makePlacingOutput(new PassthroughAudioOutput(leaf));
+
+    await output.captureFrame(makeFrame(1000));
+    output.flush();
+
+    leaf.onPlaybackProgressed({ startedAt: 100_000, offset: 0, duration: 400 });
+    leaf.onPlaybackFinished({ playbackPosition: 0.4, interrupted: false });
+
+    expect(placed).toHaveLength(1);
+    // the sink's own timestamp, not the `Date.now()` the endpoint fallback would have used
+    expect(placed[0]!.startedAt).toBe(100_000);
+    expect(frameDurationMs(placed[0]!.frame)).toBeCloseTo(400);
+    state.started = false;
+    await recorder.close();
+  });
+});
+
+describe('RecorderIO write task', () => {
+  it('waits on the agent but not on a quiet source', async () => {
+    // A segment in flight holds the timeline; a microphone that went quiet does not.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000_000);
+      const flushed: number[] = [];
+      const recorder = new RecorderIO({ agentSession: {} as AgentSession });
+      recorder.recordInput(new FakeAudioInput());
+      const audioOut = recorder.recordOutput(new FakeAudioOutput());
+      const state = recorder as unknown as {
+        started: boolean;
+        t0: number;
+        inputSettled: number;
+        enqueue: (item: { kind: string; until?: number }) => void;
+        write: (signal: AbortSignal) => Promise<void>;
+      };
+      state.started = true;
+      state.t0 = state.inputSettled = Date.now();
+      state.enqueue = (item) => {
+        if (item.kind === 'flush') flushed.push(item.until!);
+      };
+
+      const controller = new AbortController();
+      const writing = state.write(controller.signal);
+
+      // the source has delivered nothing, so the writer waits out the stall timeout and no more
+      await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS);
+      expect(flushed.at(-1)).toBe(Date.now() - INPUT_STALL_TIMEOUT_MS);
+
+      // a segment opens, and it has not said where its audio went
+      await audioOut.captureFrame(makeFrame(200));
+      const segmentBegan = audioOut.pendingSince;
+      await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS);
+      expect(flushed.at(-1)).toBe(segmentBegan);
+
+      controller.abort();
+      await writing;
+      state.started = false;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/agents/src/voice/recorder_io/recorder_io.test.ts
+++ b/agents/src/voice/recorder_io/recorder_io.test.ts
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { AudioFrame, type Room, TrackPublishOptions } from '@livekit/rtc-node';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { resolveFfmpegPath } from '../../ffmpeg.js';
 import { initializeLogger } from '../../log.js';
 import { type StreamChannel, createStreamChannel } from '../../stream/stream_channel.js';
 import { Future, isWritableStreamClosedError } from '../../utils.js';
@@ -13,7 +15,7 @@ import type { AgentSession } from '../agent_session.js';
 import { AudioInput, AudioOutput, type PlaybackFinishedEvent, TextOutput } from '../io.js';
 import { ParticipantAudioOutput } from '../room_io/_output.js';
 import { TranscriptionSynchronizer } from '../transcription/synchronizer.js';
-import { RecorderIO } from './recorder_io.js';
+import { RecorderIO, Track } from './recorder_io.js';
 
 class FakeAudioInput extends AudioInput {
   private chan: StreamChannel<AudioFrame> = createStreamChannel<AudioFrame>();
@@ -412,7 +414,9 @@ async function settleOrStall<T>(
   }
 }
 
-function makeFrame(durationMs: number, sampleRate = 48000, channels = 1): AudioFrame {
+const RECORDING_RATE = 48000;
+
+function makeFrame(durationMs: number, sampleRate = RECORDING_RATE, channels = 1): AudioFrame {
   const samplesPerChannel = Math.floor((durationMs / 1000) * sampleRate);
   return new AudioFrame(
     new Int16Array(samplesPerChannel * channels),
@@ -420,6 +424,47 @@ function makeFrame(durationMs: number, sampleRate = 48000, channels = 1): AudioF
     channels,
     samplesPerChannel,
   );
+}
+
+function frameDurationMs(frame: AudioFrame): number {
+  return (frame.samplesPerChannel / frame.sampleRate) * 1000;
+}
+
+/** A 1kHz tone loud enough to survive the opus encoder. */
+function makeToneFrame(durationMs: number, sampleRate = RECORDING_RATE): AudioFrame {
+  const samplesPerChannel = Math.floor((durationMs / 1000) * sampleRate);
+  const data = new Int16Array(samplesPerChannel);
+  for (let i = 0; i < samplesPerChannel; i++) {
+    data[i] = Math.round(8000 * Math.sin((2 * Math.PI * 1000 * i) / sampleRate));
+  }
+  return new AudioFrame(data, sampleRate, 1, samplesPerChannel);
+}
+
+interface PlacedAudio {
+  channel: 0 | 1;
+  startedAt: number;
+  frame: AudioFrame;
+}
+
+/**
+ * A recorder whose queue is replaced by a list, so a test can see exactly which audio the output
+ * handed over and when it says it played.
+ */
+function makePlacingOutput<T extends AudioOutput>(downstream: T) {
+  const placed: PlacedAudio[] = [];
+  const recorder = new RecorderIO({ agentSession: {} as AgentSession });
+  const state = recorder as unknown as {
+    started: boolean;
+    enqueue: (item: { kind: string } & Partial<PlacedAudio>) => void;
+  };
+  state.started = true;
+  state.enqueue = (item) => {
+    if (item.kind === 'captured') {
+      placed.push(item as PlacedAudio);
+    }
+  };
+  const output = recorder.recordOutput(downstream);
+  return { recorder, output, downstream, placed, state };
 }
 
 function makeRecorder() {
@@ -473,8 +518,8 @@ describe('RecorderIO close', () => {
     await recorder.close();
 
     expect(Date.now() - start).toBeGreaterThanOrEqual(140);
-    // Nothing reached the encoder, so no file was produced.
-    expect(fs.existsSync(outputPath)).toBe(false);
+    // The unreported agent segment is dropped, but the window itself is still recorded as silence.
+    expect(fs.existsSync(outputPath)).toBe(true);
   }, 15000);
 
   it('settles a dropped, never-flushed segment on close without stalling or warning', async () => {
@@ -512,124 +557,35 @@ describe('RecorderIO close', () => {
   }, 15000);
 
   it('flushes trailing input audio on close', async () => {
-    const { recorder, input, inWrapped, outputPath } = makeRecorder();
-    await recorder.start(outputPath);
+    // only Date is faked, so the frames arrive on a clock that matches their own duration
+    vi.useFakeTimers({ toFake: ['Date'] });
+    try {
+      vi.setSystemTime(1_000_000);
+      const { recorder, input, inWrapped, outputPath } = makeRecorder();
+      await recorder.start(outputPath);
 
-    // Frames only accumulate while flowing through the intercepting stream,
-    // so consume them like the session does.
-    const reader = inWrapped.stream.getReader();
-    for (let i = 0; i < 5; i++) {
-      await input.push(makeFrame(100));
-      await reader.read();
+      // Frames only reach the recorder while flowing through the intercepting stream,
+      // so consume them like the session does.
+      const reader = inWrapped.stream.getReader();
+      for (let i = 0; i < 5; i++) {
+        vi.setSystemTime(Date.now() + 100);
+        await input.push(makeFrame(100));
+        await reader.read();
+      }
+      reader.releaseLock();
+
+      // Close before the 2.5s write tick: without the final flush this audio would be dropped.
+      await recorder.close();
+
+      expect(fs.existsSync(outputPath)).toBe(true);
+      expect(fs.statSync(outputPath).size).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
     }
-    reader.releaseLock();
-
-    // Close before the 2.5s forward tick: without the final input flush this
-    // audio would be dropped.
-    await recorder.close();
-
-    expect(fs.existsSync(outputPath)).toBe(true);
-    expect(fs.statSync(outputPath).size).toBeGreaterThan(0);
   }, 15000);
 });
 
 describe('RecorderAudioOutput', () => {
-  it('drops pauses before the segment', async () => {
-    vi.useFakeTimers();
-    try {
-      const writes: AudioFrame[][] = [];
-      const recorder = new RecorderIO({ agentSession: {} as AgentSession });
-      const recorderState = recorder as unknown as {
-        started: boolean;
-        writeCb: (buf: AudioFrame[]) => void;
-      };
-      recorderState.started = true;
-      recorderState.writeCb = (buf) => writes.push(buf);
-      const output = recorder.recordOutput(new FakeAudioOutput());
-
-      vi.setSystemTime(10_000);
-      output.pause();
-      vi.setSystemTime(10_500);
-      output.resume();
-      vi.setSystemTime(11_000);
-      const frame = makeFrame(20);
-      await output.captureFrame(frame);
-      output.flush();
-      vi.setSystemTime(11_020);
-      output.onPlaybackFinished({ playbackPosition: 0.02, interrupted: false });
-
-      expect(writes).toHaveLength(1);
-      expect(writes[0]!.reduce((sum, item) => sum + item.samplesPerChannel, 0)).toBe(960);
-      recorderState.started = false;
-      await recorder.close();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('clips a pause that overlaps the segment', async () => {
-    vi.useFakeTimers();
-    try {
-      const writes: AudioFrame[][] = [];
-      const recorder = new RecorderIO({ agentSession: {} as AgentSession });
-      const recorderState = recorder as unknown as {
-        started: boolean;
-        writeCb: (buf: AudioFrame[]) => void;
-      };
-      recorderState.started = true;
-      recorderState.writeCb = (buf) => writes.push(buf);
-      const output = recorder.recordOutput(new FakeAudioOutput());
-
-      vi.setSystemTime(10_000);
-      output.pause();
-      vi.setSystemTime(10_500);
-      const frame = makeFrame(20);
-      await output.captureFrame(frame);
-      vi.setSystemTime(10_700);
-      output.resume();
-      output.flush();
-      vi.setSystemTime(10_720);
-      output.onPlaybackFinished({ playbackPosition: 0.02, interrupted: false });
-
-      expect(writes).toHaveLength(1);
-      expect(writes[0]!.reduce((sum, item) => sum + item.samplesPerChannel, 0)).toBe(10560);
-      recorderState.started = false;
-      await recorder.close();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('keeps trailing silence for a midsegment pause', async () => {
-    vi.useFakeTimers();
-    try {
-      const writes: AudioFrame[][] = [];
-      const recorder = new RecorderIO({ agentSession: {} as AgentSession });
-      const recorderState = recorder as unknown as {
-        started: boolean;
-        writeCb: (buf: AudioFrame[]) => void;
-      };
-      recorderState.started = true;
-      recorderState.writeCb = (buf) => writes.push(buf);
-      const output = recorder.recordOutput(new FakeAudioOutput());
-
-      vi.setSystemTime(10_000);
-      await output.captureFrame(makeFrame(100));
-      vi.setSystemTime(10_050);
-      output.pause();
-      output.flush();
-      vi.setSystemTime(10_200);
-      output.onPlaybackFinished({ playbackPosition: 0.05, interrupted: true });
-
-      expect(writes).toHaveLength(1);
-      expect(writes[0]!.reduce((sum, item) => sum + item.samplesPerChannel, 0)).toBe(9600);
-      recorderState.started = false;
-      await recorder.close();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it('does not lose a playback finish emitted during first-frame capture', async () => {
     const recorder = new RecorderIO({ agentSession: {} as AgentSession });
     const output = recorder.recordOutput(new FinishDuringCaptureOutput());
@@ -877,16 +833,9 @@ describe('RecorderAudioOutput', () => {
   });
 
   it('keeps later segment audio when an older overlapping segment finishes', async () => {
-    const writes: AudioFrame[][] = [];
-    const recorder = new RecorderIO({ agentSession: {} as AgentSession });
-    const recorderState = recorder as unknown as {
-      started: boolean;
-      writeCb: (buf: AudioFrame[]) => void;
-    };
-    recorderState.started = true;
-    recorderState.writeCb = (buf) => writes.push(buf);
-    const downstream = new FakeAudioOutput();
-    const output = recorder.recordOutput(downstream);
+    const { recorder, output, downstream, placed, state } = makePlacingOutput(
+      new FakeAudioOutput(),
+    );
 
     await output.captureFrame(makeFrame(1));
     output.flush();
@@ -897,22 +846,15 @@ describe('RecorderAudioOutput', () => {
     downstream.onPlaybackFinished({ playbackPosition: 0.001, interrupted: false });
     downstream.onPlaybackFinished({ playbackPosition: 0.001, interrupted: false });
 
-    expect(writes).toHaveLength(2);
-    recorderState.started = false;
+    expect(placed).toHaveLength(2);
+    state.started = false;
     await recorder.close();
   });
 
   it('keeps the audio a finish reports as played while the first frame was parked', async () => {
-    const writes: AudioFrame[][] = [];
-    const recorder = new RecorderIO({ agentSession: {} as AgentSession });
-    const recorderState = recorder as unknown as {
-      started: boolean;
-      writeCb: (buf: AudioFrame[]) => void;
-    };
-    recorderState.started = true;
-    recorderState.writeCb = (buf) => writes.push(buf);
-    const downstream = new ParkFirstFrameOutput();
-    const output = recorder.recordOutput(downstream);
+    const { recorder, output, downstream, placed, state } = makePlacingOutput(
+      new ParkFirstFrameOutput(),
+    );
 
     const capture = output.captureFrame(makeFrame(100));
     await downstream.frameParked.await;
@@ -923,11 +865,9 @@ describe('RecorderAudioOutput', () => {
     await capture;
     output.flush();
 
-    const capturedSamples = writes
-      .flat()
-      .reduce((total, frame) => total + frame.samplesPerChannel, 0);
-    expect(capturedSamples).toBe(0.05 * 48000);
-    recorderState.started = false;
+    const capturedSamples = placed.reduce((total, item) => total + item.frame.samplesPerChannel, 0);
+    expect(capturedSamples).toBe(0.05 * RECORDING_RATE);
+    state.started = false;
     await recorder.close();
   });
 
@@ -1174,4 +1114,284 @@ describe('RecorderIO writable stream error detection', () => {
 
     expect(isWritableStreamClosedError(err)).toBe(false);
   });
+});
+
+describe('RecorderAudioOutput placement', () => {
+  it('places each report at the time the sink says it played', async () => {
+    // A gap between two reports is a gap in the recording, not silence moved to the front.
+    const { recorder, output, placed, state } = makePlacingOutput(new FakeAudioOutput());
+    await output.captureFrame(makeFrame(1000));
+    output.flush();
+
+    output.onPlaybackProgressed({ startedAt: 100_000, offset: 0, duration: 400 });
+    output.onPlaybackProgressed({ startedAt: 101_000, offset: 400, duration: 600 });
+    output.onPlaybackFinished({ playbackPosition: 1.0, interrupted: false });
+
+    expect(placed.map((item) => item.startedAt)).toEqual([100_000, 101_000]);
+    expect(placed.map((item) => frameDurationMs(item.frame))).toEqual([400, 600]);
+    state.started = false;
+    await recorder.close();
+  });
+
+  it('skips the audio a report says never played', async () => {
+    // Audio dropped from the sink's queue is a hole in the middle, not a shortened end.
+    const { recorder, output, placed, state } = makePlacingOutput(new FakeAudioOutput());
+    await output.captureFrame(makeFrame(1000));
+    output.flush();
+
+    // 0.2s of the segment was discarded on pause, so the next run resumes past it
+    output.onPlaybackProgressed({ startedAt: 100_000, offset: 0, duration: 300 });
+    output.onPlaybackProgressed({ startedAt: 100_800, offset: 500, duration: 500 });
+    output.onPlaybackFinished({ playbackPosition: 0.8, interrupted: false });
+
+    expect(placed.map((item) => item.startedAt)).toEqual([100_000, 100_800]);
+    expect(placed.map((item) => frameDurationMs(item.frame))).toEqual([300, 500]);
+    state.started = false;
+    await recorder.close();
+  });
+
+  it('anchors a sink that reports nothing at playbackStarted', async () => {
+    // The fallback is the shape a remote sink sends: one report for the whole segment.
+    vi.useFakeTimers();
+    try {
+      const { recorder, output, placed, state } = makePlacingOutput(new FakeAudioOutput());
+      await output.captureFrame(makeFrame(1000));
+      output.flush();
+
+      output.onPlaybackStarted(100_000);
+      vi.setSystemTime(105_000); // noticed long after the audio really stopped
+      output.onPlaybackFinished({ playbackPosition: 1.0, interrupted: false });
+
+      expect(placed).toHaveLength(1);
+      // not 105_000 - 1000, which is where the old recorder put it
+      expect(placed[0]!.startedAt).toBe(100_000);
+      expect(frameDurationMs(placed[0]!.frame)).toBe(1000);
+      state.started = false;
+      await recorder.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('dates a sink with no start of its own from the segment end', async () => {
+    // Last resort for a remote sink that never reports a start.
+    vi.useFakeTimers();
+    try {
+      const { recorder, output, placed, state } = makePlacingOutput(new FakeAudioOutput());
+      await output.captureFrame(makeFrame(1000));
+      output.flush();
+
+      vi.setSystemTime(105_000);
+      output.onPlaybackFinished({ playbackPosition: 1.0, interrupted: false });
+
+      expect(placed).toHaveLength(1);
+      expect(placed[0]!.startedAt).toBe(104_000);
+      state.started = false;
+      await recorder.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('truncates an interrupted segment in the fallback', async () => {
+    const { recorder, output, placed, state } = makePlacingOutput(new FakeAudioOutput());
+    await output.captureFrame(makeFrame(1000));
+    output.flush();
+
+    output.onPlaybackStarted(100_000);
+    output.onPlaybackFinished({ playbackPosition: 0.4, interrupted: true });
+
+    expect(placed).toHaveLength(1);
+    expect(frameDurationMs(placed[0]!.frame)).toBe(400);
+    state.started = false;
+    await recorder.close();
+  });
+
+  it('holds the timeline while a segment is in flight', async () => {
+    // The writer cannot settle a window whose agent audio has not been reported yet.
+    const { recorder, output, state } = makePlacingOutput(new FakeAudioOutput());
+    expect(output.pendingSince).toBeUndefined();
+
+    await output.captureFrame(makeFrame(1000));
+    expect(output.pendingSince).toBeDefined();
+
+    output.onPlaybackProgressed({ startedAt: 100_000, offset: 0, duration: 1000 });
+    output.onPlaybackFinished({ playbackPosition: 1.0, interrupted: false });
+    expect(output.pendingSince).toBeUndefined();
+    state.started = false;
+    await recorder.close();
+  });
+});
+
+describe('Track', () => {
+  /** A frame whose every sample is loud, so placement shows up as non-zero samples. */
+  function loudFrame(samples: number, sampleRate = 1000, channels = 1): AudioFrame {
+    return new AudioFrame(
+      new Int16Array(samples * channels).fill(1000),
+      sampleRate,
+      channels,
+      samples,
+    );
+  }
+
+  const placedStarts = (track: Track) =>
+    (track as unknown as { placed: Array<{ start: number }> }).placed.map((run) => run.start);
+
+  it('lands placed audio at its own timestamp', () => {
+    const track = new Track(1000, 0);
+    track.push(2000, loudFrame(100));
+
+    const block = track.take(0, 3000);
+    expect(block.slice(0, 2000).every((sample) => sample === 0)).toBe(true);
+    expect(block.slice(2000, 2100).every((sample) => sample > 0)).toBe(true);
+    expect(block.slice(2100).every((sample) => sample === 0)).toBe(true);
+  });
+
+  it('keeps a gap between two runs a gap', () => {
+    const track = new Track(1000, 0);
+    track.push(0, loudFrame(100));
+    track.push(500, loudFrame(100));
+
+    const block = track.take(0, 1000);
+    expect(block.slice(0, 100).every((sample) => sample > 0)).toBe(true);
+    expect(block.slice(100, 500).every((sample) => sample === 0)).toBe(true);
+    expect(block.slice(500, 600).every((sample) => sample > 0)).toBe(true);
+  });
+
+  it('drops and counts audio that arrives after its window was written', () => {
+    const track = new Track(1000, 0);
+    track.take(0, 2000); // the first two seconds have already gone to the encoder
+    track.push(500, loudFrame(100));
+
+    expect(track.take(2000, 3000).every((sample) => sample === 0)).toBe(true);
+    expect(track.droppedSamples).toBe(100);
+  });
+
+  it('re-anchors a run when its clock drifts', () => {
+    const track = new Track(1000, 0);
+    track.push(0, loudFrame(100));
+    track.push(100, loudFrame(100)); // contiguous, extends the run
+    track.push(5000, loudFrame(100)); // beyond tolerance, anchors on its own timestamp
+
+    expect(placedStarts(track)).toEqual([0, 100, 5000]);
+  });
+
+  it('resamples a source below the recording rate in place', () => {
+    const track = new Track(48000, 0);
+    track.push(1000, loudFrame(2400, 24000)); // 100ms at 24kHz
+    track.push(9000, loudFrame(2400, 24000)); // a new run, so the first one is complete
+
+    const block = track.take(0, 48000 * 2);
+    expect(block.slice(0, 48000).every((sample) => sample === 0)).toBe(true);
+    // 100ms of audio, twice as many samples at the recording rate; the samples the resampler
+    // still held when the run ended are part of it
+    const nonZero = block.slice(48000).filter((sample) => sample !== 0).length;
+    expect(nonZero).toBeGreaterThan(4750);
+    expect(nonZero).toBeLessThan(4850);
+  });
+
+  it('mixes a stereo source down', () => {
+    const track = new Track(1000, 0);
+    track.push(0, loudFrame(100, 1000, 2));
+
+    const block = track.take(0, 200);
+    // samples, not interleaved values
+    expect(block.filter((sample) => sample !== 0).length).toBe(100);
+    expect(block[0]).toBeCloseTo(1000 / 32768, 4);
+  });
+});
+
+describe('RecorderIO end to end', () => {
+  /** Decode the recording back to two float channels at its own sample rate. */
+  function decodeStereo(filePath: string): [Float32Array, Float32Array] {
+    const raw = execFileSync(
+      resolveFfmpegPath() ?? 'ffmpeg',
+      [
+        '-v',
+        'error',
+        '-i',
+        filePath,
+        '-f',
+        's16le',
+        '-ac',
+        '2',
+        '-ar',
+        String(RECORDING_RATE),
+        '-',
+      ],
+      { maxBuffer: 1 << 28 },
+    );
+    // copied into a fresh buffer: the pipe's Buffer is not guaranteed to be 2-byte aligned
+    const pcm = new Int16Array(new Uint8Array(raw).buffer);
+    const left = new Float32Array(pcm.length / 2);
+    const right = new Float32Array(pcm.length / 2);
+    for (let i = 0; i < left.length; i++) {
+      left[i] = pcm[i * 2]! / 32768;
+      right[i] = pcm[i * 2 + 1]! / 32768;
+    }
+    return [left, right];
+  }
+
+  /** Peak amplitude over `[fromMs, toMs)` of one decoded channel. */
+  function peak(channel: Float32Array, fromMs: number, toMs: number): number {
+    const from = Math.round((fromMs / 1000) * RECORDING_RATE);
+    const to = Math.min(Math.round((toMs / 1000) * RECORDING_RATE), channel.length);
+    let loudest = 0;
+    for (let i = from; i < to; i++) {
+      loudest = Math.max(loudest, Math.abs(channel[i]!));
+    }
+    return loudest;
+  }
+
+  it('records each channel where it happened', async () => {
+    // The agent speaks 0.5s, goes quiet for 0.5s, speaks 0.5s. The microphone delivers for the
+    // first second, then stops. Neither hole may be filled by moving the audio around it.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    try {
+      vi.setSystemTime(1_000_000);
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'recorder-io-test-'));
+      const outputPath = path.join(dir, 'session.ogg');
+      const recorder = new RecorderIO({ agentSession: {} as AgentSession });
+      const source = new FakeAudioInput();
+      const audioIn = recorder.recordInput(source);
+      const audioOut = recorder.recordOutput(new FakeAudioOutput());
+      await recorder.start(outputPath);
+      const t0 = Date.now();
+
+      // a microphone that delivers for one second, then goes quiet
+      const reader = audioIn.stream.getReader();
+      for (let i = 0; i < 10; i++) {
+        vi.setSystemTime(Date.now() + 100);
+        await source.push(makeToneFrame(100));
+        await reader.read();
+      }
+      reader.releaseLock();
+
+      // the agent speaks, stalls, then speaks again
+      await audioOut.captureFrame(makeToneFrame(1000));
+      audioOut.flush();
+      audioOut.onPlaybackStarted(t0 + 1500);
+      audioOut.onPlaybackProgressed({ startedAt: t0 + 1500, offset: 0, duration: 500 });
+      audioOut.onPlaybackProgressed({ startedAt: t0 + 2500, offset: 500, duration: 500 });
+      vi.setSystemTime(t0 + 3000);
+      audioOut.onPlaybackFinished({ playbackPosition: 1.0, interrupted: false });
+
+      await recorder.close();
+
+      const [userChannel, agentChannel] = decodeStereo(outputPath);
+      expect(userChannel.length / RECORDING_RATE).toBeCloseTo(3.0, 1);
+
+      // the microphone's first second is there, and its silence is silence
+      expect(peak(userChannel, 50, 950)).toBeGreaterThan(0.05);
+      expect(peak(userChannel, 1050, 3000)).toBeLessThan(0.01);
+
+      // the agent's two utterances sit either side of the stall, not packed together
+      expect(peak(agentChannel, 0, 1450)).toBeLessThan(0.01);
+      expect(peak(agentChannel, 1550, 1950)).toBeGreaterThan(0.05);
+      expect(peak(agentChannel, 2050, 2450)).toBeLessThan(0.01);
+      expect(peak(agentChannel, 2550, 2950)).toBeGreaterThan(0.05);
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 30000);
 });

--- a/agents/src/voice/recorder_io/recorder_io.ts
+++ b/agents/src/voice/recorder_io/recorder_io.ts
@@ -34,12 +34,12 @@ configureFfmpeg();
 // Both channels sit on one absolute timeline: the user's audio where it arrived, the agent's
 // where the device reports it played. Silence is whatever nothing was written over.
 
-const WRITE_INTERVAL_MS = 2500;
+export const WRITE_INTERVAL_MS = 2500;
 const DEFAULT_SAMPLE_RATE = 48000;
 const CLOSE_PLAYOUT_FLUSH_TIMEOUT_MS = 2000;
 
 /** How long the writer waits on a source that stopped delivering before taking the silence as real. */
-const INPUT_STALL_TIMEOUT_MS = 1000;
+export const INPUT_STALL_TIMEOUT_MS = 1000;
 
 /**
  * A run continues while its own clock stays this close to the timestamps coming in; re-anchoring

--- a/agents/src/voice/recorder_io/recorder_io.ts
+++ b/agents/src/voice/recorder_io/recorder_io.ts
@@ -22,38 +22,169 @@ import {
   isWritableStreamClosedError,
 } from '../../utils.js';
 import type { AgentSession } from '../agent_session.js';
-import { AudioInput, AudioOutput, type PlaybackFinishedEvent } from '../io.js';
-import { createSilenceFrame } from '../utils.js';
+import {
+  AudioInput,
+  AudioOutput,
+  type PlaybackFinishedEvent,
+  type PlaybackProgressedEvent,
+} from '../io.js';
 
 configureFfmpeg();
+
+// Both channels sit on one absolute timeline: the user's audio where it arrived, the agent's
+// where the device reports it played. Silence is whatever nothing was written over.
 
 const WRITE_INTERVAL_MS = 2500;
 const DEFAULT_SAMPLE_RATE = 48000;
 const CLOSE_PLAYOUT_FLUSH_TIMEOUT_MS = 2000;
+
+/** How long the writer waits on a source that stopped delivering before taking the silence as real. */
+const INPUT_STALL_TIMEOUT_MS = 1000;
+
+/**
+ * A run continues while its own clock stays this close to the timestamps coming in; re-anchoring
+ * beyond it keeps a drifting capture clock from sliding the channel.
+ */
+const RESYNC_TOLERANCE_MS = 100;
 
 export interface RecorderOptions {
   agentSession: AgentSession;
   sampleRate?: number;
 }
 
-interface ResampleAndMixOptions {
-  frames: AudioFrame[];
-  resampler: AudioResampler | undefined;
-  flush?: boolean;
+type QueueItem =
+  | { kind: 'captured'; channel: 0 | 1; startedAt: number; frame: AudioFrame }
+  | { kind: 'flush'; until: number };
+
+/** One channel of the recording, holding runs of audio placed on the absolute timeline. */
+export class Track {
+  /** Placed runs, each a mono float32 block starting at an absolute sample index. */
+  private placed: Array<{ start: number; samples: Float32Array }> = [];
+  private resampler?: AudioResampler;
+  private sourceRate?: number;
+  private runStart?: number;
+  private runSamples: number = 0;
+  droppedSamples: number = 0;
+
+  constructor(
+    private readonly sampleRate: number,
+    private readonly t0: number,
+  ) {}
+
+  /** Mono frames at the recording rate, of which the resampler may still hold some back. */
+  private resample(frame: AudioFrame): AudioFrame[] {
+    let mono = frame.data;
+    if (frame.channels > 1) {
+      mono = new Int16Array(frame.samplesPerChannel);
+      for (let i = 0; i < frame.samplesPerChannel; i++) {
+        let sum = 0;
+        for (let ch = 0; ch < frame.channels; ch++) {
+          sum += frame.data[i * frame.channels + ch]!;
+        }
+        mono[i] = Math.round(sum / frame.channels);
+      }
+    }
+
+    const monoFrame = new AudioFrame(mono, frame.sampleRate, 1, frame.samplesPerChannel);
+    if (frame.sampleRate === this.sampleRate) {
+      return [monoFrame];
+    }
+
+    if (!this.resampler || this.sourceRate !== frame.sampleRate) {
+      this.resampler?.close();
+      this.sourceRate = frame.sampleRate;
+      this.resampler = new AudioResampler(frame.sampleRate, this.sampleRate, 1);
+    }
+
+    return this.resampler.push(monoFrame);
+  }
+
+  /** Append resampled audio to the open run, which begins at `runStart`. */
+  private place(frames: AudioFrame[]): void {
+    if (frames.length === 0) {
+      return;
+    }
+
+    const total = frames.reduce((count, frame) => count + frame.samplesPerChannel, 0);
+    const samples = new Float32Array(total);
+    let pos = 0;
+    for (const frame of frames) {
+      for (let i = 0; i < frame.samplesPerChannel; i++) {
+        samples[pos++] = frame.data[i]! / 32768;
+      }
+    }
+
+    const start =
+      Math.round(((this.runStart! - this.t0) / 1000) * this.sampleRate) + this.runSamples;
+    this.placed.push({ start, samples });
+    this.runSamples += total;
+  }
+
+  /** Add audio that began at `startedAt`, extending the open run where it fits. */
+  push(startedAt: number, frame: AudioFrame): void {
+    const expected =
+      this.runStart === undefined
+        ? undefined
+        : this.runStart + (this.runSamples / this.sampleRate) * 1000;
+
+    if (expected === undefined || Math.abs(startedAt - expected) > RESYNC_TOLERANCE_MS) {
+      if (this.resampler) {
+        // whatever the resampler still holds is the tail of the run that just ended
+        this.place(this.resampler.flush());
+      }
+      this.runStart = startedAt;
+      this.runSamples = 0;
+    }
+
+    this.place(this.resample(frame));
+  }
+
+  /** The channel over `[start, end)`, silent wherever nothing was placed. */
+  take(start: number, end: number): Float32Array {
+    const block = new Float32Array(Math.max(0, end - start));
+    const keep: Array<{ start: number; samples: Float32Array }> = [];
+
+    for (const run of this.placed) {
+      const stop = run.start + run.samples.length;
+      if (stop <= start) {
+        this.droppedSamples += run.samples.length;
+        continue;
+      }
+      if (run.start >= end) {
+        keep.push(run);
+        continue;
+      }
+
+      const lo = Math.max(run.start, start);
+      const hi = Math.min(stop, end);
+      for (let i = lo; i < hi; i++) {
+        block[i - start]! += run.samples[i - run.start]!;
+      }
+      if (stop > end) {
+        keep.push({ start: end, samples: run.samples.subarray(end - run.start) });
+      }
+    }
+
+    this.placed = keep;
+    return block;
+  }
+
+  close(): void {
+    this.resampler?.close();
+  }
 }
 
 export class RecorderIO {
   private inRecord?: RecorderAudioInput;
   private outRecord?: RecorderAudioOutput;
 
-  private inChan: StreamChannel<AudioFrame[]> = createStreamChannel<AudioFrame[]>();
-  private outChan: StreamChannel<AudioFrame[]> = createStreamChannel<AudioFrame[]>();
+  private chan: StreamChannel<QueueItem> = createStreamChannel<QueueItem>();
 
   private session: AgentSession;
   private sampleRate: number;
 
   private _outputPath?: string;
-  private forwardTask?: Task<void>;
+  private writeTask?: Task<void>;
   private encodeTask?: Task<void>;
 
   private closeFuture: Future<void> = new Future();
@@ -62,11 +193,14 @@ export class RecorderIO {
   private closing: boolean = false;
   private closePlayoutFlushTimeoutMs: number = CLOSE_PLAYOUT_FLUSH_TIMEOUT_MS;
 
+  /** Zero of the absolute timeline both channels are placed on. */
+  private t0?: number;
+  /** Wall time up to which the user channel has delivered everything it is going to. */
+  private inputSettled: number = 0;
+
   // FFmpeg streaming state
   private pcmStream?: PassThrough;
   private ffmpegPromise?: Promise<void>;
-  private inResampler?: AudioResampler;
-  private outResampler?: AudioResampler;
 
   private logger = log();
 
@@ -93,6 +227,7 @@ export class RecorderIO {
       this.started = true;
       this.closing = false;
       this.closeFuture = new Future();
+      this.t0 = this.inputSettled = Date.now();
 
       // Ensure output directory exists
       const dir = path.dirname(outputPath);
@@ -100,7 +235,7 @@ export class RecorderIO {
         fs.mkdirSync(dir, { recursive: true });
       }
 
-      this.forwardTask = Task.from(({ signal }) => this.forward(signal));
+      this.writeTask = Task.from(({ signal }) => this.write(signal));
       this.encodeTask = Task.from(() => this.encode(), undefined, 'recorder_io_encode_task');
     } finally {
       unlock();
@@ -143,26 +278,21 @@ export class RecorderIO {
       this.closing = true;
       this.started = false;
 
-      if (this.forwardTask) {
-        await cancelAndWait([this.forwardTask]);
-        this.forwardTask = undefined;
+      if (this.writeTask) {
+        await cancelAndWait([this.writeTask]);
+        this.writeTask = undefined;
       }
 
-      // Flush input captured since the last write so the recording tail isn't dropped.
-      const inputBuf = this.inRecord?.takeBuf(this.outRecord?._lastSpeechEndTime) ?? [];
-      if (inputBuf.length > 0) {
-        try {
-          await this.inChan.write(inputBuf);
-          await this.outChan.write([]);
-        } catch (err) {
-          if (!isWritableStreamClosedError(err)) {
-            this.logger.error({ err }, 'Error writing final RecorderIO input buffer');
-          }
+      // Everything up to now is settled, so the recording keeps its tail instead of dropping it.
+      try {
+        await this.chan.write({ kind: 'flush', until: Date.now() });
+      } catch (err) {
+        if (!isWritableStreamClosedError(err)) {
+          this.logger.error({ err }, 'Error writing the final RecorderIO flush');
         }
       }
 
-      await this.inChan.close();
-      await this.outChan.close();
+      await this.chan.close();
       await this.closeFuture.await;
 
       if (this.encodeTask) {
@@ -177,29 +307,29 @@ export class RecorderIO {
   }
 
   recordInput(audioInput: AudioInput): RecorderAudioInput {
-    this.inRecord = new RecorderAudioInput(this, audioInput);
+    this.inRecord = new RecorderAudioInput(this, audioInput, (startedAt, frame) => {
+      // a contiguous stream, so what has arrived is exactly what is settled
+      this.inputSettled = startedAt + (frame.samplesPerChannel / frame.sampleRate) * 1000;
+      this.enqueue({ kind: 'captured', channel: 0, startedAt, frame });
+    });
     return this.inRecord;
   }
 
   recordOutput(audioOutput: AudioOutput): RecorderAudioOutput {
-    this.outRecord = new RecorderAudioOutput(this, audioOutput, (buf) => this.writeCb(buf));
+    this.outRecord = new RecorderAudioOutput(this, audioOutput, (startedAt, frame) =>
+      this.enqueue({ kind: 'captured', channel: 1, startedAt, frame }),
+    );
     return this.outRecord;
   }
 
-  private writeCb(buf: AudioFrame[]): void {
-    if (!this.started || this.closing || this.inChan.closed || this.outChan.closed) {
+  private enqueue(item: QueueItem): void {
+    if (!this.started || this.closing || this.chan.closed) {
       return;
     }
 
-    const inputBuf = this.inRecord!.takeBuf(this.outRecord?._lastSpeechEndTime);
-    this.inChan.write(inputBuf).catch((err) => {
+    this.chan.write(item).catch((err) => {
       if (!isWritableStreamClosedError(err)) {
-        this.logger.error({ err }, 'Error writing RecorderIO input buffer');
-      }
-    });
-    this.outChan.write(buf).catch((err) => {
-      if (!isWritableStreamClosedError(err)) {
-        this.logger.error({ err }, 'Error writing RecorderIO output buffer');
+        this.logger.error({ err }, 'Error writing to the RecorderIO queue');
       }
     });
   }
@@ -213,24 +343,13 @@ export class RecorderIO {
   }
 
   get recordingStartedAt(): number | undefined {
-    const inT = this.inRecord?.startedWallTime;
-    const outT = this.outRecord?.startedWallTime;
-
-    if (inT === undefined) {
-      return outT;
-    }
-
-    if (outT === undefined) {
-      return inT;
-    }
-
-    return Math.min(inT, outT);
+    return this.t0;
   }
 
   /**
-   * Forward task: periodically flush input buffer to encoder
+   * Write task: settle the timeline up to the last moment both channels can account for
    */
-  private async forward(signal: AbortSignal): Promise<void> {
+  private async write(signal: AbortSignal): Promise<void> {
     while (!signal.aborted && this.started && !this.closing) {
       try {
         await delay(WRITE_INTERVAL_MS, { signal });
@@ -239,24 +358,15 @@ export class RecorderIO {
         break;
       }
 
-      if (this.outRecord!.hasPendingData) {
-        // If the output is currently playing audio, wait for it to stay in sync
-        continue;
+      // a source gone quiet would hold the writer forever, so it is only waited on so long
+      let settled = Math.max(this.inputSettled, Date.now() - INPUT_STALL_TIMEOUT_MS);
+      const pendingSince = this.outRecord!.pendingSince;
+      if (pendingSince !== undefined) {
+        // a segment in flight has not said where its audio went
+        settled = Math.min(settled, pendingSince);
       }
 
-      // Flush input buffer
-      const inputBuf = this.inRecord!.takeBuf(this.outRecord!._lastSpeechEndTime);
-      try {
-        await this.inChan.write(inputBuf);
-        await this.outChan.write([]);
-      } catch (err) {
-        if (this.inChan.closed || this.outChan.closed || isWritableStreamClosedError(err)) {
-          // Channel closure is expected during teardown; stop forwarding to avoid noisy logs.
-          break;
-        }
-
-        this.logger.error({ err }, 'Error writing RecorderIO output buffer');
-      }
+      this.enqueue({ kind: 'flush', until: settled });
     }
   }
 
@@ -295,131 +405,49 @@ export class RecorderIO {
   }
 
   /**
-   * Resample and mix frames to mono Float32
+   * Interleave one settled block of both channels and stream it to FFmpeg
    */
-  private resampleAndMix(opts: ResampleAndMixOptions): {
-    samples: Float32Array;
-    resampler: AudioResampler | undefined;
-  } {
-    const INV_INT16 = 1.0 / 32768.0;
-    const { frames, flush = false } = opts;
-    let { resampler } = opts;
+  private writePCM(left: Float32Array, right: Float32Array): void {
+    if (left.length === 0) return;
 
-    if (frames.length === 0 && !flush) {
-      return { samples: new Float32Array(0), resampler };
-    }
-
-    if (!resampler && frames.length > 0) {
-      const firstFrame = frames[0]!;
-      resampler = new AudioResampler(firstFrame.sampleRate, this.sampleRate, firstFrame.channels);
-    }
-
-    const resampledFrames: AudioFrame[] = [];
-    for (const frame of frames) {
-      if (resampler) {
-        resampledFrames.push(...resampler.push(frame));
-      }
-    }
-
-    if (flush && resampler) {
-      resampledFrames.push(...resampler.flush());
-    }
-
-    const totalSamples = resampledFrames.reduce((acc, frame) => acc + frame.samplesPerChannel, 0);
-    const samples = new Float32Array(totalSamples);
-
-    let pos = 0;
-    for (const frame of resampledFrames) {
-      const data = frame.data;
-      const numChannels = frame.channels;
-      for (let i = 0; i < frame.samplesPerChannel; i++) {
-        let sum = 0;
-        for (let ch = 0; ch < numChannels; ch++) {
-          sum += data[i * numChannels + ch]!;
-        }
-        samples[pos++] = (sum / numChannels) * INV_INT16;
-      }
-    }
-
-    return { samples, resampler };
-  }
-
-  /**
-   * Write PCM chunk to FFmpeg stream
-   */
-  private writePCM(leftSamples: Float32Array, rightSamples: Float32Array): void {
     if (!this.pcmStream) {
       this.startFFmpeg();
     }
 
-    // Handle length mismatch by prepending silence
-    if (leftSamples.length !== rightSamples.length) {
-      const diff = Math.abs(leftSamples.length - rightSamples.length);
-      if (leftSamples.length < rightSamples.length) {
-        this.logger.warn(
-          `Input is shorter by ${diff} samples; silence has been prepended to align the input channel.`,
-        );
-        const padded = new Float32Array(rightSamples.length);
-        padded.set(leftSamples, diff);
-        leftSamples = padded;
-      } else {
-        const padded = new Float32Array(leftSamples.length);
-        padded.set(rightSamples, diff);
-        rightSamples = padded;
-      }
-    }
-
-    const maxLen = Math.max(leftSamples.length, rightSamples.length);
-    if (maxLen <= 0) return;
-
-    // Interleave stereo samples and convert back to Int16
-    const stereoData = new Int16Array(maxLen * 2);
-    for (let i = 0; i < maxLen; i++) {
-      stereoData[i * 2] = Math.max(
-        -32768,
-        Math.min(32767, Math.round((leftSamples[i] ?? 0) * 32768)),
-      );
-      stereoData[i * 2 + 1] = Math.max(
-        -32768,
-        Math.min(32767, Math.round((rightSamples[i] ?? 0) * 32768)),
-      );
+    const stereoData = new Int16Array(left.length * 2);
+    for (let i = 0; i < left.length; i++) {
+      stereoData[i * 2] = Math.max(-32768, Math.min(32767, Math.round(left[i]! * 32768)));
+      stereoData[i * 2 + 1] = Math.max(-32768, Math.min(32767, Math.round(right[i]! * 32768)));
     }
 
     this.pcmStream!.write(Buffer.from(stereoData.buffer));
   }
 
   /**
-   * Encode task: read from channels, mix to stereo, stream to FFmpeg
+   * Encode task: place audio on the timeline, then hand each settled window to FFmpeg
    */
   private async encode(): Promise<void> {
-    if (!this._outputPath) return;
+    if (!this._outputPath || this.t0 === undefined) return;
 
-    const inReader = this.inChan.stream().getReader();
-    const outReader = this.outChan.stream().getReader();
+    const tracks = [new Track(this.sampleRate, this.t0), new Track(this.sampleRate, this.t0)];
+    let cursor = 0;
+    const reader = this.chan.stream().getReader();
 
     try {
       while (true) {
-        const [inResult, outResult] = await Promise.all([inReader.read(), outReader.read()]);
+        const { done, value } = await reader.read();
+        if (done) break;
 
-        if (inResult.done || outResult.done) {
-          break;
+        if (value.kind === 'captured') {
+          tracks[value.channel]!.push(value.startedAt, value.frame);
+          continue;
         }
 
-        const inputBuf = inResult.value;
-        const outputBuf = outResult.value;
+        const end = Math.round(((value.until - this.t0) / 1000) * this.sampleRate);
+        if (end <= cursor) continue;
 
-        const inMixed = this.resampleAndMix({ frames: inputBuf, resampler: this.inResampler });
-        this.inResampler = inMixed.resampler;
-
-        const outMixed = this.resampleAndMix({
-          frames: outputBuf,
-          resampler: this.outResampler,
-          flush: outputBuf.length > 0,
-        });
-        this.outResampler = outMixed.resampler;
-
-        // Stream PCM data directly to FFmpeg
-        this.writePCM(inMixed.samples, outMixed.samples);
+        this.writePCM(tracks[0]!.take(cursor, end), tracks[1]!.take(cursor, end));
+        cursor = end;
       }
 
       // Close FFmpeg stream and wait for encoding to complete
@@ -431,10 +459,19 @@ export class RecorderIO {
       this.logger.error({ err }, 'Error in encode task');
     } finally {
       try {
-        inReader.releaseLock();
-        outReader.releaseLock();
-        this.inResampler?.close();
-        this.outResampler?.close();
+        reader.releaseLock();
+        for (const [channel, track] of [
+          ['input', tracks[0]!],
+          ['output', tracks[1]!],
+        ] as const) {
+          if (track.droppedSamples) {
+            this.logger.warn(
+              { channel, samples: track.droppedSamples },
+              'recorder dropped audio that reached it after its place in the timeline had been written',
+            );
+          }
+          track.close();
+        }
       } finally {
         if (!this.closeFuture.done) {
           this.closeFuture.resolve();
@@ -447,72 +484,25 @@ export class RecorderIO {
 class RecorderAudioInput extends AudioInput {
   private source: AudioInput;
   private recorderIO: RecorderIO;
-  private accFrames: AudioFrame[] = [];
-  private _startedWallTime?: number;
-  private _padded: boolean = false;
-  private logger = log();
+  private onFrame: (startedAt: number, frame: AudioFrame) => void;
 
-  constructor(recorderIO: RecorderIO, source: AudioInput) {
+  constructor(
+    recorderIO: RecorderIO,
+    source: AudioInput,
+    onFrame: (startedAt: number, frame: AudioFrame) => void,
+  ) {
     super();
     this.recorderIO = recorderIO;
     this.source = source;
+    this.onFrame = onFrame;
 
     // Set up the intercepting stream
     this.multiStream.addInputStream(this.createInterceptingStream());
   }
 
   /**
-   * Wall-clock time when the first frame was captured
-   */
-  get startedWallTime(): number | undefined {
-    return this._startedWallTime;
-  }
-
-  /**
-   * Take accumulated frames and clear the buffer
-   * @param padSince - If provided and input started after this time, pad with silence
-   */
-  takeBuf(padSince?: number): AudioFrame[] {
-    let frames = this.accFrames;
-    this.accFrames = [];
-
-    if (
-      padSince !== undefined &&
-      this._startedWallTime !== undefined &&
-      this._startedWallTime > padSince &&
-      !this._padded &&
-      frames.length > 0
-    ) {
-      const padding = this._startedWallTime - padSince;
-      this.logger.warn(
-        {
-          lastAgentSpeechTime: padSince,
-          inputStartedTime: this._startedWallTime,
-        },
-        'input speech started after last agent speech ended',
-      );
-      this._padded = true;
-      const firstFrame = frames[0]!;
-      frames = [createSilenceFrame(padding, firstFrame.sampleRate, firstFrame.channels), ...frames];
-    } else if (
-      padSince !== undefined &&
-      this._startedWallTime === undefined &&
-      !this._padded &&
-      frames.length === 0
-    ) {
-      // We could pad with silence here with some fixed SR and channels,
-      // but it's better for the user to know that this is happening
-      this.logger.warn(
-        "input speech hasn't started yet, skipping silence padding, recording may be inaccurate until the speech starts",
-      );
-    }
-
-    return frames;
-  }
-
-  /**
    * Creates a stream that intercepts frames from the source,
-   * accumulates them when recording, and passes them through unchanged.
+   * hands them to the recorder when recording, and passes them through unchanged.
    */
   private createInterceptingStream(): ReadableStream<AudioFrame> {
     const sourceStream = this.source.stream;
@@ -520,12 +510,10 @@ class RecorderAudioInput extends AudioInput {
 
     const transform = new TransformStream<AudioFrame, AudioFrame>({
       transform: (frame, controller) => {
-        // Accumulate frames when recording is active
         if (this.recorderIO.recording) {
-          if (this._startedWallTime === undefined) {
-            this._startedWallTime = Date.now();
-          }
-          this.accFrames.push(frame);
+          // frames carry no capture timestamp, so arrival is the clock
+          const duration = (frame.samplesPerChannel / frame.sampleRate) * 1000;
+          this.onFrame(Date.now() - duration, frame);
         }
 
         controller.enqueue(frame);
@@ -582,6 +570,8 @@ class RecorderAudioInput extends AudioInput {
 
 interface RecorderOutputSegment {
   frames: AudioFrame[];
+  /** The segment's frames joined, built on the first slice and dropped by the next capture. */
+  pcm?: Int16Array;
   acceptedDownstream: boolean;
   captureFailed: boolean;
   capturesInFlight: number;
@@ -597,75 +587,58 @@ interface RecorderOutputSegment {
   playoutAwaited: boolean;
   playbackEvent?: PlaybackFinishedEvent;
   /** Wall-clock time the segment was opened, i.e. when its first frame entered `captureFrame`. */
-  speechStartTime: number;
-  currentPauseStart?: number;
-  pauseWallTimes: Array<[number, number]>;
+  segmentSince: number;
+  /** When the sink said this segment began to play, if it said so at all. */
+  startedAt?: number;
+  /** Whether the sink reported where any of this segment's audio went. */
+  reported: boolean;
 }
 
 class RecorderAudioOutput extends AudioOutput {
   private recorderIO: RecorderIO;
-  private writeFn: (buf: AudioFrame[]) => void;
+  private onPlayed: (startedAt: number, frame: AudioFrame) => void;
   private segments: RecorderOutputSegment[] = [];
   private currentSegment?: RecorderOutputSegment;
   private deferredFinishes: PlaybackFinishedEvent[] = [];
-  private _startedWallTime?: number;
-  private currentPauseStart?: number;
-  private pauseWallTimes: Array<[number, number]> = [];
   private _logger = log();
-
-  _lastSpeechEndTime?: number;
 
   constructor(
     recorderIO: RecorderIO,
     audioOutput: AudioOutput,
-    writeFn: (buf: AudioFrame[]) => void,
+    onPlayed: (startedAt: number, frame: AudioFrame) => void,
   ) {
     super(audioOutput.sampleRate, audioOutput, { pause: true });
     this.recorderIO = recorderIO;
-    this.writeFn = writeFn;
-  }
-
-  get startedWallTime(): number | undefined {
-    return this._startedWallTime;
+    this.onPlayed = onPlayed;
   }
 
   get hasPendingData(): boolean {
     return this.segments.some((segment) => segment.frames.length > 0);
   }
 
-  pause(): void {
-    if (this.currentPauseStart === undefined && this.recorderIO.recording) {
-      this.currentPauseStart = Date.now();
-    }
+  /** Wall time from which the agent channel is unsettled, while a segment is in flight. */
+  get pendingSince(): number | undefined {
+    return this.segments[0]?.segmentSince;
+  }
 
-    const segment = this.currentSegment ?? this.segments.at(-1);
-    if (segment && segment.currentPauseStart === undefined && this.recorderIO.recording) {
-      segment.currentPauseStart = this.currentPauseStart;
-    }
+  onPlaybackStarted(createdAt: number): void {
+    super.onPlaybackStarted(createdAt);
 
-    if (this.nextInChain) {
-      this.nextInChain.pause();
+    const segment = this.segments[0];
+    if (segment && segment.startedAt === undefined) {
+      segment.startedAt = createdAt;
     }
   }
 
-  /**
-   * Resume playback and record the pause interval
-   */
-  resume(): void {
-    const resumedAt = Date.now();
-    if (this.currentPauseStart !== undefined && this.recorderIO.recording) {
-      this.pauseWallTimes.push([this.currentPauseStart, resumedAt]);
-      this.currentPauseStart = undefined;
-    }
+  onPlaybackProgressed(ev: PlaybackProgressedEvent): void {
+    super.onPlaybackProgressed(ev);
 
-    const segment = this.currentSegment ?? this.segments.at(-1);
-    if (segment?.currentPauseStart !== undefined && this.recorderIO.recording) {
-      segment.pauseWallTimes.push([segment.currentPauseStart, resumedAt]);
-      segment.currentPauseStart = undefined;
-    }
-
-    if (this.nextInChain) {
-      this.nextInChain.resume();
+    // A report describes the audio playing now, which belongs to the oldest segment we have not
+    // settled — the same attribution `drainFinishes` gives a finish.
+    const segment = this.segments[0];
+    if (segment && this.recorderIO.recording) {
+      segment.reported = true;
+      this.place(segment, ev.startedAt, ev.offset, ev.duration);
     }
   }
 
@@ -772,127 +745,53 @@ class RecorderAudioOutput extends AudioOutput {
       }
     }
 
-    const finishTime = segment.currentPauseStart ?? Date.now();
-    const trailingSilenceDuration = Math.max(0, Date.now() - finishTime);
+    segment.playbackEvent = options;
+    super.onPlaybackFinished(options);
 
-    // Convert playbackPosition from seconds to ms for internal calculations
-    let playbackPosition = options.playbackPosition * 1000;
-
-    // Clamp playbackPosition to actual elapsed time (all in ms)
-    playbackPosition = Math.max(
-      0,
-      Math.min(finishTime - segment.speechStartTime, playbackPosition),
-    );
-
-    // Convert back to seconds for the event
-    segment.playbackEvent = { ...options, playbackPosition: playbackPosition / 1000 };
-    super.onPlaybackFinished(segment.playbackEvent);
-
-    if (!this.recorderIO.recording) {
+    if (!this.recorderIO.recording || segment.reported) {
       return;
     }
 
-    if (segment.currentPauseStart !== undefined) {
-      segment.pauseWallTimes.push([segment.currentPauseStart, finishTime]);
-      segment.currentPauseStart = undefined;
-    }
+    // the sink reports nothing of its own, so its endpoints describe the segment
+    const playbackPosition = options.playbackPosition * 1000;
+    this.place(segment, segment.startedAt ?? Date.now() - playbackPosition, 0, playbackPosition);
+  }
 
-    if (segment.frames.length === 0) {
-      this._lastSpeechEndTime = Date.now();
+  /** Hand the recorder the captured audio a report covers, at the time it played. */
+  private place(
+    segment: RecorderOutputSegment,
+    startedAt: number,
+    offset: number,
+    duration: number,
+  ): void {
+    if (segment.frames.length === 0 || duration <= 0) {
       return;
     }
 
-    // pauseEvents stores (position, duration) in ms
-    const pauseEvents: Array<[number, number]> = [];
-    let playbackStartTime = finishTime - playbackPosition;
-
-    if (segment.pauseWallTimes.length > 0) {
-      const totalPauseDuration = segment.pauseWallTimes.reduce(
-        (sum, [start, end]) => sum + (end - start),
-        0,
+    const { sampleRate, channels } = segment.frames[0]!;
+    if (!segment.pcm) {
+      const pcm = new Int16Array(
+        segment.frames.reduce((count, frame) => count + frame.data.length, 0),
       );
-      playbackStartTime = finishTime - playbackPosition - totalPauseDuration;
-
-      let accumulatedPause = 0;
-      for (const [pauseStart, pauseEnd] of segment.pauseWallTimes) {
-        let position = pauseStart - playbackStartTime - accumulatedPause;
-        const duration = pauseEnd - pauseStart;
-        position = Math.max(0, Math.min(position, playbackPosition));
-        pauseEvents.push([position, duration]);
-        accumulatedPause += duration;
+      let pos = 0;
+      for (const frame of segment.frames) {
+        pcm.set(frame.data, pos);
+        pos += frame.data.length;
       }
+      segment.pcm = pcm;
     }
 
-    const buf: AudioFrame[] = [];
-    let accDur = 0;
-    const sampleRate = segment.frames[0]!.sampleRate;
-    const numChannels = segment.frames[0]!.channels;
-
-    let pauseIdx = 0;
-    let shouldBreak = false;
-
-    for (const frame of segment.frames) {
-      let currentFrame = frame;
-      const frameDuration = (frame.samplesPerChannel / frame.sampleRate) * 1000;
-
-      if (frameDuration + accDur > playbackPosition) {
-        const [left] = splitFrame(currentFrame, (playbackPosition - accDur) / 1000);
-        currentFrame = left;
-        shouldBreak = true;
-      }
-
-      // Process any pauses before this frame starts
-      while (pauseIdx < pauseEvents.length && pauseEvents[pauseIdx]![0] <= accDur) {
-        const [, pauseDur] = pauseEvents[pauseIdx]!;
-        buf.push(createSilenceFrame(pauseDur, sampleRate, numChannels));
-        pauseIdx++;
-      }
-
-      // Process any pauses within this frame
-      const currentFrameDuration =
-        (currentFrame.samplesPerChannel / currentFrame.sampleRate) * 1000;
-      while (
-        pauseIdx < pauseEvents.length &&
-        pauseEvents[pauseIdx]![0] < accDur + currentFrameDuration
-      ) {
-        const [pausePos, pauseDur] = pauseEvents[pauseIdx]!;
-        const [left, right] = splitFrame(currentFrame, (pausePos - accDur) / 1000);
-        buf.push(left);
-        accDur += (left.samplesPerChannel / left.sampleRate) * 1000;
-        buf.push(createSilenceFrame(pauseDur, sampleRate, numChannels));
-
-        currentFrame = right;
-        pauseIdx++;
-      }
-
-      buf.push(currentFrame);
-      accDur += (currentFrame.samplesPerChannel / currentFrame.sampleRate) * 1000;
-
-      if (shouldBreak) {
-        break;
-      }
+    const lo = Math.round((offset / 1000) * sampleRate) * channels;
+    const hi = Math.min(
+      Math.round(((offset + duration) / 1000) * sampleRate) * channels,
+      segment.pcm.length,
+    );
+    if (hi <= lo) {
+      return;
     }
 
-    // Process remaining pauses
-    while (pauseIdx < pauseEvents.length) {
-      const [pausePos, pauseDur] = pauseEvents[pauseIdx]!;
-      if (pausePos <= playbackPosition) {
-        buf.push(createSilenceFrame(pauseDur, sampleRate, numChannels));
-      }
-      pauseIdx++;
-    }
-
-    // Filter out empty frames from split operations to avoid spurious buffer writes
-    const filteredBuf = buf.filter((f) => f.samplesPerChannel > 0);
-
-    if (filteredBuf.length > 0) {
-      if (trailingSilenceDuration > 0) {
-        filteredBuf.push(createSilenceFrame(trailingSilenceDuration, sampleRate, numChannels));
-      }
-      this.writeFn(filteredBuf);
-    }
-
-    this._lastSpeechEndTime = Date.now();
+    const chunk = segment.pcm.slice(lo, hi);
+    this.onPlayed(startedAt, new AudioFrame(chunk, sampleRate, channels, chunk.length / channels));
   }
 
   async captureFrame(frame: AudioFrame): Promise<void> {
@@ -907,14 +806,6 @@ class RecorderAudioOutput extends AudioOutput {
     const startedNewSegment = this.capturedPlayoutSegments > capturedBefore;
     let segment = this.currentSegment;
     if (startedNewSegment) {
-      const captureTime = Date.now();
-      this.pauseWallTimes = this.pauseWallTimes
-        .filter(([, end]) => end > captureTime)
-        .map(([start, end]) => [Math.max(start, captureTime), end]);
-      if (this.currentPauseStart !== undefined) {
-        this.currentPauseStart = Math.max(this.currentPauseStart, captureTime);
-      }
-
       segment = {
         frames: [],
         acceptedDownstream: this.nextInChain === undefined,
@@ -923,16 +814,12 @@ class RecorderAudioOutput extends AudioOutput {
         finishRequested: false,
         flushed: false,
         playoutAwaited: false,
+        reported: false,
         // Stamped here, before the frame leaves, rather than once the downstream output accepts
-        // it. A downstream output may park the frame (the `ParticipantAudioOutput` pause gate)
-        // and a finish can land while it is parked. `finishSegment` clamps the reported playback
-        // position against `finishTime - speechStartTime`, so a timestamp taken after the park
-        // would make the elapsed window ~zero (negative if we are still paused, since
-        // `finishTime` is then the pause start) and truncate away every frame the sink just
-        // reported as played.
-        speechStartTime: captureTime,
-        currentPauseStart: this.currentPauseStart,
-        pauseWallTimes: [...this.pauseWallTimes],
+        // it. A downstream output may park the frame (the `ParticipantAudioOutput` pause gate),
+        // and the recorder holds the timeline open from this moment: audio that is about to play
+        // must not be written off as silence while the sink is still deciding where it went.
+        segmentSince: Date.now(),
       };
       this.segments.push(segment);
       this.currentSegment = segment;
@@ -955,10 +842,7 @@ class RecorderAudioOutput extends AudioOutput {
 
       if (this.recorderIO.recording) {
         segment.frames.push(frame);
-      }
-
-      if (this._startedWallTime === undefined) {
-        this._startedWallTime = Date.now();
+        segment.pcm = undefined;
       }
 
       captureCompleted = true;
@@ -1058,41 +942,4 @@ class RecorderAudioOutput extends AudioOutput {
       this.nextInChain.clearBuffer();
     }
   }
-}
-
-/**
- * Split an audio frame at the given position (in seconds)
- * Returns [left, right] frames
- */
-function splitFrame(frame: AudioFrame, position: number): [AudioFrame, AudioFrame] {
-  if (position <= 0) {
-    const emptyFrame = new AudioFrame(new Int16Array(0), frame.sampleRate, frame.channels, 0);
-    return [emptyFrame, frame];
-  }
-
-  const frameDuration = frame.samplesPerChannel / frame.sampleRate;
-  if (position >= frameDuration) {
-    const emptyFrame = new AudioFrame(new Int16Array(0), frame.sampleRate, frame.channels, 0);
-    return [frame, emptyFrame];
-  }
-
-  // samplesNeeded is samples per channel (i.e., sample count in time)
-  const samplesNeeded = Math.min(Math.floor(position * frame.sampleRate), frame.samplesPerChannel);
-  // Int16Array: each element is one sample, interleaved by channel
-  // So total elements = samplesPerChannel * channels
-  const numChannels = frame.channels;
-
-  const leftData = frame.data.slice(0, samplesNeeded * numChannels);
-  const rightData = frame.data.slice(samplesNeeded * numChannels);
-
-  const leftFrame = new AudioFrame(leftData, frame.sampleRate, frame.channels, samplesNeeded);
-
-  const rightFrame = new AudioFrame(
-    rightData,
-    frame.sampleRate,
-    frame.channels,
-    frame.samplesPerChannel - samplesNeeded,
-  );
-
-  return [leftFrame, rightFrame];
 }

--- a/agents/src/voice/room_io/_output.test.ts
+++ b/agents/src/voice/room_io/_output.test.ts
@@ -2,13 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { AudioFrame, LocalAudioTrack, TrackPublishOptions, TrackSource } from '@livekit/rtc-node';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ATTRIBUTE_TRANSCRIPTION_EXPRESSION,
   ATTRIBUTE_TRANSCRIPTION_FINAL,
 } from '../../constants.js';
 import { TranscriptMarkupStripper } from '../../tts/provider_format.js';
 import { Future } from '../../utils.js';
+import type { PlaybackProgressedEvent } from '../io.js';
 import { ParticipantAudioOutput, ParticipantTranscriptionOutput } from './_output.js';
 
 type CaptureFrameArg = Parameters<ParticipantAudioOutput['captureFrame']>[0];
@@ -598,6 +599,206 @@ describe('ParticipantAudioOutput discarded audio accounting', () => {
       playbackPosition: nextFrame.samplesPerChannel / nextFrame.sampleRate,
     });
     expect(onPlaybackFinished).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * The room sink reports where its audio actually went.
+ *
+ * Playback is continuous between discontinuities, so an event exists to describe a boundary: the
+ * source queue drained, the queue was cleared, or the segment finished.
+ */
+describe('ParticipantAudioOutput playback progress', () => {
+  type ProgressOutput = TestParticipantAudioOutput & {
+    runOffset: number;
+    dryAt?: number;
+    onPlaybackProgressed: (ev: PlaybackProgressedEvent) => void;
+  };
+
+  function makeProgressOutput(source: QueuedAudioSource) {
+    const output = makeTestOutput(source) as ProgressOutput;
+    output.runOffset = 0;
+    const progress: PlaybackProgressedEvent[] = [];
+    output.onPlaybackProgressed = (ev) => progress.push(ev);
+    return { output, progress };
+  }
+
+  beforeEach(() => {
+    // only Date is faked: the tests still rely on real microtask and timer scheduling
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(100_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const advance = (ms: number) => vi.setSystemTime(Date.now() + ms);
+
+  it('reports uninterrupted playback once', async () => {
+    const source = new QueuedAudioSource();
+    const { output, progress } = makeProgressOutput(source);
+
+    source.queuedDuration = 500; // a backlog the clock never catches up with
+    for (let i = 0; i < 3; i++) {
+      await output.captureFrame(audioFrame(100));
+      advance(100);
+    }
+
+    expect(progress, 'nothing to report while playback is continuous').toEqual([]);
+
+    output.flush();
+    await output.waitForPlayout();
+
+    expect(progress).toHaveLength(1);
+    expect(progress[0]!.offset).toBe(0);
+    expect(progress[0]!.duration).toBeCloseTo(300);
+  });
+
+  it('ends a drained run when the source ran dry, not when we noticed', async () => {
+    const source = new QueuedAudioSource();
+    const { output, progress } = makeProgressOutput(source);
+
+    await output.captureFrame(audioFrame(200));
+    const dryAt = output.dryAt!;
+
+    source.queuedDuration = 0;
+    vi.setSystemTime(dryAt + 500); // the next audio arrives half a second after the source ran out
+    await output.captureFrame(audioFrame(100));
+
+    expect(progress).toHaveLength(1);
+    expect(progress[0]!.offset).toBe(0);
+    expect(progress[0]!.duration).toBeCloseTo(200);
+    // the run ended when the queue emptied, not when the next push revealed it
+    expect(progress[0]!.startedAt).toBeCloseTo(dryAt - 200);
+  });
+
+  it('ends a run at the moment the source ran dry when the flush trails it', async () => {
+    const source = new QueuedAudioSource();
+    const { output, progress } = makeProgressOutput(source);
+
+    await output.captureFrame(audioFrame(200));
+    const dryAt = output.dryAt!;
+
+    source.queuedDuration = 0;
+    vi.setSystemTime(dryAt + 700); // the flush arrives long after the last audio played
+    output.flush();
+    await output.waitForPlayout();
+
+    expect(progress).toHaveLength(1);
+    expect(progress[0]!.offset).toBe(0);
+    expect(progress[0]!.duration).toBeCloseTo(200);
+    expect(progress[0]!.startedAt).toBeCloseTo(dryAt - 200);
+  });
+
+  it('leaves a hole rather than a short tail when the queue is cleared', async () => {
+    const source = new QueuedAudioSource();
+    const { output, progress } = makeProgressOutput(source);
+
+    await output.captureFrame(audioFrame(500));
+    advance(300);
+    source.queuedDuration = 200; // 0.2s queued and about to be thrown away
+
+    output.pause();
+    const held = output.captureFrame(audioFrame(100));
+    await nextTick(); // the capture notices the pause and clears the queue
+    expect(source.clearCount).toBe(1);
+
+    expect(progress).toHaveLength(1);
+    expect(progress[0]!.offset).toBe(0);
+    expect(progress[0]!.duration).toBeCloseTo(300);
+    // the next run resumes past the discarded audio rather than replaying it
+    expect(output.runOffset).toBeCloseTo(500);
+
+    output.resume();
+    await held;
+  });
+
+  it('reports two runs around the hole a pause leaves', async () => {
+    const source = new QueuedAudioSource();
+    const { output, progress } = makeProgressOutput(source);
+
+    await output.captureFrame(audioFrame(500));
+    advance(300);
+    source.queuedDuration = 200;
+
+    output.pause();
+    const held = output.captureFrame(audioFrame(500));
+    await nextTick();
+
+    advance(1000); // the agent stays silent while the user speaks
+    const resumedAt = Date.now();
+    source.queuedDuration = 2000; // a backlog the clock never catches up with
+    output.resume();
+    await held;
+
+    advance(1000); // the resumed audio plays out
+    output.flush();
+    await output.waitForPlayout();
+
+    expect(progress).toHaveLength(2);
+    const [first, second] = progress as [PlaybackProgressedEvent, PlaybackProgressedEvent];
+    expect(first.offset).toBe(0);
+    expect(first.duration).toBeCloseTo(300);
+    // the second run resumes past the discarded audio, and only after playback came back
+    expect(second.offset).toBeCloseTo(500);
+    expect(second.startedAt).toBeGreaterThan(resumedAt);
+    expect(second.startedAt).toBeGreaterThan(first.startedAt + first.duration);
+  });
+
+  it('reports the run once when a pause is followed by an interruption', async () => {
+    const source = new QueuedAudioSource();
+    const { output, progress } = makeProgressOutput(source);
+
+    await output.captureFrame(audioFrame(500));
+    source.queuedDuration = 200;
+
+    output.pause();
+    const held = output.captureFrame(audioFrame(100));
+    await nextTick();
+    expect(progress).toHaveLength(1);
+
+    // the pause already ended the run; the interruption has nothing left to add
+    output.flush();
+    output.clearBuffer();
+    await held;
+    await output.waitForPlayout();
+
+    expect(progress).toHaveLength(1);
+    expect(progress[0]!.duration).toBeCloseTo(300);
+  });
+
+  it('ends the run at the playhead when playback is interrupted', async () => {
+    const source = new QueuedAudioSource();
+    const { output, progress } = makeProgressOutput(source);
+
+    await output.captureFrame(audioFrame(500));
+    source.queuedDuration = 150; // queued and about to be dropped
+
+    output.flush();
+    output.clearBuffer();
+    await output.waitForPlayout();
+
+    expect(progress).toHaveLength(1);
+    expect(progress[0]!.duration).toBeCloseTo(350);
+  });
+
+  it('restarts offsets with each segment', async () => {
+    const source = new QueuedAudioSource();
+    const { output, progress } = makeProgressOutput(source);
+
+    for (let i = 0; i < 2; i++) {
+      source.queuedDuration = 500;
+      await output.captureFrame(audioFrame(200));
+      output.flush();
+      await output.waitForPlayout();
+      advance(1000);
+    }
+
+    expect(progress.map((ev) => ev.offset)).toEqual([0, 0]);
+    for (const ev of progress) {
+      expect(ev.duration).toBeCloseTo(200);
+    }
   });
 });
 

--- a/agents/src/voice/room_io/_output.ts
+++ b/agents/src/voice/room_io/_output.ts
@@ -519,6 +519,12 @@ export class ParticipantAudioOutput extends AudioOutput {
   private firstFrameEmitted: boolean = false;
   /** Gate held closed while the output is paused; frame forwarding awaits it. */
   private playbackEnabledFuture: Future<void> = new Future();
+  /**
+   * The playhead sits at `sourcePushedDuration` minus what the source still holds; `dryAt` is
+   * when the source runs out if nothing more is pushed, which dates a run that has ended.
+   */
+  private runOffset: number = 0;
+  private dryAt?: number;
 
   constructor(room: Room, options: AudioOutputOptions) {
     super(options.sampleRate, undefined, { pause: true });
@@ -549,6 +555,24 @@ export class ParticipantAudioOutput extends AudioOutput {
 
   get subscribed(): boolean {
     return this.startedFuture.done;
+  }
+
+  /** Report the open run, and begin the next past any audio that never played. */
+  private reportRun(opts: { offset: number; endedAt: number; resumesAt?: number }): void {
+    const { offset, resumesAt } = opts;
+    // a run cannot outlast the audio the source held, however late the caller noticed
+    const endedAt = this.dryAt !== undefined ? Math.min(opts.endedAt, this.dryAt) : opts.endedAt;
+
+    const duration = offset - this.runOffset;
+    if (duration > 0) {
+      this.onPlaybackProgressed({
+        startedAt: endedAt - duration,
+        offset: this.runOffset,
+        duration,
+      });
+    }
+    this.runOffset = resumesAt ?? offset;
+    this.dryAt = undefined;
   }
 
   async start(signal: AbortSignal): Promise<void> {
@@ -589,6 +613,12 @@ export class ParticipantAudioOutput extends AudioOutput {
       while (!this.playbackEnabledFuture.done) {
         const queuedDuration = this.audioSource.queuedDuration;
         this.sourceDiscardedDuration += queuedDuration / 1000;
+        // the dropped queue never plays, so the next run resumes past it
+        this.reportRun({
+          offset: this.sourcePushedDuration * 1000 - queuedDuration,
+          endedAt: Date.now(),
+          resumesAt: this.sourcePushedDuration * 1000,
+        });
         this.audioSource.clearQueue();
         await Promise.race([this.playbackEnabledFuture.await, interruptionFuture.await]);
         if (interruptionGeneration !== this.interruptionGeneration || interruptionFuture.done) {
@@ -601,8 +631,14 @@ export class ParticipantAudioOutput extends AudioOutput {
         this.onPlaybackStarted(Date.now());
       }
 
+      if (this.dryAt !== undefined && Date.now() >= this.dryAt) {
+        // the source ran out before this frame arrived
+        this.reportRun({ offset: this.sourcePushedDuration * 1000, endedAt: this.dryAt });
+      }
+
       this.sourcePushedDuration += frameDuration;
       await this.audioSource.captureFrame(frame);
+      this.dryAt = Date.now() + this.audioSource.queuedDuration;
     } finally {
       this.forwardingCount--;
       if (this.forwardingCount === 0) {
@@ -624,10 +660,20 @@ export class ParticipantAudioOutput extends AudioOutput {
     let pushedDuration = Math.max(this.sourcePushedDuration - this.sourceDiscardedDuration, 0);
 
     if (interrupted) {
-      pushedDuration = Math.max(pushedDuration - this.audioSource.queuedDuration / 1000, 0);
+      const queuedDuration = this.audioSource.queuedDuration;
+      pushedDuration = Math.max(pushedDuration - queuedDuration / 1000, 0);
+      // the playhead stops where the cleared queue begins
+      this.reportRun({
+        offset: this.sourcePushedDuration * 1000 - queuedDuration,
+        endedAt: Date.now(),
+      });
       this.audioSource.clearQueue();
+    } else {
+      // the source drained, so everything pushed has played
+      this.reportRun({ offset: this.sourcePushedDuration * 1000, endedAt: Date.now() });
     }
 
+    this.runOffset = 0;
     this.pushedDuration = 0;
     this.sourcePushedDuration = 0;
     this.sourceDiscardedDuration = 0;


### PR DESCRIPTION
Ports livekit/agents#6921, merged upstream as `d3621006`.

**Problem**

RecorderIO rebuilds the agent channel by inference.
It collects the frames it forwarded, places them from the moment `playbackFinished` arrives, and pads the difference with silence.
Nothing measures where the audio really went.

Four conditions break that inference: a sink that runs dry mid-segment, a late flush, audio discarded on `pause()`, and a microphone that stops.
Each one moves the audio, and none of them records the gap.
A slow TTS or a muted participant can hit it.

**Fix**

A sink that owns its playback device now reports where its audio went.
`AudioOutput` gains `playbackProgressed` next to `playbackStarted` and `playbackFinished`, and `ParticipantAudioOutput` reports one run at a time.
Each report is past tense, so it is never revised, and a jump in its offset describes audio the sink discarded rather than played.

RecorderIO places both channels on one absolute timeline and leaves unwritten time silent.
When a sink reports nothing, the recorder uses its segment endpoints instead, which is all a remote avatar worker can know.
That removes the pause reconstruction, the end-anchored padding, and the `playbackPosition` truncation.

Two behaviour changes follow from the absolute timeline: `close()` now always writes the settled tail, so a silent session still produces a file, and the recording only extends as far as the wall clock does.

The checked-in `agents.api.md` is stale on `main`, so this change adds only the lines for the new event.
