### PR TITLE
fix: surface inference gateway status errors

### DIFF
--- a/.changeset/surface-inference-gateway-errors.md
+++ b/.changeset/surface-inference-gateway-errors.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-Surface inference gateway response details when a WebSocket handshake fails.
+Surface inference gateway HTTP status codes when a WebSocket handshake fails.

--- a/.changeset/surface-inference-gateway-errors.md
+++ b/.changeset/surface-inference-gateway-errors.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-Surface inference gateway HTTP status codes when a WebSocket handshake fails.
+Surface inference gateway status errors from WebSocket handshakes and active STT sessions.

--- a/.changeset/surface-inference-gateway-errors.md
+++ b/.changeset/surface-inference-gateway-errors.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Surface inference gateway response details when a WebSocket handshake fails.

--- a/agents/src/inference/api_protos.ts
+++ b/agents/src/inference/api_protos.ts
@@ -204,11 +204,13 @@ export const sttSessionClosedEventSchema = z.object({
 });
 
 // Error event
-export const sttErrorEventSchema = z.object({
-  type: z.literal('error'),
-  message: z.string().optional(),
-  code: z.number().optional(),
-});
+export const sttErrorEventSchema = z
+  .object({
+    type: z.literal('error'),
+    message: z.string().optional(),
+    code: z.number().optional(),
+  })
+  .passthrough();
 
 // Discriminated union for well-known STT server events
 export const sttKnownServerEventSchema = z.discriminatedUnion('type', [

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { once } from 'node:events';
 import type { AddressInfo } from 'node:net';
+import { stdSerializers } from 'pino';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { WebSocketServer } from 'ws';
 import { APIStatusError } from '../_exceptions.js';
@@ -848,11 +849,12 @@ describe('Inference STT errors', () => {
 
     expect(error).toBeInstanceOf(APIStatusError);
     expect(error).toMatchObject({
-      message: `LiveKit Inference STT returned error: ${testCase.gatewayError.message}`,
+      message: 'LiveKit STT returned an error',
       statusCode: testCase.statusCode,
       body: testCase.gatewayError,
       retryable: true,
     });
+    expect(JSON.stringify(stdSerializers.err(error))).not.toContain(testCase.gatewayError.message);
   });
 });
 

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { WebSocketServer } from 'ws';
+import { APIStatusError } from '../_exceptions.js';
 import * as agents from '../index.js';
 import { normalizeLanguage } from '../language.js';
 import { initializeLogger } from '../log.js';
@@ -599,6 +603,63 @@ describe('STT VAD handling for Speechmatics models', () => {
 
     stt.updateOptions({ model: 'speechmatics/enhanced' });
     expect(stt['vad']).toBeInstanceOf(InferenceVAD);
+  });
+});
+
+describe('Inference STT errors', () => {
+  async function receiveGatewayError(gatewayError: Record<string, unknown>): Promise<Error> {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    const { port } = server.address() as AddressInfo;
+
+    server.on('connection', (socket) => {
+      socket.once('message', () => {
+        setImmediate(() => socket.send(JSON.stringify(gatewayError)));
+      });
+    });
+
+    const stt = makeStt({ baseURL: `http://127.0.0.1:${port}` });
+    const errorPromise = new Promise<Error>((resolve) => {
+      stt.once('error', ({ error }) => resolve(error));
+    });
+    const stream = stt.stream({
+      connOptions: { maxRetry: 0, retryIntervalMs: 0, timeoutMs: 1_000 },
+    });
+
+    try {
+      return await errorPromise;
+    } finally {
+      stream.close();
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }
+
+  it.each([
+    {
+      gatewayError: {
+        type: 'error',
+        message: 'STT connection limit exceeded',
+        code: 429,
+        category: 'MaxConcurrentGatewaySTT',
+        remaining_limit: 0,
+      },
+      statusCode: 429,
+    },
+    {
+      gatewayError: { type: 'error', message: 'unknown gateway failure' },
+      statusCode: -1,
+    },
+  ])('surfaces a mid-session gateway error with status $statusCode', async (testCase) => {
+    const error = await receiveGatewayError(testCase.gatewayError);
+
+    expect(error).toBeInstanceOf(APIStatusError);
+    expect(error).toMatchObject({
+      message: `LiveKit Inference STT returned error: ${testCase.gatewayError.message}`,
+      statusCode: testCase.statusCode,
+      body: testCase.gatewayError,
+      retryable: true,
+    });
   });
 });
 

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { once } from 'node:events';
 import type { AddressInfo } from 'node:net';
-import { stdSerializers } from 'pino';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { WebSocketServer } from 'ws';
 import { APIStatusError } from '../_exceptions.js';
@@ -849,12 +848,11 @@ describe('Inference STT errors', () => {
 
     expect(error).toBeInstanceOf(APIStatusError);
     expect(error).toMatchObject({
-      message: 'LiveKit STT returned an error',
+      message: `LiveKit Inference STT returned error: ${testCase.gatewayError.message}`,
       statusCode: testCase.statusCode,
       body: testCase.gatewayError,
       retryable: true,
     });
-    expect(JSON.stringify(stdSerializers.err(error))).not.toContain(testCase.gatewayError.message);
   });
 });
 

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -4,7 +4,7 @@
 import { type AudioFrame } from '@livekit/rtc-node';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import type { WebSocket } from 'ws';
-import { APIError, APIStatusError } from '../_exceptions.js';
+import { APIStatusError } from '../_exceptions.js';
 import { AudioByteStream } from '../audio.js';
 import { type LanguageCode, areLanguagesEquivalent, normalizeLanguage } from '../language.js';
 import { log } from '../log.js';
@@ -1000,7 +1000,13 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
               case 'error':
                 this.#logger.error({ error: event }, 'Received error from LiveKit STT');
                 resourceCleanup();
-                throw new APIError(`LiveKit STT returned error: ${JSON.stringify(event)}`);
+                throw new APIStatusError({
+                  message: `LiveKit Inference STT returned error: ${event.message}`,
+                  options: {
+                    statusCode: event.code ?? -1,
+                    body: event,
+                  },
+                });
             }
           }
         } finally {

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -1028,13 +1028,17 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
                     },
                   });
                 }
-                throw new APIStatusError({
-                  message: `LiveKit Inference STT returned error: ${event.message}`,
+                const error = new APIStatusError({
+                  message: 'LiveKit STT returned an error',
                   options: {
                     statusCode: event.code ?? -1,
                     body: event,
                   },
                 });
+                // Pino serializes enumerable Error fields into retry logs. Keep the gateway
+                // payload available to callers without copying it into telemetry.
+                Object.defineProperty(error, 'body', { enumerable: false });
+                throw error;
             }
           }
         } finally {

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -1028,17 +1028,13 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
                     },
                   });
                 }
-                const error = new APIStatusError({
-                  message: 'LiveKit STT returned an error',
+                throw new APIStatusError({
+                  message: `LiveKit Inference STT returned error: ${event.message}`,
                   options: {
                     statusCode: event.code ?? -1,
                     body: event,
                   },
                 });
-                // Pino serializes enumerable Error fields into retry logs. Keep the gateway
-                // payload available to callers without copying it into telemetry.
-                Object.defineProperty(error, 'body', { enumerable: false });
-                throw error;
             }
           }
         } finally {

--- a/agents/src/inference/utils.test.ts
+++ b/agents/src/inference/utils.test.ts
@@ -9,14 +9,10 @@ import { connectWs } from './utils.js';
 
 const servers: http.Server[] = [];
 
-async function rejectWebSocket(
-  statusCode: number,
-  body = '',
-  contentType = 'text/plain',
-): Promise<string> {
+async function rejectWebSocket(statusCode: number): Promise<string> {
   const server = http.createServer((_request, response) => {
-    response.writeHead(statusCode, { 'Content-Type': contentType });
-    response.end(body);
+    response.writeHead(statusCode);
+    response.end();
   });
   servers.push(server);
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
@@ -36,16 +32,8 @@ afterEach(async () => {
 });
 
 describe('connectWs', () => {
-  it('surfaces a structured gateway error in the response body', async () => {
-    const body = {
-      type: 'inference_quota_exceeded',
-      error: 'STT connection limit exceeded, category: MaxConcurrentGatewaySTT',
-      category: 'MaxConcurrentGatewaySTT',
-      current_usage: '55',
-      remaining_limit: '0',
-      status: 'QuotaStatusExceeded',
-    };
-    const url = await rejectWebSocket(429, JSON.stringify(body), 'application/json');
+  it('surfaces a 429 response as a retryable status error', async () => {
+    const url = await rejectWebSocket(429);
 
     const error = await connectWs(url, {}, 1_000).catch((error: unknown) => error);
 
@@ -54,13 +42,12 @@ describe('connectWs', () => {
       message: 'Unexpected server response: 429',
       statusCode: 429,
       retryable: true,
-      body,
+      body: null,
     });
-    expect((error as Error).stack).not.toContain(body.error);
   });
 
-  it('surfaces a plain-text gateway error in the response body', async () => {
-    const url = await rejectWebSocket(401, 'invalid authorization token');
+  it('surfaces a 401 response as a non-retryable status error', async () => {
+    const url = await rejectWebSocket(401);
 
     const error = await connectWs(url, {}, 1_000).catch((error: unknown) => error);
 
@@ -69,12 +56,11 @@ describe('connectWs', () => {
       message: 'Unexpected server response: 401',
       statusCode: 401,
       retryable: false,
-      body: { error: 'invalid authorization token' },
+      body: null,
     });
-    expect((error as Error).stack).not.toContain('invalid authorization token');
   });
 
-  it('falls back to the status when a rejected handshake has no body', async () => {
+  it('surfaces a 500 response as a retryable status error', async () => {
     const url = await rejectWebSocket(500);
 
     const error = await connectWs(url, {}, 1_000).catch((error: unknown) => error);
@@ -86,23 +72,6 @@ describe('connectWs', () => {
       retryable: true,
       body: null,
     });
-  });
-
-  it('limits oversized gateway response bodies', async () => {
-    const url = await rejectWebSocket(502, 'x'.repeat(70 * 1024));
-
-    const error = await connectWs(url, {}, 1_000).catch((error: unknown) => error);
-
-    expect(error).toBeInstanceOf(APIStatusError);
-    expect(error).toMatchObject({
-      message: 'Unexpected server response: 502',
-      statusCode: 502,
-      body: { truncated: true },
-    });
-    const body = (error as APIStatusError).body as { error: string };
-    expect(Buffer.byteLength(body.error)).toBe(64 * 1024);
-    expect(body.error.startsWith('x')).toBe(true);
-    expect(body.error.endsWith('x')).toBe(true);
   });
 
   it('preserves the message from a network error', async () => {

--- a/agents/src/inference/utils.test.ts
+++ b/agents/src/inference/utils.test.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { APIConnectionError, APIStatusError, APITimeoutError } from '../_exceptions.js';
+import { connectWs } from './utils.js';
+
+const servers: http.Server[] = [];
+
+async function rejectWebSocket(
+  statusCode: number,
+  body = '',
+  contentType = 'text/plain',
+): Promise<string> {
+  const server = http.createServer((_request, response) => {
+    response.writeHead(statusCode, { 'Content-Type': contentType });
+    response.end(body);
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return `ws://127.0.0.1:${port}`;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        }),
+    ),
+  );
+});
+
+describe('connectWs', () => {
+  it('surfaces a structured gateway error from a rejected handshake', async () => {
+    const body = {
+      type: 'inference_quota_exceeded',
+      error: 'STT connection limit exceeded, category: MaxConcurrentGatewaySTT',
+      category: 'MaxConcurrentGatewaySTT',
+      current_usage: '55',
+      remaining_limit: '0',
+      status: 'QuotaStatusExceeded',
+    };
+    const url = await rejectWebSocket(429, JSON.stringify(body), 'application/json');
+
+    const error = await connectWs(url, {}, 1_000).catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(APIStatusError);
+    expect(error).toMatchObject({
+      message: body.error,
+      statusCode: 429,
+      retryable: true,
+      body,
+    });
+  });
+
+  it('surfaces a plain-text error from a rejected handshake', async () => {
+    const url = await rejectWebSocket(401, 'invalid authorization token');
+
+    const error = await connectWs(url, {}, 1_000).catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(APIStatusError);
+    expect(error).toMatchObject({
+      message: 'invalid authorization token',
+      statusCode: 401,
+      retryable: false,
+      body: null,
+    });
+  });
+
+  it('falls back to the status when a rejected handshake has no body', async () => {
+    const url = await rejectWebSocket(500);
+
+    const error = await connectWs(url, {}, 1_000).catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(APIStatusError);
+    expect(error).toMatchObject({
+      message: 'Unexpected server response: 500',
+      statusCode: 500,
+      retryable: true,
+      body: null,
+    });
+  });
+
+  it('preserves the message from a network error', async () => {
+    const error = await connectWs('ws://127.0.0.1:1', {}, 1_000).catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(APIConnectionError);
+    expect(error).toMatchObject({ retryable: true });
+    expect((error as Error).message).toContain('ECONNREFUSED');
+  });
+
+  it('times out an unresponsive handshake', async () => {
+    const server = http.createServer(() => {});
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+
+    const error = await connectWs(`ws://127.0.0.1:${port}`, {}, 25).catch(
+      (error: unknown) => error,
+    );
+
+    expect(error).toBeInstanceOf(APITimeoutError);
+    expect((error as Error).message).toBe('Timeout connecting to LiveKit WebSocket');
+  });
+});

--- a/agents/src/inference/utils.test.ts
+++ b/agents/src/inference/utils.test.ts
@@ -74,12 +74,14 @@ describe('connectWs', () => {
     });
   });
 
-  it('preserves the message from a network error', async () => {
+  it('does not expose the message from a network error', async () => {
     const error = await connectWs('ws://127.0.0.1:1', {}, 1_000).catch((error: unknown) => error);
 
     expect(error).toBeInstanceOf(APIConnectionError);
-    expect(error).toMatchObject({ retryable: true });
-    expect((error as Error).message).toContain('ECONNREFUSED');
+    expect(error).toMatchObject({
+      message: 'Error connecting to LiveKit WebSocket',
+      retryable: true,
+    });
   });
 
   it('times out an unresponsive handshake', async () => {

--- a/agents/src/inference/utils.test.ts
+++ b/agents/src/inference/utils.test.ts
@@ -36,7 +36,7 @@ afterEach(async () => {
 });
 
 describe('connectWs', () => {
-  it('surfaces a structured gateway error from a rejected handshake', async () => {
+  it('surfaces a structured gateway error in the response body', async () => {
     const body = {
       type: 'inference_quota_exceeded',
       error: 'STT connection limit exceeded, category: MaxConcurrentGatewaySTT',
@@ -51,25 +51,27 @@ describe('connectWs', () => {
 
     expect(error).toBeInstanceOf(APIStatusError);
     expect(error).toMatchObject({
-      message: body.error,
+      message: 'Unexpected server response: 429',
       statusCode: 429,
       retryable: true,
       body,
     });
+    expect((error as Error).stack).not.toContain(body.error);
   });
 
-  it('surfaces a plain-text error from a rejected handshake', async () => {
+  it('surfaces a plain-text gateway error in the response body', async () => {
     const url = await rejectWebSocket(401, 'invalid authorization token');
 
     const error = await connectWs(url, {}, 1_000).catch((error: unknown) => error);
 
     expect(error).toBeInstanceOf(APIStatusError);
     expect(error).toMatchObject({
-      message: 'invalid authorization token',
+      message: 'Unexpected server response: 401',
       statusCode: 401,
       retryable: false,
-      body: null,
+      body: { error: 'invalid authorization token' },
     });
+    expect((error as Error).stack).not.toContain('invalid authorization token');
   });
 
   it('falls back to the status when a rejected handshake has no body', async () => {
@@ -84,6 +86,23 @@ describe('connectWs', () => {
       retryable: true,
       body: null,
     });
+  });
+
+  it('limits oversized gateway response bodies', async () => {
+    const url = await rejectWebSocket(502, 'x'.repeat(70 * 1024));
+
+    const error = await connectWs(url, {}, 1_000).catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(APIStatusError);
+    expect(error).toMatchObject({
+      message: 'Unexpected server response: 502',
+      statusCode: 502,
+      body: { truncated: true },
+    });
+    const body = (error as APIStatusError).body as { error: string };
+    expect(Buffer.byteLength(body.error)).toBe(64 * 1024);
+    expect(body.error.startsWith('x')).toBe(true);
+    expect(body.error.endsWith('x')).toBe(true);
   });
 
   it('preserves the message from a network error', async () => {

--- a/agents/src/inference/utils.ts
+++ b/agents/src/inference/utils.ts
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { AccessToken } from 'livekit-server-sdk';
+import type { IncomingMessage } from 'node:http';
+import { text } from 'node:stream/consumers';
 import { WebSocket } from 'ws';
 import { APIConnectionError, APIStatusError, APITimeoutError } from '../_exceptions.js';
 import { getJobContext } from '../job.js';
@@ -51,6 +53,37 @@ export async function createAccessToken(
   token.addInferenceGrant({ perform: true });
 
   return await token.toJwt();
+}
+
+async function statusErrorFromResponse(response: IncomingMessage): Promise<APIStatusError> {
+  const statusCode = response.statusCode ?? -1;
+  let message = `Unexpected server response: ${statusCode}`;
+  let body: object | null = null;
+  let rawBody = '';
+
+  try {
+    rawBody = (await text(response)).trim();
+  } catch {
+    // The HTTP status still identifies the handshake failure when the body cannot be read.
+  }
+
+  if (rawBody) {
+    try {
+      const parsed: unknown = JSON.parse(rawBody);
+      if (parsed !== null && typeof parsed === 'object') {
+        body = parsed;
+        if ('error' in parsed && typeof parsed.error === 'string' && parsed.error) {
+          message = parsed.error;
+        }
+      } else {
+        message = rawBody;
+      }
+    } catch {
+      message = rawBody;
+    }
+  }
+
+  return new APIStatusError({ message, options: { statusCode, body } });
 }
 
 /**
@@ -109,18 +142,18 @@ export async function connectWs(
       resolve(socket);
     };
 
+    const onUnexpectedResponse = (_request: unknown, response: IncomingMessage) => {
+      void statusErrorFromResponse(response).then((error) => {
+        clearTimeout(timeout);
+        socket.terminate();
+        reject(error);
+      });
+    };
+
     const onError = (err: unknown) => {
       clearTimeout(timeout);
-      if (err && typeof err === 'object' && 'code' in err && (err as any).code === 429) {
-        reject(
-          new APIStatusError({
-            message: 'LiveKit gateway quota exceeded',
-            options: { statusCode: 429 },
-          }),
-        );
-      } else {
-        reject(new APIConnectionError({ message: 'Error connecting to LiveKit WebSocket' }));
-      }
+      const message = err instanceof Error ? err.message : 'Error connecting to LiveKit WebSocket';
+      reject(new APIConnectionError({ message }));
     };
 
     const onClose = () => {
@@ -134,6 +167,7 @@ export async function connectWs(
       }
     };
     socket.once('open', onOpen);
+    socket.once('unexpected-response', onUnexpectedResponse);
     socket.once('error', onError);
     socket.once('close', onClose);
   });

--- a/agents/src/inference/utils.ts
+++ b/agents/src/inference/utils.ts
@@ -122,10 +122,9 @@ export async function connectWs(
       socket.terminate();
     };
 
-    const onError = (err: unknown) => {
+    const onError = () => {
       clearTimeout(timeout);
-      const message = err instanceof Error ? err.message : 'Error connecting to LiveKit WebSocket';
-      reject(new APIConnectionError({ message }));
+      reject(new APIConnectionError({ message: 'Error connecting to LiveKit WebSocket' }));
     };
 
     const onClose = () => {

--- a/agents/src/inference/utils.ts
+++ b/agents/src/inference/utils.ts
@@ -21,8 +21,6 @@ export const STAGING_INFERENCE_URL = 'https://agent-gateway.staging.livekit.clou
 export const INFERENCE_PROVIDER_HEADER = 'X-LiveKit-Inference-Provider';
 export const INFERENCE_PRIORITY_HEADER = 'X-LiveKit-Inference-Priority';
 
-const MAX_ERROR_BODY_BYTES = 64 * 1024;
-
 /**
  * Get the default inference URL based on the environment.
  *
@@ -54,64 +52,6 @@ export async function createAccessToken(
   token.addInferenceGrant({ perform: true });
 
   return await token.toJwt();
-}
-
-async function readResponseBody(
-  response: IncomingMessage,
-): Promise<{ rawBody: string; truncated: boolean }> {
-  const output = Buffer.allocUnsafe(MAX_ERROR_BODY_BYTES);
-  let length = 0;
-  let truncated = false;
-
-  for await (const chunk of response) {
-    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    const copyLength = Math.min(bytes.length, MAX_ERROR_BODY_BYTES - length);
-    bytes.copy(output, length, 0, copyLength);
-    length += copyLength;
-
-    if (copyLength < bytes.length) {
-      truncated = true;
-      break;
-    }
-  }
-
-  return {
-    rawBody: output.subarray(0, length).toString('utf8').trim(),
-    truncated,
-  };
-}
-
-async function statusErrorFromResponse(response: IncomingMessage): Promise<APIStatusError> {
-  const statusCode = response.statusCode ?? -1;
-  let body: object | null = null;
-  let rawBody = '';
-  let truncated = false;
-
-  try {
-    ({ rawBody, truncated } = await readResponseBody(response));
-  } catch {
-    // The HTTP status still identifies the handshake failure when the body cannot be read.
-  }
-
-  if (truncated) {
-    body = { error: rawBody, truncated: true };
-  } else if (rawBody) {
-    try {
-      const parsed: unknown = JSON.parse(rawBody);
-      if (parsed !== null && typeof parsed === 'object') {
-        body = parsed;
-      } else {
-        body = { error: parsed };
-      }
-    } catch {
-      body = { error: rawBody };
-    }
-  }
-
-  return new APIStatusError({
-    message: `Unexpected server response: ${statusCode}`,
-    options: { statusCode, body },
-  });
 }
 
 /**
@@ -171,11 +111,15 @@ export async function connectWs(
     };
 
     const onUnexpectedResponse = (_request: unknown, response: IncomingMessage) => {
-      void statusErrorFromResponse(response).then((error) => {
-        clearTimeout(timeout);
-        reject(error);
-        socket.terminate();
-      });
+      const statusCode = response.statusCode ?? -1;
+      clearTimeout(timeout);
+      reject(
+        new APIStatusError({
+          message: `Unexpected server response: ${statusCode}`,
+          options: { statusCode },
+        }),
+      );
+      socket.terminate();
     };
 
     const onError = (err: unknown) => {

--- a/agents/src/inference/utils.ts
+++ b/agents/src/inference/utils.ts
@@ -4,7 +4,6 @@
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { AccessToken } from 'livekit-server-sdk';
 import type { IncomingMessage } from 'node:http';
-import { text } from 'node:stream/consumers';
 import { WebSocket } from 'ws';
 import { APIConnectionError, APIStatusError, APITimeoutError } from '../_exceptions.js';
 import { getJobContext } from '../job.js';
@@ -21,6 +20,8 @@ export const STAGING_INFERENCE_URL = 'https://agent-gateway.staging.livekit.clou
 /** LiveKit Agent Gateway routing header names. */
 export const INFERENCE_PROVIDER_HEADER = 'X-LiveKit-Inference-Provider';
 export const INFERENCE_PRIORITY_HEADER = 'X-LiveKit-Inference-Priority';
+
+const MAX_ERROR_BODY_BYTES = 64 * 1024;
 
 /**
  * Get the default inference URL based on the environment.
@@ -55,35 +56,62 @@ export async function createAccessToken(
   return await token.toJwt();
 }
 
+async function readResponseBody(
+  response: IncomingMessage,
+): Promise<{ rawBody: string; truncated: boolean }> {
+  const output = Buffer.allocUnsafe(MAX_ERROR_BODY_BYTES);
+  let length = 0;
+  let truncated = false;
+
+  for await (const chunk of response) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    const copyLength = Math.min(bytes.length, MAX_ERROR_BODY_BYTES - length);
+    bytes.copy(output, length, 0, copyLength);
+    length += copyLength;
+
+    if (copyLength < bytes.length) {
+      truncated = true;
+      break;
+    }
+  }
+
+  return {
+    rawBody: output.subarray(0, length).toString('utf8').trim(),
+    truncated,
+  };
+}
+
 async function statusErrorFromResponse(response: IncomingMessage): Promise<APIStatusError> {
   const statusCode = response.statusCode ?? -1;
-  let message = `Unexpected server response: ${statusCode}`;
   let body: object | null = null;
   let rawBody = '';
+  let truncated = false;
 
   try {
-    rawBody = (await text(response)).trim();
+    ({ rawBody, truncated } = await readResponseBody(response));
   } catch {
     // The HTTP status still identifies the handshake failure when the body cannot be read.
   }
 
-  if (rawBody) {
+  if (truncated) {
+    body = { error: rawBody, truncated: true };
+  } else if (rawBody) {
     try {
       const parsed: unknown = JSON.parse(rawBody);
       if (parsed !== null && typeof parsed === 'object') {
         body = parsed;
-        if ('error' in parsed && typeof parsed.error === 'string' && parsed.error) {
-          message = parsed.error;
-        }
       } else {
-        message = rawBody;
+        body = { error: parsed };
       }
     } catch {
-      message = rawBody;
+      body = { error: rawBody };
     }
   }
 
-  return new APIStatusError({ message, options: { statusCode, body } });
+  return new APIStatusError({
+    message: `Unexpected server response: ${statusCode}`,
+    options: { statusCode, body },
+  });
 }
 
 /**
@@ -145,8 +173,8 @@ export async function connectWs(
     const onUnexpectedResponse = (_request: unknown, response: IncomingMessage) => {
       void statusErrorFromResponse(response).then((error) => {
         clearTimeout(timeout);
-        socket.terminate();
         reject(error);
+        socket.terminate();
       });
     };
 


### PR DESCRIPTION
**Behavior:** Rejected inference WebSocket handshakes and active STT error events now return `APIStatusError` with the gateway status. Active STT errors retain the full diagnostic payload.

**Parity:** Matches Python's handshake and mid-session STT error handling. Commit `3883973b` credits agents-js #1075 author David Levine as co-author.

Addresses AJS-487

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> Investigate Linear AJS-487. I am pretty sure this is a parity gap as well.
>
> Let's create a new PR, credit the 1075 author with co-author.
>
> run a subagent for code review and $babysit-devin-review
>
> why are we reading raw response?
>
> yeah, python parity is enough
>
> so we had 429 before?
>
> but it literally had an api status error with 429?
>
> did we cover mid-session 429s?
>
> can you fix that? Make sure we match the python implementation. Show me the implementation parity table.

</details>
