### PR TITLE
fix: preserve unicode in windows pretty logs

### DIFF
--- a/.changeset/fix-windows-pretty-unicode.md
+++ b/.changeset/fix-windows-pretty-unicode.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Preserve non-ASCII characters in pretty logs on Windows terminals.

--- a/agents/src/log.test.ts
+++ b/agents/src/log.test.ts
@@ -10,12 +10,57 @@ import {
 } from './telemetry/pino_otel_transport.js';
 import { REDACTED_EXCEPTION_MESSAGE } from './telemetry/utils.js';
 
+const prettyMocks = vi.hoisted(() => ({ pinoPretty: vi.fn() }));
+
+vi.mock('pino-pretty', async () => {
+  const { PassThrough } = await import('node:stream');
+  prettyMocks.pinoPretty.mockImplementation(() => new PassThrough());
+  return { build: prettyMocks.pinoPretty };
+});
+
 const OTEL_ENABLED_KEY = Symbol.for('@livekit/agents:otelEnabled');
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+const stdoutIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
 
 function resetOtelLoggingState() {
   delete (globalThis as Record<symbol, unknown>)[OTEL_ENABLED_KEY];
   initializeLogger({ pretty: false, level: 'silent' });
 }
+
+describe('pretty logging', () => {
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', platformDescriptor);
+    if (stdoutIsTTYDescriptor) {
+      Object.defineProperty(process.stdout, 'isTTY', stdoutIsTTYDescriptor);
+    } else {
+      Reflect.deleteProperty(process.stdout, 'isTTY');
+    }
+    prettyMocks.pinoPretty.mockClear();
+    initializeLogger({ pretty: false, level: 'silent' });
+  });
+
+  it.each([
+    ['win32', true, process.stdout],
+    ['win32', false, undefined],
+    ['linux', true, undefined],
+  ] as const)(
+    'selects the pino-pretty destination on %s when isTTY is %s',
+    async (platform, isTTY, destination) => {
+      Object.defineProperty(process, 'platform', { ...platformDescriptor, value: platform });
+      Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: isTTY });
+      vi.resetModules();
+      const { initializeLogger: initializePrettyLogger } = await import('./log.js');
+
+      initializePrettyLogger({ pretty: true, level: 'silent' });
+
+      expect(prettyMocks.pinoPretty).toHaveBeenCalledOnce();
+      expect(prettyMocks.pinoPretty).toHaveBeenCalledWith({
+        colorize: true,
+        ...(destination && { destination }),
+      });
+    },
+  );
+});
 
 describe('OTEL logging', () => {
   afterEach(() => {

--- a/agents/src/log.ts
+++ b/agents/src/log.ts
@@ -24,7 +24,17 @@ export { log, loggerOptions, type LoggerOptions };
 const createLogger = ({ pretty, level }: LoggerOptions): Logger => {
   const logLevel = level || 'info';
   const streams: { stream: DestinationStream; level: string }[] = [
-    { stream: pretty ? pinoPretty({ colorize: true }) : process.stdout, level: logLevel },
+    {
+      stream: pretty
+        ? pinoPretty({
+            colorize: true,
+            ...(process.platform === 'win32' && process.stdout.isTTY
+              ? { destination: process.stdout }
+              : {}),
+          })
+        : process.stdout,
+      level: logLevel,
+    },
     { stream: new OtelDestination(), level: 'debug' },
   ];
 


### PR DESCRIPTION
**Bug:** `pino-pretty` writes pretty logs to raw file descriptor 1 by default. Windows consoles with a non-UTF-8 code page can mangle non-ASCII text.

Use `process.stdout` only for interactive Windows output. Keep the current SonicBoom path on other platforms and for redirected output.

Adds regression coverage for Windows TTY, Windows redirection, and non-Windows TTY output.

Addresses AGT-3392

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> can you investigate https://linear.app/livekit/issue/AGT-3392/bug-pino-pretty-writes-to-raw-fd-1-mangling-non-ascii-on-windows?
>
> should we limit that change to windows only?
>
> there is no win64?
>
> okay then, let's create a PR for that

</details>
