### PR TITLE
chore(changeset): downgrade simulation telemetry bump to patch

### DIFF
--- a/.changeset/tidy-simulations-report.md
+++ b/.changeset/tidy-simulations-report.md
@@ -1,5 +1,5 @@
 ---
-'@livekit/agents': minor
+'@livekit/agents': patch
 ---
 
 Stamp simulation run and job IDs on session telemetry and expose them on `SimulationContext`.


### PR DESCRIPTION
The `tidy-simulations-report` changeset was the only pending `minor` bump, which pulled the entire fixed version group (`@livekit/agents`, all `@livekit/agents-plugin-*`, `@livekit/agents-plugins-test`) up to **1.8.0** in the Version Packages PR.

Downgrading it to `patch` so the next release lands as **1.7.1**, matching the intent of 60971ac5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)