### PR TITLE
fix: cancel speech refused while scheduling is paused

### DIFF
--- a/.changeset/cancel-refused-speech.md
+++ b/.changeset/cancel-refused-speech.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+fix(voice): cancel a speech that `scheduleSpeech` refuses while scheduling is paused, so its speech task does not stay parked and block the next `drain()`/`pause()` and `AgentSession.close()`

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -4856,8 +4856,17 @@ export class AgentActivity implements RecognitionHooks {
   ): void {
     // when force=true, we allow tool responses to bypass scheduling pause
     // This allows for tool responses to be generated before the AgentActivity is finalized
-    if (this.schedulingPaused && !force) {
-      throw new SchedulingPausedError();
+    const schedulingPaused = this.schedulingPaused && !force;
+    if (schedulingPaused || this._mainTask?.done) {
+      this.logger.warn(
+        { speech_id: speechHandle.id, scheduling_paused: schedulingPaused },
+        'attempting to schedule a new SpeechHandle while speech scheduling is paused or stopped; the speech will be cancelled',
+      );
+      speechHandle.interrupt(true);
+      if (schedulingPaused) {
+        throw new SchedulingPausedError();
+      }
+      return;
     }
 
     // Monotonic time to avoid near 0 collisions

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2280,7 +2280,8 @@ export class AgentActivity implements RecognitionHooks {
       });
     };
 
-    const task = Task.from(wrappedFn, controller, name);
+    const taskController = controller ?? new AbortController();
+    const task = Task.from(wrappedFn, taskController, name);
     _setActivityTaskInfo(task, { speechHandle: ownedSpeechHandle, inlineTask });
 
     this.speechTasks.add(task);
@@ -2289,6 +2290,15 @@ export class AgentActivity implements RecognitionHooks {
     });
 
     if (ownedSpeechHandle) {
+      const interruptOwnedSpeech = () => ownedSpeechHandle.interrupt(true);
+      taskController.signal.addEventListener('abort', interruptOwnedSpeech, { once: true });
+      if (taskController.signal.aborted) {
+        interruptOwnedSpeech();
+      }
+      task.addDoneCallback(() => {
+        taskController.signal.removeEventListener('abort', interruptOwnedSpeech);
+      });
+
       ownedSpeechHandle._tasks.push(task);
       task.addDoneCallback(() => {
         if (ownedSpeechHandle._tasks.every((t) => t.done)) {

--- a/agents/src/voice/agent_activity_speech_lifecycle.test.ts
+++ b/agents/src/voice/agent_activity_speech_lifecycle.test.ts
@@ -2,11 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it, vi } from 'vitest';
+import { Future, type Task } from '../utils.js';
 import { AgentActivity, SchedulingPausedError } from './agent_activity.js';
 import { SpeechHandle } from './speech_handle.js';
 
 interface AgentActivitySpeechLifecycle {
   scheduleSpeech(speechHandle: SpeechHandle, priority: number, force?: boolean): void;
+  createSpeechTask(options: {
+    taskFn: (controller: AbortController) => Promise<void>;
+    controller?: AbortController;
+    ownedSpeechHandle?: SpeechHandle;
+    inlineTask?: boolean;
+    name?: string;
+  }): Task<void>;
 }
 
 const activityLifecycle = AgentActivity.prototype as unknown as AgentActivitySpeechLifecycle;
@@ -57,5 +65,31 @@ describe('AgentActivity speech lifecycle', () => {
     } finally {
       speechHandle._markDone();
     }
+  });
+
+  it('interrupts owned speech when its task is canceled', async () => {
+    const speechTasks = new Set<Task<void>>();
+    const activity = Object.assign(Object.create(AgentActivity.prototype), {
+      speechTasks,
+      wakeupMainTask: vi.fn(),
+    }) as AgentActivity;
+    const speechHandle = SpeechHandle.create({ allowInterruptions: false });
+    const taskStarted = new Future<void>();
+    const task = activityLifecycle.createSpeechTask.call(activity, {
+      taskFn: async (controller) => {
+        taskStarted.resolve();
+        await new Promise<void>((resolve) => {
+          controller.signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      },
+      ownedSpeechHandle: speechHandle,
+      name: 'owned-speech-test',
+    });
+
+    await taskStarted.await;
+    await task.cancelAndWait();
+
+    expect(task.done).toBe(true);
+    expect(speechHandle.interrupted).toBe(true);
   });
 });

--- a/agents/src/voice/agent_activity_speech_lifecycle.test.ts
+++ b/agents/src/voice/agent_activity_speech_lifecycle.test.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it, vi } from 'vitest';
+import { AgentActivity, SchedulingPausedError } from './agent_activity.js';
+import { SpeechHandle } from './speech_handle.js';
+
+interface AgentActivitySpeechLifecycle {
+  scheduleSpeech(speechHandle: SpeechHandle, priority: number, force?: boolean): void;
+}
+
+const activityLifecycle = AgentActivity.prototype as unknown as AgentActivitySpeechLifecycle;
+
+describe('AgentActivity speech lifecycle', () => {
+  it('interrupts speech refused while scheduling is paused', () => {
+    const warn = vi.fn();
+    const activity = Object.assign(Object.create(AgentActivity.prototype), {
+      _schedulingPaused: true,
+      logger: { warn },
+    }) as AgentActivity;
+    const speechHandle = SpeechHandle.create({ allowInterruptions: false });
+
+    try {
+      expect(() =>
+        activityLifecycle.scheduleSpeech.call(
+          activity,
+          speechHandle,
+          SpeechHandle.SPEECH_PRIORITY_NORMAL,
+        ),
+      ).toThrow(SchedulingPausedError);
+      expect(speechHandle.interrupted).toBe(true);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      speechHandle._markDone();
+    }
+  });
+
+  it('interrupts speech when the scheduling task has already stopped', () => {
+    const warn = vi.fn();
+    const activity = Object.assign(Object.create(AgentActivity.prototype), {
+      _schedulingPaused: false,
+      _mainTask: { done: true },
+      logger: { warn },
+    }) as AgentActivity;
+    const speechHandle = SpeechHandle.create({ allowInterruptions: false });
+
+    try {
+      expect(() =>
+        activityLifecycle.scheduleSpeech.call(
+          activity,
+          speechHandle,
+          SpeechHandle.SPEECH_PRIORITY_NORMAL,
+        ),
+      ).not.toThrow();
+      expect(speechHandle.interrupted).toBe(true);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      speechHandle._markDone();
+    }
+  });
+});

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -75,6 +75,7 @@ import type { Agent } from './agent.js';
 import {
   AgentActivity,
   type ReusableResources,
+  SchedulingPausedError,
   cleanupReusableResources,
   isSchedulingPausedError,
 } from './agent_activity.js';
@@ -1131,7 +1132,7 @@ export class AgentSession<
         if (!nextActivity) {
           throw new Error('AgentSession is closing, cannot use say()');
         }
-        return nextActivity.say(text, options);
+        throw new SchedulingPausedError();
       }
       return activity.say(text, options);
     };

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -75,7 +75,6 @@ import type { Agent } from './agent.js';
 import {
   AgentActivity,
   type ReusableResources,
-  SchedulingPausedError,
   cleanupReusableResources,
   isSchedulingPausedError,
 } from './agent_activity.js';
@@ -1132,7 +1131,9 @@ export class AgentSession<
         if (!nextActivity) {
           throw new Error('AgentSession is closing, cannot use say()');
         }
-        throw new SchedulingPausedError();
+        // Keep Python parity: the queued activity creates the refused speech, then its paused
+        // scheduler interrupts the handle so the speech task can settle.
+        return nextActivity.say(text, options);
       }
       return activity.say(text, options);
     };

--- a/agents/src/voice/agent_task_say_during_pause.test.ts
+++ b/agents/src/voice/agent_task_say_during_pause.test.ts
@@ -35,7 +35,7 @@ async function resolvesWithin(p: Promise<unknown>, ms: number): Promise<void> {
 describe('AgentSession.say() during an AgentTask pause', () => {
   initializeLogger({ pretty: false, level: 'silent' });
 
-  it('rejects refused speech before creation so task hand-back and session close complete', async () => {
+  it('interrupts refused speech so task hand-back and session close complete', async () => {
     class TransferTask extends AgentTask<void> {
       constructor() {
         super({ instructions: 'transfer task' });
@@ -78,7 +78,7 @@ describe('AgentSession.say() during an AgentTask pause', () => {
     const session = new AgentSession({ llm });
     const internals = session as unknown as {
       activity?: { schedulingPaused: boolean };
-      nextActivity?: object;
+      nextActivity?: { speechTasks: Set<{ done: boolean }> };
     };
     await session.start({ agent });
 
@@ -92,12 +92,19 @@ describe('AgentSession.say() during an AgentTask pause', () => {
       ),
     ).toBe(true);
 
-    // say() during the pause must fail before it creates speech on the task activity
+    // say() during the pause is routed to the task activity, which has not started yet
+    const taskActivity = internals.nextActivity!;
     const onSpeechCreated = vi.fn();
     session.on(AgentSessionEventTypes.SpeechCreated, onSpeechCreated);
     expect(() => session.say('oops')).toThrow(SchedulingPausedError);
-    expect(onSpeechCreated).not.toHaveBeenCalled();
+    expect(onSpeechCreated).toHaveBeenCalledOnce();
+    expect(onSpeechCreated.mock.calls[0]![0].speechHandle.interrupted).toBe(true);
     session.off(AgentSessionEventTypes.SpeechCreated, onSpeechCreated);
+
+    // the refused speech must not leave a parked speech task behind
+    expect(await waitFor(() => [...taskActivity.speechTasks].every((t) => t.done), 1000)).toBe(
+      true,
+    );
 
     // let the hold speech finish so the pause completes and the task activity starts
     holdController.enqueue('please hold');

--- a/agents/src/voice/agent_task_say_during_pause.test.ts
+++ b/agents/src/voice/agent_task_say_during_pause.test.ts
@@ -2,13 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { ReadableStream, type ReadableStreamDefaultController } from 'node:stream/web';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { tool } from '../llm/index.js';
 import { initializeLogger } from '../log.js';
 import { Agent, AgentTask } from './agent.js';
 import { SchedulingPausedError } from './agent_activity.js';
 import { AgentSession } from './agent_session.js';
+import { AgentSessionEventTypes } from './events.js';
 import { FakeLLM } from './testing/fake_llm.js';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -22,21 +23,19 @@ async function waitFor(cond: () => boolean, timeoutMs: number): Promise<boolean>
   return false;
 }
 
-async function settlesWithin(p: Promise<unknown>, ms: number): Promise<boolean> {
-  const result = await Promise.race([
-    p.then(
-      () => 'settled' as const,
-      () => 'settled' as const,
-    ),
-    sleep(ms).then(() => 'timeout' as const),
-  ]);
-  return result === 'settled';
+async function resolvesWithin(p: Promise<unknown>, ms: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`promise did not resolve within ${ms}ms`)), ms);
+  });
+
+  await Promise.race([p, timeout]).finally(() => clearTimeout(timer));
 }
 
 describe('AgentSession.say() during an AgentTask pause', () => {
   initializeLogger({ pretty: false, level: 'silent' });
 
-  it('cancels the refused speech so the task hand-back and session close complete', async () => {
+  it('rejects refused speech before creation so task hand-back and session close complete', async () => {
     class TransferTask extends AgentTask<void> {
       constructor() {
         super({ instructions: 'transfer task' });
@@ -79,7 +78,7 @@ describe('AgentSession.say() during an AgentTask pause', () => {
     const session = new AgentSession({ llm });
     const internals = session as unknown as {
       activity?: { schedulingPaused: boolean };
-      nextActivity?: { speechTasks: Set<{ done: boolean }> };
+      nextActivity?: object;
     };
     await session.start({ agent });
 
@@ -93,20 +92,12 @@ describe('AgentSession.say() during an AgentTask pause', () => {
       ),
     ).toBe(true);
 
-    // say() during the pause is routed to the task activity, which has not started yet
-    const taskActivity = internals.nextActivity!;
-    let sayError: unknown;
-    try {
-      session.say('oops');
-    } catch (error) {
-      sayError = error;
-    }
-    expect(sayError).toBeInstanceOf(SchedulingPausedError);
-
-    // the refused speech must not leave a parked speech task behind
-    expect(await waitFor(() => [...taskActivity.speechTasks].every((t) => t.done), 1000)).toBe(
-      true,
-    );
+    // say() during the pause must fail before it creates speech on the task activity
+    const onSpeechCreated = vi.fn();
+    session.on(AgentSessionEventTypes.SpeechCreated, onSpeechCreated);
+    expect(() => session.say('oops')).toThrow(SchedulingPausedError);
+    expect(onSpeechCreated).not.toHaveBeenCalled();
+    session.off(AgentSessionEventTypes.SpeechCreated, onSpeechCreated);
 
     // let the hold speech finish so the pause completes and the task activity starts
     holdController.enqueue('please hold');
@@ -124,6 +115,6 @@ describe('AgentSession.say() during an AgentTask pause', () => {
       ),
     ).toBe(true);
 
-    expect(await settlesWithin(session.close(), 3000)).toBe(true);
+    await expect(resolvesWithin(session.close(), 3000)).resolves.toBeUndefined();
   }, 30_000);
 });

--- a/agents/src/voice/agent_task_say_during_pause.test.ts
+++ b/agents/src/voice/agent_task_say_during_pause.test.ts
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { ReadableStream, type ReadableStreamDefaultController } from 'node:stream/web';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { tool } from '../llm/index.js';
+import { initializeLogger } from '../log.js';
+import { Agent, AgentTask } from './agent.js';
+import { SchedulingPausedError } from './agent_activity.js';
+import { AgentSession } from './agent_session.js';
+import { FakeLLM } from './testing/fake_llm.js';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitFor(cond: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return true;
+    await sleep(10);
+  }
+  return false;
+}
+
+async function settlesWithin(p: Promise<unknown>, ms: number): Promise<boolean> {
+  const result = await Promise.race([
+    p.then(
+      () => 'settled' as const,
+      () => 'settled' as const,
+    ),
+    sleep(ms).then(() => 'timeout' as const),
+  ]);
+  return result === 'settled';
+}
+
+describe('AgentSession.say() during an AgentTask pause', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('cancels the refused speech so the task hand-back and session close complete', async () => {
+    class TransferTask extends AgentTask<void> {
+      constructor() {
+        super({ instructions: 'transfer task' });
+      }
+    }
+
+    let holdController!: ReadableStreamDefaultController<string>;
+    const holdStream = new ReadableStream<string>({
+      start(controller) {
+        holdController = controller;
+      },
+    });
+
+    let task: TransferTask | undefined;
+    class RootAgent extends Agent {
+      constructor() {
+        super({
+          instructions: 'root',
+          tools: [
+            tool({
+              name: 'transfer',
+              description: 'Transfer the call.',
+              parameters: z.object({}),
+              execute: async () => {
+                // A pending speech that is not drain-blocked keeps the pause waiting,
+                // like a parallel tool reply in production.
+                this.session.say(holdStream, { allowInterruptions: false });
+                task = new TransferTask();
+                await task.run();
+                return 'transferred';
+              },
+            }),
+          ],
+        });
+      }
+    }
+
+    const llm = new FakeLLM([{ input: 'go', toolCalls: [{ name: 'transfer', args: {} }] }]);
+    const agent = new RootAgent();
+    const session = new AgentSession({ llm });
+    const internals = session as unknown as {
+      activity?: { schedulingPaused: boolean };
+      nextActivity?: { speechTasks: Set<{ done: boolean }> };
+    };
+    await session.start({ agent });
+
+    session.generateReply({ userInput: 'go' });
+
+    // the root activity is pausing and the task activity is queued as nextActivity
+    expect(
+      await waitFor(
+        () => internals.activity?.schedulingPaused === true && internals.nextActivity !== undefined,
+        5000,
+      ),
+    ).toBe(true);
+
+    // say() during the pause is routed to the task activity, which has not started yet
+    const taskActivity = internals.nextActivity!;
+    let sayError: unknown;
+    try {
+      session.say('oops');
+    } catch (error) {
+      sayError = error;
+    }
+    expect(sayError).toBeInstanceOf(SchedulingPausedError);
+
+    // the refused speech must not leave a parked speech task behind
+    expect(await waitFor(() => [...taskActivity.speechTasks].every((t) => t.done), 1000)).toBe(
+      true,
+    );
+
+    // let the hold speech finish so the pause completes and the task activity starts
+    holdController.enqueue('please hold');
+    holdController.close();
+    expect(await waitFor(() => session.currentAgent === task, 5000)).toBe(true);
+
+    // completing the task drains the task activity and resumes the root agent
+    task!.complete(undefined);
+    expect(
+      await waitFor(
+        () =>
+          internals.activity === (agent._agentActivity as unknown) &&
+          internals.activity?.schedulingPaused === false,
+        3000,
+      ),
+    ).toBe(true);
+
+    expect(await settlesWithin(session.close(), 3000)).toBe(true);
+  }, 30_000);
+});

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -1975,11 +1975,11 @@ export class AudioRecognition {
     const unlock = await this.sttLifecycleLock.lock();
     try {
       const pipeline = this.sttPipeline;
-      this.sttPipeline = undefined;
-      this.sttOwnershipTransferred = pipeline !== undefined;
-
       await this.sttConsumerTask?.cancelAndWait();
       this.sttConsumerTask = undefined;
+
+      this.sttPipeline = undefined;
+      this.sttOwnershipTransferred = pipeline !== undefined;
 
       return pipeline;
     } finally {

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -1975,8 +1975,14 @@ export class AudioRecognition {
     const unlock = await this.sttLifecycleLock.lock();
     try {
       const pipeline = this.sttPipeline;
-      await this.sttConsumerTask?.cancelAndWait();
-      this.sttConsumerTask = undefined;
+      const consumerTask = this.sttConsumerTask;
+      try {
+        await consumerTask?.cancelAndWait();
+      } finally {
+        if (this.sttConsumerTask === consumerTask) {
+          this.sttConsumerTask = undefined;
+        }
+      }
 
       this.sttPipeline = undefined;
       this.sttOwnershipTransferred = pipeline !== undefined;

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -284,9 +284,10 @@ describe('AudioRecognition STT pipeline handoff', () => {
 
       expect(state.sttPipeline).toBe(pipeline);
       expect(state.sttOwnershipTransferred).toBe(false);
+      expect(state.sttConsumerTask).toBeUndefined();
 
-      state.sttConsumerTask = undefined;
-      await expect(recognition.detachSttPipeline()).resolves.toBe(pipeline);
+      await expect(recognition.close()).resolves.toBeUndefined();
+      expect(state.sttPipeline).toBeUndefined();
     } finally {
       await consumerTask.result.catch(() => undefined);
       await recognition.close();

--- a/agents/src/voice/audio_recognition_handoff.test.ts
+++ b/agents/src/voice/audio_recognition_handoff.test.ts
@@ -6,8 +6,15 @@ import { describe, expect, it, vi } from 'vitest';
 import { ChatContext } from '../llm/chat_context.js';
 import { initializeLogger } from '../log.js';
 import { type SpeechEvent, SpeechEventType } from '../stt/stt.js';
+import { Task } from '../utils.js';
 import { AudioRecognition, type RecognitionHooks, STTPipeline } from './audio_recognition.js';
 import type { STTNode } from './io.js';
+
+interface AudioRecognitionTestState {
+  sttPipeline?: STTPipeline;
+  sttOwnershipTransferred: boolean;
+  sttConsumerTask?: Task<void>;
+}
 
 function createHooks() {
   const hooks: RecognitionHooks = {
@@ -252,6 +259,38 @@ describe('AudioRecognition STT pipeline handoff', () => {
       expect((recognition as any).sttPipeline).toBeUndefined();
     } finally {
       await recognition.close();
+    }
+  });
+
+  it('retains pipeline ownership when consumer cancellation fails', async () => {
+    const sttNode: STTNode = async () =>
+      new ReadableStream<SpeechEvent | string>({
+        start() {},
+      });
+    const pipeline = new STTPipeline(sttNode);
+    const { recognition } = createRecognition(sttNode);
+    const state = recognition as unknown as AudioRecognitionTestState;
+    const consumerTask = Task.from(async ({ signal }) => {
+      await new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      throw new Error('consumer cancellation failed');
+    });
+    state.sttPipeline = pipeline;
+    state.sttConsumerTask = consumerTask;
+
+    try {
+      await expect(recognition.detachSttPipeline()).rejects.toThrow('consumer cancellation failed');
+
+      expect(state.sttPipeline).toBe(pipeline);
+      expect(state.sttOwnershipTransferred).toBe(false);
+
+      state.sttConsumerTask = undefined;
+      await expect(recognition.detachSttPipeline()).resolves.toBe(pipeline);
+    } finally {
+      await consumerTask.result.catch(() => undefined);
+      await recognition.close();
+      await pipeline.close();
     }
   });
 });


### PR DESCRIPTION
**Why:** During an `AgentTask` handoff, `session.say()` can target a paused next activity. Its unscheduled speech task then waits forever and blocks later drains and `AgentSession.close()`.

**What:** Keep parity with Python next-activity routing. If the scheduler refuses speech, force-interrupt its handle so the task settles. Task cancellation and STT handoff cleanup add defense in depth. The regression test requires normal `session.close()` resolution.

**Python reference:** livekit/agents#4730, [`_schedule_speech`](https://github.com/livekit/agents/blob/d3e4279ed3c637e08e7462201b475e33b0925fc0/livekit-agents/livekit/agents/voice/agent_activity.py#L1050-L1065)
```python
if self._scheduling_paused and not force:
    speech.interrupt(force=True)
    raise RuntimeError(
        "cannot schedule new speech, the speech scheduling is draining/pausing, the speech will be cancelled"
    )

if self._scheduling_atask and self._scheduling_atask.done():
    logger.warning(
        "attempting to schedule a new SpeechHandle, but the scheduling_task is not running, the speech will be cancelled"
    )
    speech.interrupt(force=True)
    return
```

Addresses AGT-3403

Fixes #2373

<details>
<summary>Initial prompt and agent context</summary>

**Model:** Claude Fable 5

> I got a customer report: FYI noticed a regression in worker shutdown / finalization after upgrading the SDK from 1.6.4 to 1.7.1: [...] Are there known 1.7.1 regressions involving: AgentActivity.drain() or AgentSession.close(), AgentTask handoff or inline-task serialization, shutdown of nested AgentSession instances, worker jobs remaining alive during shutdown [...] Could you inspect the task/activity state for these job IDs and tell us what prevented their job processes from responding and closing? Can you investigate?

> okay, can you create the PR?

> did you include python implementation for reference?

</details>