### PR TITLE
fix: include SDK version in session reports

### DIFF
--- a/.changeset/report-sdk-version.md
+++ b/.changeset/report-sdk-version.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Include the JavaScript SDK version in Cloud observability session reports.

--- a/agents/src/telemetry/traces.test.ts
+++ b/agents/src/telemetry/traces.test.ts
@@ -15,6 +15,7 @@ import FormData from 'form-data';
 import { PassThrough } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatContext } from '../llm/chat_context.js';
+import { version } from '../version.js';
 import type { SessionReport } from '../voice/report.js';
 import { SimpleOTLPHttpLogExporter } from './otel_http_exporter.js';
 import {
@@ -411,7 +412,7 @@ describe('uploadSessionReport metadata', () => {
     else process.env.LIVEKIT_API_SECRET = prevSecret;
   });
 
-  it('includes simulation and redaction metadata on exported session-report logs', async () => {
+  it('includes the SDK version, simulation, and redaction metadata on exported session-report logs', async () => {
     const exportSpy = vi
       .spyOn(SimpleOTLPHttpLogExporter.prototype, 'export')
       .mockResolvedValue(undefined);
@@ -434,6 +435,7 @@ describe('uploadSessionReport metadata', () => {
 
     const records = exportSpy.mock.calls[0]?.[0] ?? [];
     expect(records[0]?.attributes).toMatchObject({
+      sdk_version: version,
       'lk.simulation.enabled': true,
       'lk.redaction.enabled': true,
     });

--- a/agents/src/telemetry/traces.ts
+++ b/agents/src/telemetry/traces.ts
@@ -42,6 +42,7 @@ import {
   ATTRIBUTE_SIMULATION_ENABLED,
   recordingEnabled,
 } from '../types.js';
+import { version } from '../version.js';
 import { type SessionReport, sessionReportToJSON } from '../voice/report.js';
 import { type SimpleLogRecord, SimpleOTLPHttpLogExporter } from './otel_http_exporter.js';
 import { flushPinoLogs, initPinoCloudExporter } from './pino_otel_transport.js';
@@ -608,6 +609,7 @@ export async function uploadSessionReport(options: {
       'session.options': serializeSessionOptions(report.options),
       'session.report_timestamp': report.timestamp,
       agent_name: agentName,
+      sdk_version: version,
       usage,
     },
   });


### PR DESCRIPTION
**Problem:** JS serialized `sdk_version` locally but omitted it from the OTLP session-report record sent to Cloud. Observability exports could not identify the deployed SDK.

**Behavior:** Cloud session reports now include the package version, matching Python. A regression test covers the exported log record.

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> Can you investigate /Users/chenghao/Downloads/observability-RM_TWnirUbYjseD.zip
>
> Specifically why the agent turn started at Aug 24, 2026, 9:30:18.688 PM was not interrupted (by a new user input at Aug 24, 2026, 9:30:25.817 PM), and was delayed by ~10s instead?
>
> so we are not reporting sdk version in session report like Python does?
>
> okay, we should fix that. Can you create a PR for that?
>
> skip linear ticket for now

</details>
