### PR TITLE
fix: interrupt superseded queued replies

### DIFF
--- a/.changeset/stale-speeches-stop.md
+++ b/.changeset/stale-speeches-stop.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Interrupt superseded queued replies when a new user turn arrives during interrupted speech cleanup.

--- a/agents/src/voice/agent_activity.test.ts
+++ b/agents/src/voice/agent_activity.test.ts
@@ -1885,6 +1885,9 @@ describe('AgentActivity - preemptive generation reconciliation', () => {
     const speechHandle = SpeechHandle.create();
     const scheduleSpeech = vi.fn();
     const generateReply = vi.fn();
+    const speechQueue = new Heap<[number, number, SpeechHandle]>(
+      (a, b) => b[0] - a[0] || a[1] - b[1],
+    );
 
     const fakeActivity = {
       _preemptiveGenerationCount: 1,
@@ -1913,6 +1916,7 @@ describe('AgentActivity - preemptive generation reconciliation', () => {
       },
       scheduleSpeech,
       generateReply,
+      speechQueue,
     };
     Object.setPrototypeOf(fakeActivity, AgentActivity.prototype);
 

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2216,6 +2216,24 @@ export class AgentActivity implements RecognitionHooks {
     return interrupted;
   }
 
+  private interruptQueuedSpeeches(force: boolean): void {
+    // Heap iteration pops in playout order. Walk a clone so retained speeches stay queued and
+    // interrupted ones remain for mainTask to drain.
+    for (const [, , speech] of this.speechQueue.clone()) {
+      if (speech.interrupted || speech.done()) continue;
+
+      if (!force && !speech.allowInterruptions) {
+        this.logger.warn(
+          { speech_id: speech.id },
+          'a queued speech does not allow interruptions and will play after the interruption, use interrupt({ force: true }) to interrupt it as well',
+        );
+        break;
+      }
+
+      speech.interrupt(force);
+    }
+  }
+
   private createSpeechTask(options: {
     taskFn: (controller: AbortController) => Promise<void>;
     controller?: AbortController;
@@ -2696,21 +2714,7 @@ export class AgentActivity implements RecognitionHooks {
 
     this.realtimeSession?.interrupt();
 
-    // Heap iteration pops in playout order. Walk a clone so retained speeches stay queued and
-    // interrupted ones remain for mainTask to drain.
-    for (const [, , speech] of this.speechQueue.clone()) {
-      if (speech.interrupted || speech.done()) continue;
-
-      if (!force && !speech.allowInterruptions) {
-        this.logger.warn(
-          { speech_id: speech.id },
-          'a queued speech does not allow interruptions and will play after the interruption, use interrupt({ force: true }) to interrupt it as well',
-        );
-        break;
-      }
-
-      speech.interrupt(force);
-    }
+    this.interruptQueuedSpeeches(force);
 
     if (force) {
       // Force-interrupt (used during shutdown): cancel all speech tasks so they
@@ -2825,23 +2829,31 @@ export class AgentActivity implements RecognitionHooks {
     // Capture into a local before awaiting cancelSpeechPause: the main scheduling
     // loop can reset this._currentSpeech = undefined during the await (#1430).
     const currentSpeech = this._currentSpeech;
+    const activeSpeech =
+      currentSpeech && !currentSpeech.interrupted && !currentSpeech.done()
+        ? currentSpeech
+        : undefined;
+    if (activeSpeech && !activeSpeech.allowInterruptions) {
+      this.logger.warn(
+        { 'lk.pii.user_input': info.newTranscript },
+        'skipping user input, current speech generation cannot be interrupted',
+      );
+      return;
+    }
+
+    this.interruptQueuedSpeeches(false);
+
     if (currentSpeech) {
-      if (!currentSpeech.allowInterruptions) {
-        this.logger.warn(
-          { 'lk.pii.user_input': info.newTranscript },
-          'skipping user input, current speech generation cannot be interrupted',
-        );
-        return;
-      }
-
       await this.cancelSpeechPause();
+    }
 
+    if (activeSpeech) {
       this.logger.info(
-        { 'speech id': currentSpeech.id },
+        { 'speech id': activeSpeech.id },
         'speech interrupted, new user turn detected',
       );
 
-      currentSpeech.interrupt();
+      activeSpeech.interrupt();
       this.realtimeSession?.interrupt();
     }
 

--- a/agents/src/voice/agent_activity_handoff.test.ts
+++ b/agents/src/voice/agent_activity_handoff.test.ts
@@ -313,6 +313,7 @@ describe('AgentActivity blockNewTurns (handoff transition)', () => {
     activity.logger = { warn: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn() };
     activity.cancelPreemptiveGeneration = vi.fn();
     activity.createSpeechTask = vi.fn(() => ({ cancel: vi.fn() }));
+    activity.speechQueue = { clone: () => [] };
     return activity;
   }
 

--- a/agents/src/voice/agent_activity_interrupt.test.ts
+++ b/agents/src/voice/agent_activity_interrupt.test.ts
@@ -11,6 +11,8 @@
  */
 import { Heap } from 'heap-js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ChatContext } from '../llm/chat_context.js';
+import { Future } from '../utils.js';
 import { AgentActivity } from './agent_activity.js';
 import { SpeechHandle } from './speech_handle.js';
 
@@ -37,7 +39,7 @@ function makeActivity() {
     _preemptiveGeneration: undefined,
     realtimeSession: { interrupt: realtimeInterrupt },
     speechTasks: new Set(),
-    logger: { warn },
+    logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn },
   });
   return { activity, speechQueue, realtimeInterrupt, warn };
 }
@@ -141,5 +143,48 @@ describe('AgentActivity - interrupt protected queued speech', () => {
     expect(current.interrupted).toBe(true);
     expect(queued.interrupted).toBe(true);
     expect(realtimeInterrupt).toHaveBeenCalledOnce();
+  });
+
+  it('interrupts a queued reply while the scheduler owner finishes interrupted cleanup', async () => {
+    const { activity, speechQueue } = makeActivity();
+    const cleanupOwner = makeSpeech(true);
+    const queuedReply = makeSpeech(true);
+    const releasePauseCleanup = new Future<void>();
+    cleanupOwner.interrupt();
+    enqueue(speechQueue, queuedReply);
+
+    Object.assign(activity, {
+      _currentSpeech: cleanupOwner,
+      _preemptiveGenerationCount: 0,
+      _schedulingPaused: false,
+      newTurnsBlocked: false,
+      cancelSpeechPause: vi.fn(() => releasePauseCleanup.await),
+      agent: {
+        _llm: undefined,
+        chatCtx: ChatContext.empty(),
+        onUserTurnCompleted: vi.fn(async () => {}),
+      },
+      agentSession: { llm: undefined, emit: vi.fn() },
+    });
+
+    const turnCompletion = (
+      activity as unknown as {
+        userTurnCompleted(info: {
+          newTranscript: string;
+          transcriptConfidence: number;
+          skipReply: boolean;
+        }): Promise<void>;
+      }
+    ).userTurnCompleted({
+      newTranscript: 'new user turn',
+      transcriptConfidence: 1,
+      skipReply: false,
+    });
+
+    expect(cleanupOwner.done()).toBe(false);
+    expect(queuedReply.interrupted).toBe(true);
+
+    releasePauseCleanup.resolve();
+    await turnCompletion;
   });
 });


### PR DESCRIPTION
**Problem:** A confirmed user turn could leave a superseded queued reply eligible when `_currentSpeech` still referred to interrupted cleanup.

**Behavior:** Confirmed turns now interrupt queued replies before pause cleanup. Protected-speech ordering, output serialization, and the new turn's preemptive generation remain unchanged.

Addresses AJS-485

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> $ponytail what should be the right minimal fix if _currentSpeech can be stale? What does Python repo do in this case?
>
> okay, can you create a PR for this?
>
> maybe as a stacked PR on top of 2340

</details>
