### PR TITLE
chore: remove ElevenLabs from LiveKit Inference

### DIFF
--- a/.changeset/retire-gateway-elevenlabs.md
+++ b/.changeset/retire-gateway-elevenlabs.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Remove retired ElevenLabs models from LiveKit Inference STT and TTS.

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -3037,44 +3037,6 @@ export class DynamicEndpointing extends BaseEndpointing {
     }): void;
 }
 
-// Warning: (ae-missing-release-tag) "ElevenlabsModels" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-type ElevenlabsModels = 'elevenlabs/eleven_flash_v2' | 'elevenlabs/eleven_flash_v2_5' | 'elevenlabs/eleven_turbo_v2' | 'elevenlabs/eleven_turbo_v2_5' | 'elevenlabs/eleven_multilingual_v2' | 'elevenlabs/eleven_v3';
-
-// Warning: (ae-missing-release-tag) "ElevenlabsOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-interface ElevenlabsOptions {
-    apply_text_normalization?: 'auto' | 'off' | 'on';
-    // (undocumented)
-    auto_mode?: boolean;
-    // (undocumented)
-    chunk_length_schedule?: number[];
-    // (undocumented)
-    enable_logging?: boolean;
-    // (undocumented)
-    enable_ssml_parsing?: boolean;
-    inactivity_timeout?: number;
-    // (undocumented)
-    language_code?: string;
-    // (undocumented)
-    preferred_alignment?: string;
-    similarity_boost?: number;
-    speed?: number;
-    stability?: number;
-    style?: number;
-    // (undocumented)
-    sync_alignment?: boolean;
-    // (undocumented)
-    use_speaker_boost?: boolean;
-}
-
-// Warning: (ae-missing-release-tag) "ElevenlabsSTTModels" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-type ElevenlabsSTTModels = 'elevenlabs/scribe_v2_realtime';
-
 // Warning: (ae-missing-release-tag) "emitToOtel" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -7151,7 +7113,6 @@ declare namespace stt_2 {
         DeepgramFluxModels,
         CartesiaModels,
         AssemblyaiModels,
-        ElevenlabsSTTModels,
         XaiSTTModels,
         SpeechmaticsModels,
         InworldSTTModels,
@@ -8182,13 +8143,11 @@ declare namespace tts_2 {
         normalizeTTSFallback,
         CartesiaModels_2 as CartesiaModels,
         DeepgramTTSModels,
-        ElevenlabsModels,
         InworldModels,
         RimeModels,
         XaiTTSModels,
         FishAudioModels,
         CartesiaOptions_2 as CartesiaOptions,
-        ElevenlabsOptions,
         DeepgramTTSOptions,
         RimeOptions,
         InworldOptions,
@@ -8285,7 +8244,7 @@ export type TTSMetrics = {
 // Warning: (ae-missing-release-tag) "TTSModels" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-type TTSModels = CartesiaModels_2 | DeepgramTTSModels | ElevenlabsModels | RimeModels | InworldModels | XaiTTSModels | FishAudioModels | AnyString;
+type TTSModels = CartesiaModels_2 | DeepgramTTSModels | RimeModels | InworldModels | XaiTTSModels | FishAudioModels | AnyString;
 
 // Warning: (ae-missing-release-tag) "TTSModelUsage" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -8303,7 +8262,7 @@ export type TTSModelUsage = {
 // Warning: (ae-missing-release-tag) "TTSOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-type TTSOptions<TModel extends TTSModels> = TModel extends CartesiaModels_2 ? CartesiaOptions_2 : TModel extends DeepgramTTSModels ? DeepgramTTSOptions : TModel extends ElevenlabsModels ? ElevenlabsOptions : TModel extends RimeModels ? RimeOptions : TModel extends InworldModels ? InworldOptions : TModel extends XaiTTSModels ? XaiTTSOptions : TModel extends FishAudioModels ? FishAudioOptions : Record<string, unknown>;
+type TTSOptions<TModel extends TTSModels> = TModel extends CartesiaModels_2 ? CartesiaOptions_2 : TModel extends DeepgramTTSModels ? DeepgramTTSOptions : TModel extends RimeModels ? RimeOptions : TModel extends InworldModels ? InworldOptions : TModel extends XaiTTSModels ? XaiTTSOptions : TModel extends FishAudioModels ? FishAudioOptions : Record<string, unknown>;
 
 // Warning: (ae-forgotten-export) The symbol "BaseStreamingTurnDetector" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "TurnDetector" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9155,7 +9114,7 @@ export const zipFunctionCallsAndOutputs: (event: FunctionToolsExecutedEvent) => 
 //
 // src/_exceptions.ts:90:5 - (ae-forgotten-export) The symbol "APIStatusErrorOptions" needs to be exported by the entry point index.d.ts
 // src/_exceptions.ts:128:5 - (ae-forgotten-export) The symbol "APIErrorOptions" needs to be exported by the entry point index.d.ts
-// src/inference/tts.ts:320:5 - (ae-forgotten-export) The symbol "TTSEncoding" needs to be exported by the entry point index.d.ts
+// src/inference/tts.ts:282:5 - (ae-forgotten-export) The symbol "TTSEncoding" needs to be exported by the entry point index.d.ts
 // src/llm/chat_context.ts:76:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "audio"
 // src/llm/tool_context.ts:702:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "ToolFlag" has more than one declaration; you need to add a TSDoc member reference selector
 // src/llm/tool_context.ts:746:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "ToolFlag" has more than one declaration; you need to add a TSDoc member reference selector

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -50,8 +50,6 @@ export type AssemblyaiModels =
   | 'assemblyai/u3-rt-pro'
   | 'assemblyai/universal-3-5-pro';
 
-export type ElevenlabsSTTModels = 'elevenlabs/scribe_v2_realtime';
-
 export type XaiSTTModels = 'xai/stt-1';
 
 export type SpeechmaticsModels =
@@ -314,7 +312,6 @@ const WORD_ALIGNED_MODELS = new Set([
   'assemblyai/universal-streaming-multilingual',
   'assemblyai/u3-rt-pro',
   'assemblyai/universal-3-5-pro',
-  'elevenlabs/scribe_v2_realtime',
   'xai/stt-1',
   'speechmatics/enhanced',
   'speechmatics/standard',
@@ -336,7 +333,6 @@ type _STTModels =
   | DeepgramFluxModels
   | CartesiaModels
   | AssemblyaiModels
-  | ElevenlabsSTTModels
   | XaiSTTModels
   | SpeechmaticsModels
   | InworldSTTModels

--- a/agents/src/inference/tts.test.ts
+++ b/agents/src/inference/tts.test.ts
@@ -479,10 +479,6 @@ describeLiveKitInference('LiveKit Inference TTS integration', agents, async (har
       model: 'cartesia/sonic-3',
       voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc',
     },
-    {
-      model: 'elevenlabs/eleven_flash_v2',
-      voice: 'Xb7hH8MSUJpSbSDYk0k2',
-    },
     { model: 'inworld/inworld-tts-2', voice: 'Ashley' },
     { model: 'rime/coda', voice: 'celeste' },
   ] as const;

--- a/agents/src/inference/tts.test.ts
+++ b/agents/src/inference/tts.test.ts
@@ -57,7 +57,7 @@ describe('parseTTSModelString', () => {
   });
 
   it.each([
-    ['elevenlabs/eleven_flash_v2:voice123', 'elevenlabs/eleven_flash_v2', 'voice123'],
+    ['deepgram/aura-2:voice123', 'deepgram/aura-2', 'voice123'],
     ['rime:speaker-a', 'rime', 'speaker-a'],
     ['rime/mist:narrator', 'rime/mist', 'narrator'],
     ['inworld/inworld-tts-1:character', 'inworld/inworld-tts-1', 'character'],
@@ -93,42 +93,42 @@ describe('normalizeTTSFallback', () => {
   });
 
   it('list of string models', () => {
-    const result = normalizeTTSFallback(['cartesia/sonic', 'elevenlabs/eleven_flash_v2']);
+    const result = normalizeTTSFallback(['cartesia/sonic', 'deepgram/aura-2']);
     expect(result).toEqual([
       { model: 'cartesia/sonic', voice: '' },
-      { model: 'elevenlabs/eleven_flash_v2', voice: '' },
+      { model: 'deepgram/aura-2', voice: '' },
     ]);
   });
 
   it('list of string models with voices', () => {
-    const result = normalizeTTSFallback(['cartesia/sonic:voice1', 'elevenlabs:voice2']);
+    const result = normalizeTTSFallback(['cartesia/sonic:voice1', 'deepgram/aura-2:voice2']);
     expect(result).toEqual([
       { model: 'cartesia/sonic', voice: 'voice1' },
-      { model: 'elevenlabs', voice: 'voice2' },
+      { model: 'deepgram/aura-2', voice: 'voice2' },
     ]);
   });
 
   it('list of FallbackModel dicts', () => {
     const fallbacks: TTSFallbackModel[] = [
       { model: 'cartesia/sonic', voice: 'narrator' },
-      { model: 'elevenlabs', voice: '' },
+      { model: 'deepgram/aura-2', voice: '' },
     ];
     const result = normalizeTTSFallback(fallbacks);
     expect(result).toEqual([
       { model: 'cartesia/sonic', voice: 'narrator' },
-      { model: 'elevenlabs', voice: '' },
+      { model: 'deepgram/aura-2', voice: '' },
     ]);
   });
 
   it('mixed list of strings and dicts', () => {
     const result = normalizeTTSFallback([
       'cartesia/sonic:voice1',
-      { model: 'elevenlabs/eleven_flash_v2', voice: 'custom' } as TTSFallbackModel,
+      { model: 'deepgram/aura-2', voice: 'custom' } as TTSFallbackModel,
       'rime/mist',
     ]);
     expect(result).toEqual([
       { model: 'cartesia/sonic', voice: 'voice1' },
-      { model: 'elevenlabs/eleven_flash_v2', voice: 'custom' },
+      { model: 'deepgram/aura-2', voice: 'custom' },
       { model: 'rime/mist', voice: '' },
     ]);
   });
@@ -152,12 +152,12 @@ describe('normalizeTTSFallback', () => {
   it('list with extraKwargs preserved', () => {
     const result = normalizeTTSFallback([
       { model: 'cartesia/sonic', voice: 'v1', extraKwargs: { speed: 'slow' } } as TTSFallbackModel,
-      'elevenlabs:voice2',
+      'deepgram/aura-2:voice2',
       { model: 'rime/mist', voice: '', extraKwargs: { custom: true } } as TTSFallbackModel,
     ]);
     expect(result).toEqual([
       { model: 'cartesia/sonic', voice: 'v1', extraKwargs: { speed: 'slow' } },
-      { model: 'elevenlabs', voice: 'voice2' },
+      { model: 'deepgram/aura-2', voice: 'voice2' },
       { model: 'rime/mist', voice: '', extraKwargs: { custom: true } },
     ]);
   });
@@ -192,8 +192,8 @@ describe('TTS constructor fallback and connOptions', () => {
   });
 
   it('fallback single string is normalized', () => {
-    const tts = makeTts({ fallback: 'elevenlabs/eleven_flash_v2' });
-    expect(tts['opts'].fallback).toEqual([{ model: 'elevenlabs/eleven_flash_v2', voice: '' }]);
+    const tts = makeTts({ fallback: 'deepgram/aura-2' });
+    expect(tts['opts'].fallback).toEqual([{ model: 'deepgram/aura-2', voice: '' }]);
   });
 
   it('fallback single string with voice is normalized', () => {
@@ -202,10 +202,10 @@ describe('TTS constructor fallback and connOptions', () => {
   });
 
   it('fallback list of strings is normalized', () => {
-    const tts = makeTts({ fallback: ['cartesia/sonic', 'elevenlabs'] });
+    const tts = makeTts({ fallback: ['cartesia/sonic', 'deepgram/aura-2'] });
     expect(tts['opts'].fallback).toEqual([
       { model: 'cartesia/sonic', voice: '' },
-      { model: 'elevenlabs', voice: '' },
+      { model: 'deepgram/aura-2', voice: '' },
     ]);
   });
 
@@ -235,13 +235,13 @@ describe('TTS constructor fallback and connOptions', () => {
     const tts = makeTts({
       fallback: [
         'cartesia/sonic:voice1',
-        { model: 'elevenlabs', voice: 'custom', extraKwargs: { speed: 'slow' } },
+        { model: 'deepgram/aura-2', voice: 'custom', extraKwargs: { mip_opt_out: true } },
         'rime/mist',
       ],
     });
     expect(tts['opts'].fallback).toEqual([
       { model: 'cartesia/sonic', voice: 'voice1' },
-      { model: 'elevenlabs', voice: 'custom', extraKwargs: { speed: 'slow' } },
+      { model: 'deepgram/aura-2', voice: 'custom', extraKwargs: { mip_opt_out: true } },
       { model: 'rime/mist', voice: '' },
     ]);
   });
@@ -276,25 +276,6 @@ describe('TTS constructor fallback and connOptions', () => {
 });
 
 describe('TTS provider modelOptions', () => {
-  it('preserves ElevenLabs inference model options', () => {
-    const modelOptions = {
-      speed: 1.2,
-      stability: 0.5,
-      similarity_boost: 0.8,
-      enable_logging: false,
-    };
-
-    const tts = new TTS({
-      model: 'elevenlabs/eleven_flash_v2_5' as const,
-      apiKey: 'test-key',
-      apiSecret: 'test-secret',
-      baseURL: 'https://example.livekit.cloud',
-      modelOptions,
-    });
-
-    expect(tts['opts'].modelOptions).toEqual(modelOptions);
-  });
-
   it('accepts expanded Cartesia inference model options', () => {
     const modelOptions = {
       speed: 1.15,
@@ -365,25 +346,18 @@ describe('TTS provider modelOptions', () => {
 describe('hasAlignedTranscript', () => {
   it('returns false for unknown provider', () => {
     expect(hasAlignedTranscript('rime/mistv2', { add_timestamps: true })).toBe(false);
-    expect(hasAlignedTranscript('deepgram/aura-2', { sync_alignment: true })).toBe(false);
+    expect(hasAlignedTranscript('deepgram/aura-2', { timestamp_type: 'WORD' })).toBe(false);
   });
 
   it('returns false for an empty options payload', () => {
     expect(hasAlignedTranscript('cartesia/sonic', {})).toBe(false);
-    expect(hasAlignedTranscript('elevenlabs/eleven_flash_v2', undefined)).toBe(false);
+    expect(hasAlignedTranscript('inworld/inworld-tts-1', undefined)).toBe(false);
     expect(hasAlignedTranscript(undefined, { add_timestamps: true })).toBe(false);
   });
 
   it('detects Cartesia add_timestamps opt-in', () => {
     expect(hasAlignedTranscript('cartesia/sonic', { add_timestamps: true })).toBe(true);
     expect(hasAlignedTranscript('cartesia/sonic-3', { add_timestamps: false })).toBe(false);
-  });
-
-  it('detects ElevenLabs sync_alignment opt-in', () => {
-    expect(hasAlignedTranscript('elevenlabs/eleven_flash_v2', { sync_alignment: true })).toBe(true);
-    expect(
-      hasAlignedTranscript('elevenlabs/eleven_multilingual_v2', { sync_alignment: false }),
-    ).toBe(false);
   });
 
   it('detects Inworld WORD/CHARACTER timestamp types', () => {
@@ -413,14 +387,6 @@ describe('TTS alignedTranscript capability', () => {
     expect(tts.capabilities.alignedTranscript).toBe(true);
   });
 
-  it('reports alignedTranscript=true when ElevenLabs sync_alignment is set', () => {
-    const tts = makeTts({
-      model: 'elevenlabs/eleven_flash_v2',
-      modelOptions: { sync_alignment: true },
-    });
-    expect(tts.capabilities.alignedTranscript).toBe(true);
-  });
-
   it('reports alignedTranscript=true when Inworld timestamp_type is WORD', () => {
     const tts = makeTts({
       model: 'inworld/inworld-tts-1',
@@ -443,11 +409,11 @@ describe('TTS alignedTranscript capability', () => {
   it('recomputes alignedTranscript when updateOptions changes the model', () => {
     const tts = makeTts({
       model: 'cartesia/sonic',
-      modelOptions: { sync_alignment: true },
+      modelOptions: { timestamp_type: 'WORD' },
     });
     expect(tts.capabilities.alignedTranscript).toBe(false);
 
-    tts.updateOptions({ model: 'elevenlabs/eleven_flash_v2' });
+    tts.updateOptions({ model: 'inworld/inworld-tts-1' });
     expect(tts.capabilities.alignedTranscript).toBe(true);
   });
 
@@ -458,7 +424,7 @@ describe('TTS alignedTranscript capability', () => {
     tts.updateOptions({ modelOptions: { add_timestamps: true } });
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
 
-    tts.updateOptions({ model: 'elevenlabs/eleven_flash_v2' });
+    tts.updateOptions({ model: 'deepgram/aura-2' });
     expect(invalidateSpy).toHaveBeenCalledTimes(2);
 
     tts.updateOptions({ voice: 'narrator' });

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -44,14 +44,6 @@ export type CartesiaModels =
 
 export type DeepgramTTSModels = 'deepgram/aura' | 'deepgram/aura-2';
 
-export type ElevenlabsModels =
-  | 'elevenlabs/eleven_flash_v2'
-  | 'elevenlabs/eleven_flash_v2_5'
-  | 'elevenlabs/eleven_turbo_v2'
-  | 'elevenlabs/eleven_turbo_v2_5'
-  | 'elevenlabs/eleven_multilingual_v2'
-  | 'elevenlabs/eleven_v3';
-
 export type InworldModels =
   | 'inworld/inworld-tts-2'
   | 'inworld/inworld-tts-1.5-max'
@@ -81,29 +73,6 @@ export interface CartesiaOptions {
   add_timestamps?: boolean;
   add_phoneme_timestamps?: boolean;
   use_normalized_timestamps?: boolean;
-}
-
-export interface ElevenlabsOptions {
-  /** Inactivity timeout in seconds. Default: 60. */
-  inactivity_timeout?: number;
-  /** Text normalization mode. Default: "auto". */
-  apply_text_normalization?: 'auto' | 'off' | 'on';
-  auto_mode?: boolean;
-  enable_logging?: boolean;
-  enable_ssml_parsing?: boolean;
-  sync_alignment?: boolean;
-  language_code?: string;
-  /** Voice stability tuning, typically in the range [0, 1]. */
-  stability?: number;
-  /** Voice similarity tuning, typically in the range [0, 1]. */
-  similarity_boost?: number;
-  /** Style exaggeration tuning, typically in the range [0, 1]. */
-  style?: number;
-  /** Speech speed multiplier. */
-  speed?: number;
-  use_speaker_boost?: boolean;
-  chunk_length_schedule?: number[];
-  preferred_alignment?: string;
 }
 
 export interface DeepgramTTSOptions {
@@ -179,7 +148,6 @@ export interface FishAudioOptions {
 type _TTSModels =
   | CartesiaModels
   | DeepgramTTSModels
-  | ElevenlabsModels
   | RimeModels
   | InworldModels
   | XaiTTSModels
@@ -188,7 +156,6 @@ type _TTSModels =
 export type TTSModels =
   | CartesiaModels
   | DeepgramTTSModels
-  | ElevenlabsModels
   | RimeModels
   | InworldModels
   | XaiTTSModels
@@ -201,17 +168,15 @@ export type TTSOptions<TModel extends TTSModels> = TModel extends CartesiaModels
   ? CartesiaOptions
   : TModel extends DeepgramTTSModels
     ? DeepgramTTSOptions
-    : TModel extends ElevenlabsModels
-      ? ElevenlabsOptions
-      : TModel extends RimeModels
-        ? RimeOptions
-        : TModel extends InworldModels
-          ? InworldOptions
-          : TModel extends XaiTTSModels
-            ? XaiTTSOptions
-            : TModel extends FishAudioModels
-              ? FishAudioOptions
-              : Record<string, unknown>;
+    : TModel extends RimeModels
+      ? RimeOptions
+      : TModel extends InworldModels
+        ? InworldOptions
+        : TModel extends XaiTTSModels
+          ? XaiTTSOptions
+          : TModel extends FishAudioModels
+            ? FishAudioOptions
+            : Record<string, unknown>;
 
 /** Parse a model string into [model, voice]. Voice is undefined if not specified. */
 export function parseTTSModelString(model: string): [string, string | undefined] {
@@ -240,9 +205,6 @@ export function hasAlignedTranscript(
   if (provider === 'cartesia') {
     return Boolean(opts.add_timestamps);
   }
-  if (provider === 'elevenlabs') {
-    return Boolean(opts.sync_alignment);
-  }
   if (provider === 'inworld') {
     return opts.timestamp_type === 'WORD' || opts.timestamp_type === 'CHARACTER';
   }
@@ -251,7 +213,7 @@ export function hasAlignedTranscript(
 
 /** Inference Fallback Adapter: configuration for a fallback TTS model that runs server-side in LiveKit Inference, providing automatic fallback between providers. */
 export interface TTSFallbackModel {
-  /** Model name (e.g. "cartesia/sonic", "elevenlabs/eleven_flash_v2", "rime/coda"). */
+  /** Model name (e.g. "cartesia/sonic", "deepgram/aura-2", "rime/coda"). */
   model: string;
   /** Voice to use for the model. */
   voice: string;

--- a/examples/src/basic_agent.ts
+++ b/examples/src/basic_agent.ts
@@ -59,10 +59,7 @@ export default defineAgent({
       tts: new inference.TTS({
         model: 'cartesia/sonic-3',
         voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc',
-        fallback: [
-          { model: 'elevenlabs/eleven_flash_v2', voice: '9626c31c-bec5-4cca-baa8-f8ba9e84c8bc' },
-          { model: 'rime/coda', voice: 'luna' },
-        ],
+        fallback: [{ model: 'rime/coda', voice: 'luna' }],
       }),
       ttsTextTransforms: ['filter_markdown', 'filter_emoji'],
       turnHandling: {

--- a/examples/src/basic_agent_task.ts
+++ b/examples/src/basic_agent_task.ts
@@ -20,7 +20,7 @@ import { z } from 'zod';
 function createInfoTask(info: string): AgentTask<string> {
   const task = AgentTask.create<string>({
     instructions: `Collect the user's information. around ${info}. Once you have the information, call the saveUserInfo tool to save the information to the database IMMEDIATELY. DO NOT have chitchat with the user, just collect the information and call the saveUserInfo tool.`,
-    tts: 'elevenlabs/eleven_turbo_v2_5',
+    tts: 'deepgram/aura-2',
     tools: [
       llm.tool({
         name: 'saveUserInfo',

--- a/examples/src/basic_task_group.ts
+++ b/examples/src/basic_task_group.ts
@@ -15,7 +15,7 @@ import * as openai from '@livekit/agents-plugin-openai';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
-const taskTts = 'elevenlabs/eleven_turbo_v2_5';
+const taskTts = 'deepgram/aura-2';
 
 class CollectNameTask extends voice.AgentTask<string> {
   constructor() {


### PR DESCRIPTION
ElevenLabs no longer routes through LiveKit Inference, but the Node.js client still advertised its STT and TTS models and provider options.

Remove those active gateway surfaces, capability handling, tests, examples, and API references. Keep the standalone ElevenLabs plugin unchanged.

Addresses AJS-488

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> we retire 11labs in gateway, we need to update our tests
>
> create a PR
>
> did you move 11labs from stt and tts? We need to clean up any mentioned of gateway 11labs too.

</details>