### PR TITLE
fix(agents): keep downstream-cancelled stream channels from leaking unhandled rejections

### DIFF
--- a/.changeset/stream-channel-downstream-cancel.md
+++ b/.changeset/stream-channel-downstream-cancel.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Stream channels: tolerate the consumer cancelling the readable side. Fire-and-forget write() and close() on a downstream-cancelled channel no longer surface as unhandled promise rejections (`Error: undefined`), the `closed` getter now reflects downstream cancellation, and the audio forwarder cancels its reader with a real reason.

--- a/agents/src/log.ts
+++ b/agents/src/log.ts
@@ -5,7 +5,7 @@ import { Writable } from 'node:stream';
 import type { DestinationStream, Logger } from 'pino';
 import { multistream, pino } from 'pino';
 import { build as pinoPretty } from 'pino-pretty';
-import { type LoggerOptions, log, loggerOptions, setLoggerState } from './log_core.js';
+import { type LoggerOptions, log, loggerOptions, setLoggerState, tryLog } from './log_core.js';
 import { type PinoLogObject, emitToOtel } from './telemetry/pino_otel_transport.js';
 
 const OTEL_ENABLED_KEY = Symbol.for('@livekit/agents:otelEnabled');
@@ -19,7 +19,7 @@ const globals = globalThis as typeof globalThis & GlobalState;
 // LiveKit Cloud injects this into deployed agents. Child processes inherit it.
 const deployedRegion = process.env.LIVEKIT_REGION_NAME || undefined;
 
-export { log, loggerOptions, type LoggerOptions };
+export { log, loggerOptions, tryLog, type LoggerOptions };
 
 const createLogger = ({ pretty, level }: LoggerOptions): Logger => {
   const logLevel = level || 'info';

--- a/agents/src/log_core.ts
+++ b/agents/src/log_core.ts
@@ -34,6 +34,12 @@ export const log = (): Logger => {
   return logger;
 };
 
+/**
+ * Like {@link log}, but returns undefined before initializeLogger() has run.
+ * For best-effort logging from code that may run outside a worker.
+ */
+export const tryLog = (): Logger | undefined => globals[LOGGER_KEY];
+
 /** @internal */
 export const setLoggerState = (logger: Logger, options: LoggerOptions): void => {
   globals[LOGGER_OPTIONS_KEY] = options;

--- a/agents/src/stream/stream_channel.test.ts
+++ b/agents/src/stream/stream_channel.test.ts
@@ -163,4 +163,40 @@ describe('StreamChannel', () => {
     const result3 = await read3;
     expect(result3.done).toBe(true);
   });
+
+  it('should not produce unhandled rejections when the reader cancels mid-stream', async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const channel = createStreamChannel<string>();
+      const reader = channel.stream().getReader();
+
+      await channel.write('before');
+      await reader.read();
+      await reader.cancel();
+
+      // Fire-and-forget write and close after the consumer is gone, as
+      // realtime producers do.
+      channel.write('after-cancel');
+      await channel.close();
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(unhandled).toEqual([]);
+      expect(channel.closed).toBe(true);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('should still reject an awaited write after the reader cancelled', async () => {
+    const channel = createStreamChannel<string>();
+    const reader = channel.stream().getReader();
+
+    await reader.cancel(new Error('consumer gone'));
+
+    await expect(channel.write('late')).rejects.toThrow('consumer gone');
+  });
 });

--- a/agents/src/stream/stream_channel.ts
+++ b/agents/src/stream/stream_channel.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { ReadableStream } from 'node:stream/web';
+import { tryLog } from '../log.js';
 import { IdentityTransform } from './identity_transform.js';
 
 export interface StreamChannel<T, E extends Error = Error> {
@@ -18,8 +19,29 @@ export function createStreamChannel<T, E extends Error = Error>(): StreamChannel
   const writer = transform.writable.getWriter();
   let isClosed = false;
 
+  // The consumer side can cancel the readable (or the stream can error), which
+  // errors the writable and would otherwise reject every later write() and
+  // close() with the cancel reason - surfacing as unhandled rejections from
+  // fire-and-forget producers.
+  writer.closed.catch((error: unknown) => {
+    if (!isClosed) {
+      isClosed = true;
+      tryLog()?.debug({ error }, 'stream channel writable errored or was cancelled downstream');
+    }
+  });
+
   return {
-    write: (chunk: T) => writer.write(chunk),
+    write: (chunk: T) => {
+      const result = writer.write(chunk);
+      // Mark the rejection as handled for fire-and-forget producers; callers
+      // that await the returned promise still observe it.
+      result.catch((error: unknown) => {
+        if (!isClosed) {
+          tryLog()?.debug({ error }, 'stream channel write failed');
+        }
+      });
+      return result;
+    },
     stream: () => transform.readable,
     abort: async (error: E) => {
       if (isClosed) return;
@@ -53,16 +75,15 @@ export function createStreamChannel<T, E extends Error = Error>(): StreamChannel
     },
     close: async () => {
       try {
-        const result = await writer.close();
-        isClosed = true;
-        return result;
+        return await writer.close();
       } catch (e) {
-        if (e instanceof Error && e.name === 'TypeError') {
-          // Ignore error if the stream is already closed
-          isClosed = true;
-          return;
+        // Ignore error if the stream is already closed or errored - either way
+        // no more data flows, which is what close() asks for.
+        if (!isClosed && !(e instanceof Error && e.name === 'TypeError')) {
+          tryLog()?.debug({ error: e }, 'stream channel close failed');
         }
-        throw e;
+      } finally {
+        isClosed = true;
       }
     },
     get closed() {

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -1049,7 +1049,9 @@ async function forwardAudio(
   const reader = ttsStream.getReader();
   let resampler: AudioResampler | null = null;
   const cancelReader = () => {
-    void reader.cancel().catch((error) => {
+    // Cancel with a reason so producers still writing into the stream see a
+    // real error instead of `undefined`.
+    void reader.cancel(new Error('audio forwarding aborted')).catch((error) => {
       logger.debug({ error }, 'failed to cancel TTS stream reader after abort');
     });
   };


### PR DESCRIPTION
## What

Since 1.7.0, `forwardAudio` cancels its reader on abort (`reader.cancel()` with no reason). Cancelling the readable side of a stream channel errors the writable side with `undefined`, so every later fire-and-forget `write()` / `close()` from a realtime producer rejects with `undefined` and surfaces as an unhandled promise rejection (`Error: undefined`, no application frames).

In production (google realtime plugin, `livekit-agents` worker on node 22) this fires on every barge-in: the plugin keeps writing the frames that arrive after the interrupt into the cancelled audio channel (`realtime_api.ts` `gen.audioChannel.write(audioFrame)` / `markCurrentGenerationDone` → `audioChannel.close()`). We saw ~640 events across 54 users in 24h after upgrading.

## Fix

At the `createStreamChannel` seam, so every producer is covered:

- Watch `writer.closed` so the channel learns about downstream cancellation / errors, flips `isClosed`, and debug-logs the transition (also fixes the stale `closed` getter).
- `write()` attaches a handler to each write promise (no more unhandled rejections from fire-and-forget producers) while returning the original promise, so awaiting callers keep exact backpressure and rejection semantics.
- `close()` swallows "already closed or errored" failures instead of only `TypeError` instances — an `undefined` cancel reason slipped past the `e instanceof Error` check.
- Logging is best-effort via a new `tryLog()` export next to `log()` - it returns the logger or `undefined` before `initializeLogger()` has run (`log()` throws there, and a throw inside these handlers would recreate the unhandled rejection).

Complementary one-liner: `forwardAudio` now cancels with `new Error('audio forwarding aborted')` so anything that still observes the reason sees a real error instead of `undefined`. Note this line alone does NOT fix the bug - it only relabels the rejections; the `createStreamChannel` hardening is what removes them (verified below).

## Tests

- New: a cancelled-mid-stream consumer no longer produces unhandled rejections and flips `closed`; an awaited `write()` after cancel still rejects with the cancel reason.
- Full `agents` suite passes (2283 tests).

## Live verification

Ran our production voice agent (google realtime plugin, real LiveKit + Gemini session) with this fix applied to the installed 1.7.0 dist:

- Full smoke suite passes patched (opening, barge-in, text filter, seeded history, typed text, tool injection, closing TTS) with warning sets identical to the unpatched control - no functional regression.
- The live race is hard to script: `interrupt()` closes the audio channel via `markCurrentGenerationDone()` whenever the generation already has output, so a scripted interrupt lands after that window. A deterministic replay of the plugin's exact post-cancel calls (`gen.audioChannel.write(audioFrame)` and `audioChannel.close()` after `forwardAudio`'s `reader.cancel()`) shows **8 unhandled rejections unpatched (including the `undefined`-reason ones we see in Sentry) vs 0 patched**, on both the ESM and CJS builds.
- The new debug line (`stream channel writable errored or was cancelled downstream`) doubles as a detector for the bug condition in the wild.

