### PR TITLE
fix(agents): evict dead warmed processes

### DIFF
--- a/.changeset/evict-dead-warmed-processes.md
+++ b/.changeset/evict-dead-warmed-processes.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Remove warmed processes from the pool queue when they exit before receiving a job.

--- a/agents/src/ipc/proc_pool.test.ts
+++ b/agents/src/ipc/proc_pool.test.ts
@@ -30,6 +30,26 @@ async function flushMicrotasks(ticks = 10): Promise<void> {
   }
 }
 
+function createControlledJoinExecutor() {
+  let resolveJoin: () => void = () => {};
+  const joinPromise = new Promise<void>((resolve) => {
+    resolveJoin = resolve;
+  });
+  const executor: JobExecutor = {
+    ...createMockExecutor(),
+    join: vi.fn(() => joinPromise),
+  };
+  return { executor, resolveJoin };
+}
+
+function mockJobProcExecutor(executor: JobExecutor) {
+  return vi
+    .spyOn(jobProcExecutorModule, 'JobProcExecutor')
+    .mockImplementation(function MockJobProcExecutor(this: unknown) {
+      return executor as unknown as jobProcExecutorModule.JobProcExecutor;
+    } as unknown as typeof jobProcExecutorModule.JobProcExecutor);
+}
+
 describe('ProcPool warmed process lock handling', () => {
   it('releases lock token from the dequeued warmed process entry', async (): Promise<
     Throws<void, Error>
@@ -87,21 +107,8 @@ describe('ProcPool warmed process lock handling', () => {
     const pool = new ProcPool('agent', 1, 1000, 1000, undefined, 0, 0);
     const initUnlock = vi.fn();
     const procUnlock = vi.fn();
-
-    let joinResolve: () => void = () => {};
-    const joinPromise = new Promise<void>((resolve) => {
-      joinResolve = resolve;
-    });
-    const mockProc: JobExecutor = {
-      ...createMockExecutor(),
-      join: vi.fn(() => joinPromise),
-    };
-
-    const jobProcExecutorSpy = vi
-      .spyOn(jobProcExecutorModule, 'JobProcExecutor')
-      .mockImplementation(function MockJobProcExecutor(this: unknown) {
-        return mockProc as unknown as jobProcExecutorModule.JobProcExecutor;
-      } as unknown as typeof jobProcExecutorModule.JobProcExecutor);
+    const { executor: mockProc, resolveJoin } = createControlledJoinExecutor();
+    const jobProcExecutorSpy = mockJobProcExecutor(mockProc);
 
     pool.initMutex.lock = vi.fn(async () => initUnlock);
 
@@ -114,12 +121,102 @@ describe('ProcPool warmed process lock handling', () => {
       expect(pool.warmedProcQueue.items.length).toBe(1);
       expect(mockProc.join).toHaveBeenCalledTimes(1);
 
-      joinResolve();
+      const warmedProcEntry = await pool.warmedProcQueue.get();
+      warmedProcEntry.unlock();
+      resolveJoin();
       await watchPromise;
 
-      // finally block must not double-release.
+      // The watcher must not release a lock token already claimed by a consumer.
       expect(initUnlock).toHaveBeenCalledTimes(1);
-      expect(procUnlock).not.toHaveBeenCalled();
+      expect(procUnlock).toHaveBeenCalledTimes(1);
+    } finally {
+      jobProcExecutorSpy.mockRestore();
+    }
+  });
+
+  it('evicts a warmed process that exits before it is dequeued', async (): Promise<
+    Throws<void, Error>
+  > => {
+    const pool = new ProcPool('agent', 1, 1000, 1000, undefined, 0, 0);
+    const initUnlock = vi.fn();
+    const procUnlock = vi.fn();
+    const { executor: mockProc, resolveJoin } = createControlledJoinExecutor();
+    const jobProcExecutorSpy = mockJobProcExecutor(mockProc);
+
+    pool.initMutex.lock = vi.fn(async () => initUnlock);
+
+    try {
+      const watchPromise = pool.procWatchTask(procUnlock);
+      await flushMicrotasks();
+
+      expect(pool.warmedProcQueue.items).toHaveLength(1);
+
+      resolveJoin();
+      await watchPromise;
+
+      expect(pool.warmedProcQueue.items).toHaveLength(0);
+      expect(procUnlock).toHaveBeenCalledTimes(1);
+    } finally {
+      jobProcExecutorSpy.mockRestore();
+    }
+  });
+
+  it('keeps other warmed processes queued when one exits', async (): Promise<
+    Throws<void, Error>
+  > => {
+    const pool = new ProcPool('agent', 2, 1000, 1000, undefined, 0, 0);
+    const initUnlock = vi.fn();
+    const healthyProcUnlock = vi.fn();
+    const exitedProcUnlock = vi.fn();
+    const healthyProc = createMockExecutor();
+    const { executor: exitedProc, resolveJoin } = createControlledJoinExecutor();
+    const jobProcExecutorSpy = mockJobProcExecutor(exitedProc);
+
+    pool.initMutex.lock = vi.fn(async () => initUnlock);
+    await pool.warmedProcQueue.put({ proc: healthyProc, unlock: healthyProcUnlock });
+
+    try {
+      const watchPromise = pool.procWatchTask(exitedProcUnlock);
+      await flushMicrotasks();
+
+      expect(pool.warmedProcQueue.items).toHaveLength(2);
+
+      resolveJoin();
+      await watchPromise;
+
+      expect(pool.warmedProcQueue.items).toEqual([
+        { proc: healthyProc, unlock: healthyProcUnlock },
+      ]);
+      expect(exitedProcUnlock).toHaveBeenCalledTimes(1);
+      expect(healthyProcUnlock).not.toHaveBeenCalled();
+    } finally {
+      jobProcExecutorSpy.mockRestore();
+    }
+  });
+
+  it('does not double-release a queued process lock during close', async (): Promise<
+    Throws<void, Error>
+  > => {
+    const pool = new ProcPool('agent', 1, 1000, 1000, undefined, 0, 0);
+    const initUnlock = vi.fn();
+    const procUnlock = vi.fn();
+    const { executor: mockProc, resolveJoin } = createControlledJoinExecutor();
+    const jobProcExecutorSpy = mockJobProcExecutor(mockProc);
+
+    pool.initMutex.lock = vi.fn(async () => initUnlock);
+    pool.started = true;
+
+    try {
+      const watchPromise = pool.procWatchTask(procUnlock);
+      await flushMicrotasks();
+
+      const closePromise = pool.close();
+      expect(pool.warmedProcQueue.items).toHaveLength(0);
+
+      resolveJoin();
+      await Promise.all([closePromise, watchPromise]);
+
+      expect(procUnlock).toHaveBeenCalledTimes(1);
     } finally {
       jobProcExecutorSpy.mockRestore();
     }

--- a/agents/src/ipc/proc_pool.ts
+++ b/agents/src/ipc/proc_pool.ts
@@ -98,7 +98,7 @@ export class ProcPool {
 
       const unlock = await this.initMutex.lock();
       let initReleased = false;
-      let procUnlockTransferred = false;
+      let warmedProcEntry: { proc: JobExecutor; unlock: () => void } | undefined;
       try {
         if (this.closed) {
           return;
@@ -107,8 +107,9 @@ export class ProcPool {
         await proc.start();
         try {
           await proc.initialize();
-          await this.warmedProcQueue.put({ proc, unlock: procUnlock });
-          procUnlockTransferred = true;
+          const entry = { proc, unlock: procUnlock };
+          await this.warmedProcQueue.put(entry);
+          warmedProcEntry = entry;
           // Release initMutex after enqueue — holding it through join() serialises
           // the pool to concurrency 1 since child procs are one-shot.
           unlock();
@@ -122,8 +123,15 @@ export class ProcPool {
         if (!initReleased) {
           unlock();
         }
-        if (!procUnlockTransferred) {
+        if (!warmedProcEntry) {
           procUnlock();
+        } else {
+          // A missing entry has already been claimed by launchJob() or close().
+          const entryIndex = this.warmedProcQueue.items.indexOf(warmedProcEntry);
+          if (entryIndex !== -1) {
+            this.warmedProcQueue.items.splice(entryIndex, 1);
+            warmedProcEntry.unlock();
+          }
         }
       }
     } finally {
@@ -169,7 +177,9 @@ export class ProcPool {
     }
     this.closed = true;
     this.controller.abort();
-    this.warmedProcQueue.items.forEach((e) => {
+    // Claim queued entries before closing them so their watchers cannot release the same slots.
+    const warmedProcs = this.warmedProcQueue.items.splice(0);
+    warmedProcs.forEach((e) => {
       e.unlock();
       e.proc.close();
     });


### PR DESCRIPTION
## Description

Fixes #2321.

`ProcPool` transferred ownership of a warmed process's `MultiMutex` unlock token to `warmedProcQueue`, but the watcher only removed the executor from `executors` when that idle process exited. The stale queue entry could therefore be dequeued for a later job, and its capacity slot remained occupied until then.

## Changes Made

- Retain the exact warmed queue entry in `procWatchTask` and remove it by object identity if the process exits before a consumer claims it.
- Release the associated process slot when the watcher removes a dead queued entry.
- Drain queued entries before shutdown cleanup so `close()` and the watcher cannot release the same slot twice.
- Add deterministic race coverage for process exit before dequeue, dequeue before exit, shutdown while queued, and preservation of other healthy entries.

## Pre-Review Checklist

- [x] **Build passes**: Build, lint, typecheck, formatting, tests, and Throws validation pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are documented and justified above
- [x] **Scope appropriate**: All changes address the warmed-process queue lifecycle
- [x] **Video demo**: Not applicable; this is an internal process-pool race covered deterministically by unit tests

## Testing

- [x] Automated tests added/updated
- [x] `pnpm test agents/src/ipc/proc_pool.test.ts` — 8 passed
- [x] `pnpm test agents --silent` — 2,322 passed, 5 skipped
- [x] `pnpm build:agents`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm throws:check`
- [x] `restaurant_agent.ts` and `realtime_agent.ts` manual checks are not applicable to this internal process lifecycle fix

## Additional Notes

The ownership rule is based on synchronous queue removal: `launchJob()`, watcher cleanup, and `close()` each release a token only after successfully claiming its queue entry. This keeps every warmed-process capacity slot paired with exactly one release path.

---

**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.
