### PR TITLE
fix(voice): watch the async reply as a Task so session.run() can settle

### DIFF
--- a/agents/src/voice/tool_executor.ts
+++ b/agents/src/voice/tool_executor.ts
@@ -18,7 +18,7 @@ import {
   tool,
 } from '../llm/tool_context.js';
 import { log } from '../log.js';
-import { Future } from '../utils.js';
+import { Future, Task } from '../utils.js';
 import type { AgentSession } from './agent_session.js';
 import type { PromptTemplate, RunContext, UpdatePromptArgs } from './run_context.js';
 
@@ -157,7 +157,7 @@ export class ToolExecutor {
   private runningTasks = new Map<string, RunningTask>();
   private duplicateLock = new Mutex();
   private pendingUpdates: PendingUpdate[] = [];
-  private _replyTask?: Promise<void>;
+  private _replyTask?: Task<void>;
   private _replyTaskDone = false;
   toolOptions: AsyncToolOptions;
 
@@ -175,7 +175,7 @@ export class ToolExecutor {
   private owningActivity: ToolExecutorActivity | null;
 
   get replyTask(): Promise<void> | undefined {
-    return this._replyTask;
+    return this._replyTask?.result;
   }
 
   setOwningActivity(activity: ToolExecutorActivity | null): void {
@@ -298,7 +298,7 @@ export class ToolExecutor {
 
   async waitForAll(): Promise<void> {
     await Promise.allSettled([...this.runningTasks.values()].map((task) => task.promise));
-    if (this._replyTask) await this._replyTask;
+    if (this._replyTask) await this._replyTask.result;
   }
 
   async cancel(callId: string): Promise<boolean> {
@@ -429,15 +429,24 @@ export class ToolExecutor {
     this.pendingUpdates.push({ ctx, items, target });
     if (this._replyTask === undefined || this._replyTaskDone) {
       this._replyTaskDone = false;
-      this._replyTask = this.deliverReply(ctx.session).catch((error) => {
-        log().warn(
-          { error },
-          'deliverReply failed; async tool result may not trigger a follow-up reply',
-        );
-      });
+      // A Task, not a bare promise: RunResult._watchHandle registers a done
+      // callback on whatever it is handed, and a promise has none. Watching a
+      // promise threw and left the handle permanently un-watched, so a run
+      // driven by session.run() never settled.
+      this._replyTask = Task.from(
+        () =>
+          this.deliverReply(ctx.session).catch((error) => {
+            log().warn(
+              { error },
+              'deliverReply failed; async tool result may not trigger a follow-up reply',
+            );
+          }),
+        undefined,
+        'ToolExecutor.deliverReply',
+      );
       const runState = (
         ctx.session as unknown as {
-          _globalRunState?: { _watchHandle?: (p: Promise<void>) => void };
+          _globalRunState?: { _watchHandle?: (handle: Task<void>) => void };
         }
       )._globalRunState;
       runState?._watchHandle?.(this._replyTask);

--- a/agents/src/voice/tool_executor_reply_task.test.ts
+++ b/agents/src/voice/tool_executor_reply_task.test.ts
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeAll, describe, expect, it } from 'vitest';
+import { ChatContext, FunctionCall, FunctionCallOutput } from '../llm/chat_context.js';
+import { initializeLogger } from '../log.js';
+import { Task } from '../utils.js';
+import type { RunContext } from './run_context.js';
+import { ToolExecutor } from './tool_executor.js';
+
+beforeAll(() => {
+  initializeLogger({ pretty: false, level: 'silent' });
+});
+
+/**
+ * `enqueueReply` hands its reply task to `RunResult._watchHandle`, which
+ * registers a done callback on it. A bare promise has none, so watching one
+ * threw `TypeError: handle.addDoneCallback is not a function` — and because the
+ * callback never registered, the run it belonged to never settled. The visible
+ * symptom was `session.run()` hanging until the caller's timeout, with the
+ * exception surfacing separately as an unhandled error.
+ */
+describe('ToolExecutor reply task', () => {
+  const callPair = (): [FunctionCall, FunctionCallOutput] => [
+    FunctionCall.create({ callId: 'call-1', name: 'tool', args: '{}' }),
+    FunctionCallOutput.create({
+      callId: 'call-1',
+      name: 'tool',
+      output: 'ok',
+      isError: false,
+    }),
+  ];
+
+  const executorWithStubbedAgent = () => {
+    const agent = {
+      chatCtx: ChatContext.empty(),
+      updateChatCtx: async () => {},
+    };
+
+    return new ToolExecutor({
+      owningActivity: { agent } as unknown as ConstructorParameters<
+        typeof ToolExecutor
+      >[0]['owningActivity'],
+    });
+  };
+
+  it('hands _watchHandle something it can register a done callback on', async () => {
+    const watched: unknown[] = [];
+    const executor = executorWithStubbedAgent();
+
+    const ctx = {
+      session: {
+        history: { insert: () => {} },
+        _globalRunState: {
+          _watchHandle: (handle: unknown) => {
+            watched.push(handle);
+          },
+        },
+      },
+    } as unknown as RunContext<unknown>;
+
+    await executor.enqueueReply(ctx, callPair());
+
+    expect(watched).toHaveLength(1);
+    // The contract `_watchHandle` actually relies on. Asserted structurally as
+    // well as by type, because the regression arrived through a cast that made
+    // the wrong thing typecheck.
+    expect(watched[0]).toBeInstanceOf(Task);
+    expect(typeof (watched[0] as { addDoneCallback?: unknown }).addDoneCallback).toBe('function');
+  });
+
+  it('settles the watched handle so a run driven by it can finish', async () => {
+    let settled = false;
+    const executor = executorWithStubbedAgent();
+
+    const ctx = {
+      session: {
+        history: { insert: () => {} },
+        _globalRunState: {
+          _watchHandle: (handle: Task<void>) => {
+            handle.addDoneCallback(() => {
+              settled = true;
+            });
+          },
+        },
+      },
+    } as unknown as RunContext<unknown>;
+
+    await executor.enqueueReply(ctx, callPair());
+    // The reply itself fails against this stub session and is swallowed by the
+    // task's own catch — which is the point: the handle must reach `done`
+    // whether the reply succeeded or not, or the run waits on it forever.
+    await executor.waitForAll();
+
+    expect(settled).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #2354.

`enqueueReply` was handing `RunResult._watchHandle` a bare promise. `_watchHandle` registers a done callback on whatever it gets, promises don't have one, so the call threw with `TypeError: handle.addDoneCallback is not a function`.

The mismatch was hidden by an inline cast redeclaring `_watchHandle` as taking `Promise<void>`. Its real signature is `SpeechHandle | Task<void>`, and `Task` is the thing that actually has `addDoneCallback`. So this wraps the reply in a `Task` and types the cast honestly, which also puts the compiler back in a position to catch this if it comes back.

`Task` starts eagerly in its constructor and fires its done callbacks when the result settles, so the timing is unchanged. `replyTask` stays `Promise<void> | undefined` for callers — `run_context.ts` awaits it and doesn't need to know.

### Scope — please read before merging

I originally wrote this up as "and that's why `session.run()` hangs". That claim was too strong and I've walked it back.

What I'm confident of: the cast is unsound, `_watchHandle` gets something it cannot watch, and the `TypeError` is real. This patch removes it, and the two tests below fail without it.

What I am **not** claiming: that this makes async toolsets usable under `session.run()`. In my own suite the run still fails to complete after applying it — the `TypeError` is gone, but something else is still holding the run open. I haven't isolated that yet and it may well be my own code rather than the SDK. I'd rather say so than have this land as a fix for a hang it may not fix.

So: treat this as a type-safety and correctness fix at the call site, not as a hang fix. If it turns out the remaining problem is also in the SDK I'll open that separately with a proper reproduction.

### Tests

Two, both against `enqueueReply` directly:

- the handle it watches is a `Task` and has `addDoneCallback`
- that handle reaches done, so anything waiting on it can proceed

The second fails with the original `TypeError` if you revert the fix — I checked by stashing the change and re-running, rather than assuming.

There's no end-to-end test driving a real async toolset through `session.run()`. That's the case I originally hit, and given the paragraph above I'd only be guessing at what it should assert. Happy to add one once the remaining behaviour is understood.
