### PR TITLE
fix: report redaction chat timestamps in seconds

### DIFF
--- a/.changeset/fix-realtime-redaction-timestamps.md
+++ b/.changeset/fix-realtime-redaction-timestamps.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Report recording chat-item timestamps in Unix seconds and warn that audio redaction may be inaccurate for realtime sessions.

--- a/agents/src/proto.ts
+++ b/agents/src/proto.ts
@@ -24,6 +24,11 @@ export function msToTimestamp(ms: number): Timestamp {
   return Timestamp.fromDate(new Date(ms));
 }
 
+export function msToUnixSeconds(ms: number): number {
+  const timestamp = msToTimestamp(ms);
+  return Number(timestamp.seconds) + timestamp.nanos / 1e9;
+}
+
 function encodeMetrics(metrics: MetricsReport): pb.MetricsReport {
   const report = new pb.MetricsReport();
   // wall-clock metrics are seconds here and Timestamps on the wire

--- a/agents/src/voice/__snapshots__/report.test.ts.snap
+++ b/agents/src/voice/__snapshots__/report.test.ts.snap
@@ -7,7 +7,7 @@ exports[`sessionReportToJSON > serializes the full chat history to the Python sn
       "content": [
         "Check out this image and audio:",
       ],
-      "created_at": 3000000000,
+      "created_at": 3000000,
       "id": "msg_user_1",
       "interrupted": false,
       "role": "user",
@@ -16,7 +16,7 @@ exports[`sessionReportToJSON > serializes the full chat history to the Python sn
     {
       "arguments": "{"location": "Paris, France", "unit": "celsius"}",
       "call_id": "call_weather_123",
-      "created_at": 3000000001,
+      "created_at": 3000000.001,
       "group_id": "grp_1",
       "id": "func_call_1",
       "name": "get_weather",
@@ -25,7 +25,7 @@ exports[`sessionReportToJSON > serializes the full chat history to the Python sn
     },
     {
       "call_id": "call_weather_123",
-      "created_at": 3000000002,
+      "created_at": 3000000.002,
       "id": "func_output_1",
       "is_error": false,
       "name": "get_weather",
@@ -36,14 +36,14 @@ exports[`sessionReportToJSON > serializes the full chat history to the Python sn
       "content": [
         "It is 22°C and partly cloudy in Paris.",
       ],
-      "created_at": 3000000003,
+      "created_at": 3000000.003,
       "id": "msg_assistant_1",
       "interrupted": false,
       "role": "assistant",
       "type": "message",
     },
     {
-      "created_at": 3000000004,
+      "created_at": 3000000.004,
       "id": "item_handoff_1",
       "new_agent_id": "agent_booking",
       "old_agent_id": "agent_greeter",

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -451,7 +451,7 @@ export class AgentActivity implements RecognitionHooks {
       !this.agentSession._warnedRealtimeAudioRedaction
     ) {
       this.logger.warn(
-        'audio redaction may be inaccurate when using a RealtimeModel because realtime user turns do not include complete speech timestamps',
+        'RealtimeModel user turns lack complete speech timestamps, so audio redaction may be inaccurate; disable audio recording to keep transcript redaction enabled',
       );
       this.agentSession._warnedRealtimeAudioRedaction = true;
     }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -444,6 +444,18 @@ export class AgentActivity implements RecognitionHooks {
       asyncToolOptions: this.agent._asyncToolOptions ?? this.agentSession._asyncToolOptions,
     });
 
+    if (
+      this.llm instanceof RealtimeModel &&
+      this.agentSession.sessionOptions.recordingOptions.audio &&
+      this.agentSession._redactionEnabled &&
+      !this.agentSession._warnedRealtimeAudioRedaction
+    ) {
+      this.logger.warn(
+        'audio redaction may be inaccurate when using a RealtimeModel because realtime user turns do not include complete speech timestamps',
+      );
+      this.agentSession._warnedRealtimeAudioRedaction = true;
+    }
+
     this._resolvedTurnDetection = this._resolveTurnDetection(this.turnDetection);
     this.turnDetectionMode =
       typeof this._resolvedTurnDetection === 'string' ? this._resolvedTurnDetection : undefined;

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -451,7 +451,7 @@ export class AgentActivity implements RecognitionHooks {
       !this.agentSession._warnedRealtimeAudioRedaction
     ) {
       this.logger.warn(
-        'RealtimeModel may leave PII unredacted in audio; disable audio recording to keep transcript redaction enabled',
+        'RealtimeModel user turns lack complete speech timestamps, so audio redaction may be inaccurate; disable audio recording to prevent redaction leak.',
       );
       this.agentSession._warnedRealtimeAudioRedaction = true;
     }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -451,7 +451,7 @@ export class AgentActivity implements RecognitionHooks {
       !this.agentSession._warnedRealtimeAudioRedaction
     ) {
       this.logger.warn(
-        'RealtimeModel user turns lack complete speech timestamps, risking unredacted PII in audio; disable audio recording to prevent leaks while keeping transcript redaction enabled',
+        'RealtimeModel may leave PII unredacted in audio; disable audio recording to keep transcript redaction enabled',
       );
       this.agentSession._warnedRealtimeAudioRedaction = true;
     }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -451,7 +451,7 @@ export class AgentActivity implements RecognitionHooks {
       !this.agentSession._warnedRealtimeAudioRedaction
     ) {
       this.logger.warn(
-        'RealtimeModel user turns lack complete speech timestamps, so audio redaction may be inaccurate; disable audio recording to keep transcript redaction enabled',
+        'RealtimeModel user turns lack complete speech timestamps, risking unredacted PII in audio; disable audio recording to prevent leaks while keeping transcript redaction enabled',
       );
       this.agentSession._warnedRealtimeAudioRedaction = true;
     }

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -632,6 +632,12 @@ export class AgentSession<
     return recordingEnabled(this.sessionOptions.recordingOptions);
   }
 
+  /** @internal True when project or session redaction is enabled. */
+  _redactionEnabled = false;
+
+  /** @internal Whether the realtime audio-redaction warning was emitted for this session. */
+  _warnedRealtimeAudioRedaction = false;
+
   /** @internal - Timestamp when the session started (milliseconds) */
   _startedAt?: number;
 
@@ -1027,6 +1033,10 @@ export class AgentSession<
         await ctx.initRecording(this.sessionOptions.recordingOptions);
       }
     }
+
+    this._redactionEnabled = Boolean(
+      ctx?.job.enableRedaction || this.sessionOptions.recordingOptions.redaction,
+    );
 
     this.sessionSpan = tracer.startSpan({
       name: 'agent_session',

--- a/agents/src/voice/realtime_message_metrics.test.ts
+++ b/agents/src/voice/realtime_message_metrics.test.ts
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AudioFrame } from '@livekit/rtc-node';
 import { ReadableStream } from 'node:stream/web';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { type JobContext, runWithJobContextAsync } from '../job.js';
 import { ChatContext, type FunctionCall } from '../llm/chat_context.js';
 import {
   type GenerationCreatedEvent,
@@ -13,7 +14,8 @@ import {
   RealtimeSession,
 } from '../llm/realtime.js';
 import { type ToolChoice, ToolContext } from '../llm/tool_context.js';
-import { initializeLogger } from '../log.js';
+import { initializeLogger, log } from '../log.js';
+import { FakeSTT } from '../stt/testing/fake_stt.js';
 import { Agent } from './agent.js';
 import { AgentSession } from './agent_session.js';
 import { AgentSessionEventTypes, type ConversationItemAddedEvent } from './events.js';
@@ -91,10 +93,10 @@ class FakeRealtimeSession extends RealtimeSession {
 class FakeRealtimeModel extends RealtimeModel {
   readonly activeSession: FakeRealtimeSession;
 
-  constructor() {
+  constructor(turnDetection = false) {
     const capabilities: RealtimeCapabilities = {
       messageTruncation: false,
-      turnDetection: false,
+      turnDetection,
       userTranscription: false,
       autoToolReplyGeneration: false,
       audioOutput: false,
@@ -117,6 +119,46 @@ class FakeRealtimeModel extends RealtimeModel {
   }
 
   async close(): Promise<void> {}
+}
+
+const REALTIME_REDACTION_WARNING =
+  'audio redaction may be inaccurate when using a RealtimeModel because realtime user turns do not include complete speech timestamps';
+
+function fakeJobContext(enableRedaction: boolean): JobContext {
+  return {
+    job: { enableRecording: true, enableRedaction },
+    simulationContext: () => undefined,
+    initRecording: vi.fn(async () => {}),
+    _primaryAgentSession: undefined,
+    sessionDirectory: undefined,
+  } as unknown as JobContext;
+}
+
+async function runRealtimeSession({
+  projectRedaction,
+  sessionRedaction,
+  stt,
+  serverTurnDetection = true,
+}: {
+  projectRedaction: boolean;
+  sessionRedaction: boolean;
+  stt?: FakeSTT;
+  serverTurnDetection?: boolean;
+}): Promise<void> {
+  const session = new AgentSession({
+    llm: new FakeRealtimeModel(serverTurnDetection),
+    stt,
+    vad: null,
+    turnHandling: { turnDetection: null },
+  });
+
+  await runWithJobContextAsync(fakeJobContext(projectRedaction), async () => {
+    await session.start({
+      agent: new Agent({ instructions: 'test' }),
+      record: sessionRedaction ? { redaction: true } : true,
+    });
+    await session.close();
+  });
 }
 
 describe('Realtime message metrics', () => {
@@ -142,5 +184,65 @@ describe('Realtime message metrics', () => {
 
     expect(assistantMessages).toHaveLength(1);
     expect(assistantMessages[0]?.metrics.providerRequestIds).toEqual(['provider-response-id']);
+  });
+});
+
+describe('Realtime audio redaction warning', () => {
+  it.each([
+    { source: 'project', projectRedaction: true, sessionRedaction: false },
+    { source: 'session', projectRedaction: false, sessionRedaction: true },
+  ])('warns when $source redaction is enabled', async (options) => {
+    const warn = vi.spyOn(log(), 'warn').mockImplementation(() => undefined);
+
+    try {
+      await runRealtimeSession(options);
+      expect(warn).toHaveBeenCalledWith(REALTIME_REDACTION_WARNING);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('warns when STT is configured', async () => {
+    const warn = vi.spyOn(log(), 'warn').mockImplementation(() => undefined);
+
+    try {
+      await runRealtimeSession({
+        projectRedaction: true,
+        sessionRedaction: false,
+        stt: new FakeSTT(),
+      });
+      expect(warn).toHaveBeenCalledWith(REALTIME_REDACTION_WARNING);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('warns when server-side turn detection is disabled', async () => {
+    const warn = vi.spyOn(log(), 'warn').mockImplementation(() => undefined);
+
+    try {
+      await runRealtimeSession({
+        projectRedaction: true,
+        sessionRedaction: false,
+        serverTurnDetection: false,
+      });
+      expect(warn).toHaveBeenCalledWith(REALTIME_REDACTION_WARNING);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not warn when redaction is disabled', async () => {
+    const warn = vi.spyOn(log(), 'warn').mockImplementation(() => undefined);
+
+    try {
+      await runRealtimeSession({
+        projectRedaction: false,
+        sessionRedaction: false,
+      });
+      expect(warn).not.toHaveBeenCalledWith(REALTIME_REDACTION_WARNING);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/agents/src/voice/realtime_message_metrics.test.ts
+++ b/agents/src/voice/realtime_message_metrics.test.ts
@@ -122,7 +122,7 @@ class FakeRealtimeModel extends RealtimeModel {
 }
 
 const REALTIME_REDACTION_WARNING =
-  'RealtimeModel may leave PII unredacted in audio; disable audio recording to keep transcript redaction enabled';
+  'RealtimeModel user turns lack complete speech timestamps, so audio redaction may be inaccurate; disable audio recording to prevent redaction leak.';
 
 function fakeJobContext(enableRedaction: boolean): JobContext {
   return {

--- a/agents/src/voice/realtime_message_metrics.test.ts
+++ b/agents/src/voice/realtime_message_metrics.test.ts
@@ -122,7 +122,7 @@ class FakeRealtimeModel extends RealtimeModel {
 }
 
 const REALTIME_REDACTION_WARNING =
-  'audio redaction may be inaccurate when using a RealtimeModel because realtime user turns do not include complete speech timestamps';
+  'RealtimeModel user turns lack complete speech timestamps, so audio redaction may be inaccurate; disable audio recording to keep transcript redaction enabled';
 
 function fakeJobContext(enableRedaction: boolean): JobContext {
   return {

--- a/agents/src/voice/realtime_message_metrics.test.ts
+++ b/agents/src/voice/realtime_message_metrics.test.ts
@@ -122,7 +122,7 @@ class FakeRealtimeModel extends RealtimeModel {
 }
 
 const REALTIME_REDACTION_WARNING =
-  'RealtimeModel user turns lack complete speech timestamps, so audio redaction may be inaccurate; disable audio recording to keep transcript redaction enabled';
+  'RealtimeModel user turns lack complete speech timestamps, risking unredacted PII in audio; disable audio recording to prevent leaks while keeping transcript redaction enabled';
 
 function fakeJobContext(enableRedaction: boolean): JobContext {
   return {

--- a/agents/src/voice/realtime_message_metrics.test.ts
+++ b/agents/src/voice/realtime_message_metrics.test.ts
@@ -122,7 +122,7 @@ class FakeRealtimeModel extends RealtimeModel {
 }
 
 const REALTIME_REDACTION_WARNING =
-  'RealtimeModel user turns lack complete speech timestamps, risking unredacted PII in audio; disable audio recording to prevent leaks while keeping transcript redaction enabled';
+  'RealtimeModel may leave PII unredacted in audio; disable audio recording to keep transcript redaction enabled';
 
 function fakeJobContext(enableRedaction: boolean): JobContext {
   return {

--- a/agents/src/voice/report.test.ts
+++ b/agents/src/voice/report.test.ts
@@ -306,6 +306,33 @@ describe('sessionReportToJSON', () => {
     expect((payload.options as Record<string, unknown>).user_away_timeout).toBe(15);
   });
 
+  it('serializes chat item timestamps as Unix seconds', () => {
+    const chatHistory = ChatContext.empty();
+    chatHistory.addMessage({
+      role: 'user',
+      content: 'hello',
+      createdAt: 1787458002314,
+    });
+
+    const report = createSessionReport({
+      jobId: 'job',
+      roomId: 'room-id',
+      room: 'room',
+      options: baseOptions(),
+      events: [],
+      chatHistory,
+      enableRecording: false,
+      timestamp: 0,
+      startedAt: 0,
+    });
+
+    const payload = sessionReportToJSON(report);
+    const serializedHistory = payload.chat_history as {
+      items: Array<{ created_at: number }>;
+    };
+    expect(serializedHistory.items[0]?.created_at).toBe(1787458002.314);
+  });
+
   it('serializes the full chat history to the Python snake_case wire format', () => {
     // Mirrors the camelCase fixtures snapshotted in chat_context.test.ts, but asserts the
     // *converted* output: `chat_history` is what the report layer (toSnakeCaseDeep) emits, so

--- a/agents/src/voice/report.ts
+++ b/agents/src/voice/report.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ChatContext } from '../llm/chat_context.js';
 import { type ModelUsage, filterZeroValues } from '../metrics/model_usage.js';
+import { msToUnixSeconds } from '../proto.js';
 import { version } from '../version.js';
 import type {
   AgentSessionOptions,
@@ -204,6 +205,22 @@ function modelUsageToJSON(usage: ModelUsage): Record<string, unknown> {
   return out;
 }
 
+function chatHistoryToStandardJSON(chatHistory: ChatContext): unknown {
+  const json = chatHistory.toJSON({ excludeTimestamp: false }) as {
+    items?: Array<Record<string, unknown>>;
+  };
+
+  for (const item of json.items ?? []) {
+    if (typeof item.createdAt === 'number') {
+      // Direct OTLP logs use msToTimestamp(). The redaction collector rebuilds that same
+      // protobuf from standard report JSON, where created_at is Unix seconds.
+      item.createdAt = msToUnixSeconds(item.createdAt);
+    }
+  }
+
+  return toSnakeCaseDeep(json);
+}
+
 //   - header: protobuf MetricsRecordingHeader (room_id, duration, start_time)
 //   - chat_history: JSON serialized chat history (use sessionReportToJSON)
 //   - audio: audio recording file if available (ogg format)
@@ -269,7 +286,7 @@ export function sessionReportToJSON(report: SessionReport): Record<string, unkno
       preemptive_generation: options.turnHandling?.preemptiveGeneration ?? {},
       recording_options: { ...options.recordingOptions },
     },
-    chat_history: toSnakeCaseDeep(report.chatHistory.toJSON({ excludeTimestamp: false })),
+    chat_history: chatHistoryToStandardJSON(report.chatHistory),
     enable_user_data_training: report.enableRecording,
     timestamp: report.timestamp,
     usage: report.modelUsage ? report.modelUsage.map(modelUsageToJSON) : null,


### PR DESCRIPTION
**Bug:** Node reports sent millisecond `createdAt` values to a collector that reads Unix seconds. The conversion overflowed to 1677, misplacing redacted user turns.

Normalize recorded chat history to the cross-SDK seconds contract while leaving direct OTLP logs unchanged. Warn once for redacted realtime audio because those turns lack complete speech intervals, and direct users to disable audio recording for transcript-only redaction.

Addresses AGT-3375

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> I've got a customer report about missing correct timestamps for user turns, and this led to missed audio redaction: user turns have no timestamp, so audio redaction cannot sync with them
> ---
> Every user chat item is stored with created_at = 1677-09-21T00:12:43.145224192Z (-2^63 ms, the int64 minimum). Assistant items have correct times. In the session timeline all user turns show 00:00.00, so the transcript and the audio are out of sync for user turns, and audio redaction, which locates a turn by its timestamps, cannot mute the user's speech.
> Example: Session: RM_sp6dFbzsE2gR (job AJ_Yr3imrzTTNK3, 2026-08-23 04:06Z){"logger.name":"chat_history","room_id":"RM_sp6dFbzsE2gR","job_id":"AJ_Yr3imrzTTNK3","chat.item":{"message":{"content":[{"text":"NTTデータの<redaction type=\"name\"/>と申します。電気が切れてますので対応お願いします。"}],"created_at":"1677-09-21T00:12:43.145224192Z","id":"item_EFtlXAWppotE5bG0ALjhj","role":"USER"}},"lk.id":"c7a42107-3d6b-9956-e34e-a15756b3ea43"}
>
> Expected created_at = 2026-08-23T04:06:42.314Z: the SDK item had createdAt = 1787458002314 ms (we store it ourselves from the same object), and the SDK encodes every item with Timestamp.fromDate(new Date(ms)). The valid time leaves the SDK; only user items arrive as the sentinel.
>
>
> Can you verify this issue?

**Essential follow-ups:**

> okay we need to fix the node time scale issue by reporting like Python so the collector stays the same. And we need to warn when realtime is used without STT + when redact is True or job has enabled redaction that audio redaction might be inaccurate with realtime-only sessions.

> okay, then we should reuse that function and add a comment please

> but realtime + STT won't work either so realtime is just not compatible at all.

> chatHistoryToPythonJSON is too specific, chatHistoryToStandardJSON so we could add more conversion later if needed.

> Add to the warning: they can disable audio recording if they want to keep redaction enabled. but make it concise.

</details>
