### PR TITLE
fix: handle room disconnect after failed warm transfer

### DIFF
--- a/.changeset/restore-warm-transfer-room-close.md
+++ b/.changeset/restore-warm-transfer-room-close.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Fix `WarmTransferTask` hanging after a failed participant move when the human agent disconnects.

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -2,12 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { SIPParticipantInfo } from '@livekit/protocol';
-import { ParticipantKind, Room, RoomEvent } from '@livekit/rtc-node';
+import { DisconnectReason, ParticipantKind, Room, RoomEvent } from '@livekit/rtc-node';
 import { AccessToken, RoomServiceClient, SipClient } from 'livekit-server-sdk';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as job from '../job.js';
 import type { JobContext } from '../job.js';
 import { ChatContext, type FunctionTool } from '../llm/index.js';
+import { log } from '../log.js';
 import { AgentTask } from '../voice/agent.js';
 import { AgentSession } from '../voice/agent_session.js';
 import { BackgroundAudioPlayer } from '../voice/background_audio.js';
@@ -91,10 +92,14 @@ const mockDial = (sipParticipant: Promise<unknown> = Promise.resolve({})) => {
   vi.stubEnv('LIVEKIT_API_KEY', 'api-key');
   vi.stubEnv('LIVEKIT_API_SECRET', 'api-secret');
   vi.spyOn(AccessToken.prototype, 'toJwt').mockResolvedValue('token');
-  vi.spyOn(Room.prototype, 'connect').mockImplementation(async function () {
+  const connect = vi.spyOn(Room.prototype, 'connect').mockImplementation(async function () {
     Object.defineProperty(this, 'name', {
       configurable: true,
       value: 'caller-room-human-agent',
+    });
+    Object.defineProperty(this, 'isConnected', {
+      configurable: true,
+      get: () => true,
     });
   });
   const disconnect = vi.spyOn(Room.prototype, 'disconnect').mockResolvedValue();
@@ -105,7 +110,7 @@ const mockDial = (sipParticipant: Promise<unknown> = Promise.resolve({})) => {
     .spyOn(SipClient.prototype, 'createSipParticipant')
     .mockReturnValue(sipParticipant as never);
   vi.spyOn(BackgroundAudioPlayer.prototype, 'close').mockResolvedValue();
-  return { close, createSipParticipant, disconnect, shutdown };
+  return { close, connect, createSipParticipant, disconnect, shutdown };
 };
 
 const setupTransfer = (abortSignal: AbortSignal) => {
@@ -493,6 +498,58 @@ describe('createWarmTransferTask', () => {
 
     expect(complete).toHaveBeenCalledWith(reason);
   });
+
+  it.each(['before', 'after'] as const)(
+    'observes human agent room closure %s a participant move failure',
+    async (timing) => {
+      const controller = new AbortController();
+      const warn = vi.spyOn(log(), 'warn').mockImplementation(() => undefined);
+      const { connect: connectRoom } = mockDial();
+      let failMove!: (error: Error) => void;
+      const move = new Promise<void>((_resolve, reject) => {
+        failMove = reject;
+      });
+      const moveParticipant = vi
+        .spyOn(RoomServiceClient.prototype, 'moveParticipant')
+        .mockReturnValue(move as never);
+      const { complete, create } = setupTransfer(controller.signal);
+
+      const options = create.mock.calls[0]![0];
+      await options.onEnter!({} as never);
+      const connect = (options.tools as FunctionTool[]).find(
+        (entry) => entry.name === 'connect_to_caller',
+      )!;
+      const humanAgentRoom = connectRoom.mock.instances[0]!;
+      const isConnected = vi.spyOn(humanAgentRoom, 'isConnected', 'get').mockReturnValue(true);
+
+      const merging = connect.execute({}, {} as never);
+      await vi.waitFor(() => expect(moveParticipant).toHaveBeenCalled());
+      if (timing === 'before') {
+        isConnected.mockReturnValue(false);
+        humanAgentRoom.emit(RoomEvent.Disconnected, DisconnectReason.CLIENT_INITIATED);
+      }
+
+      failMove(new Error('move failed'));
+      await expect(merging).rejects.toThrow('move failed');
+      if (timing === 'after') {
+        expect(complete).not.toHaveBeenCalled();
+        isConnected.mockReturnValue(false);
+        humanAgentRoom.emit(RoomEvent.Disconnected, DisconnectReason.CLIENT_INITIATED);
+      }
+
+      const expectedReason =
+        timing === 'before' ? DisconnectReason.UNKNOWN_REASON : DisconnectReason.CLIENT_INITIATED;
+      expect(warn).toHaveBeenCalledWith(
+        { reason: expectedReason },
+        'human agent room disconnected before transfer completed',
+      );
+      expect(complete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: `room closed: ${expectedReason}`,
+        }),
+      );
+    },
+  );
 
   it('starts greeting speech only after the outbound SIP call answers', async () => {
     vi.stubEnv('LIVEKIT_API_KEY', 'api-key');

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { SIPOutboundConfig } from '@livekit/protocol';
-import { type DisconnectReason, type ParticipantKind, Room, RoomEvent } from '@livekit/rtc-node';
+import { DisconnectReason, type ParticipantKind, Room, RoomEvent } from '@livekit/rtc-node';
 import { AccessToken, RoomServiceClient, SipClient, type VideoGrant } from 'livekit-server-sdk';
 import { z } from 'zod';
 import type { LLMModels, STTModelString, TTSModelString } from '../inference/index.js';
@@ -279,7 +279,9 @@ export function createWarmTransferTask({
   };
 
   const onHumanAgentRoomClose = (reason: DisconnectReason): void => {
-    logger.debug({ reason }, 'human agent room closed');
+    if (!task.done) {
+      logger.warn({ reason }, 'human agent room disconnected before transfer completed');
+    }
     humanAgentFailedFut.resolve();
     setResult(new ToolError(`room closed: ${reason}`));
   };
@@ -589,6 +591,11 @@ export function createWarmTransferTask({
           if (abortSignal?.aborted) {
             setResult(asError(abortSignal.reason ?? new Error('warm transfer aborted')));
             return;
+          }
+          const room = humanAgentRoom;
+          room?.on(RoomEvent.Disconnected, onHumanAgentRoomClose);
+          if (room && !room.isConnected && !task.done) {
+            onHumanAgentRoomClose(DisconnectReason.UNKNOWN_REASON);
           }
           abortSignal?.addEventListener('abort', onAbort, { once: true });
           throw error;


### PR DESCRIPTION
A failed participant move could detach the consultation room's close observer and leave the transfer waiting forever. Restore observation after failure, recover a disconnect missed during the move, and warn when the room disconnects before completion. Successful moves still treat source-room teardown as expected.

Addresses AGT-3390
Related to #2358
Supersedes #2360

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> investigate agt3390
>
> okay, yeah let's fix that. So a failed move caused the hang, right?
>
> could it be too late if the room is already disconnected?
>
> okay, yeah, we should check room state like how we check abortSignal aborted state first. But also, we don't need to do this for success path, right? But why if so?
>
> do we have a warning log about this? it could be helpful to know human agent disconnected, right?

</details>