### PR TITLE
fix: align OpenAI ws peer snapshots

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@types/ws':
       specifier: ^8.5.10
       version: 8.18.1
+    ws:
+      specifier: ^8.21.0
+      version: 8.21.3
 
 overrides:
   adm-zip@<0.6.0: ^0.6.0
@@ -629,7 +632,7 @@ importers:
         version: 3.1.3
       openai:
         specifier: ^6.8.1
-        version: 6.8.1(ws@8.21.1)(zod@4.3.6)
+        version: 6.8.1(ws@8.21.3)(zod@4.3.6)
     devDependencies:
       '@livekit/agents':
         specifier: workspace:*
@@ -802,7 +805,7 @@ importers:
         version: 0.4.0
       openai:
         specifier: ^6.8.1
-        version: 6.8.1(ws@8.21.1)(zod@4.3.6)
+        version: 6.8.1(ws@8.21.3)(zod@4.3.6)
     devDependencies:
       '@livekit/agents':
         specifier: workspace:*
@@ -1186,7 +1189,7 @@ importers:
     dependencies:
       openai:
         specifier: ^6.8.1
-        version: 6.8.1(ws@8.21.1)(zod@4.3.6)
+        version: 6.8.1(ws@8.21.3)(zod@4.3.6)
       zod:
         specifier: ^3.25.76 || ^4.1.8
         version: 4.3.6
@@ -5456,18 +5459,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.21.1:
-    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -5951,7 +5942,7 @@ snapshots:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.6.5
-      ws: 8.21.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6381,7 +6372,7 @@ snapshots:
 
   '@mistralai/mistralai@2.2.1':
     dependencies:
-      ws: 8.21.1
+      ws: 8.21.3
       zod: 4.3.6
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
@@ -8568,7 +8559,7 @@ snapshots:
       bent: 7.3.12
       https-proxy-agent: 4.0.0
       uuid: 11.1.1
-      ws: 8.21.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8709,11 +8700,6 @@ snapshots:
       platform: 1.3.6
       protobufjs: 7.6.5
 
-  openai@6.8.1(ws@8.21.1)(zod@4.3.6):
-    optionalDependencies:
-      ws: 8.21.1
-      zod: 4.3.6
-
   openai@6.8.1(ws@8.21.3)(zod@3.25.76):
     optionalDependencies:
       ws: 8.21.3
@@ -8798,7 +8784,7 @@ snapshots:
 
   phonic@0.32.15:
     dependencies:
-      ws: 8.21.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9741,8 +9727,6 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
-
-  ws@8.21.1: {}
 
   ws@8.21.3: {}
 


### PR DESCRIPTION
The `ws@8.21.3` lockfile update left `openai@6.8.1` installed with both `ws@8.21.1` and `ws@8.21.3` peer snapshots. OpenAI's private field makes those physical class copies type-incompatible, which breaks Perplexity declarations and would next break Cerebras.

Normalize compatible `ws` resolutions to `8.21.3` so OpenAI-compatible plugins share one class declaration.

Addresses AJS-486

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> I am seeing Property '#private' in type 'OpenAI' refers to a different member that cannot be accessed from within type 'OpenAI'. in https://github.com/livekit/agents-js/actions/runs/33521727147/job/99902404071
>
> Okay, create a PR please

</details>
