### PR TITLE
fix(openai): reject TTS bodies that aren't raw PCM

### DIFF
--- a/.changeset/openai-tts-reject-undecodable-audio.md
+++ b/.changeset/openai-tts-reject-undecodable-audio.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+fix(openai): reject TTS bodies that aren't raw PCM instead of playing them as samples, and allow response_format to be set

--- a/plugins/openai/etc/agents-plugin-openai.api.md
+++ b/plugins/openai/etc/agents-plugin-openai.api.md
@@ -1897,14 +1897,17 @@ export interface TTSOptions {
     instructions?: string;
     // (undocumented)
     model: TTSModels | string;
-    // Warning: (ae-forgotten-export) The symbol "TTSResponseFormat" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents-plugin-openai" does not have an export "UNPLAYABLE_CONTENT_TYPES"
     responseFormat?: TTSResponseFormat;
     // (undocumented)
     speed: number;
     // (undocumented)
     voice: TTSVoices;
 }
+
+// Warning: (ae-missing-release-tag) "TTSResponseFormat" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type TTSResponseFormat = NonNullable<OpenAI.Audio.SpeechCreateParams['response_format']>;
 
 // Warning: (ae-missing-release-tag) "TTSVoices" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/openai/etc/agents-plugin-openai.api.md
+++ b/plugins/openai/etc/agents-plugin-openai.api.md
@@ -1897,6 +1897,9 @@ export interface TTSOptions {
     instructions?: string;
     // (undocumented)
     model: TTSModels | string;
+    // Warning: (ae-forgotten-export) The symbol "TTSResponseFormat" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents-plugin-openai" does not have an export "UNPLAYABLE_CONTENT_TYPES"
+    responseFormat?: TTSResponseFormat;
     // (undocumented)
     speed: number;
     // (undocumented)

--- a/plugins/openai/src/index.ts
+++ b/plugins/openai/src/index.ts
@@ -9,7 +9,7 @@ export * from './tools.js';
 export * as realtime from './realtime/index.js';
 export * as responses from './responses/index.js';
 export { STT, type STTOptions } from './stt.js';
-export { ChunkedStream, TTS, type TTSOptions } from './tts.js';
+export { ChunkedStream, TTS, type TTSOptions, type TTSResponseFormat } from './tts.js';
 export * as ws from './ws/index.js';
 
 class OpenAIPlugin extends Plugin {

--- a/plugins/openai/src/tts.test.ts
+++ b/plugins/openai/src/tts.test.ts
@@ -2,9 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { tts } from '@livekit/agents-plugins-test';
-import { describe, it } from 'vitest';
+import { OpenAI } from 'openai';
+import { describe, expect, it } from 'vitest';
 import { STT } from './stt.js';
-import { TTS } from './tts.js';
+import { TTS, type TTSResponseFormat } from './tts.js';
 
 const hasOpenAIApiKey = Boolean(process.env.OPENAI_API_KEY);
 
@@ -17,3 +18,98 @@ if (hasOpenAIApiKey) {
     it.skip('requires OPENAI_API_KEY', () => {});
   });
 }
+
+/** 200ms of 24kHz mono 16-bit PCM. */
+const pcm = Buffer.alloc(9600);
+
+/** The same audio wrapped in a RIFF/WAVE container. */
+const wav = (() => {
+  const h = Buffer.alloc(44);
+  h.write('RIFF', 0);
+  h.writeUInt32LE(36 + pcm.length, 4);
+  h.write('WAVE', 8);
+  h.write('fmt ', 12);
+  h.writeUInt32LE(16, 16);
+  h.writeUInt16LE(1, 20);
+  h.writeUInt16LE(1, 22);
+  h.writeUInt32LE(24000, 24);
+  h.writeUInt32LE(48000, 28);
+  h.writeUInt16LE(2, 32);
+  h.writeUInt16LE(16, 34);
+  h.write('data', 36);
+  h.writeUInt32LE(pcm.length, 40);
+  return Buffer.concat([h, pcm]);
+})();
+
+function ttsAgainst(
+  body: Buffer,
+  contentType: string,
+  opts: {
+    responseFormat?: TTSResponseFormat;
+    onRequest?: (body: { response_format?: string }) => void;
+  } = {},
+): TTS {
+  const client = new OpenAI({
+    apiKey: 'test',
+    baseURL: 'https://compatible.example.com/v1',
+    maxRetries: 0,
+    fetch: async (_url, init) => {
+      opts.onRequest?.(JSON.parse(String((init as RequestInit).body)));
+      return new Response(new Uint8Array(body), {
+        status: 200,
+        headers: { 'content-type': contentType },
+      });
+    },
+  });
+  return new TTS({ client, model: 'kokoro', responseFormat: opts.responseFormat });
+}
+
+async function collect(instance: TTS): Promise<{ audio: Buffer; errors: Error[] }> {
+  // the framework emits `error` before rethrowing; without a listener Node raises ERR_UNHANDLED_ERROR
+  const errors: Error[] = [];
+  instance.on('error', (ev: { error: Error }) => errors.push(ev.error));
+
+  const chunks: Buffer[] = [];
+  for await (const ev of instance.synthesize('hello')) {
+    chunks.push(
+      Buffer.from(ev.frame.data.buffer, ev.frame.data.byteOffset, ev.frame.data.byteLength),
+    );
+  }
+  return { audio: Buffer.concat(chunks), errors };
+}
+
+describe('OpenAI TTS against an OpenAI-compatible endpoint', () => {
+  it('plays a raw pcm body', async () => {
+    const { audio } = await collect(ttsAgainst(pcm, 'audio/pcm'));
+    expect(audio.subarray(0, pcm.length).equals(pcm)).toBe(true);
+  });
+
+  it('still plays a body whose content type is unknown', async () => {
+    const { audio } = await collect(ttsAgainst(pcm, 'application/octet-stream'));
+    expect(audio.subarray(0, pcm.length).equals(pcm)).toBe(true);
+  });
+
+  it('reports an error for a container body instead of playing the header as samples', async () => {
+    const { audio, errors } = await collect(ttsAgainst(wav, 'audio/wav'));
+    expect(audio.length).toBe(0);
+    expect(errors.map((e) => e.message).join()).toMatch(/cannot be played as raw/);
+  });
+
+  it('reports an error for a compressed body', async () => {
+    const { audio, errors } = await collect(ttsAgainst(pcm, 'audio/mpeg'));
+    expect(audio.length).toBe(0);
+    expect(errors.map((e) => e.message).join()).toMatch(/cannot be played as raw/);
+  });
+
+  it('requests pcm by default and honours an override', async () => {
+    let body: { response_format?: string } | undefined;
+
+    await collect(ttsAgainst(pcm, 'audio/pcm', { onRequest: (b) => (body = b) }));
+    expect(body?.response_format).toBe('pcm');
+
+    await collect(
+      ttsAgainst(pcm, 'audio/pcm', { responseFormat: 'wav', onRequest: (b) => (body = b) }),
+    );
+    expect(body?.response_format).toBe('wav');
+  });
+});

--- a/plugins/openai/src/tts.ts
+++ b/plugins/openai/src/tts.ts
@@ -1,13 +1,39 @@
 // SPDX-FileCopyrightText: 2024 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { type APIConnectOptions, AudioByteStream, shortuuid, tts } from '@livekit/agents';
+import { type APIConnectOptions, APIError, AudioByteStream, shortuuid, tts } from '@livekit/agents';
 import type { AudioFrame } from '@livekit/rtc-node';
 import { OpenAI } from 'openai';
 import type { TTSModels, TTSVoices } from './models.js';
 
 const OPENAI_TTS_SAMPLE_RATE = 24000;
 const OPENAI_TTS_CHANNELS = 1;
+
+/** The `response_format` values the OpenAI-compatible speech endpoint accepts. */
+export type TTSResponseFormat = NonNullable<OpenAI.Audio.SpeechCreateParams['response_format']>;
+
+/**
+ * Content types this plugin cannot consume. The response body is written straight into an
+ * `AudioByteStream` as 16-bit samples, so a container or compressed body would be played as
+ * noise. Unknown types (including `application/octet-stream`) are left alone: a compatible
+ * server may return raw PCM without labelling it precisely.
+ */
+const UNPLAYABLE_CONTENT_TYPES = new Set([
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/x-mpeg',
+  'audio/aac',
+  'audio/x-aac',
+  'audio/flac',
+  'audio/x-flac',
+  'audio/wav',
+  'audio/wave',
+  'audio/x-wav',
+  'audio/opus',
+  'audio/ogg',
+  'audio/webm',
+  'audio/mp4',
+]);
 
 export interface TTSOptions {
   model: TTSModels | string;
@@ -17,6 +43,12 @@ export interface TTSOptions {
   baseURL?: string;
   client?: OpenAI;
   apiKey?: string;
+  /**
+   * Format requested from the provider. Defaults to `pcm`, the only format this plugin can
+   * play — it has no decoder. Requesting another format throws once the response arrives,
+   * unless the server ignores the request and answers with PCM anyway.
+   */
+  responseFormat?: TTSResponseFormat;
 }
 
 const defaultTTSOptions: TTSOptions = {
@@ -24,6 +56,7 @@ const defaultTTSOptions: TTSOptions = {
   model: 'tts-1',
   voice: 'alloy',
   speed: 1,
+  responseFormat: 'pcm',
 };
 
 export class TTS extends tts.TTS {
@@ -90,7 +123,7 @@ export class TTS extends tts.TTS {
           model: this.#opts.model,
           voice: this.#opts.voice,
           instructions: this.#opts.instructions,
-          response_format: 'pcm',
+          response_format: this.#opts.responseFormat ?? 'pcm',
           speed: this.#opts.speed,
         },
         { signal },
@@ -127,7 +160,21 @@ export class ChunkedStream extends tts.ChunkedStream {
 
   protected async run() {
     try {
-      const buffer = await this.stream.then((r) => r.arrayBuffer());
+      const response = await this.stream;
+      const contentType = (response.headers.get('content-type') ?? '')
+        .split(';')[0]!
+        .trim()
+        .toLowerCase();
+      if (UNPLAYABLE_CONTENT_TYPES.has(contentType)) {
+        throw new APIError(
+          `openai TTS received '${contentType}', which cannot be played as raw PCM. ` +
+            `This plugin has no decoder, so the body would be emitted as samples. ` +
+            `Request 'pcm' from the provider, or use a TTS plugin for that format.`,
+          { retryable: false },
+        );
+      }
+
+      const buffer = await response.arrayBuffer();
       const requestId = shortuuid();
       const audioByteStream = new AudioByteStream(OPENAI_TTS_SAMPLE_RATE, OPENAI_TTS_CHANNELS);
       const frames = audioByteStream.write(buffer);


### PR DESCRIPTION
Closes #2320.

The plugin asked for `pcm` and then wrote whatever came back into an `AudioByteStream` as 16-bit samples, with no decoder and no look at the response `Content-Type`. Against api.openai.com that's fine. Against an OpenAI-compatible server that doesn't support `pcm`, or ignores `response_format` and answers with its own default, the body is played as audio: a container header becomes a click, and a compressed body becomes noise for the whole utterance. No error, no warning, no retry.

### What this does

Rejects bodies the plugin cannot play, and lets `response_format` be set:

- A `Content-Type` in a small deny set (`audio/mpeg`, `audio/wav`, `audio/ogg`, …) now throws `APIError(..., { retryable: false })` instead of being emitted as samples.
- `responseFormat` is exposed on `TTSOptions`, still defaulting to `pcm`.

The deny set is deliberately a denylist rather than a PCM allowlist. Unknown types  `application/octet-stream` in particular  keep flowing, because a compatible server may return raw PCM without labelling it precisely, and I didn't want to break setups that work today.

### Why this doesn't mirror the Python fix

livekit/agents#6930 fixed the analogous bug by selecting a decoder from the response `Content-Type`. That isn't available here: `agents/src/audio.ts` only exposes file-based ffmpeg helpers (`audioFramesFromFile`), so there's no way to decode a response buffer without building a streaming decoder first. So JS turns silent corruption into a clear error rather than decoding  the behaviour still differs from Python, and closing that gap properly would mean adding a decoder. Happy to look at that separately if it's wanted.

`APIError` with `retryable: false` follows the existing precedent in `plugins/elevenlabs/src/tts.ts`, which does the same content-type check for the same reason, and keeps the failure recognisable to `instanceof APIError` call sites such as `tts/fallback_adapter.ts`.

### Tests

Added to `plugins/openai/src/tts.test.ts`, using a stubbed `fetch` so they run in CI without network or an API key the existing suite in that file requires `OPENAI_API_KEY` and skips without one, which is why this path had no coverage.

Three of the five fail on `main`. Serving a 9644-byte WAV (44-byte RIFF header + 9600 bytes of 24 kHz mono PCM) currently emits 9600 bytes beginning with the ASCII characters `RIFF`.

Also regenerated `etc/agents-plugin-openai.api.md`, since the new public option and type weren't in the report.
