### PR TITLE
fix: ignore session metadata in OpenAI Realtime context

### DIFF
--- a/.changeset/openai-realtime-session-metadata.md
+++ b/.changeset/openai-realtime-session-metadata.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-openai': patch
+---
+
+Ignore session metadata when syncing the OpenAI Realtime chat context.

--- a/plugins/openai/src/realtime/realtime_model.test.ts
+++ b/plugins/openai/src/realtime/realtime_model.test.ts
@@ -1096,6 +1096,38 @@ describe('RealtimeSession chat context update events', () => {
     expect((events[0] as api_proto.ConversationItemDeleteEvent).item_id).toBe('item_1');
     expect((events[1] as api_proto.ConversationItemCreateEvent).item.id).toBe('item_1');
   });
+
+  it('ignores session metadata when creating provider events', async () => {
+    const existingMessage = llm.ChatMessage.create({
+      id: 'item_1',
+      role: 'assistant',
+      content: ['What is two plus two?'],
+    });
+    const session = createChatCtxUpdateSession(existingMessage);
+
+    const events = await session.createChatCtxUpdateEvents(
+      new llm.ChatContext([
+        existingMessage,
+        new llm.AgentConfigUpdate({
+          id: 'item_config',
+          instructions: 'Ask the next math question.',
+        }),
+        new llm.AgentHandoffItem({
+          id: 'item_handoff',
+          oldAgentId: 'agent_1',
+          newAgentId: 'agent_2',
+        }),
+        llm.ChatMessage.create({ id: 'item_2', role: 'user', content: ['four'] }),
+      ]),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'conversation.item.create',
+      previous_item_id: 'item_1',
+      item: { id: 'item_2' },
+    });
+  });
 });
 
 describe('RealtimeSession.updateOptions', () => {

--- a/plugins/openai/src/realtime/realtime_model.ts
+++ b/plugins/openai/src/realtime/realtime_model.ts
@@ -710,7 +710,10 @@ export class RealtimeSession extends llm.RealtimeSession {
     chatCtx: llm.ChatContext,
     addMockAudio: boolean = false,
   ): Promise<(api_proto.ConversationItemCreateEvent | api_proto.ConversationItemDeleteEvent)[]> {
-    const newChatCtx = chatCtx.copy();
+    const newChatCtx = chatCtx.copy({
+      excludeHandoff: true,
+      excludeConfigUpdate: true,
+    });
     if (addMockAudio) {
       newChatCtx.items.push(createMockAudioItem());
     } else {


### PR DESCRIPTION
OpenAI Realtime attempted to serialize session metadata during task transitions, which aborted the full context update. Exclude `agent_config_update` and `agent_handoff` before diffing so provider conversation items continue to sync.

Adds regression coverage for mixed metadata and provider items.

Addresses AGT-3377

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> Investigate https://linear.app/livekit/issue/AGT-3377/livekitagents-plugin-openai-throws-error-unsupported-item-type-agent
>
> yes, let's fix that by removing them before diffing.
>
> okay, let's create the PR

</details>