### PR TITLE
fix(google): restart the realtime session on abnormal WebSocket close

### DIFF
--- a/.changeset/google-realtime-restart-on-abnormal-close.md
+++ b/.changeset/google-realtime-restart-on-abnormal-close.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-google': patch
+---
+
+Gemini realtime: restart the session when the WebSocket closes abnormally (e.g. code 1006), mirroring the network-error path - the main task reconnects and re-seeds the chat context instead of leaving the session parked on a dead socket. The emitted error is marked recoverable when a restart will happen.

--- a/plugins/google/src/realtime/realtime_api.ts
+++ b/plugins/google/src/realtime/realtime_api.ts
@@ -1057,6 +1057,11 @@ export class RealtimeSession extends llm.RealtimeSession {
                 const errorMsg = event.reason || `WebSocket closed with code ${event.code}`;
                 this.#logger.error(`Gemini Live session error: ${errorMsg}${truncationNote}`);
 
+                // An abnormal close is the same failure as `onerror`'s
+                // network-level errors: restart so the main task reconnects and
+                // re-seeds the chat context, instead of leaving the session
+                // parked forever on a dead socket.
+                const willRestart = !this.sessionShouldClose.isSet;
                 this.emitError(
                   new APIStatusError({
                     message: `${errorMsg}${truncationNote}`,
@@ -1068,8 +1073,11 @@ export class RealtimeSession extends llm.RealtimeSession {
                         : null,
                     },
                   }),
-                  false,
+                  willRestart,
                 );
+                if (willRestart) {
+                  this.markRestartNeeded();
+                }
               } else {
                 this.#logger.debug('Gemini Live session closed:', event.code, event.reason);
               }

--- a/plugins/google/src/realtime/realtime_reconnect.test.ts
+++ b/plugins/google/src/realtime/realtime_reconnect.test.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type * as genai from '@google/genai';
+import { describe, expect, it, vi } from 'vitest';
+import { RealtimeModel } from './realtime_api.js';
+
+type LiveCallbacks = {
+  onopen: () => void;
+  onmessage: (message: unknown) => void;
+  onerror: (error: unknown) => void;
+  onclose: (event: { code: number; reason: string }) => void;
+};
+
+const { connects } = vi.hoisted(() => ({
+  connects: [] as Array<{ callbacks: LiveCallbacks }>,
+}));
+
+vi.mock('@google/genai', async (importOriginal) => {
+  const actual = await importOriginal<typeof genai>();
+  return {
+    ...actual,
+    GoogleGenAI: class {
+      live = {
+        connect: async ({ callbacks }: { callbacks: LiveCallbacks }) => {
+          connects.push({ callbacks });
+          callbacks.onopen();
+          return {
+            sendClientContent: () => {},
+            sendRealtimeInput: () => {},
+            sendToolResponse: () => {},
+            close: () => {},
+          };
+        },
+      };
+    },
+  };
+});
+
+/**
+ * An abnormal WebSocket close is the same failure as `onerror`'s network-level
+ * errors: without a restart the main task stays parked on
+ * `sessionShouldClose.wait()` with a dead socket, and the session never
+ * recovers.
+ */
+describe('RealtimeSession on abnormal WebSocket close', () => {
+  it('restarts the session and emits the error as recoverable', async () => {
+    connects.length = 0;
+    const session = new RealtimeModel({
+      model: 'gemini-2.0-flash-live-001',
+      apiKey: 'test-key',
+    }).session();
+    const errors: Array<{ error: Error; recoverable: boolean }> = [];
+    session.on('error', (ev) => errors.push(ev));
+
+    await vi.waitFor(() => expect(connects).toHaveLength(1));
+    connects[0]!.callbacks.onclose({ code: 1006, reason: '' });
+
+    await vi.waitFor(() => expect(connects).toHaveLength(2));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.recoverable).toBe(true);
+    expect(errors[0]!.error.message).toContain('WebSocket closed with code 1006');
+
+    await session.close();
+  });
+
+  it('does not restart or emit on a normal close', async () => {
+    connects.length = 0;
+    const session = new RealtimeModel({
+      model: 'gemini-2.0-flash-live-001',
+      apiKey: 'test-key',
+    }).session();
+    const errors: Array<{ error: Error; recoverable: boolean }> = [];
+    session.on('error', (ev) => errors.push(ev));
+
+    await vi.waitFor(() => expect(connects).toHaveLength(1));
+    connects[0]!.callbacks.onclose({ code: 1000, reason: '' });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(connects).toHaveLength(1);
+    expect(errors).toHaveLength(0);
+
+    await session.close();
+  });
+});


### PR DESCRIPTION
## What

When the Gemini Live WebSocket dies abnormally, the session never recovers. In our production voice agent this branch fires for two distinct error groups: bare `WebSocket closed with code 1006` (a few per day) and closes carrying Google's `The operation was aborted.` reason (TLS connection dropped server-side) - the latter at **~2,800 events / ~1,800 users over two months, ~30 live sessions dying per day**. Every one of them passed our teardown filter, i.e. genuinely mid-conversation:

- `onerror` (network-level failures) calls `markRestartNeeded()`, so `#mainTask`'s reconnect loop tears down, reconnects, and re-seeds the chat context.
- `onclose` with a non-normal code only logs, emits an unrecoverable error, and marks the generation done. Nothing sets `sessionShouldClose`, so the main task stays parked on `sessionShouldClose.wait()` with a dead socket — the user keeps talking into a session that will never answer. Outbound sends on the closed `ws` socket don't throw, so the retry path in `#mainTask`'s catch never triggers either.

## Fix

Mirror `onerror` in `onclose`: on a non-normal close while the session isn't already closing, call `markRestartNeeded()` so the main task reconnects and re-seeds history. The emitted error is marked `recoverable: true` in that case — a restart is coming, and apps that treat unrecoverable errors as fatal shouldn't tear down a session that's about to recover. When the session is already closing (`sessionShouldClose` set), behavior is unchanged (`recoverable: false`, no restart).

Same as the existing `onerror` path, these restarts don't consume the retry budget; a repeatedly failing endpoint behaves as it does today for network errors.

## Tests

`realtime_reconnect.test.ts` drives the live-connect callbacks through a mocked `@google/genai`:

- abnormal close (1006) → a second `connect` happens and the error is emitted with `recoverable: true` (fails without the fix: no reconnect, `recoverable: false`),
- normal close (1000) → no reconnect, no error emitted.

Full `@livekit/agents-plugin-google` suite passes (59 tests).

## Live verification

Applied this change to the installed 1.7.0 dist of a production voice agent and killed the real Gemini socket mid-session (`ws.terminate()` on the underlying `ws@8.19.0` socket — the client observes exactly a 1006), with a probe question whose answer (`47`) existed only in the seeded chat history:

- **Unfixed**: `WebSocket closed with code 1006` logged, no reconnect ever, and one step worse than the parked loop: the `recoverable: false` error makes `AgentSession` close outright (`AgentSession is closing due to an unrecoverable error` — `ev.type` is undefined so `_onError`'s `maxUnrecoverableErrors` counting is skipped). The session dies mid-conversation.
- **Fixed**: reconnect fires 3 ms after the close (`sessionShouldClose:true` → new `Connecting to Gemini Realtime API...`), `recoverable: true` keeps the AgentSession alive, and the model answers `47.` — proving both the reconnect and the chat-context re-seed.
- Full agent smoke suite passes on the fixed build (opening, barge-in, seeded history, typed text, tool injection, closing TTS).

So beyond un-parking the main task, `recoverable: true` also prevents the framework-level session teardown on a transient socket drop.

