### PR TITLE
fix(voice): flush zero-duration transcription segments

### DIFF
--- a/.changeset/flush-zero-duration-transcripts.md
+++ b/.changeset/flush-zero-duration-transcripts.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Flush synchronized transcription text when TTS completes without producing audio frames.

--- a/agents/src/voice/transcription/synchronizer.test.ts
+++ b/agents/src/voice/transcription/synchronizer.test.ts
@@ -294,6 +294,76 @@ describe('TranscriptionSynchronizer enabled behavior', () => {
       await synchronizer.close();
     }
   });
+
+  it('flushes a zero-duration segment while an audible segment awaits playback finish', async () => {
+    const audioOutput = new MockAudioOutput();
+    const textOutput = new MockTextOutput();
+    const synchronizer = new TranscriptionSynchronizer(audioOutput, textOutput);
+    const frame = new AudioFrame(new Int16Array(160), 8000, 1, 160);
+
+    try {
+      await synchronizer.textOutput.captureText('audible reply');
+      await synchronizer.textOutput.flush();
+      await synchronizer.audioOutput.captureFrame(frame);
+      synchronizer.audioOutput.flush();
+      audioOutput.onPlaybackStarted(Date.now());
+
+      await synchronizer.textOutput.captureText('silent reply');
+      await synchronizer.textOutput.flush();
+      expect(synchronizer._pendingRotatedSegments).toHaveLength(1);
+
+      synchronizer.audioOutput.flush();
+      await synchronizer.barrier();
+
+      const transcript = textOutput.captured.join('');
+      expect(transcript).toContain('silent reply');
+      expect(transcript.split('silent reply')).toHaveLength(2);
+      expect(synchronizer._pendingRotatedSegments).toHaveLength(1);
+
+      audioOutput.onPlaybackFinished({ playbackPosition: 0.02, interrupted: false });
+      expect(synchronizer._pendingRotatedSegments).toHaveLength(0);
+    } finally {
+      await synchronizer.close();
+    }
+  });
+
+  it('does not apply a rotated segment audio flush to the following silent segment', async () => {
+    const audioOutput = new MockAudioOutput();
+    const textOutput = new MockTextOutput();
+    const synchronizer = new TranscriptionSynchronizer(audioOutput, textOutput);
+    const frame = new AudioFrame(new Int16Array(160), 8000, 1, 160);
+
+    try {
+      await synchronizer.textOutput.captureText('audible reply');
+      await synchronizer.textOutput.flush();
+      await synchronizer.audioOutput.captureFrame(frame);
+      audioOutput.onPlaybackStarted(Date.now());
+
+      await synchronizer.textOutput.captureText('silent reply');
+      await synchronizer.textOutput.flush();
+      expect(synchronizer._pendingRotatedSegments).toHaveLength(1);
+
+      const silentSegment = synchronizer._impl;
+      synchronizer.audioOutput.flush();
+
+      expect(synchronizer._impl).toBe(silentSegment);
+      expect(silentSegment.audioInputEnded).toBe(false);
+      expect(textOutput.captured.join('')).not.toContain('silent reply');
+
+      synchronizer.audioOutput.flush();
+      await synchronizer.barrier();
+
+      const transcript = textOutput.captured.join('');
+      expect(transcript).toContain('silent reply');
+      expect(transcript.split('silent reply')).toHaveLength(2);
+      expect(synchronizer._pendingRotatedSegments).toHaveLength(1);
+
+      audioOutput.onPlaybackFinished({ playbackPosition: 0.02, interrupted: false });
+      expect(synchronizer._pendingRotatedSegments).toHaveLength(0);
+    } finally {
+      await synchronizer.close();
+    }
+  });
 });
 
 describe('TranscriptionSynchronizer attachment warnings', () => {

--- a/agents/src/voice/transcription/synchronizer.test.ts
+++ b/agents/src/voice/transcription/synchronizer.test.ts
@@ -4,7 +4,7 @@
 import { AudioFrame } from '@livekit/rtc-node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as logModule from '../../log.js';
-import { AudioOutput, TextOutput } from '../io.js';
+import { AudioOutput, TextOutput, type TimedString, isTimedString } from '../io.js';
 import {
   SpeakingRateData,
   TranscriptionSynchronizer,
@@ -227,8 +227,8 @@ class MockAudioOutput extends AudioOutput {
 class MockTextOutput extends TextOutput {
   captured: string[] = [];
 
-  async captureText(text: string): Promise<void> {
-    this.captured.push(text);
+  async captureText(text: string | TimedString): Promise<void> {
+    this.captured.push(isTimedString(text) ? text.text : text);
   }
 
   flush(): void {}
@@ -246,6 +246,53 @@ describe('TranscriptionSynchronizer enabled behavior', () => {
 
     expect(downstream.captured).toEqual(['hello']);
     await synchronizer.close();
+  });
+
+  it('flushes pending text when audio input ends without frames', async () => {
+    const downstream = new MockTextOutput();
+    const synchronizer = new TranscriptionSynchronizer(new MockAudioOutput(), downstream);
+
+    try {
+      await synchronizer.textOutput.captureText('silent reply');
+      await synchronizer.textOutput.flush();
+      synchronizer.audioOutput.flush();
+
+      await synchronizer.barrier();
+      expect(downstream.captured.join('')).toBe('silent reply');
+    } finally {
+      await synchronizer.close();
+    }
+  });
+
+  it('preserves playback gating for an audible segment after a zero-duration segment', async () => {
+    const audioOutput = new MockAudioOutput();
+    const textOutput = new MockTextOutput();
+    const synchronizer = new TranscriptionSynchronizer(audioOutput, textOutput);
+    const frame = new AudioFrame(new Int16Array(160), 8000, 1, 160);
+
+    try {
+      await synchronizer.textOutput.captureText('silent reply');
+      synchronizer.audioOutput.flush();
+      await synchronizer.textOutput.flush();
+
+      await synchronizer.barrier();
+      expect(textOutput.captured.join('')).toBe('silent reply');
+      expect(synchronizer._pendingRotatedSegments).toHaveLength(0);
+
+      await synchronizer.textOutput.captureText('audible reply');
+      await synchronizer.textOutput.flush();
+      await synchronizer.audioOutput.captureFrame(frame);
+      synchronizer.audioOutput.flush();
+
+      expect(textOutput.captured.join('')).toBe('silent reply');
+
+      audioOutput.onPlaybackStarted(Date.now());
+      audioOutput.onPlaybackFinished({ playbackPosition: 0.02, interrupted: false });
+      await synchronizer.barrier();
+      expect(textOutput.captured.join('')).toBe('silent replyaudible reply');
+    } finally {
+      await synchronizer.close();
+    }
   });
 });
 

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -148,6 +148,12 @@ interface AudioData {
   annotatedRate: SpeakingRateData | null;
 }
 
+interface PendingRotatedSegment {
+  impl: SegmentSynchronizerImpl;
+  acceptedDownstream: boolean;
+  awaitingAudioFlush: boolean;
+}
+
 class SegmentSynchronizerImpl {
   private enabled: boolean;
   private textData: TextData;
@@ -660,10 +666,12 @@ export class TranscriptionSynchronizer {
    * `acceptedDownstream` records whether the next-in-chain audio output counted the segment:
    * accepted segments owe a *real* finish from downstream, dropped segments owe a *synthetic*
    * drift finish from `waitForPlayout()` — pairing by kind keeps a synthetic finish from
-   * consuming an entry whose real finish is still in flight.
+   * consuming an entry whose real finish is still in flight. `awaitingAudioFlush` records
+   * whether the rotated segment also owns the next audio flush, so a segment that only awaits
+   * playback finish does not block the current segment's audio boundary.
    * @internal
    */
-  _pendingRotatedSegments: { impl: SegmentSynchronizerImpl; acceptedDownstream: boolean }[] = [];
+  _pendingRotatedSegments: PendingRotatedSegment[] = [];
 
   private logger = log();
 
@@ -870,11 +878,14 @@ class SyncedAudioOutput extends AudioOutput {
       return;
     }
 
-    // If a previous (interrupted) speech was rotated out early by an incoming capture_text,
-    // this flush belongs to that already-closed segment. Applying endAudioInput to the current
-    // `_impl` would mark the NEXT reply's audio as ended and trigger a spurious rotation that
-    // drops its transcript. Skip it; the pending stale playback_finished finalizes the old one.
-    if (this.synchronizer._pendingRotatedSegments.length > 0) {
+    // A segment rotated by incoming text can still own a late audio flush. Consume only that
+    // outstanding boundary; queued segments whose audio already ended merely await playback
+    // finish and must not block the current segment's flush.
+    const pendingAudioFlushOwner = this.synchronizer._pendingRotatedSegments.find(
+      (entry) => entry.awaitingAudioFlush,
+    );
+    if (pendingAudioFlushOwner) {
+      pendingAudioFlushOwner.awaitingAudioFlush = false;
       return;
     }
 
@@ -896,6 +907,9 @@ class SyncedAudioOutput extends AudioOutput {
     }
 
     this.synchronizer._impl.endAudioInput();
+    if (this.synchronizer._impl.tryCompleteZeroDurationSegment()) {
+      this.synchronizer.rotateSegment();
+    }
   }
 
   clearBuffer() {
@@ -1051,6 +1065,7 @@ class SyncedTextOutput extends TextOutput {
       this.synchronizer._pendingRotatedSegments.push({
         impl: this.synchronizer._impl,
         acceptedDownstream: this.synchronizer.audioOutput._rotationCandidateAccepted,
+        awaitingAudioFlush: !this.synchronizer._impl.audioInputEnded,
       });
       this.synchronizer.rotateSegment();
       await this.synchronizer.barrier();

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -330,6 +330,29 @@ class SegmentSynchronizerImpl {
     }
   }
 
+  /**
+   * Complete a text-only segment that cannot receive playback callbacks.
+   *
+   * @returns `true` only when this call completed the segment, so the caller can rotate it.
+   */
+  tryCompleteZeroDurationSegment(): boolean {
+    if (
+      this.playbackCompleted ||
+      !this.textData.done ||
+      !this.audioData.done ||
+      this.audioData.pushedDuration > 0
+    ) {
+      return false;
+    }
+
+    this.playbackCompleted = true;
+    this.startWallTime ??= Date.now();
+    if (!this.startFuture.done) {
+      this.startFuture.resolve();
+    }
+    return true;
+  }
+
   pause(): void {
     if (this.closed) {
       this.logger.warn('SegmentSynchronizerImpl.pause called after close');
@@ -862,6 +885,9 @@ class SyncedAudioOutput extends AudioOutput {
       if (this.synchronizer._impl.hasPendingText) {
         // Text is pending - end audio input to allow text processing
         this.synchronizer._impl.endAudioInput();
+        if (this.synchronizer._impl.tryCompleteZeroDurationSegment()) {
+          this.synchronizer.rotateSegment();
+        }
         return;
       }
       // No text and no audio - rotate the segment
@@ -1049,6 +1075,9 @@ class SyncedTextOutput extends TextOutput {
 
     this.capturing = false;
     this.synchronizer._impl.endTextInput();
+    if (this.synchronizer._impl.tryCompleteZeroDurationSegment()) {
+      this.synchronizer.rotateSegment();
+    }
   }
 
   onAttached(): void {


### PR DESCRIPTION
## Description

Fixes #2383.

`TranscriptionSynchronizer` waits for playback to start before forwarding paced text. When TTS completes with non-empty text but produces zero audio frames, no playback-started event can occur, so the segment keeps its transcript indefinitely.

This change completes a segment only when both text and audio inputs have ended and its pushed audio duration is zero. It releases the existing text-forwarding task and rotates the completed segment. Segments containing audio continue to use the existing playback-gated pacing path.

Related duplicate report: #2384.

## Changes Made

- Complete and rotate zero-duration segments regardless of whether text or audio input ends first.
- Add deterministic regression coverage for zero-frame transcript delivery and the following audible segment.
- Preserve playback gating for segments that contain audio.
- Add a patch changeset for `@livekit/agents`.

## Pre-Review Checklist

- [x] **Build passes**: Build, lint, typecheck, tests, formatting, and throws checks pass locally.
- [x] **AI-generated code reviewed**: Reviewed the complete base-to-head diff, naming, lifecycle races, and scope.
- [x] **Changes explained**: The zero-duration state transition and preserved audio path are documented above.
- [x] **Scope appropriate**: Changes are limited to the transcription synchronizer, its tests, and a changeset.
- [x] **Video demo**: Not applicable; this internal edge case is reproduced and verified deterministically without external services.

## Testing

- [x] Automated tests added.
- [x] `pnpm test agents --silent` — 141 files passed; 2,321 tests passed and 5 skipped.
- [x] `pnpm exec turbo run build --filter=@livekit/agents... --output-logs=errors-only` — passed.
- [x] `pnpm exec turbo lint typecheck throws:check --output-logs=errors-only` — 74 tasks passed.
- [x] `pnpm format:check` — passed.
- [x] Built-code reproduction delivered `silent reply` with zero pending rotated segments.
- [x] `restaurant_agent.ts` and `realtime_agent.ts`: not applicable for this focused internal lifecycle fix.

## Additional Notes

`pnpm api:check` reports existing declaration drift on current main. The same failure reproduces outside this branch, and its generated differences do not include the transcription synchronizer or any symbol changed here. This PR does not change public API.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.