### PR TITLE
fix(tokenize): strip backslash and all declared punctuation from words

### DIFF
--- a/.changeset/fix-word-tokenizer-punctuation.md
+++ b/.changeset/fix-word-tokenizer-punctuation.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Strip all declared punctuation from words in the basic word tokenizer, including backslash, which the previous data-built regex escaped away.

--- a/agents/src/tokenize/basic/word.ts
+++ b/agents/src/tokenize/basic/word.ts
@@ -3,6 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { PUNCTUATIONS } from '../tokenizer.js';
 
+// Strip punctuation by set membership rather than a regex built from the joined
+// list: concatenating the characters into a `[...]` class mis-parses the members
+// that are regex-significant (e.g. `\` followed by `]` becomes an escaped `]`, so
+// backslash was never stripped, and `,-.` silently forms a range).
+const PUNCTUATION_SET = new Set(PUNCTUATIONS);
+
 /**
  * Split the text into words.
  */
@@ -17,7 +23,9 @@ export const splitWords = (text: string, ignorePunctuation = true): [string, num
     const end = start + word.length;
 
     if (ignorePunctuation) {
-      word = word.replace(new RegExp(`[${PUNCTUATIONS.join('')}]`, 'g'), '');
+      word = Array.from(word)
+        .filter((c) => !PUNCTUATION_SET.has(c))
+        .join('');
     }
 
     words.push([word, start, end]);

--- a/agents/src/tokenize/tokenizer.test.ts
+++ b/agents/src/tokenize/tokenizer.test.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
-import { SentenceTokenizer, WordTokenizer, hyphenateWord } from './basic/index.js';
+import { SentenceTokenizer, WordTokenizer, hyphenateWord, splitWords } from './basic/index.js';
 import { splitParagraphs } from './basic/paragraph.js';
 
 const TEXT =
@@ -254,6 +254,19 @@ describe('tokenizer', () => {
       PARAGRAPH_TEST_CASES.forEach(([a, b]) => {
         expect(splitParagraphs(a)).toStrictEqual(b);
       });
+    });
+  });
+  describe('splitWords', () => {
+    it('strips backslash, a declared punctuation the joined-list regex escaped away', () => {
+      // Regression: PUNCTUATIONS includes both '\\' and ']', but building a regex
+      // from the joined list produced the fragment `[\]` inside the character
+      // class, where `\]` is an escaped literal ']' — consuming the backslash so
+      // it was never a class member and never stripped.
+      expect(splitWords('c\\d', true)).toStrictEqual([['cd', 0, 3]]);
+    });
+
+    it('keeps punctuation when ignorePunctuation is false', () => {
+      expect(splitWords('c\\d', false)).toStrictEqual([['c\\d', 0, 3]]);
     });
   });
 });


### PR DESCRIPTION
## What

`splitWords` (the basic word tokenizer's punctuation stripper) builds its filter by concatenating `PUNCTUATIONS` into a regex character class: `new RegExp(`[${PUNCTUATIONS.join('')}]`, 'g')`. Because the list contains both `\` and `]`, the joined class contains the fragment `[\]`, where `\]` is parsed as an escaped literal `]` — so the backslash is consumed as an escape and is **never a class member**. Backslash (a declared punctuation) is therefore never stripped when `ignorePunctuation` is on (the default). The adjacent `,-.` also silently forms a character range.

## Fix

Strip by `Set` membership instead of a regex built from data — removes exactly the declared characters (backslash included) and eliminates the escaping/range fragility. `splitWords`' signature and behavior are otherwise unchanged.

## Test

Adds a regression test in `tokenizer.test.ts`: `splitWords('c\\d', true)` now yields `[['cd', 0, 3]]` (was `[['c\\d', 0, 3]]`), and confirms `ignorePunctuation: false` still preserves it. Full tokenizer suite green; typecheck, lint, and prettier clean.