### PR TITLE
fix: close inference STT sessions

### DIFF
--- a/.changeset/stop-idle-stt-retries.md
+++ b/.changeset/stop-idle-stt-retries.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Close LiveKit Inference STT sessions and sockets when input ends, include the model in WebSocket dials, and stop retrying gateway inactivity closures.

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { WebSocketServer } from 'ws';
 import * as agents from '../index.js';
 import { normalizeLanguage } from '../language.js';
 import { initializeLogger } from '../log.js';
@@ -599,6 +602,144 @@ describe('STT VAD handling for Speechmatics models', () => {
 
     stt.updateOptions({ model: 'speechmatics/enhanced' });
     expect(stt['vad']).toBeInstanceOf(InferenceVAD);
+  });
+});
+
+describe('Inference STT connection lifecycle', () => {
+  it('includes the model in the dial and closes the session after input ends', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    const address = server.address() as AddressInfo;
+    const messageTypes: string[] = [];
+    let requestUrl: string | undefined;
+    let resolveSocketClosed!: () => void;
+    const socketClosed = new Promise<void>((resolve) => {
+      resolveSocketClosed = resolve;
+    });
+
+    server.on('connection', (socket, request) => {
+      requestUrl = request.url;
+      socket.on('close', resolveSocketClosed);
+      socket.on('message', (raw) => {
+        const event = JSON.parse(raw.toString()) as { type: string };
+        messageTypes.push(event.type);
+        if (event.type === 'session.close') {
+          socket.send(JSON.stringify({ type: 'session.closed' }));
+        }
+      });
+    });
+
+    const stt = makeStt({
+      model: 'deepgram/nova-3',
+      baseURL: `http://127.0.0.1:${address.port}`,
+      connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1_000 },
+    });
+    const stream = stt.stream();
+
+    try {
+      stream.endInput();
+      for await (const _ of stream) {
+        /* drain */
+      }
+      await socketClosed;
+
+      expect(new URL(requestUrl!, 'ws://127.0.0.1').searchParams.get('model')).toBe(
+        'deepgram/nova-3',
+      );
+      expect(messageTypes).toEqual(['session.create', 'session.finalize', 'session.close']);
+    } finally {
+      stream.close();
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('sends session.close and closes the socket when the stream closes', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    const address = server.address() as AddressInfo;
+    const messageTypes: string[] = [];
+    let resolveSessionCreated!: () => void;
+    const sessionCreated = new Promise<void>((resolve) => {
+      resolveSessionCreated = resolve;
+    });
+    let resolveSocketClosed!: () => void;
+    const socketClosed = new Promise<void>((resolve) => {
+      resolveSocketClosed = resolve;
+    });
+
+    server.on('connection', (socket) => {
+      socket.on('close', resolveSocketClosed);
+      socket.on('message', (raw) => {
+        const event = JSON.parse(raw.toString()) as { type: string };
+        messageTypes.push(event.type);
+        if (event.type === 'session.create') resolveSessionCreated();
+      });
+    });
+
+    const stt = makeStt({
+      baseURL: `http://127.0.0.1:${address.port}`,
+      connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1_000 },
+    });
+    const stream = stt.stream();
+
+    try {
+      await sessionCreated;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      stream.close();
+      await socketClosed;
+
+      expect(messageTypes).toEqual(['session.create', 'session.close']);
+    } finally {
+      stream.close();
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('does not retry an inactivity timeout', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    const address = server.address() as AddressInfo;
+    let connectionCount = 0;
+
+    server.on('connection', (socket) => {
+      connectionCount += 1;
+      socket.on('message', (raw) => {
+        const event = JSON.parse(raw.toString()) as { type: string };
+        if (event.type !== 'session.finalize') return;
+        socket.send(
+          JSON.stringify({
+            type: 'error',
+            code: 2007,
+            message: 'session closed due to agent inactivity',
+          }),
+        );
+      });
+    });
+
+    const stt = makeStt({
+      baseURL: `http://127.0.0.1:${address.port}`,
+      connOptions: { maxRetry: 3, retryIntervalMs: 1, timeoutMs: 1_000 },
+    });
+    const errors: Error[] = [];
+    stt.on('error', ({ error }) => errors.push(error));
+    const stream = stt.stream();
+
+    try {
+      stream.endInput();
+      for await (const _ of stream) {
+        /* drain */
+      }
+
+      expect(connectionCount).toBe(1);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({ retryable: false });
+    } finally {
+      stream.close();
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });
 

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -611,6 +611,7 @@ describe('Inference STT connection lifecycle', () => {
     await once(server, 'listening');
     const address = server.address() as AddressInfo;
     const messageTypes: string[] = [];
+    const transcripts: string[] = [];
     let requestUrl: string | undefined;
     let resolveSocketClosed!: () => void;
     const socketClosed = new Promise<void>((resolve) => {
@@ -624,6 +625,13 @@ describe('Inference STT connection lifecycle', () => {
         const event = JSON.parse(raw.toString()) as { type: string };
         messageTypes.push(event.type);
         if (event.type === 'session.close') {
+          socket.send(
+            JSON.stringify({
+              type: 'final_transcript',
+              transcript: 'final words',
+              language: 'en',
+            }),
+          );
           socket.send(JSON.stringify({ type: 'session.closed' }));
         }
       });
@@ -638,8 +646,10 @@ describe('Inference STT connection lifecycle', () => {
 
     try {
       stream.endInput();
-      for await (const _ of stream) {
-        /* drain */
+      for await (const event of stream) {
+        if (event.type === SpeechEventType.FINAL_TRANSCRIPT) {
+          transcripts.push(event.alternatives![0].text);
+        }
       }
       await socketClosed;
 
@@ -647,6 +657,45 @@ describe('Inference STT connection lifecycle', () => {
         'deepgram/nova-3',
       );
       expect(messageTypes).toEqual(['session.create', 'session.finalize', 'session.close']);
+      expect(transcripts).toEqual(['final words']);
+    } finally {
+      stream.close();
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('reports a disconnect before session.closed after input ends', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    const address = server.address() as AddressInfo;
+    let connectionCount = 0;
+
+    server.on('connection', (socket) => {
+      connectionCount += 1;
+      socket.on('message', (raw) => {
+        const event = JSON.parse(raw.toString()) as { type: string };
+        if (event.type === 'session.close') socket.close(1011, 'missing session.closed');
+      });
+    });
+
+    const stt = makeStt({
+      baseURL: `http://127.0.0.1:${address.port}`,
+      connOptions: { maxRetry: 3, retryIntervalMs: 1, timeoutMs: 1_000 },
+    });
+    const errors: Error[] = [];
+    stt.on('error', ({ error }) => errors.push(error));
+    const stream = stt.stream();
+
+    try {
+      stream.endInput();
+      for await (const _ of stream) {
+        /* drain */
+      }
+
+      expect(connectionCount).toBe(1);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({ retryable: false, statusCode: 1011 });
     } finally {
       stream.close();
       for (const client of server.clients) client.terminate();
@@ -712,7 +761,7 @@ describe('Inference STT connection lifecycle', () => {
           JSON.stringify({
             type: 'error',
             code: 2007,
-            message: 'session closed due to agent inactivity',
+            message: 'customer content must not reach the API error',
           }),
         );
       });
@@ -734,7 +783,11 @@ describe('Inference STT connection lifecycle', () => {
 
       expect(connectionCount).toBe(1);
       expect(errors).toHaveLength(1);
-      expect(errors[0]).toMatchObject({ retryable: false });
+      expect(errors[0]).toMatchObject({
+        message: 'LiveKit STT returned an error',
+        body: { code: 2007 },
+        retryable: false,
+      });
     } finally {
       stream.close();
       for (const client of server.clients) client.terminate();

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -815,7 +815,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       const vad = await this.stt.vadPromise;
       // Create fresh resources for each connection attempt
       let ws: WebSocket | null = null;
-      let closing = false;
+      let inputEnded = false;
       let cleanedUp = false;
       let finalReceived = false;
       let sessionCloseSent = false;
@@ -832,7 +832,6 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       const resourceCleanup = () => {
         if (cleanedUp) return;
         cleanedUp = true;
-        closing = true;
         void eventChannel.close().catch((error) => {
           this.#logger.debug({ error }, 'Failed to close STT event channel');
         });
@@ -869,7 +868,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
           });
 
           ws.on('close', (code: number) => {
-            const expectedClose = closing || finalReceived;
+            const expectedClose = finalReceived || signal.aborted;
             resourceCleanup();
 
             if (expectedClose) return resolve();
@@ -879,7 +878,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
             reject(
               new APIStatusError({
                 message: 'LiveKit STT connection closed unexpectedly',
-                options: { statusCode: code },
+                options: { statusCode: code, retryable: !inputEnded },
               }),
             );
           });
@@ -928,7 +927,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
             }
           }
 
-          closing = true;
+          inputEnded = true;
           vadStream?.endInput();
           socket.send(JSON.stringify({ type: 'session.finalize' }));
           sendSessionClose(socket);
@@ -1017,9 +1016,10 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
                 this.processTranscript(event, SpeechEventType.PREFLIGHT_TRANSCRIPT);
                 break;
               case 'error':
-                this.#logger.error({ error: event }, 'Received error from LiveKit STT');
+                this.#logger.error({ 'lk.pii.event': event }, 'Received error from LiveKit STT');
                 resourceCleanup();
-                throw new APIError(`LiveKit STT returned error: ${JSON.stringify(event)}`, {
+                throw new APIError('LiveKit STT returned an error', {
+                  body: { code: event.code },
                   retryable: event.code !== INACTIVITY_TIMEOUT_ERROR_CODE,
                 });
             }

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -420,6 +420,7 @@ export type STTEncoding = 'pcm_s16le';
 const DEFAULT_ENCODING: STTEncoding = 'pcm_s16le';
 const DEFAULT_SAMPLE_RATE = 16000;
 const DEFAULT_CANCEL_TIMEOUT = 5000;
+const INACTIVITY_TIMEOUT_ERROR_CODE = 2007;
 
 export interface InferenceSTTOptions<TModel extends STTModels> {
   model?: TModel;
@@ -719,7 +720,7 @@ export class STT<TModel extends STTModels> extends BaseSTT {
     }
 
     const token = await createAccessToken(this.opts.apiKey, this.opts.apiSecret);
-    const url = `${baseURL}/stt`;
+    const url = `${baseURL}/stt?model=${encodeURIComponent(this.model)}`;
     const headers = { Authorization: `Bearer ${token}` } as Record<string, string>;
 
     const socket = await connectWs(url, headers, timeout);
@@ -815,17 +816,34 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       // Create fresh resources for each connection attempt
       let ws: WebSocket | null = null;
       let closing = false;
+      let cleanedUp = false;
       let finalReceived = false;
+      let sessionCloseSent = false;
       let vadStream: VADStream | null = null;
 
       const eventChannel = createStreamChannel<SttServerEvent>();
 
+      const sendSessionClose = (socket: WebSocket) => {
+        if (sessionCloseSent || socket.readyState !== 1) return;
+        sessionCloseSent = true;
+        socket.send(JSON.stringify({ type: 'session.close' }));
+      };
+
       const resourceCleanup = () => {
-        if (closing) return;
+        if (cleanedUp) return;
+        cleanedUp = true;
         closing = true;
-        eventChannel.close();
-        ws?.removeAllListeners();
-        ws?.close();
+        void eventChannel.close().catch((error) => {
+          this.#logger.debug({ error }, 'Failed to close STT event channel');
+        });
+        if (ws) {
+          try {
+            sendSessionClose(ws);
+          } catch (error) {
+            this.#logger.debug({ error }, 'Failed to send session.close');
+          }
+          ws.close();
+        }
       };
 
       const createWsListener = async (ws: WebSocket, signal: AbortSignal) => {
@@ -839,7 +857,9 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
 
           ws.on('message', (data) => {
             const json = JSON.parse(data.toString()) as SttServerEvent;
-            eventChannel.write(json);
+            void eventChannel.write(json).catch((error) => {
+              this.#logger.debug({ error }, 'Failed to queue STT server event');
+            });
           });
 
           ws.on('error', (e) => {
@@ -849,10 +869,12 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
           });
 
           ws.on('close', (code: number) => {
+            const expectedClose = closing || finalReceived;
             resourceCleanup();
 
-            if (!closing) return this.#logger.error('WebSocket closed unexpectedly');
-            if (finalReceived) return resolve();
+            if (expectedClose) return resolve();
+
+            this.#logger.error('WebSocket closed unexpectedly');
 
             reject(
               new APIStatusError({
@@ -909,6 +931,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
           closing = true;
           vadStream?.endInput();
           socket.send(JSON.stringify({ type: 'session.finalize' }));
+          sendSessionClose(socket);
         } catch (e) {
           if ((e as Error).message === 'Send aborted') {
             // Expected abort, don't log
@@ -996,7 +1019,9 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
               case 'error':
                 this.#logger.error({ error: event }, 'Received error from LiveKit STT');
                 resourceCleanup();
-                throw new APIError(`LiveKit STT returned error: ${JSON.stringify(event)}`);
+                throw new APIError(`LiveKit STT returned error: ${JSON.stringify(event)}`, {
+                  retryable: event.code !== INACTIVITY_TIMEOUT_ERROR_CODE,
+                });
             }
           }
         } finally {

--- a/agents/src/inference/tts.test.ts
+++ b/agents/src/inference/tts.test.ts
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { type WebSocket, WebSocketServer } from 'ws';
 import * as agents from '../index.js';
 import { normalizeLanguage } from '../language.js';
 import { initializeLogger } from '../log.js';
@@ -30,6 +33,41 @@ function makeTts(overrides: Record<string, unknown> = {}) {
   };
   return new TTS({ ...defaults, ...overrides });
 }
+
+describe('Inference TTS connection', () => {
+  it('includes the model in the dial URL', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    const address = server.address() as AddressInfo;
+    let resolveRequestUrl!: (url: string) => void;
+    const requestUrl = new Promise<string>((resolve) => {
+      resolveRequestUrl = resolve;
+    });
+
+    server.on('connection', (_socket, request) => {
+      resolveRequestUrl(request.url ?? '');
+    });
+
+    const tts = makeTts({
+      model: 'cartesia/sonic-3',
+      baseURL: `http://127.0.0.1:${address.port}`,
+    });
+    let socket: WebSocket | undefined;
+
+    try {
+      socket = await tts.connectWs(1_000);
+
+      expect(new URL(await requestUrl, 'ws://127.0.0.1').searchParams.get('model')).toBe(
+        'cartesia/sonic-3',
+      );
+    } finally {
+      socket?.terminate();
+      for (const client of server.clients) client.terminate();
+      await tts.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
 
 describe('parseTTSModelString', () => {
   it('simple model without voice', () => {

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -469,7 +469,7 @@ export class TTS<TModel extends TTSModels> extends BaseTTS {
     }
 
     const token = await createAccessToken(this.opts.apiKey, this.opts.apiSecret);
-    const url = `${baseURL}/tts`;
+    const url = `${baseURL}/tts?model=${encodeURIComponent(this.model)}`;
     const headers = { Authorization: `Bearer ${token}` } as Record<string, string>;
 
     const params = {


### PR DESCRIPTION
**Why:** Ended inference STT inputs left gateway WebSockets alive and consumed concurrency until inactivity cleanup. STT and TTS dials also omitted the model needed for dial-time attribution and quotas.
**Behavior:** STT now closes sessions and sockets and does not retry inactivity errors. STT and TTS WebSocket dials now include the selected model.
Addresses AJS-423

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> **agents-js 1.6.0 never aborted the stream.** The retry loop in `agents/src/stt/stt.ts` exits immediately when the abort controller is aborted. Three retries happened, so `SpeechStream.close()` was never called. The input was ended, but the stream object was left alive.
>
> **The inactivity error frame is treated as retryable.** The gateway sends error code 2007 before closing. The client turns it into an `APIError` with the default `retryable: true`, and retries up to `maxRetry` (3). Each retry reconnects with an already-closed input, sends finalize, and idles for another 30 minutes.
>
> Essential follow-up:
>
> ## Fixes, in order of impact
>
> 1. **agents-js: close the STT socket and send `session.close`.** Same fix as before. It also frees the concurrency slot immediately. This removes the denials.
> 2. **agents-js: add `?model=` to the STT dial**, matching Python. This fixes the blank `model` column and lets per-model quota limits apply to agents-js traffic.
>
> do we need to fix the missing model in tts too?
>
> yes please. Check other inference dial urls too

</details>