### PR TITLE
fix(workflows): re-attach the human agent room close listener when a warm transfer merge fails

### DIFF
--- a/.changeset/warm-transfer-reattach-room-close.md
+++ b/.changeset/warm-transfer-reattach-room-close.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Re-attach the human agent room close listener when a warm transfer merge fails. A human agent who hangs up after the failed move now completes the task instead of leaving the caller on hold.

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { SIPParticipantInfo } from '@livekit/protocol';
-import { ParticipantKind, Room, RoomEvent } from '@livekit/rtc-node';
+import { DisconnectReason, ParticipantKind, Room, RoomEvent } from '@livekit/rtc-node';
 import { AccessToken, RoomServiceClient, SipClient } from 'livekit-server-sdk';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as job from '../job.js';
 import type { JobContext } from '../job.js';
-import { ChatContext, type FunctionTool } from '../llm/index.js';
+import { ChatContext, type FunctionTool, ToolError } from '../llm/index.js';
 import { AgentTask } from '../voice/agent.js';
 import { AgentSession } from '../voice/agent_session.js';
 import { BackgroundAudioPlayer } from '../voice/background_audio.js';
@@ -492,6 +492,71 @@ describe('createWarmTransferTask', () => {
     controller.abort(reason);
 
     expect(complete).toHaveBeenCalledWith(reason);
+  });
+
+  it('completes when the human agent hangs up after a participant move fails', async () => {
+    const controller = new AbortController();
+    mockDial();
+    let humanAgentRoom: Room | undefined;
+    vi.spyOn(AgentSession.prototype, 'start').mockImplementation(async (startOptions) => {
+      humanAgentRoom = startOptions.room;
+    });
+    vi.spyOn(RoomServiceClient.prototype, 'moveParticipant').mockRejectedValue(
+      new Error('move failed'),
+    );
+    const { complete, create } = setupTransfer(controller.signal);
+
+    const options = create.mock.calls[0]![0];
+    await options.onEnter!({} as never);
+    const connect = (options.tools as FunctionTool[]).find(
+      (entry) => entry.name === 'connect_to_caller',
+    )!;
+
+    await expect(connect.execute({}, {} as never)).rejects.toThrow('move failed');
+    expect(complete).not.toHaveBeenCalled();
+
+    humanAgentRoom!.emit(RoomEvent.Disconnected, DisconnectReason.CLIENT_INITIATED);
+
+    expect(complete).toHaveBeenCalledOnce();
+    expect(complete).toHaveBeenCalledWith(
+      new ToolError(`room closed: ${DisconnectReason.CLIENT_INITIATED}`),
+    );
+  });
+
+  it('ignores the human agent room closing while the participant move is in flight', async () => {
+    const controller = new AbortController();
+    mockDial();
+    let humanAgentRoom: Room | undefined;
+    vi.spyOn(AgentSession.prototype, 'start').mockImplementation(async (startOptions) => {
+      humanAgentRoom = startOptions.room;
+    });
+    let finishMove!: () => void;
+    const move = new Promise<void>((resolve) => {
+      finishMove = resolve;
+    });
+    const moveParticipant = vi
+      .spyOn(RoomServiceClient.prototype, 'moveParticipant')
+      .mockReturnValue(move as never);
+    const { complete, create } = setupTransfer(controller.signal);
+
+    const options = create.mock.calls[0]![0];
+    await options.onEnter!({} as never);
+    const connect = (options.tools as FunctionTool[]).find(
+      (entry) => entry.name === 'connect_to_caller',
+    )!;
+    const merging = connect.execute({}, {} as never);
+    await vi.waitFor(() => expect(moveParticipant).toHaveBeenCalled());
+
+    // Moving the human agent out tears their room down; that is the expected
+    // end of a successful merge, not a failure.
+    humanAgentRoom!.emit(RoomEvent.Disconnected, DisconnectReason.CLIENT_INITIATED);
+    expect(complete).not.toHaveBeenCalled();
+
+    finishMove();
+    await merging;
+
+    expect(complete).toHaveBeenCalledOnce();
+    expect(complete).toHaveBeenCalledWith({ humanAgentIdentity: 'human-agent-sip' });
   });
 
   it('starts greeting speech only after the outbound SIP call answers', async () => {

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -590,6 +590,10 @@ export function createWarmTransferTask({
             setResult(asError(abortSignal.reason ?? new Error('warm transfer aborted')));
             return;
           }
+          // The move failed, so the human agent is still in their own room: a
+          // close is a failure again, not the post-move teardown `mergeCalls`
+          // detached for.
+          humanAgentRoom?.on(RoomEvent.Disconnected, onHumanAgentRoomClose);
           abortSignal?.addEventListener('abort', onAbort, { once: true });
           throw error;
         }


### PR DESCRIPTION
## Description

Fixes #2358.

`mergeCalls` detaches `onHumanAgentRoomClose` at `warm_transfer.ts:434` before awaiting `moveParticipant`. That is correct for the success case — moving the human agent out tears their room down, and that close is expected teardown rather than a failure.

When the move throws, the `catch` in `connect_to_caller` re-attaches the abort listener but not this one. From then on the human agent hanging up calls no `setResult`, `task.done` stays `false`, and the caller is left on hold with the agent's IO still disabled (`setIoEnabled(true)` only runs in `onExit`, which needs the task to complete).

This re-attaches the listener alongside the abort listener.

## Changes Made

- `warm_transfer.ts`: re-attach `onHumanAgentRoomClose` in `connect_to_caller`'s catch, next to the existing abort listener re-attach.
- `warm_transfer.test.ts`: two tests — one that the human agent hanging up after a failed move completes the task, and one that a room close *during* an in-flight move does not (which is what the `off()` at `:434` exists to prevent, and was previously untested).
- Changeset.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: not applicable — the trigger is a `moveParticipant` rejection, which isn't reachable from the playground.

## Testing
- [x] Automated tests added/updated (if applicable)
- [x] All tests pass

`pnpm vitest run` in `agents/`: 2282 passed, exit 0. `pnpm build` (tsup + `tsc --declaration`) exit 0. `pnpm lint` 0 errors.

Both tests were checked against mutations rather than just run:

| Mutation | Result |
|---|---|
| Remove the re-attach (the bug) | fails |
| Remove the `off()` at `:434` | fails |
| Remove both | fails |
| Re-attach to `callerRoom` / wrong handler / wrong event | fails |
| Drop the reason from the `ToolError` message | fails |

## Additional Notes

Placement — the re-attach sits *after* the `if (abortSignal?.aborted)` early return, so an aborted signal doesn't re-attach. That branch calls `setResult`, which nulls `humanAgentRoom`, so there'd be nothing to attach to. The `?.` is load-bearing for a different reason: `cancelForCallerHangup` can null `humanAgentRoom` between the `off()` and the catch if the caller hangs up mid-move.

Considered and not done — moving the re-attach inside `mergeCalls`'s own try/catch so the pair is local and symmetric. The whole file still passes that way, but it also re-attaches on the abort path where this deliberately doesn't, so it didn't seem clearly better. Happy to switch if you prefer it. I also considered dropping the `off()` entirely in favour of a `mergeSucceeded` flag on the handler, but that's isomorphic to the attach/detach and adds another mutable field to the closure.

One case worth naming: if `moveParticipant` rejects but the server did perform the move (a timeout on a successful request), the re-attached listener converts the eventual room close into a `room closed:` result instead of success. Still better than the caller being stranded, and the local participant stays in the human agent room until session shutdown so it won't fire promptly.
