### PR TITLE
fix: avoid top-level await in pretty log test

### DIFF
--- a/agents/src/log.test.ts
+++ b/agents/src/log.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { enableOtelLogging, initializeLogger, log } from './log.js';
 import {
   PinoCloudExporter,
@@ -32,14 +32,17 @@ function stubConsole(platform: NodeJS.Platform, isTTY: boolean | undefined) {
   Object.defineProperty(process.stdout, 'isTTY', { value: isTTY, configurable: true });
 }
 
-// vitest.setup.ts imported log.js before the pino-pretty mock above was
-// registered, so a fresh copy is needed to observe the mock.
-vi.resetModules();
-const { initializeLogger: initializePrettyLogger } = await import('./log.js');
-
 describe('pretty logging', () => {
+  let initializePrettyLogger = initializeLogger;
   const { platform } = process;
   const { isTTY } = process.stdout;
+
+  beforeAll(async () => {
+    // vitest.setup.ts imported log.js before the pino-pretty mock above was
+    // registered, so a fresh copy is needed to observe the mock.
+    vi.resetModules();
+    ({ initializeLogger: initializePrettyLogger } = await import('./log.js'));
+  });
 
   afterEach(() => {
     stubConsole(platform, isTTY);


### PR DESCRIPTION
The agents package builds test files in both ESM and CommonJS. PR #2369 moved the mocked logger import to module scope, so CommonJS rejected its top-level await.

Load the fresh logger once in beforeAll. This preserves the test behavior and restores the package and workspace builds.

Addresses AGT-3401

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> build failed https://github.com/livekit/agents-js/actions/runs/33186970337/job/98902370703?pr=2369 but I already merged it, can you fix it?

</details>