### PR TITLE
feat(perplexity): deprecate chat completions clients

### DIFF
--- a/.changeset/perplexity-agent-api-migration.md
+++ b/.changeset/perplexity-agent-api-migration.md
@@ -1,0 +1,6 @@
+---
+'@livekit/agents-plugin-openai': patch
+'@livekit/agents-plugin-perplexity': patch
+---
+
+Recommend the Perplexity Agent API client and deprecate the legacy Sonar Chat Completions clients.

--- a/plugins/openai/etc/agents-plugin-openai.api.md
+++ b/plugins/openai/etc/agents-plugin-openai.api.md
@@ -676,6 +676,7 @@ export class LLM extends llm.LLM {
         client: OpenAI;
     }>): LLM;
     static withOVHcloud(opts?: Partial<LLMOptions>): LLM;
+    // @deprecated
     static withPerplexity(opts?: Partial<{
         model: string | PerplexityChatModels;
         apiKey?: string;
@@ -919,7 +920,7 @@ interface OutputTextContent {
 // Warning: (ae-missing-release-tag) "PerplexityChatModels" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type PerplexityChatModels = 'llama-3.1-sonar-small-128k-online' | 'llama-3.1-sonar-small-128k-chat' | 'llama-3.1-sonar-large-128k-online' | 'llama-3.1-sonar-large-128k-chat' | 'llama-3.1-8b-instruct' | 'llama-3.1-70b-instruct';
+export type PerplexityChatModels = 'sonar' | 'sonar-pro' | 'sonar-reasoning-pro' | 'sonar-deep-research';
 
 // @internal
 function processBaseURL(input: {

--- a/plugins/openai/src/llm.test.ts
+++ b/plugins/openai/src/llm.test.ts
@@ -44,6 +44,20 @@ describe('OpenAI LLM prewarm', () => {
   });
 });
 
+describe('Perplexity compatibility helper', () => {
+  it('uses a supported default model and warns with the Agent API migration path', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const llm = LLM.withPerplexity({ apiKey: 'test-key' });
+
+      expect(llm.model).toBe('sonar-pro');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('responses.LLM'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
 it('does not crash the stream when usage token counts are null', async () => {
   // Null fields inside a non-null usage object must not terminate the stream. Missing counts
   // default to zero.

--- a/plugins/openai/src/llm.ts
+++ b/plugins/openai/src/llm.ts
@@ -336,6 +336,10 @@ export class LLM extends llm.LLM {
   /**
    * Create a new instance of PerplexityAI LLM.
    *
+   * @deprecated This helper uses Sonar Chat Completions. Install
+   * `@livekit/agents-plugin-perplexity` and use `perplexity.responses.LLM` for the Perplexity
+   * Agent API.
+   *
    * @remarks
    * `apiKey` must be set to your PerplexityAI API key, either using the argument or by setting the
    * `PERPLEXITY_API_KEY` environment variable.
@@ -350,6 +354,10 @@ export class LLM extends llm.LLM {
       client: OpenAI;
     }> = {},
   ): LLM {
+    console.warn(
+      '[Perplexity] openai.LLM.withPerplexity() uses Sonar Chat Completions and is deprecated. ' +
+        'Install @livekit/agents-plugin-perplexity and use responses.LLM for the Perplexity Agent API.',
+    );
     opts.apiKey = opts.apiKey || process.env.PERPLEXITY_API_KEY;
     if (opts.apiKey === undefined) {
       throw new Error(
@@ -358,7 +366,7 @@ export class LLM extends llm.LLM {
     }
 
     return new LLM({
-      model: 'llama-3.1-sonar-small-128k-chat',
+      model: 'sonar-pro',
       baseURL: 'https://api.perplexity.ai',
       ...opts,
     });

--- a/plugins/openai/src/models.ts
+++ b/plugins/openai/src/models.ts
@@ -92,12 +92,10 @@ export type TelnyxChatModels =
 export type CerebrasChatModels = 'gpt-oss-120b' | 'zai-glm-4.7' | 'gemma-4-31b';
 
 export type PerplexityChatModels =
-  | 'llama-3.1-sonar-small-128k-online'
-  | 'llama-3.1-sonar-small-128k-chat'
-  | 'llama-3.1-sonar-large-128k-online'
-  | 'llama-3.1-sonar-large-128k-chat'
-  | 'llama-3.1-8b-instruct'
-  | 'llama-3.1-70b-instruct';
+  | 'sonar'
+  | 'sonar-pro'
+  | 'sonar-reasoning-pro'
+  | 'sonar-deep-research';
 
 export type GroqChatModels =
   | 'llama-3.1-8b-instant'

--- a/plugins/perplexity/README.md
+++ b/plugins/perplexity/README.md
@@ -1,7 +1,6 @@
 # Perplexity plugin for LiveKit Agents
 
-Support for [Perplexity](https://www.perplexity.ai/) LLMs via the OpenAI-compatible
-chat completions endpoint at `https://api.perplexity.ai`.
+Support for [Perplexity](https://www.perplexity.ai/) models through the Agent API.
 
 See [https://docs.livekit.io/agents/models/llm/perplexity/](https://docs.livekit.io/agents/models/llm/perplexity/) for more information.
 
@@ -19,32 +18,31 @@ You'll need an API key from Perplexity. It can be passed directly or set as the
 ## Usage
 
 ```ts
-import { LLM } from '@livekit/agents-plugin-perplexity';
-
-const llm = new LLM({
-  model: 'sonar-pro',
-  // apiKey is picked up from PERPLEXITY_API_KEY if omitted
-});
-```
-
-The plugin reuses the OpenAI plugin's chat completions transport with
-`baseURL: 'https://api.perplexity.ai'` and forwards an `X-Pplx-Integration`
-attribution header on every outgoing request.
-
-## Agent API usage
-
-Perplexity's Agent API is compatible with OpenAI's Responses API and is available
-through the `responses` submodule.
-
-```ts
 import { responses } from '@livekit/agents-plugin-perplexity';
 
 const llm = new responses.LLM({
-  model: 'sonar-pro',
+  model: 'perplexity/sonar',
   // apiKey is picked up from PERPLEXITY_API_KEY if omitted
 });
 ```
 
 The Responses LLM uses `baseURL: 'https://api.perplexity.ai/v1'`, disables
-WebSocket transport, and sends the same `X-Pplx-Integration` attribution header
-on its OpenAI-compatible client.
+WebSocket transport, and sends an `X-Pplx-Integration` attribution header on
+its OpenAI-compatible client.
+
+## Migrating from Chat Completions
+
+The `LLM` class and `openai.LLM.withPerplexity()` use Sonar Chat Completions and
+are deprecated. Replace either legacy path with the Responses LLM:
+
+```ts
+import { responses } from '@livekit/agents-plugin-perplexity';
+
+const llm = new responses.LLM({
+  model: 'perplexity/sonar',
+  // apiKey is picked up from PERPLEXITY_API_KEY if omitted
+});
+```
+
+See Perplexity's [migration guide](https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar/overview)
+for request and model changes when moving from Sonar to the Agent API.

--- a/plugins/perplexity/etc/agents-plugin-perplexity.api.md
+++ b/plugins/perplexity/etc/agents-plugin-perplexity.api.md
@@ -36,7 +36,7 @@ import { z } from 'zod';
 
 // Warning: (ae-forgotten-export) The symbol "LLM_2" needs to be exported by the entry point index.d.ts
 //
-// @public
+// @public @deprecated
 export class LLM extends LLM_2 {
     constructor(opts?: Partial<LLMOptions>);
     // (undocumented)
@@ -115,7 +115,7 @@ export const PERPLEXITY_BASE_URL = "https://api.perplexity.ai";
 const PERPLEXITY_RESPONSES_BASE_URL = "https://api.perplexity.ai/v1";
 
 // @public (undocumented)
-export type PerplexityChatModels = 'sonar-pro';
+export type PerplexityChatModels = 'sonar' | 'sonar-pro' | 'sonar-reasoning-pro' | 'sonar-deep-research';
 
 // @public (undocumented)
 export type PerplexityResponsesModels = 'perplexity/sonar';

--- a/plugins/perplexity/src/llm.test.ts
+++ b/plugins/perplexity/src/llm.test.ts
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type OpenAI from 'openai';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LLM, PERPLEXITY_BASE_URL } from './llm.js';
 
 const originalPerplexityApiKey = process.env.PERPLEXITY_API_KEY;
+let warnSpy: ReturnType<typeof vi.spyOn>;
 
 interface LLMInternals {
   _client: OpenAI;
@@ -17,7 +18,12 @@ interface OpenAIInternals {
   };
 }
 
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
 afterEach(() => {
+  warnSpy.mockRestore();
   if (originalPerplexityApiKey === undefined) {
     delete process.env.PERPLEXITY_API_KEY;
   } else {
@@ -26,6 +32,14 @@ afterEach(() => {
 });
 
 describe('Perplexity LLM', () => {
+  it('warns with the Agent API migration path', () => {
+    process.env.PERPLEXITY_API_KEY = 'test-key';
+
+    new LLM();
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('responses.LLM'));
+  });
+
   it('defaults to sonar-pro and Perplexity base URL', () => {
     process.env.PERPLEXITY_API_KEY = 'test-key';
 

--- a/plugins/perplexity/src/llm.ts
+++ b/plugins/perplexity/src/llm.ts
@@ -13,6 +13,10 @@ const ATTRIBUTION_HEADER = {
   'X-Pplx-Integration': `livekit-agents/${__PACKAGE_VERSION__}`,
 };
 
+const DEPRECATION_WARNING =
+  '[Perplexity] LLM uses Sonar Chat Completions and is deprecated. ' +
+  'Use responses.LLM for the Perplexity Agent API.';
+
 /** @public */
 export interface LLMOptions {
   model: string | PerplexityChatModels;
@@ -34,6 +38,9 @@ const defaultLLMOptions: LLMOptions = {
 /**
  * Create a new instance of Perplexity LLM.
  *
+ * @deprecated This client uses Sonar Chat Completions. Use `responses.LLM` for the Perplexity
+ * Agent API.
+ *
  * @public
  */
 export class LLM extends OpenAILLM {
@@ -41,6 +48,7 @@ export class LLM extends OpenAILLM {
   private readonly _opts: LLMOptions;
 
   constructor(opts: Partial<LLMOptions> = {}) {
+    console.warn(DEPRECATION_WARNING);
     const merged = { ...defaultLLMOptions, ...opts };
 
     merged.apiKey = merged.apiKey || process.env.PERPLEXITY_API_KEY;

--- a/plugins/perplexity/src/models.ts
+++ b/plugins/perplexity/src/models.ts
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /** @public */
-export type PerplexityChatModels = 'sonar-pro';
+export type PerplexityChatModels =
+  | 'sonar'
+  | 'sonar-pro'
+  | 'sonar-reasoning-pro'
+  | 'sonar-deep-research';
 
 /** @public */
 export type PerplexityResponsesModels = 'perplexity/sonar';


### PR DESCRIPTION
## Why

The Node Perplexity integration still presents Sonar Chat Completions as the primary path even though the plugin already includes an Agent API Responses client. Its Responses README example also passes the Chat Completions model name `sonar-pro`, while both legacy TypeScript entry points offer no actionable migration warning and the OpenAI compatibility helper defaults to a retired model.

## What changed

- Make `responses.LLM` with `perplexity/sonar` the primary Perplexity README example.
- Document migration from the legacy plugin client and `openai.LLM.withPerplexity()`.
- Add runtime warnings and TypeScript deprecation annotations to both legacy entry points.
- Restore `withPerplexity()` to the supported `sonar-pro` compatibility default and replace retired Perplexity model literals with current Sonar model IDs.
- Add regression coverage and update generated API reports and release metadata.

## Behavior and scope

This is a soft deprecation. Explicit Sonar Chat Completions configurations continue to construct and now emit an actionable warning. The dedicated `responses.LLM` remains unchanged: it defaults to `perplexity/sonar`, uses `https://api.perplexity.ai/v1`, disables WebSocket transport, reads `PERPLEXITY_API_KEY`, and sends the LiveKit attribution header.

Coordinated Python change: [livekit/agents#7069](https://github.com/livekit/agents/pull/7069).

Coordinated Perplexity guide: [ppl-ai/api-docs#807](https://github.com/ppl-ai/api-docs/pull/807).

Tracking: [Sonar to Agent migration](https://www.perplexity.ai/projects/sonar-to-agent-migration-AvXYcgZRTK6NO0y2XS9S2Q), [API-3590](https://linear.app/perplexity/issue/API-3590), and [API-3389](https://linear.app/perplexity/issue/API-3389).
