### PR TITLE
fix(voice): ignore stale speech state cleanup

### DIFF
--- a/.changeset/stale-speeches-listen.md
+++ b/.changeset/stale-speeches-listen.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Prevent delayed cleanup from an interrupted reply from marking the agent as listening while a newer reply is speaking.

--- a/.changeset/stale-speeches-listen.md
+++ b/.changeset/stale-speeches-listen.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-Prevent delayed cleanup from an interrupted reply from marking the agent as listening while a newer reply is speaking.
+Prevent delayed cleanup from an interrupted reply from overwriting the agent state owned by a newer reply.

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -507,6 +507,7 @@ describe('AgentActivity - mainTask', () => {
 
 type FalseInterruptionActivity = {
   pausedSpeech?: { handle: SpeechHandle; agentState: 'speaking'; timeout: number };
+  agentStateOwner?: { activity: unknown; speechHandle: SpeechHandle };
   _currentSpeech?: SpeechHandle;
   falseInterruptionTimer?: NodeJS.Timeout;
   falseInterruptionPending: boolean;
@@ -568,6 +569,7 @@ function falseInterruptionActivity(endOfTurnTask?: Task<void>): FalseInterruptio
     logger: { debug: vi.fn() },
   });
   activity.agentSession._activity = activity;
+  activity.agentStateOwner = { activity, speechHandle: handle };
   return activity;
 }
 
@@ -802,13 +804,15 @@ describe('AgentActivity - speech completion', () => {
     const audioRecognition = {
       onEndOfAgentSpeech: vi.fn(async () => {}),
     };
+    const speechHandle = {
+      done: () => true,
+    } as SpeechHandle;
     const fakeActivity = {
       speechQueue: {
         peek: () => undefined,
       },
-      _currentSpeech: {
-        done: () => true,
-      },
+      _currentSpeech: speechHandle,
+      agentStateOwner: undefined as unknown,
       audioRecognition,
       agentSession: {
         get _activity() {
@@ -820,11 +824,14 @@ describe('AgentActivity - speech completion', () => {
         }),
       },
     };
+    const owner = { activity: fakeActivity, speechHandle };
+    fakeActivity.agentStateOwner = owner;
+    Object.setPrototypeOf(fakeActivity, AgentActivity.prototype);
 
     const onPipelineReplyDone = (AgentActivity.prototype as Record<string, unknown>)
-      .onPipelineReplyDone as (this: typeof fakeActivity) => void;
+      .onPipelineReplyDone as (this: typeof fakeActivity, owner: typeof owner) => void;
 
-    onPipelineReplyDone.call(fakeActivity);
+    onPipelineReplyDone.call(fakeActivity, owner);
 
     expect(fakeActivity.agentSession._updateAgentState).toHaveBeenCalledWith('listening');
     expect(audioRecognition.onEndOfAgentSpeech).toHaveBeenCalledTimes(1);
@@ -1525,12 +1532,13 @@ describe('AgentActivity - realtime reply chat context push', () => {
   }
 
   async function runRealtimeReplyTask(activity: unknown, speechHandle: SpeechHandle) {
+    const owner = { activity, speechHandle };
     const realtimeReplyTask = (
       AgentActivity.prototype as unknown as {
         realtimeReplyTask(
           this: unknown,
           args: {
-            speechHandle: SpeechHandle;
+            owner: typeof owner;
             modelSettings: { toolChoice?: never };
             abortController: AbortController;
             userInput: string;
@@ -1540,7 +1548,7 @@ describe('AgentActivity - realtime reply chat context push', () => {
     ).realtimeReplyTask;
 
     await realtimeReplyTask.call(activity, {
-      speechHandle,
+      owner,
       modelSettings: {},
       abortController: new AbortController(),
       userInput: 'hello',

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -511,7 +511,7 @@ type FalseInterruptionActivity = {
     agentState: 'listening' | 'speaking';
     timeout: number;
   };
-  agentStateOwner?: { activity: unknown; speechHandle: SpeechHandle };
+  activeAgentStateLease?: { activity: unknown; speechHandle: SpeechHandle };
   _currentSpeech?: SpeechHandle;
   falseInterruptionTimer?: NodeJS.Timeout;
   falseInterruptionPending: boolean;
@@ -573,7 +573,7 @@ function falseInterruptionActivity(endOfTurnTask?: Task<void>): FalseInterruptio
     logger: { debug: vi.fn() },
   });
   activity.agentSession._activity = activity;
-  activity.agentStateOwner = { activity, speechHandle: handle };
+  activity.activeAgentStateLease = { activity, speechHandle: handle };
   return activity;
 }
 
@@ -806,7 +806,7 @@ describe('AgentActivity - false interruption resume', () => {
     const activity = falseInterruptionActivity();
     activity.pausedSpeech!.agentState = 'listening';
     activity.agentSession.agentState = 'listening';
-    activity.agentStateOwner = undefined;
+    activity.activeAgentStateLease = undefined;
 
     activity.startFalseInterruptionTimer(300);
     await vi.advanceTimersByTimeAsync(300);
@@ -843,7 +843,7 @@ describe('AgentActivity - speech completion', () => {
         peek: () => undefined,
       },
       _currentSpeech: speechHandle,
-      agentStateOwner: undefined as unknown,
+      activeAgentStateLease: undefined as unknown,
       audioRecognition,
       agentSession: {
         get _activity() {
@@ -855,14 +855,14 @@ describe('AgentActivity - speech completion', () => {
         }),
       },
     };
-    const owner = { activity: fakeActivity, speechHandle };
-    fakeActivity.agentStateOwner = owner;
+    const stateLease = { activity: fakeActivity, speechHandle };
+    fakeActivity.activeAgentStateLease = stateLease;
     Object.setPrototypeOf(fakeActivity, AgentActivity.prototype);
 
     const onPipelineReplyDone = (AgentActivity.prototype as Record<string, unknown>)
-      .onPipelineReplyDone as (this: typeof fakeActivity, owner: typeof owner) => void;
+      .onPipelineReplyDone as (this: typeof fakeActivity, stateLease: typeof stateLease) => void;
 
-    onPipelineReplyDone.call(fakeActivity, owner);
+    onPipelineReplyDone.call(fakeActivity, stateLease);
 
     expect(fakeActivity.agentSession._updateAgentState).toHaveBeenCalledWith('listening');
     expect(audioRecognition.onEndOfAgentSpeech).toHaveBeenCalledTimes(1);
@@ -1563,13 +1563,13 @@ describe('AgentActivity - realtime reply chat context push', () => {
   }
 
   async function runRealtimeReplyTask(activity: unknown, speechHandle: SpeechHandle) {
-    const owner = { activity, speechHandle };
+    const stateLease = { activity, speechHandle };
     const realtimeReplyTask = (
       AgentActivity.prototype as unknown as {
         realtimeReplyTask(
           this: unknown,
           args: {
-            owner: typeof owner;
+            stateLease: typeof stateLease;
             modelSettings: { toolChoice?: never };
             abortController: AbortController;
             userInput: string;
@@ -1579,7 +1579,7 @@ describe('AgentActivity - realtime reply chat context push', () => {
     ).realtimeReplyTask;
 
     await realtimeReplyTask.call(activity, {
-      owner,
+      stateLease,
       modelSettings: {},
       abortController: new AbortController(),
       userInput: 'hello',

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -518,6 +518,7 @@ type FalseInterruptionActivity = {
     onEndOfAgentSpeech: ReturnType<typeof vi.fn>;
   };
   agentSession: {
+    _activity?: FalseInterruptionActivity;
     agentState: 'speaking';
     sessionOptions: {
       turnHandling: {
@@ -566,6 +567,7 @@ function falseInterruptionActivity(endOfTurnTask?: Task<void>): FalseInterruptio
     disableVadInterruptionSoon: vi.fn(),
     logger: { debug: vi.fn() },
   });
+  activity.agentSession._activity = activity;
   return activity;
 }
 
@@ -809,6 +811,9 @@ describe('AgentActivity - speech completion', () => {
       },
       audioRecognition,
       agentSession: {
+        get _activity() {
+          return fakeActivity;
+        },
         agentState: 'speaking',
         _updateAgentState: vi.fn((state: string) => {
           fakeActivity.agentSession.agentState = state;

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -506,7 +506,11 @@ describe('AgentActivity - mainTask', () => {
 });
 
 type FalseInterruptionActivity = {
-  pausedSpeech?: { handle: SpeechHandle; agentState: 'speaking'; timeout: number };
+  pausedSpeech?: {
+    handle: SpeechHandle;
+    agentState: 'listening' | 'speaking';
+    timeout: number;
+  };
   agentStateOwner?: { activity: unknown; speechHandle: SpeechHandle };
   _currentSpeech?: SpeechHandle;
   falseInterruptionTimer?: NodeJS.Timeout;
@@ -520,7 +524,7 @@ type FalseInterruptionActivity = {
   };
   agentSession: {
     _activity?: FalseInterruptionActivity;
-    agentState: 'speaking';
+    agentState: 'listening' | 'speaking';
     sessionOptions: {
       turnHandling: {
         interruption: { resumeFalseInterruption: boolean; falseInterruptionTimeout: number };
@@ -795,6 +799,33 @@ describe('AgentActivity - false interruption resume', () => {
     await vi.advanceTimersByTimeAsync(1);
 
     expect(activity.agentSession.output.audio.resume).toHaveBeenCalledOnce();
+    expect(activity.pausedSpeech).toBeUndefined();
+  });
+
+  it('resumes current playout before it has claimed agent state', async () => {
+    const activity = falseInterruptionActivity();
+    activity.pausedSpeech!.agentState = 'listening';
+    activity.agentSession.agentState = 'listening';
+    activity.agentStateOwner = undefined;
+
+    activity.startFalseInterruptionTimer(300);
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(activity.agentSession.output.audio.resume).toHaveBeenCalledOnce();
+    expect(activity.agentSession._updateAgentState).not.toHaveBeenCalled();
+    expect(activity.audioRecognition!.onStartOfAgentSpeech).not.toHaveBeenCalled();
+    expect(activity.pausedSpeech).toBeUndefined();
+  });
+
+  it('does not resume playout after the activity loses ownership', async () => {
+    const activity = falseInterruptionActivity();
+    activity.agentSession._activity = undefined;
+
+    activity.startFalseInterruptionTimer(300);
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(activity.agentSession.output.audio.resume).not.toHaveBeenCalled();
+    expect(activity.agentSession._updateAgentState).not.toHaveBeenCalled();
     expect(activity.pausedSpeech).toBeUndefined();
   });
 });

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -281,8 +281,8 @@ interface PausedSpeechInfo {
   timeout: number;
 }
 
-/** Per-task agent-state lease. Tool-response tasks can reuse the same SpeechHandle. */
-interface SpeechOwner {
+/** Revocable permission for one speech task to update the session's agent state. */
+interface AgentStateLease {
   readonly activity: AgentActivity;
   readonly speechHandle: SpeechHandle;
 }
@@ -335,7 +335,7 @@ export class AgentActivity implements RecognitionHooks {
   private _authorizationPaused = false;
   private _drainBlockedTasks: Set<Task<any>> = new Set();
   private _currentSpeech?: SpeechHandle;
-  private agentStateOwner?: SpeechOwner;
+  private activeAgentStateLease?: AgentStateLease;
   private speechQueue: Heap<[number, number, SpeechHandle]>; // [priority, timestamp, speechHandle]
   private userSilenceEvent = new Event();
   private q_updated: Future<void, never>;
@@ -1561,15 +1561,15 @@ export class AgentActivity implements RecognitionHooks {
       }),
     );
 
-    const owner = this.createSpeechOwner(handle);
+    const stateLease = this.createAgentStateLease(handle);
     const task = this.createSpeechTask({
       taskFn: (abortController: AbortController) =>
-        this.ttsTask(owner, text, addToChatCtx, {}, abortController, audio),
+        this.ttsTask(stateLease, text, addToChatCtx, {}, abortController, audio),
       ownedSpeechHandle: handle,
       name: 'AgentActivity.tts_say',
     });
 
-    task.result.finally(() => this.onPipelineReplyDone(owner));
+    task.result.finally(() => this.onPipelineReplyDone(stateLease));
     this.scheduleSpeech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL);
     return handle;
   }
@@ -1752,10 +1752,10 @@ export class AgentActivity implements RecognitionHooks {
     );
     this.logger.info({ speech_id: handle.id }, 'Creating speech handle');
 
-    const owner = this.createSpeechOwner(handle);
+    const stateLease = this.createAgentStateLease(handle);
     this.createSpeechTask({
       taskFn: (abortController: AbortController) =>
-        this.realtimeGenerationTask(owner, ev, {}, abortController),
+        this.realtimeGenerationTask(stateLease, ev, {}, abortController),
       ownedSpeechHandle: handle,
       name: 'AgentActivity.realtimeGeneration',
     });
@@ -1936,12 +1936,8 @@ export class AgentActivity implements RecognitionHooks {
 
         this.updatePausedSpeech(this._currentSpeech, timeout);
         audioOutput!.pause();
-        const pausedOwner = this.agentStateOwner;
-        if (
-          wasAgentSpeaking &&
-          pausedOwner &&
-          this.transitionAgentState(pausedOwner, 'listening')
-        ) {
+        const stateLease = this.activeAgentStateLease;
+        if (wasAgentSpeaking && stateLease && this.updateAgentState(stateLease, 'listening')) {
           if (this.audioRecognition) {
             this.audioRecognition.onEndOfAgentSpeech(
               options?.ignoreUserTranscriptUntil ?? Date.now(),
@@ -2567,62 +2563,65 @@ export class AgentActivity implements RecognitionHooks {
     this.q_updated.resolve();
   }
 
-  private createSpeechOwner(speechHandle: SpeechHandle): SpeechOwner {
+  private createAgentStateLease(speechHandle: SpeechHandle): AgentStateLease {
     return { activity: this, speechHandle };
   }
 
-  private ownsAgentState(owner: SpeechOwner, expectedState?: AgentState): boolean {
+  private isAgentStateLeaseActive(
+    stateLease: AgentStateLease,
+    expectedState?: AgentState,
+  ): boolean {
     return (
-      owner.activity === this &&
+      stateLease.activity === this &&
       this.agentSession._activity === this &&
-      this.agentStateOwner === owner &&
+      this.activeAgentStateLease === stateLease &&
       (expectedState === undefined || this.agentSession.agentState === expectedState)
     );
   }
 
-  private claimAgentState(
-    owner: SpeechOwner,
+  private acquireAgentStateLease(
+    stateLease: AgentStateLease,
     state: AgentState,
     options?: { startTime?: number; otelContext?: Context },
   ): boolean {
     if (
-      owner.activity !== this ||
+      stateLease.activity !== this ||
       this.agentSession._activity !== this ||
-      owner.speechHandle.interrupted ||
-      owner.speechHandle.done()
+      stateLease.speechHandle.interrupted ||
+      stateLease.speechHandle.done()
     ) {
       return false;
     }
 
-    this.agentStateOwner = owner;
+    this.activeAgentStateLease = stateLease;
     this.agentSession._updateAgentState(state, options);
     return true;
   }
 
-  private transitionAgentState(
-    owner: SpeechOwner,
+  private updateAgentState(
+    stateLease: AgentStateLease,
     state: AgentState,
     options?: { startTime?: number; otelContext?: Context },
   ): boolean {
-    if (!this.ownsAgentState(owner)) return false;
+    if (!this.isAgentStateLeaseActive(stateLease)) return false;
 
     this.agentSession._updateAgentState(state, options);
     return true;
   }
 
-  private tryStartAgentSpeech(owner: SpeechOwner, startedSpeakingAt?: number): boolean {
-    if (this._currentSpeech !== owner.speechHandle) return false;
+  private tryStartAgentSpeech(stateLease: AgentStateLease, startedSpeakingAt?: number): boolean {
+    if (this._currentSpeech !== stateLease.speechHandle) return false;
 
-    return this.claimAgentState(owner, 'speaking', {
+    return this.acquireAgentStateLease(stateLease, 'speaking', {
       startTime: startedSpeakingAt,
-      otelContext: owner.speechHandle._agentTurnContext,
+      otelContext: stateLease.speechHandle._agentTurnContext,
     });
   }
 
-  private finishAgentState(owner: SpeechOwner, expectedState?: AgentState): boolean {
-    if (!this.ownsAgentState(owner, expectedState)) return false;
+  private releaseAgentStateLease(stateLease: AgentStateLease, expectedState?: AgentState): boolean {
+    if (!this.isAgentStateLeaseActive(stateLease, expectedState)) return false;
 
-    this.agentStateOwner = undefined;
+    this.activeAgentStateLease = undefined;
     this.agentSession._updateAgentState('listening');
     return true;
   }
@@ -2692,13 +2691,13 @@ export class AgentActivity implements RecognitionHooks {
       }),
     );
     this.logger.info({ speech_id: handle.id }, 'Creating speech handle');
-    const owner = this.createSpeechOwner(handle);
+    const stateLease = this.createAgentStateLease(handle);
 
     if (this.llm instanceof RealtimeModel) {
       this.createSpeechTask({
         taskFn: (abortController: AbortController) =>
           this.realtimeReplyTask({
-            owner,
+            stateLease,
             // TODO(brian): support llm.ChatMessage for the realtime model
             userInput: userMessage?.rawTextContent,
             instructions,
@@ -2725,7 +2724,7 @@ export class AgentActivity implements RecognitionHooks {
       const task = this.createSpeechTask({
         taskFn: (abortController: AbortController) =>
           this.pipelineReplyTask(
-            owner,
+            stateLease,
             chatCtx ?? this.agent.chatCtx,
             tools,
             {
@@ -2739,7 +2738,7 @@ export class AgentActivity implements RecognitionHooks {
         name: 'AgentActivity.pipelineReply',
       });
 
-      task.result.finally(() => this.onPipelineReplyDone(owner));
+      task.result.finally(() => this.onPipelineReplyDone(stateLease));
     }
 
     if (scheduleSpeech) {
@@ -2815,11 +2814,11 @@ export class AgentActivity implements RecognitionHooks {
     return future;
   }
 
-  private onPipelineReplyDone(owner: SpeechOwner): void {
+  private onPipelineReplyDone(stateLease: AgentStateLease): void {
     if (
       !this.speechQueue.peek() &&
       (!this._currentSpeech || this._currentSpeech.done()) &&
-      this.finishAgentState(owner)
+      this.releaseAgentStateLease(stateLease)
     ) {
       if (this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
@@ -3058,14 +3057,14 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   private async ttsTask(
-    owner: SpeechOwner,
+    stateLease: AgentStateLease,
     text: string | ReadableStream<string>,
     addToChatCtx: boolean,
     modelSettings: ModelSettings,
     replyAbortController: AbortController,
     audio?: ReadableStream<AudioFrame> | null,
   ): Promise<void> {
-    const { speechHandle } = owner;
+    const { speechHandle } = stateLease;
     speechHandle._agentTurnContext = otelContext.active();
 
     speechHandleStorage.enterWith(speechHandle);
@@ -3123,7 +3122,7 @@ export class AgentActivity implements RecognitionHooks {
     const onFirstFrame = (audioOut: _AudioOut | null, startedSpeakingAt: number = Date.now()) => {
       replyStartedSpeakingAt = startedSpeakingAt;
       replyStartedForwardingAt = audioOut?.startedForwardingAt ?? replyStartedSpeakingAt;
-      if (!this.tryStartAgentSpeech(owner, startedSpeakingAt)) return;
+      if (!this.tryStartAgentSpeech(stateLease, startedSpeakingAt)) return;
       if (this.audioRecognition) {
         this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
       }
@@ -3224,7 +3223,7 @@ export class AgentActivity implements RecognitionHooks {
         this.agentSession._conversationItemAdded(message);
       }
 
-      if (this.finishAgentState(owner, 'speaking')) {
+      if (this.releaseAgentStateLease(stateLease, 'speaking')) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -3252,7 +3251,7 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   private _pipelineReplyTaskImpl = async ({
-    owner,
+    stateLease,
     chatCtx,
     toolCtx,
     modelSettings,
@@ -3262,7 +3261,7 @@ export class AgentActivity implements RecognitionHooks {
     span,
     _previousUserMetrics,
   }: {
-    owner: SpeechOwner;
+    stateLease: AgentStateLease;
     chatCtx: ChatContext;
     toolCtx: ToolContext;
     modelSettings: ModelSettings;
@@ -3272,7 +3271,7 @@ export class AgentActivity implements RecognitionHooks {
     span: Span;
     _previousUserMetrics?: MetricsReport;
   }): Promise<void> => {
-    const { speechHandle } = owner;
+    const { speechHandle } = stateLease;
     speechHandle._agentTurnContext = otelContext.active();
 
     span.setAttribute(traceTypes.ATTR_SPEECH_ID, speechHandle.id);
@@ -3483,7 +3482,7 @@ export class AgentActivity implements RecognitionHooks {
       tasks.push(synthesizeTask);
     }
 
-    this.claimAgentState(owner, 'thinking');
+    this.acquireAgentStateLease(stateLease, 'thinking');
 
     const authorizationTasks: Promise<unknown>[] = [speechHandle._waitForAuthorization()];
     if (speechHandle.allowInterruptions) {
@@ -3504,7 +3503,7 @@ export class AgentActivity implements RecognitionHooks {
       if (agentStartedSpeakingAt !== undefined) return;
       agentStartedSpeakingAt = startedSpeakingAt;
       agentStartedForwardingAt = audioOutRef?.startedForwardingAt ?? agentStartedSpeakingAt;
-      if (!this.tryStartAgentSpeech(owner, startedSpeakingAt)) return;
+      if (!this.tryStartAgentSpeech(stateLease, startedSpeakingAt)) return;
       if (this.audioRecognition) {
         this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
       }
@@ -3755,7 +3754,7 @@ export class AgentActivity implements RecognitionHooks {
         span.setAttribute(traceTypes.ATTR_RESPONSE_TEXT, forwardedText);
       }
 
-      if (this.finishAgentState(owner, 'speaking')) {
+      if (this.releaseAgentStateLease(stateLease, 'speaking')) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -3804,7 +3803,7 @@ export class AgentActivity implements RecognitionHooks {
     if (
       !speechHandle.interrupted &&
       toolOutput.output.length > 0 &&
-      this.transitionAgentState(owner, 'thinking')
+      this.updateAgentState(stateLease, 'thinking')
     ) {
       if (this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
@@ -3812,7 +3811,7 @@ export class AgentActivity implements RecognitionHooks {
       if (this.isInterruptionDetectionEnabled) {
         this.restoreInterruptionByAudioActivity();
       }
-    } else if (this.finishAgentState(owner, 'speaking')) {
+    } else if (this.releaseAgentStateLease(stateLease, 'speaking')) {
       if (this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
@@ -3887,11 +3886,11 @@ export class AgentActivity implements RecognitionHooks {
           : 'auto';
 
       // Reuse the same speechHandle for the tool response.
-      const toolResponseOwner = this.createSpeechOwner(speechHandle);
+      const toolResponseLease = this.createAgentStateLease(speechHandle);
       const toolResponseTask = this.createSpeechTask({
         taskFn: () =>
           this.pipelineReplyTask(
-            toolResponseOwner,
+            toolResponseLease,
             chatCtx,
             toolCtx,
             { toolChoice: respondToolChoice },
@@ -3904,14 +3903,14 @@ export class AgentActivity implements RecognitionHooks {
         name: 'AgentActivity.pipelineReply',
       });
 
-      toolResponseTask.result.finally(() => this.onPipelineReplyDone(toolResponseOwner));
+      toolResponseTask.result.finally(() => this.onPipelineReplyDone(toolResponseLease));
 
       this.scheduleSpeech(speechHandle, SpeechHandle.SPEECH_PRIORITY_NORMAL, true);
     }
   };
 
   private pipelineReplyTask = async (
-    owner: SpeechOwner,
+    stateLease: AgentStateLease,
     chatCtx: ChatContext,
     toolCtx: ToolContext,
     modelSettings: ModelSettings,
@@ -3923,7 +3922,7 @@ export class AgentActivity implements RecognitionHooks {
     tracer.startActiveSpan(
       async (span) =>
         this._pipelineReplyTaskImpl({
-          owner,
+          stateLease,
           chatCtx,
           toolCtx,
           modelSettings,
@@ -3940,7 +3939,7 @@ export class AgentActivity implements RecognitionHooks {
     );
 
   private async realtimeGenerationTask(
-    owner: SpeechOwner,
+    stateLease: AgentStateLease,
     ev: GenerationCreatedEvent,
     modelSettings: ModelSettings,
     replyAbortController: AbortController,
@@ -3949,7 +3948,7 @@ export class AgentActivity implements RecognitionHooks {
     return tracer.startActiveSpan(
       async (span) =>
         this._realtimeGenerationTaskImpl({
-          owner,
+          stateLease,
           ev,
           modelSettings,
           replyAbortController,
@@ -3964,21 +3963,21 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   private async _realtimeGenerationTaskImpl({
-    owner,
+    stateLease,
     ev,
     modelSettings,
     replyAbortController,
     addToChatCtx,
     span,
   }: {
-    owner: SpeechOwner;
+    stateLease: AgentStateLease;
     ev: GenerationCreatedEvent;
     modelSettings: ModelSettings;
     replyAbortController: AbortController;
     addToChatCtx: boolean;
     span: Span;
   }): Promise<void> {
-    const { speechHandle } = owner;
+    const { speechHandle } = stateLease;
     speechHandle._agentTurnContext = otelContext.active();
 
     span.setAttribute(traceTypes.ATTR_SPEECH_ID, speechHandle.id);
@@ -4033,7 +4032,7 @@ export class AgentActivity implements RecognitionHooks {
     const onFirstFrame = (startedAt: number = Date.now()) => {
       if (startedSpeakingAt !== undefined) return;
       startedSpeakingAt = startedAt;
-      if (!this.tryStartAgentSpeech(owner, startedAt)) return;
+      if (!this.tryStartAgentSpeech(stateLease, startedAt)) return;
       if (this.audioRecognition) {
         this.audioRecognition.onStartOfAgentSpeech(startedAt);
       }
@@ -4369,7 +4368,7 @@ export class AgentActivity implements RecognitionHooks {
         }
       }
 
-      if (this.finishAgentState(owner, 'speaking')) {
+      if (this.releaseAgentStateLease(stateLease, 'speaking')) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -4385,10 +4384,10 @@ export class AgentActivity implements RecognitionHooks {
 
     let endedAgentSpeechBeforeTool = false;
     const toolBusy = !executeToolsTask.done || toolOutput.output.length > 0;
-    if (this.ownsAgentState(owner, 'speaking')) {
+    if (this.isAgentStateLeaseActive(stateLease, 'speaking')) {
       const stateUpdated = toolBusy
-        ? this.transitionAgentState(owner, 'thinking')
-        : this.finishAgentState(owner, 'speaking');
+        ? this.updateAgentState(stateLease, 'thinking')
+        : this.releaseAgentStateLease(stateLease, 'speaking');
       if (stateUpdated) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
@@ -4399,7 +4398,7 @@ export class AgentActivity implements RecognitionHooks {
         endedAgentSpeechBeforeTool = true;
       }
     } else if (toolBusy && this._currentSpeech === speechHandle) {
-      this.claimAgentState(owner, 'thinking');
+      this.acquireAgentStateLease(stateLease, 'thinking');
     }
 
     // mark the playout done before waiting for the tool execution
@@ -4414,7 +4413,7 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (toolOutput.output.length > 0) {
-      if (this.transitionAgentState(owner, 'thinking') && !endedAgentSpeechBeforeTool) {
+      if (this.updateAgentState(stateLease, 'thinking') && !endedAgentSpeechBeforeTool) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -4423,8 +4422,8 @@ export class AgentActivity implements RecognitionHooks {
         }
       }
     } else {
-      const wasSpeaking = this.ownsAgentState(owner, 'speaking');
-      if (this.finishAgentState(owner) && wasSpeaking && this.audioRecognition) {
+      const wasSpeaking = this.isAgentStateLeaseActive(stateLease, 'speaking');
+      if (this.releaseAgentStateLease(stateLease) && wasSpeaking && this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
     }
@@ -4561,11 +4560,11 @@ export class AgentActivity implements RecognitionHooks {
     );
 
     const toolChoice = schedulingPaused || modelSettings.toolChoice === 'none' ? 'none' : 'auto';
-    const replyOwner = this.createSpeechOwner(replySpeechHandle);
+    const replyLease = this.createAgentStateLease(replySpeechHandle);
     this.createSpeechTask({
       taskFn: (abortController: AbortController) =>
         this.realtimeReplyTask({
-          owner: replyOwner,
+          stateLease: replyLease,
           modelSettings: { toolChoice },
           abortController,
         }),
@@ -4714,19 +4713,19 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   private async realtimeReplyTask({
-    owner,
+    stateLease,
     modelSettings: { toolChoice },
     userInput,
     instructions,
     abortController,
   }: {
-    owner: SpeechOwner;
+    stateLease: AgentStateLease;
     modelSettings: ModelSettings;
     abortController: AbortController;
     userInput?: string;
     instructions?: string | Instructions;
   }): Promise<void> {
-    const { speechHandle } = owner;
+    const { speechHandle } = stateLease;
     speechHandleStorage.enterWith(speechHandle);
 
     if (!this.realtimeSession) {
@@ -4801,7 +4800,12 @@ export class AgentActivity implements RecognitionHooks {
       }
 
       const generationEvent = await generationPromise;
-      await this.realtimeGenerationTask(owner, generationEvent, { toolChoice }, abortController);
+      await this.realtimeGenerationTask(
+        stateLease,
+        generationEvent,
+        { toolChoice },
+        abortController,
+      );
     } finally {
       // reset toolChoice value
       if (toolChoice !== undefined && toolChoice !== originalToolChoice) {
@@ -5264,10 +5268,10 @@ export class AgentActivity implements RecognitionHooks {
         this.agentSession._activity === this &&
         this._currentSpeech === this.pausedSpeech.handle
       ) {
-        const owner = this.agentStateOwner;
+        const stateLease = this.activeAgentStateLease;
         const canRestoreAgentState =
-          owner?.speechHandle === this.pausedSpeech.handle &&
-          this.transitionAgentState(owner, this.pausedSpeech.agentState, {
+          stateLease?.speechHandle === this.pausedSpeech.handle &&
+          this.updateAgentState(stateLease, this.pausedSpeech.agentState, {
             otelContext: this.pausedSpeech.handle._agentTurnContext,
           });
         if (canRestoreAgentState) {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -5260,7 +5260,9 @@ export class AgentActivity implements RecognitionHooks {
         interruptionOptions.resumeFalseInterruption &&
         audioOutput &&
         audioOutput.canPause &&
-        !this.pausedSpeech.handle.done()
+        !this.pausedSpeech.handle.done() &&
+        this.agentSession._activity === this &&
+        this._currentSpeech === this.pausedSpeech.handle
       ) {
         const owner = this.agentStateOwner;
         const canRestoreAgentState =
@@ -5275,10 +5277,10 @@ export class AgentActivity implements RecognitionHooks {
           if (this.isInterruptionDetectionEnabled) {
             this.disableVadInterruptionSoon();
           }
-          audioOutput.resume();
-          resumed = true;
-          this.logger.debug({ timeout }, 'resumed false interrupted speech');
         }
+        audioOutput.resume();
+        resumed = true;
+        this.logger.debug({ timeout }, 'resumed false interrupted speech');
       }
 
       this.agentSession.emit(

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -4,7 +4,7 @@
 import { Mutex } from '@livekit/mutex';
 import type { AudioFrame } from '@livekit/rtc-node';
 import { type Throws, ThrowsPromise } from '@livekit/throws-transformer/throws';
-import type { Span } from '@opentelemetry/api';
+import type { Context, Span } from '@opentelemetry/api';
 import { ROOT_CONTEXT, context as otelContext, trace } from '@opentelemetry/api';
 import { Heap } from 'heap-js';
 import { AsyncLocalStorage } from 'node:async_hooks';
@@ -281,6 +281,12 @@ interface PausedSpeechInfo {
   timeout: number;
 }
 
+/** Per-task agent-state lease. Tool-response tasks can reuse the same SpeechHandle. */
+interface SpeechOwner {
+  readonly activity: AgentActivity;
+  readonly speechHandle: SpeechHandle;
+}
+
 /// Analog to Python's _ForwardOutput
 export interface ForwardOutput {
   played: 'full' | 'partial' | 'skipped';
@@ -329,7 +335,7 @@ export class AgentActivity implements RecognitionHooks {
   private _authorizationPaused = false;
   private _drainBlockedTasks: Set<Task<any>> = new Set();
   private _currentSpeech?: SpeechHandle;
-  private speakingSpeechId?: string;
+  private agentStateOwner?: SpeechOwner;
   private speechQueue: Heap<[number, number, SpeechHandle]>; // [priority, timestamp, speechHandle]
   private userSilenceEvent = new Event();
   private q_updated: Future<void, never>;
@@ -1555,14 +1561,15 @@ export class AgentActivity implements RecognitionHooks {
       }),
     );
 
+    const owner = this.createSpeechOwner(handle);
     const task = this.createSpeechTask({
       taskFn: (abortController: AbortController) =>
-        this.ttsTask(handle, text, addToChatCtx, {}, abortController, audio),
+        this.ttsTask(owner, text, addToChatCtx, {}, abortController, audio),
       ownedSpeechHandle: handle,
       name: 'AgentActivity.tts_say',
     });
 
-    task.result.finally(() => this.onPipelineReplyDone());
+    task.result.finally(() => this.onPipelineReplyDone(owner));
     this.scheduleSpeech(handle, SpeechHandle.SPEECH_PRIORITY_NORMAL);
     return handle;
   }
@@ -1745,9 +1752,10 @@ export class AgentActivity implements RecognitionHooks {
     );
     this.logger.info({ speech_id: handle.id }, 'Creating speech handle');
 
+    const owner = this.createSpeechOwner(handle);
     this.createSpeechTask({
       taskFn: (abortController: AbortController) =>
-        this.realtimeGenerationTask(handle, ev, {}, abortController),
+        this.realtimeGenerationTask(owner, ev, {}, abortController),
       ownedSpeechHandle: handle,
       name: 'AgentActivity.realtimeGeneration',
     });
@@ -1928,8 +1936,12 @@ export class AgentActivity implements RecognitionHooks {
 
         this.updatePausedSpeech(this._currentSpeech, timeout);
         audioOutput!.pause();
-        if (wasAgentSpeaking) {
-          this.agentSession._updateAgentState('listening');
+        const pausedOwner = this.agentStateOwner;
+        if (
+          wasAgentSpeaking &&
+          pausedOwner &&
+          this.transitionAgentState(pausedOwner, 'listening')
+        ) {
           if (this.audioRecognition) {
             this.audioRecognition.onEndOfAgentSpeech(
               options?.ignoreUserTranscriptUntil ?? Date.now(),
@@ -2555,27 +2567,62 @@ export class AgentActivity implements RecognitionHooks {
     this.q_updated.resolve();
   }
 
-  private tryStartAgentSpeech(speechHandle: SpeechHandle, startedSpeakingAt?: number): boolean {
-    if (this.agentSession._activity !== this || this._currentSpeech !== speechHandle) {
-      return false;
-    }
-    this.speakingSpeechId = speechHandle.id;
-    this.agentSession._updateAgentState('speaking', {
-      startTime: startedSpeakingAt,
-      otelContext: speechHandle._agentTurnContext,
-    });
-    return true;
+  private createSpeechOwner(speechHandle: SpeechHandle): SpeechOwner {
+    return { activity: this, speechHandle };
   }
 
-  private stopAgentSpeech(speechHandle: SpeechHandle): boolean {
+  private ownsAgentState(owner: SpeechOwner, expectedState?: AgentState): boolean {
+    return (
+      owner.activity === this &&
+      this.agentSession._activity === this &&
+      this.agentStateOwner === owner &&
+      (expectedState === undefined || this.agentSession.agentState === expectedState)
+    );
+  }
+
+  private claimAgentState(
+    owner: SpeechOwner,
+    state: AgentState,
+    options?: { startTime?: number; otelContext?: Context },
+  ): boolean {
     if (
+      owner.activity !== this ||
       this.agentSession._activity !== this ||
-      this.speakingSpeechId !== speechHandle.id ||
-      this.agentSession.agentState !== 'speaking'
+      owner.speechHandle.interrupted ||
+      owner.speechHandle.done()
     ) {
       return false;
     }
-    this.speakingSpeechId = undefined;
+
+    this.agentStateOwner = owner;
+    this.agentSession._updateAgentState(state, options);
+    return true;
+  }
+
+  private transitionAgentState(
+    owner: SpeechOwner,
+    state: AgentState,
+    options?: { startTime?: number; otelContext?: Context },
+  ): boolean {
+    if (!this.ownsAgentState(owner)) return false;
+
+    this.agentSession._updateAgentState(state, options);
+    return true;
+  }
+
+  private tryStartAgentSpeech(owner: SpeechOwner, startedSpeakingAt?: number): boolean {
+    if (this._currentSpeech !== owner.speechHandle) return false;
+
+    return this.claimAgentState(owner, 'speaking', {
+      startTime: startedSpeakingAt,
+      otelContext: owner.speechHandle._agentTurnContext,
+    });
+  }
+
+  private finishAgentState(owner: SpeechOwner, expectedState?: AgentState): boolean {
+    if (!this.ownsAgentState(owner, expectedState)) return false;
+
+    this.agentStateOwner = undefined;
     this.agentSession._updateAgentState('listening');
     return true;
   }
@@ -2645,12 +2692,13 @@ export class AgentActivity implements RecognitionHooks {
       }),
     );
     this.logger.info({ speech_id: handle.id }, 'Creating speech handle');
+    const owner = this.createSpeechOwner(handle);
 
     if (this.llm instanceof RealtimeModel) {
       this.createSpeechTask({
         taskFn: (abortController: AbortController) =>
           this.realtimeReplyTask({
-            speechHandle: handle,
+            owner,
             // TODO(brian): support llm.ChatMessage for the realtime model
             userInput: userMessage?.rawTextContent,
             instructions,
@@ -2677,7 +2725,7 @@ export class AgentActivity implements RecognitionHooks {
       const task = this.createSpeechTask({
         taskFn: (abortController: AbortController) =>
           this.pipelineReplyTask(
-            handle,
+            owner,
             chatCtx ?? this.agent.chatCtx,
             tools,
             {
@@ -2691,7 +2739,7 @@ export class AgentActivity implements RecognitionHooks {
         name: 'AgentActivity.pipelineReply',
       });
 
-      task.result.finally(() => this.onPipelineReplyDone());
+      task.result.finally(() => this.onPipelineReplyDone(owner));
     }
 
     if (scheduleSpeech) {
@@ -2767,11 +2815,12 @@ export class AgentActivity implements RecognitionHooks {
     return future;
   }
 
-  private onPipelineReplyDone(): void {
-    if (this.agentSession._activity !== this) return;
-
-    if (!this.speechQueue.peek() && (!this._currentSpeech || this._currentSpeech.done())) {
-      this.agentSession._updateAgentState('listening');
+  private onPipelineReplyDone(owner: SpeechOwner): void {
+    if (
+      !this.speechQueue.peek() &&
+      (!this._currentSpeech || this._currentSpeech.done()) &&
+      this.finishAgentState(owner)
+    ) {
       if (this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
@@ -3009,13 +3058,14 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   private async ttsTask(
-    speechHandle: SpeechHandle,
+    owner: SpeechOwner,
     text: string | ReadableStream<string>,
     addToChatCtx: boolean,
     modelSettings: ModelSettings,
     replyAbortController: AbortController,
     audio?: ReadableStream<AudioFrame> | null,
   ): Promise<void> {
+    const { speechHandle } = owner;
     speechHandle._agentTurnContext = otelContext.active();
 
     speechHandleStorage.enterWith(speechHandle);
@@ -3073,7 +3123,7 @@ export class AgentActivity implements RecognitionHooks {
     const onFirstFrame = (audioOut: _AudioOut | null, startedSpeakingAt: number = Date.now()) => {
       replyStartedSpeakingAt = startedSpeakingAt;
       replyStartedForwardingAt = audioOut?.startedForwardingAt ?? replyStartedSpeakingAt;
-      if (!this.tryStartAgentSpeech(speechHandle, startedSpeakingAt)) return;
+      if (!this.tryStartAgentSpeech(owner, startedSpeakingAt)) return;
       if (this.audioRecognition) {
         this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
       }
@@ -3174,7 +3224,7 @@ export class AgentActivity implements RecognitionHooks {
         this.agentSession._conversationItemAdded(message);
       }
 
-      if (this.stopAgentSpeech(speechHandle)) {
+      if (this.finishAgentState(owner, 'speaking')) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -3202,7 +3252,7 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   private _pipelineReplyTaskImpl = async ({
-    speechHandle,
+    owner,
     chatCtx,
     toolCtx,
     modelSettings,
@@ -3212,7 +3262,7 @@ export class AgentActivity implements RecognitionHooks {
     span,
     _previousUserMetrics,
   }: {
-    speechHandle: SpeechHandle;
+    owner: SpeechOwner;
     chatCtx: ChatContext;
     toolCtx: ToolContext;
     modelSettings: ModelSettings;
@@ -3222,6 +3272,7 @@ export class AgentActivity implements RecognitionHooks {
     span: Span;
     _previousUserMetrics?: MetricsReport;
   }): Promise<void> => {
+    const { speechHandle } = owner;
     speechHandle._agentTurnContext = otelContext.active();
 
     span.setAttribute(traceTypes.ATTR_SPEECH_ID, speechHandle.id);
@@ -3432,7 +3483,7 @@ export class AgentActivity implements RecognitionHooks {
       tasks.push(synthesizeTask);
     }
 
-    this.agentSession._updateAgentState('thinking');
+    this.claimAgentState(owner, 'thinking');
 
     const authorizationTasks: Promise<unknown>[] = [speechHandle._waitForAuthorization()];
     if (speechHandle.allowInterruptions) {
@@ -3453,7 +3504,7 @@ export class AgentActivity implements RecognitionHooks {
       if (agentStartedSpeakingAt !== undefined) return;
       agentStartedSpeakingAt = startedSpeakingAt;
       agentStartedForwardingAt = audioOutRef?.startedForwardingAt ?? agentStartedSpeakingAt;
-      if (!this.tryStartAgentSpeech(speechHandle, startedSpeakingAt)) return;
+      if (!this.tryStartAgentSpeech(owner, startedSpeakingAt)) return;
       if (this.audioRecognition) {
         this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
       }
@@ -3704,7 +3755,7 @@ export class AgentActivity implements RecognitionHooks {
         span.setAttribute(traceTypes.ATTR_RESPONSE_TEXT, forwardedText);
       }
 
-      if (this.stopAgentSpeech(speechHandle)) {
+      if (this.finishAgentState(owner, 'speaking')) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -3750,16 +3801,18 @@ export class AgentActivity implements RecognitionHooks {
       );
     }
 
-    if (!speechHandle.interrupted && toolOutput.output.length > 0) {
-      this.agentSession._updateAgentState('thinking');
+    if (
+      !speechHandle.interrupted &&
+      toolOutput.output.length > 0 &&
+      this.transitionAgentState(owner, 'thinking')
+    ) {
       if (this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
       if (this.isInterruptionDetectionEnabled) {
         this.restoreInterruptionByAudioActivity();
       }
-    } else if (this.agentSession.agentState === 'speaking') {
-      this.agentSession._updateAgentState('listening');
+    } else if (this.finishAgentState(owner, 'speaking')) {
       if (this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
@@ -3834,10 +3887,11 @@ export class AgentActivity implements RecognitionHooks {
           : 'auto';
 
       // Reuse the same speechHandle for the tool response.
+      const toolResponseOwner = this.createSpeechOwner(speechHandle);
       const toolResponseTask = this.createSpeechTask({
         taskFn: () =>
           this.pipelineReplyTask(
-            speechHandle,
+            toolResponseOwner,
             chatCtx,
             toolCtx,
             { toolChoice: respondToolChoice },
@@ -3850,14 +3904,14 @@ export class AgentActivity implements RecognitionHooks {
         name: 'AgentActivity.pipelineReply',
       });
 
-      toolResponseTask.result.finally(() => this.onPipelineReplyDone());
+      toolResponseTask.result.finally(() => this.onPipelineReplyDone(toolResponseOwner));
 
       this.scheduleSpeech(speechHandle, SpeechHandle.SPEECH_PRIORITY_NORMAL, true);
     }
   };
 
   private pipelineReplyTask = async (
-    speechHandle: SpeechHandle,
+    owner: SpeechOwner,
     chatCtx: ChatContext,
     toolCtx: ToolContext,
     modelSettings: ModelSettings,
@@ -3869,7 +3923,7 @@ export class AgentActivity implements RecognitionHooks {
     tracer.startActiveSpan(
       async (span) =>
         this._pipelineReplyTaskImpl({
-          speechHandle,
+          owner,
           chatCtx,
           toolCtx,
           modelSettings,
@@ -3886,7 +3940,7 @@ export class AgentActivity implements RecognitionHooks {
     );
 
   private async realtimeGenerationTask(
-    speechHandle: SpeechHandle,
+    owner: SpeechOwner,
     ev: GenerationCreatedEvent,
     modelSettings: ModelSettings,
     replyAbortController: AbortController,
@@ -3895,7 +3949,7 @@ export class AgentActivity implements RecognitionHooks {
     return tracer.startActiveSpan(
       async (span) =>
         this._realtimeGenerationTaskImpl({
-          speechHandle,
+          owner,
           ev,
           modelSettings,
           replyAbortController,
@@ -3910,20 +3964,21 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   private async _realtimeGenerationTaskImpl({
-    speechHandle,
+    owner,
     ev,
     modelSettings,
     replyAbortController,
     addToChatCtx,
     span,
   }: {
-    speechHandle: SpeechHandle;
+    owner: SpeechOwner;
     ev: GenerationCreatedEvent;
     modelSettings: ModelSettings;
     replyAbortController: AbortController;
     addToChatCtx: boolean;
     span: Span;
   }): Promise<void> {
+    const { speechHandle } = owner;
     speechHandle._agentTurnContext = otelContext.active();
 
     span.setAttribute(traceTypes.ATTR_SPEECH_ID, speechHandle.id);
@@ -3978,7 +4033,7 @@ export class AgentActivity implements RecognitionHooks {
     const onFirstFrame = (startedAt: number = Date.now()) => {
       if (startedSpeakingAt !== undefined) return;
       startedSpeakingAt = startedAt;
-      if (!this.tryStartAgentSpeech(speechHandle, startedAt)) return;
+      if (!this.tryStartAgentSpeech(owner, startedAt)) return;
       if (this.audioRecognition) {
         this.audioRecognition.onStartOfAgentSpeech(startedAt);
       }
@@ -4314,7 +4369,7 @@ export class AgentActivity implements RecognitionHooks {
         }
       }
 
-      if (this.stopAgentSpeech(speechHandle)) {
+      if (this.finishAgentState(owner, 'speaking')) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -4329,16 +4384,22 @@ export class AgentActivity implements RecognitionHooks {
     addRealtimeMessageOutputs(messageOutputs);
 
     let endedAgentSpeechBeforeTool = false;
-    if (this.agentSession.agentState === 'speaking') {
-      const toolBusy = !executeToolsTask.done || toolOutput.output.length > 0;
-      this.agentSession._updateAgentState(toolBusy ? 'thinking' : 'listening');
-      if (this.audioRecognition) {
-        this.audioRecognition.onEndOfAgentSpeech(Date.now());
+    const toolBusy = !executeToolsTask.done || toolOutput.output.length > 0;
+    if (this.ownsAgentState(owner, 'speaking')) {
+      const stateUpdated = toolBusy
+        ? this.transitionAgentState(owner, 'thinking')
+        : this.finishAgentState(owner, 'speaking');
+      if (stateUpdated) {
+        if (this.audioRecognition) {
+          this.audioRecognition.onEndOfAgentSpeech(Date.now());
+        }
+        if (this.isInterruptionDetectionEnabled) {
+          this.restoreInterruptionByAudioActivity();
+        }
+        endedAgentSpeechBeforeTool = true;
       }
-      if (this.isInterruptionDetectionEnabled) {
-        this.restoreInterruptionByAudioActivity();
-      }
-      endedAgentSpeechBeforeTool = true;
+    } else if (toolBusy && this._currentSpeech === speechHandle) {
+      this.claimAgentState(owner, 'thinking');
     }
 
     // mark the playout done before waiting for the tool execution
@@ -4353,8 +4414,7 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     if (toolOutput.output.length > 0) {
-      this.agentSession._updateAgentState('thinking');
-      if (!endedAgentSpeechBeforeTool) {
+      if (this.transitionAgentState(owner, 'thinking') && !endedAgentSpeechBeforeTool) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -4362,13 +4422,11 @@ export class AgentActivity implements RecognitionHooks {
           this.restoreInterruptionByAudioActivity();
         }
       }
-    } else if (this.agentSession.agentState === 'speaking') {
-      this.agentSession._updateAgentState('listening');
-      if (this.audioRecognition) {
+    } else {
+      const wasSpeaking = this.ownsAgentState(owner, 'speaking');
+      if (this.finishAgentState(owner) && wasSpeaking && this.audioRecognition) {
         this.audioRecognition.onEndOfAgentSpeech(Date.now());
       }
-    } else if (endedAgentSpeechBeforeTool && this.agentSession.agentState === 'thinking') {
-      this.agentSession._updateAgentState('listening');
     }
 
     if (toolOutput.output.length === 0) {
@@ -4503,10 +4561,11 @@ export class AgentActivity implements RecognitionHooks {
     );
 
     const toolChoice = schedulingPaused || modelSettings.toolChoice === 'none' ? 'none' : 'auto';
+    const replyOwner = this.createSpeechOwner(replySpeechHandle);
     this.createSpeechTask({
       taskFn: (abortController: AbortController) =>
         this.realtimeReplyTask({
-          speechHandle: replySpeechHandle,
+          owner: replyOwner,
           modelSettings: { toolChoice },
           abortController,
         }),
@@ -4655,18 +4714,19 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   private async realtimeReplyTask({
-    speechHandle,
+    owner,
     modelSettings: { toolChoice },
     userInput,
     instructions,
     abortController,
   }: {
-    speechHandle: SpeechHandle;
+    owner: SpeechOwner;
     modelSettings: ModelSettings;
     abortController: AbortController;
     userInput?: string;
     instructions?: string | Instructions;
   }): Promise<void> {
+    const { speechHandle } = owner;
     speechHandleStorage.enterWith(speechHandle);
 
     if (!this.realtimeSession) {
@@ -4741,12 +4801,7 @@ export class AgentActivity implements RecognitionHooks {
       }
 
       const generationEvent = await generationPromise;
-      await this.realtimeGenerationTask(
-        speechHandle,
-        generationEvent,
-        { toolChoice },
-        abortController,
-      );
+      await this.realtimeGenerationTask(owner, generationEvent, { toolChoice }, abortController);
     } finally {
       // reset toolChoice value
       if (toolChoice !== undefined && toolChoice !== originalToolChoice) {
@@ -5207,16 +5262,13 @@ export class AgentActivity implements RecognitionHooks {
         audioOutput.canPause &&
         !this.pausedSpeech.handle.done()
       ) {
+        const owner = this.agentStateOwner;
         const canRestoreAgentState =
-          this.agentSession._activity === this &&
-          (this.pausedSpeech.agentState !== 'speaking' ||
-            this.tryStartAgentSpeech(this.pausedSpeech.handle));
+          owner?.speechHandle === this.pausedSpeech.handle &&
+          this.transitionAgentState(owner, this.pausedSpeech.agentState, {
+            otelContext: this.pausedSpeech.handle._agentTurnContext,
+          });
         if (canRestoreAgentState) {
-          if (this.pausedSpeech.agentState !== 'speaking') {
-            this.agentSession._updateAgentState(this.pausedSpeech.agentState, {
-              otelContext: this.pausedSpeech.handle._agentTurnContext,
-            });
-          }
           if (this.audioRecognition && this.pausedSpeech.agentState === 'speaking') {
             this.audioRecognition.onStartOfAgentSpeech(Date.now());
           }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -329,6 +329,7 @@ export class AgentActivity implements RecognitionHooks {
   private _authorizationPaused = false;
   private _drainBlockedTasks: Set<Task<any>> = new Set();
   private _currentSpeech?: SpeechHandle;
+  private speakingSpeechId?: string;
   private speechQueue: Heap<[number, number, SpeechHandle]>; // [priority, timestamp, speechHandle]
   private userSilenceEvent = new Event();
   private q_updated: Future<void, never>;
@@ -2554,6 +2555,31 @@ export class AgentActivity implements RecognitionHooks {
     this.q_updated.resolve();
   }
 
+  private tryStartAgentSpeech(speechHandle: SpeechHandle, startedSpeakingAt?: number): boolean {
+    if (this.agentSession._activity !== this || this._currentSpeech !== speechHandle) {
+      return false;
+    }
+    this.speakingSpeechId = speechHandle.id;
+    this.agentSession._updateAgentState('speaking', {
+      startTime: startedSpeakingAt,
+      otelContext: speechHandle._agentTurnContext,
+    });
+    return true;
+  }
+
+  private stopAgentSpeech(speechHandle: SpeechHandle): boolean {
+    if (
+      this.agentSession._activity !== this ||
+      this.speakingSpeechId !== speechHandle.id ||
+      this.agentSession.agentState !== 'speaking'
+    ) {
+      return false;
+    }
+    this.speakingSpeechId = undefined;
+    this.agentSession._updateAgentState('listening');
+    return true;
+  }
+
   generateReply(options: {
     userMessage?: ChatMessage;
     chatCtx?: ChatContext;
@@ -2742,6 +2768,8 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   private onPipelineReplyDone(): void {
+    if (this.agentSession._activity !== this) return;
+
     if (!this.speechQueue.peek() && (!this._currentSpeech || this._currentSpeech.done())) {
       this.agentSession._updateAgentState('listening');
       if (this.audioRecognition) {
@@ -3045,10 +3073,7 @@ export class AgentActivity implements RecognitionHooks {
     const onFirstFrame = (audioOut: _AudioOut | null, startedSpeakingAt: number = Date.now()) => {
       replyStartedSpeakingAt = startedSpeakingAt;
       replyStartedForwardingAt = audioOut?.startedForwardingAt ?? replyStartedSpeakingAt;
-      this.agentSession._updateAgentState('speaking', {
-        startTime: startedSpeakingAt,
-        otelContext: speechHandle._agentTurnContext,
-      });
+      if (!this.tryStartAgentSpeech(speechHandle, startedSpeakingAt)) return;
       if (this.audioRecognition) {
         this.audioRecognition.onStartOfAgentSpeech(replyStartedSpeakingAt);
       }
@@ -3149,8 +3174,7 @@ export class AgentActivity implements RecognitionHooks {
         this.agentSession._conversationItemAdded(message);
       }
 
-      if (this.agentSession.agentState === 'speaking') {
-        this.agentSession._updateAgentState('listening');
+      if (this.stopAgentSpeech(speechHandle)) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -3429,10 +3453,7 @@ export class AgentActivity implements RecognitionHooks {
       if (agentStartedSpeakingAt !== undefined) return;
       agentStartedSpeakingAt = startedSpeakingAt;
       agentStartedForwardingAt = audioOutRef?.startedForwardingAt ?? agentStartedSpeakingAt;
-      this.agentSession._updateAgentState('speaking', {
-        startTime: startedSpeakingAt,
-        otelContext: speechHandle._agentTurnContext,
-      });
+      if (!this.tryStartAgentSpeech(speechHandle, startedSpeakingAt)) return;
       if (this.audioRecognition) {
         this.audioRecognition.onStartOfAgentSpeech(agentStartedSpeakingAt);
       }
@@ -3683,8 +3704,7 @@ export class AgentActivity implements RecognitionHooks {
         span.setAttribute(traceTypes.ATTR_RESPONSE_TEXT, forwardedText);
       }
 
-      if (this.agentSession.agentState === 'speaking') {
-        this.agentSession._updateAgentState('listening');
+      if (this.stopAgentSpeech(speechHandle)) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -3958,10 +3978,7 @@ export class AgentActivity implements RecognitionHooks {
     const onFirstFrame = (startedAt: number = Date.now()) => {
       if (startedSpeakingAt !== undefined) return;
       startedSpeakingAt = startedAt;
-      this.agentSession._updateAgentState('speaking', {
-        startTime: startedAt,
-        otelContext: speechHandle._agentTurnContext,
-      });
+      if (!this.tryStartAgentSpeech(speechHandle, startedAt)) return;
       if (this.audioRecognition) {
         this.audioRecognition.onStartOfAgentSpeech(startedAt);
       }
@@ -4297,8 +4314,7 @@ export class AgentActivity implements RecognitionHooks {
         }
       }
 
-      if (this.agentSession.agentState === 'speaking') {
-        this.agentSession._updateAgentState('listening');
+      if (this.stopAgentSpeech(speechHandle)) {
         if (this.audioRecognition) {
           this.audioRecognition.onEndOfAgentSpeech(Date.now());
         }
@@ -5191,18 +5207,26 @@ export class AgentActivity implements RecognitionHooks {
         audioOutput.canPause &&
         !this.pausedSpeech.handle.done()
       ) {
-        this.agentSession._updateAgentState(this.pausedSpeech.agentState, {
-          otelContext: this.pausedSpeech.handle._agentTurnContext,
-        });
-        if (this.audioRecognition && this.pausedSpeech.agentState === 'speaking') {
-          this.audioRecognition.onStartOfAgentSpeech(Date.now());
+        const canRestoreAgentState =
+          this.agentSession._activity === this &&
+          (this.pausedSpeech.agentState !== 'speaking' ||
+            this.tryStartAgentSpeech(this.pausedSpeech.handle));
+        if (canRestoreAgentState) {
+          if (this.pausedSpeech.agentState !== 'speaking') {
+            this.agentSession._updateAgentState(this.pausedSpeech.agentState, {
+              otelContext: this.pausedSpeech.handle._agentTurnContext,
+            });
+          }
+          if (this.audioRecognition && this.pausedSpeech.agentState === 'speaking') {
+            this.audioRecognition.onStartOfAgentSpeech(Date.now());
+          }
+          if (this.isInterruptionDetectionEnabled) {
+            this.disableVadInterruptionSoon();
+          }
+          audioOutput.resume();
+          resumed = true;
+          this.logger.debug({ timeout }, 'resumed false interrupted speech');
         }
-        if (this.isInterruptionDetectionEnabled) {
-          this.disableVadInterruptionSoon();
-        }
-        audioOutput.resume();
-        resumed = true;
-        this.logger.debug({ timeout }, 'resumed false interrupted speech');
       }
 
       this.agentSession.emit(

--- a/agents/src/voice/agent_activity_speech_ownership.test.ts
+++ b/agents/src/voice/agent_activity_speech_ownership.test.ts
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream } from 'node:stream/web';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { Future, type Task } from '../utils.js';
+import { Agent } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AudioOutput, type PlaybackFinishedEvent } from './io.js';
+
+const PLAYBACK_FINISHED: PlaybackFinishedEvent = {
+  playbackPosition: 0.02,
+  interrupted: false,
+};
+
+function frame(): AudioFrame {
+  const samples = 480;
+  return new AudioFrame(new Int16Array(samples), 24000, 1, samples);
+}
+
+function controlledAudio(): {
+  stream: ReadableStream<AudioFrame>;
+  pushAndClose: () => void;
+} {
+  let controller!: ReadableStreamDefaultController<AudioFrame>;
+  const stream = new ReadableStream<AudioFrame>({
+    start(streamController) {
+      controller = streamController;
+    },
+  });
+
+  return {
+    stream,
+    pushAndClose: () => {
+      controller.enqueue(frame());
+      controller.close();
+    },
+  };
+}
+
+class DeferredPlayoutOutput extends AudioOutput {
+  readonly firstCapture = new Future<void>();
+  readonly secondCapture = new Future<void>();
+  readonly initialWaitEntered = new Future<void>();
+  readonly delayedCleanupWaitEntered = new Future<void>();
+  readonly currentWaitEntered = new Future<void>();
+
+  private captureCount = 0;
+  private waitCount = 0;
+  private initialPlayout = new Future<PlaybackFinishedEvent>();
+  private delayedCleanup = new Future<PlaybackFinishedEvent>();
+  private currentPlayout = new Future<PlaybackFinishedEvent>();
+  private trailingPlayout = new Future<PlaybackFinishedEvent>();
+
+  constructor() {
+    super(24000);
+  }
+
+  override async captureFrame(audioFrame: AudioFrame): Promise<void> {
+    await super.captureFrame(audioFrame);
+    this.onPlaybackStarted(Date.now());
+
+    if (this.captureCount++ === 0) {
+      this.firstCapture.resolve();
+    } else {
+      this.secondCapture.resolve();
+    }
+  }
+
+  override async waitForPlayout(): Promise<PlaybackFinishedEvent> {
+    this.waitCount += 1;
+    if (this.waitCount === 1) {
+      this.initialWaitEntered.resolve();
+      return this.initialPlayout.await;
+    }
+    if (this.waitCount === 2) {
+      this.delayedCleanupWaitEntered.resolve();
+      return this.delayedCleanup.await;
+    }
+    if (this.waitCount === 3) {
+      this.currentWaitEntered.resolve();
+      return this.currentPlayout.await;
+    }
+    return this.trailingPlayout.await;
+  }
+
+  clearBuffer(): void {}
+
+  releaseDelayedCleanup(): void {
+    if (!this.delayedCleanup.done) {
+      this.delayedCleanup.resolve({ ...PLAYBACK_FINISHED, interrupted: true });
+    }
+  }
+
+  finishCurrentPlayout(): void {
+    if (!this.currentPlayout.done) {
+      this.currentPlayout.resolve(PLAYBACK_FINISHED);
+    }
+  }
+
+  releaseAll(): void {
+    if (!this.initialPlayout.done) {
+      this.initialPlayout.resolve({ ...PLAYBACK_FINISHED, interrupted: true });
+    }
+    this.releaseDelayedCleanup();
+    this.finishCurrentPlayout();
+    if (!this.trailingPlayout.done) {
+      this.trailingPlayout.resolve({ ...PLAYBACK_FINISHED, interrupted: true });
+    }
+  }
+}
+
+async function startSession(output: DeferredPlayoutOutput): Promise<AgentSession> {
+  const session = new AgentSession({
+    vad: null,
+    aecWarmupDuration: 0,
+    userAwayTimeout: 15,
+  });
+  session.output.audio = output;
+  await session.start({ agent: new Agent({ instructions: 'test' }) });
+  return session;
+}
+
+async function startInterruptedSpeech(session: AgentSession, output: DeferredPlayoutOutput) {
+  const audio = controlledAudio();
+  const speech = session.say('stale speech', { audio: audio.stream, addToChatCtx: false });
+  const task = speech._tasks[0]!;
+  audio.pushAndClose();
+
+  await output.firstCapture.await;
+  await output.initialWaitEntered.await;
+  expect(session.agentState).toBe('speaking');
+
+  session.interrupt();
+  await output.delayedCleanupWaitEntered.await;
+  return task;
+}
+
+async function startCurrentSpeech(session: AgentSession, output: DeferredPlayoutOutput) {
+  const audio = controlledAudio();
+  const speech = session.say('current speech', { audio: audio.stream, addToChatCtx: false });
+  audio.pushAndClose();
+
+  await output.secondCapture.await;
+  await output.currentWaitEntered.await;
+  expect(session.agentState).toBe('speaking');
+  return { speech };
+}
+
+describe('agent speech state ownership', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('ignores delayed cleanup after the interruption watchdog starts newer speech', async () => {
+    const output = new DeferredPlayoutOutput();
+    const session = await startSession(output);
+
+    try {
+      const staleTask = await startInterruptedSpeech(session, output);
+      const currentSpeechPromise = startCurrentSpeech(session, output);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      const { speech: currentSpeech } = await currentSpeechPromise;
+
+      output.releaseDelayedCleanup();
+      await staleTask.result.catch(() => undefined);
+
+      expect(session.agentState).toBe('speaking');
+      await vi.advanceTimersByTimeAsync(15_001);
+      expect(session.userState).toBe('listening');
+
+      output.finishCurrentPlayout();
+      await currentSpeech.waitForPlayout();
+    } finally {
+      output.releaseAll();
+      const closeTask = session.close();
+      await vi.runAllTimersAsync();
+      await closeTask;
+    }
+  });
+
+  it('ignores delayed cleanup from an inactive activity', async () => {
+    const output = new DeferredPlayoutOutput();
+    const session = await startSession(output);
+
+    try {
+      const staleTask = await startInterruptedSpeech(session, output);
+      session.updateAgent(new Agent({ instructions: 'replacement' }));
+      const transitionTask = (session as unknown as { updateActivityTask?: Task<void> })
+        .updateActivityTask;
+      expect(transitionTask).toBeDefined();
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await transitionTask!.result;
+      const { speech: currentSpeech } = await startCurrentSpeech(session, output);
+
+      output.releaseDelayedCleanup();
+      await staleTask.result.catch(() => undefined);
+
+      expect(session.agentState).toBe('speaking');
+      await vi.advanceTimersByTimeAsync(15_001);
+      expect(session.userState).toBe('listening');
+
+      output.finishCurrentPlayout();
+      await currentSpeech.waitForPlayout();
+    } finally {
+      output.releaseAll();
+      const closeTask = session.close();
+      await vi.runAllTimersAsync();
+      await closeTask;
+    }
+  });
+});

--- a/agents/src/voice/realtime_adaptive_interruption.test.ts
+++ b/agents/src/voice/realtime_adaptive_interruption.test.ts
@@ -104,6 +104,7 @@ describe('realtime adaptive interruption', () => {
     const onStartOfOverlapSpeech = vi.fn();
     const onEndOfAgentSpeech = vi.fn();
     const pause = vi.fn();
+    const speechHandle = SpeechHandle.create();
     let agentState: 'speaking' | 'listening' = 'speaking';
     const agentSession = {
       _aecWarmupRemaining: 0,
@@ -132,8 +133,10 @@ describe('realtime adaptive interruption', () => {
         onEndOfAgentSpeech: typeof onEndOfAgentSpeech;
       };
     };
+    Object.defineProperty(agentSession, '_activity', { get: () => activity });
     Object.assign(activity, {
-      _currentSpeech: { interrupted: false, allowInterruptions: true },
+      _currentSpeech: speechHandle,
+      agentStateOwner: { activity, speechHandle },
       agent: new Agent({ instructions: 'test' }),
       agentSession,
       audioRecognition: {

--- a/agents/src/voice/realtime_adaptive_interruption.test.ts
+++ b/agents/src/voice/realtime_adaptive_interruption.test.ts
@@ -136,7 +136,7 @@ describe('realtime adaptive interruption', () => {
     Object.defineProperty(agentSession, '_activity', { get: () => activity });
     Object.assign(activity, {
       _currentSpeech: speechHandle,
-      agentStateOwner: { activity, speechHandle },
+      activeAgentStateLease: { activity, speechHandle },
       agent: new Agent({ instructions: 'test' }),
       agentSession,
       audioRecognition: {

--- a/agents/src/voice/realtime_tool_output_commit.test.ts
+++ b/agents/src/voice/realtime_tool_output_commit.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { AudioFrame } from '@livekit/rtc-node';
+import { AudioFrame } from '@livekit/rtc-node';
 import { ReadableStream } from 'node:stream/web';
 import { describe, expect, it, vi } from 'vitest';
 import { ChatContext, FunctionCall } from '../llm/chat_context.js';
@@ -16,6 +16,7 @@ import { initializeLogger } from '../log.js';
 import { Future } from '../utils.js';
 import { Agent } from './agent.js';
 import { AgentSession } from './agent_session.js';
+import { AudioOutput, type PlaybackFinishedEvent } from './io.js';
 
 initializeLogger({ pretty: false, level: 'silent' });
 
@@ -28,6 +29,62 @@ function stream<T>(...items: T[]): ReadableStream<T> {
       controller.close();
     },
   });
+}
+
+const PLAYBACK_FINISHED: PlaybackFinishedEvent = {
+  playbackPosition: 0.02,
+  interrupted: false,
+};
+
+function frame(): AudioFrame {
+  const samples = 480;
+  return new AudioFrame(new Int16Array(samples), 24000, 1, samples);
+}
+
+class DelayedCleanupAudioOutput extends AudioOutput {
+  readonly initialWaitEntered = new Future<void>();
+  readonly cleanupWaitEntered = new Future<void>();
+
+  private waitCount = 0;
+  private initialPlayout = new Future<PlaybackFinishedEvent>();
+  private cleanupPlayout = new Future<PlaybackFinishedEvent>();
+
+  constructor() {
+    super(24000);
+  }
+
+  override async captureFrame(audioFrame: AudioFrame): Promise<void> {
+    await super.captureFrame(audioFrame);
+    this.onPlaybackStarted(Date.now());
+  }
+
+  override async waitForPlayout(): Promise<PlaybackFinishedEvent> {
+    this.waitCount += 1;
+    if (this.waitCount === 1) {
+      this.initialWaitEntered.resolve();
+      return this.initialPlayout.await;
+    }
+    if (this.waitCount === 2) {
+      this.cleanupWaitEntered.resolve();
+      return this.cleanupPlayout.await;
+    }
+    return PLAYBACK_FINISHED;
+  }
+
+  override clearBuffer(): void {}
+
+  releaseCleanup(): void {
+    if (!this.cleanupPlayout.done) {
+      this.cleanupPlayout.resolve({ ...PLAYBACK_FINISHED, interrupted: true });
+    }
+  }
+
+  releaseAll(): void {
+    if (!this.initialPlayout.done) {
+      this.initialPlayout.resolve({ ...PLAYBACK_FINISHED, interrupted: true });
+    }
+    this.releaseCleanup();
+  }
 }
 
 /** Emits one text message and optionally one tool call per generation. */
@@ -160,6 +217,71 @@ describe('Realtime tool output commit', () => {
       await toolFinished.await;
       await speech.waitForPlayout();
       await session.close();
+    }
+  });
+
+  it('ignores delayed cleanup while a newer reply waits for a tool', async () => {
+    vi.useFakeTimers();
+    const output = new DelayedCleanupAudioOutput();
+    const toolStarted = new Future<void>();
+    const releaseTool = new Future<void>();
+    const session = new AgentSession({
+      llm: new FakeRealtimeModel(),
+      vad: null,
+      userAwayTimeout: 15,
+      turnHandling: { turnDetection: null },
+    });
+    session.output.audio = output;
+    const agent = new Agent({
+      instructions: 'test',
+      tools: {
+        lookup_order: tool({
+          description: 'x',
+          execute: async () => {
+            toolStarted.resolve();
+            await releaseTool.await;
+            return 'ships tomorrow';
+          },
+        }),
+      },
+    });
+
+    let currentSpeech: ReturnType<AgentSession['generateReply']> | undefined;
+    await session.start({ agent });
+    try {
+      const staleSpeech = session.say('stale speech', {
+        audio: stream(frame()),
+        addToChatCtx: false,
+      });
+      const staleTask = staleSpeech._tasks[0]!;
+      await output.initialWaitEntered.await;
+      expect(session.agentState).toBe('speaking');
+
+      session.interrupt();
+      await output.cleanupWaitEntered.await;
+      currentSpeech = session.generateReply();
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await toolStarted.await;
+      await vi.waitFor(() => {
+        expect(session.agentState).toBe('thinking');
+        expect(session._activity?.currentSpeech).toBeUndefined();
+      });
+
+      output.releaseCleanup();
+      await staleTask.result.catch(() => undefined);
+
+      expect(session.agentState).toBe('thinking');
+      await vi.advanceTimersByTimeAsync(15_001);
+      expect(session.userState).toBe('listening');
+    } finally {
+      releaseTool.resolve();
+      output.releaseAll();
+      await currentSpeech?.waitForPlayout();
+      const closeTask = session.close();
+      await vi.runAllTimersAsync();
+      await closeTask;
+      vi.useRealTimers();
     }
   });
 


### PR DESCRIPTION
**Problem:** Interrupted speech can finish cleanup after a newer reply starts or after an agent handoff. The stale task can replace a newer `speaking` or `thinking` state with `listening`, which starts the user-away timer.

**Fix:** Give each speech task an activity-local state lease. Only the current owner can change or finish that state, including tool generations that reuse one `SpeechHandle`.

**Tests:** Cover the interruption watchdog, agent handoff, and delayed cleanup during a long tool call.

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> Can you investigate /Users/chenghao/Downloads/observability-RM_u4yusq2Nim9J.zip for a away timeout misfire?
>
> Okay, we should fix that.
>
> let's do the minimum safe rewrite instead.
>
> Going back to the SpeechOwner struct, is that enough for staleness check?
>
> sg, go ahead

</details>
