### PR TITLE
fix(bey): retry avatar participant join on transient disconnects   

### DIFF
--- a/.changeset/bright-socks-prove.md
+++ b/.changeset/bright-socks-prove.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-bey": patch
+---
+
+fix(bey): retry avatar participant join on transient disconnects   

--- a/plugins/bey/src/avatar.ts
+++ b/plugins/bey/src/avatar.ts
@@ -21,6 +21,7 @@ import { log } from './log.js';
 const ATTRIBUTE_PUBLISH_ON_BEHALF = 'lk.publish_on_behalf';
 
 const AVATAR_JOIN_WAIT_MAX_ATTEMPTS = 5;
+const AVATAR_JOIN_RETRY_DELAY_MS = 2000;
 const STOCK_AVATAR_ID = '694c83e2-8895-4a98-bd16-56332ca3f449';
 const DEFAULT_API_URL = 'https://api.bey.dev';
 const AVATAR_AGENT_IDENTITY = 'bey-avatar-agent';
@@ -224,11 +225,12 @@ export class AvatarSession extends voice.AvatarSession {
         this.#logger.warn(
           {
             'lk.pii.destination_identity': this.avatarParticipantIdentity,
-            error: String(err),
+            'lk.pii.error': String(err),
             attempt,
           },
           'avatar participant join wait failed, retrying (transient disconnect/reconnect is expected during avatar startup)',
         );
+        await new Promise((resolve) => setTimeout(resolve, AVATAR_JOIN_RETRY_DELAY_MS));
       }
     }
 

--- a/plugins/bey/src/avatar.ts
+++ b/plugins/bey/src/avatar.ts
@@ -9,6 +9,8 @@ import {
   getJobContext,
   intervalForRetry,
   voice,
+  waitForParticipant,
+  waitForTrackPublication,
 } from '@livekit/agents';
 import type { Room } from '@livekit/rtc-node';
 import { TrackKind } from '@livekit/rtc-node';
@@ -18,6 +20,7 @@ import { log } from './log.js';
 
 const ATTRIBUTE_PUBLISH_ON_BEHALF = 'lk.publish_on_behalf';
 
+const AVATAR_JOIN_WAIT_MAX_ATTEMPTS = 5;
 const STOCK_AVATAR_ID = '694c83e2-8895-4a98-bd16-56332ca3f449';
 const DEFAULT_API_URL = 'https://api.bey.dev';
 const AVATAR_AGENT_IDENTITY = 'bey-avatar-agent';
@@ -203,6 +206,31 @@ export class AvatarSession extends voice.AvatarSession {
 
     this.#logger.debug('starting avatar session');
     await this.startAgent(livekitUrl, livekitToken);
+
+    for (let attempt = 1; attempt <= AVATAR_JOIN_WAIT_MAX_ATTEMPTS; attempt++) {
+      try {
+        await waitForParticipant({
+          room,
+          identity: this.avatarParticipantIdentity,
+        });
+        await waitForTrackPublication({
+          room,
+          identity: this.avatarParticipantIdentity,
+          kind: TrackKind.KIND_VIDEO,
+        });
+        break;
+      } catch (err) {
+        if (attempt === AVATAR_JOIN_WAIT_MAX_ATTEMPTS) throw err;
+        this.#logger.warn(
+          {
+            'lk.pii.destination_identity': this.avatarParticipantIdentity,
+            error: String(err),
+            attempt,
+          },
+          'avatar participant join wait failed, retrying (transient disconnect/reconnect is expected during avatar startup)',
+        );
+      }
+    }
 
     agentSession.output.audio = new voice.DataStreamAudioOutput({
       room,


### PR DESCRIPTION
## Description

The Bey avatar plugin relies on `DataStreamAudioOutput._start()` to wait for the avatar participant to join the room and publish a video track. However, `_start()` has no retry logic — if the avatar participant transiently disconnects/reconnects during startup (which is expected behavior), the wait fails permanently and the session is broken.

This PR adds a retry loop in `AvatarSession.start()` that pre-validates the avatar participant's presence and video track publication **before** constructing `DataStreamAudioOutput`, working around the lack of retry in the base class.

## Changes Made
- Added `waitForParticipant` and `waitForTrackPublication` imports from `@livekit/agents`
- Added a retry loop (up to 5 attempts) in `AvatarSession.start()` after the Bey API call, that waits for the avatar participant to join and publish a video track before creating `DataStreamAudioOutput`
- On transient failure, logs a warning with the attempt number and retries; on final failure, propagates the error

## Video Demo

### Before Fix No Response From Agent
https://github.com/user-attachments/assets/8bc0053d-8c09-4459-a2b1-baf04067ba30


### After Fix Agent Responding with lips movement
https://github.com/user-attachments/assets/f233300d-8ba9-4186-930e-d790315ea29d



## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title
- [x] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green)

## Testing
- [x] Automated tests added/updated (if applicable)
- [x] All tests pass
- [x] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes

**Root cause:** `DataStreamAudioOutput._start()` in `agents/src/voice/avatar/datastream_io.ts` calls `waitForParticipant()` and `waitForTrackPublication()` with no retry. Both reject when the participant disconnects or the room disconnects. During avatar startup, transient disconnects are expected, causing the session to fail permanently.


---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.
