### PR TITLE
fix: scope interruption verdicts to agent speech

### DIFF
--- a/.changeset/quiet-moons-tap.md
+++ b/.changeset/quiet-moons-tap.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Ignore late adaptive interruption responses after the agent speech that requested them ends.

--- a/agents/src/inference/interruption/interruption_speech_boundary.test.ts
+++ b/agents/src/inference/interruption/interruption_speech_boundary.test.ts
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MockWebSocket } from './_mock_ws.js';
+import { AdaptiveInterruptionDetector } from './interruption_detector.js';
+import { InterruptionStreamBase, InterruptionStreamSentinel } from './interruption_stream.js';
+import type { OverlappingSpeechEvent } from './types.js';
+
+vi.mock('ws', async () => {
+  const { MockWebSocket } = await import('./_mock_ws.js');
+  return { default: MockWebSocket, WebSocket: MockWebSocket };
+});
+
+function makeAudioFrame(): AudioFrame {
+  const samples = new Int16Array(1600);
+  return new AudioFrame(samples, 16000, 1, samples.length);
+}
+
+function requestIds(ws: MockWebSocket): number[] {
+  return ws.sent
+    .filter((frame): frame is Uint8Array => frame instanceof Uint8Array)
+    .map((frame) => {
+      const view = new DataView(frame.buffer, frame.byteOffset, 8);
+      return view.getUint32(0, true) + view.getUint32(4, true) * 0x100000000;
+    });
+}
+
+async function openStream(): Promise<{
+  stream: InterruptionStreamBase;
+  reader: ReadableStreamDefaultReader<OverlappingSpeechEvent>;
+  ws: MockWebSocket;
+}> {
+  const detector = new AdaptiveInterruptionDetector({
+    baseUrl: 'http://localhost:9999',
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+    threshold: 0.5,
+  });
+  const stream = new InterruptionStreamBase(detector, {});
+  const reader = stream.stream().getReader();
+
+  await vi.waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+  const ws = MockWebSocket.instances[0]!;
+  ws.simulateOpen();
+  await vi.waitFor(() => expect(ws.sent).toHaveLength(1));
+
+  return { stream, reader, ws };
+}
+
+async function startAgentOverlap(
+  stream: InterruptionStreamBase,
+  ws: MockWebSocket,
+  expectedRequestCount: number,
+): Promise<number> {
+  await stream.pushFrame(InterruptionStreamSentinel.agentSpeechStarted());
+  await stream.pushFrame(InterruptionStreamSentinel.overlapSpeechStarted(0, Date.now()));
+  await stream.pushFrame(makeAudioFrame());
+  await vi.waitFor(() => expect(requestIds(ws)).toHaveLength(expectedRequestCount));
+  return requestIds(ws).at(-1)!;
+}
+
+async function endAgentOverlap(
+  stream: InterruptionStreamBase,
+  reader: ReadableStreamDefaultReader<OverlappingSpeechEvent>,
+): Promise<void> {
+  const event = reader.read();
+  await stream.pushFrame(InterruptionStreamSentinel.overlapSpeechEnded(Date.now(), true));
+  await stream.pushFrame(InterruptionStreamSentinel.agentSpeechEnded());
+  await expect(event).resolves.toMatchObject({ value: { isInterruption: false } });
+}
+
+beforeEach(() => {
+  MockWebSocket.instances.length = 0;
+});
+
+describe('interruption request speech boundaries', () => {
+  it('ignores a late verdict from a previous agent speech', async () => {
+    const { stream, reader, ws } = await openStream();
+
+    try {
+      const oldRequestId = await startAgentOverlap(stream, ws, 1);
+      await endAgentOverlap(stream, reader);
+      const newRequestId = await startAgentOverlap(stream, ws, 2);
+
+      const verdict = reader.read();
+      ws.simulateMessage({
+        type: 'bargein_detected',
+        created_at: oldRequestId,
+        probabilities: [0.99, 0.99],
+      });
+      ws.simulateMessage({
+        type: 'bargein_detected',
+        created_at: newRequestId,
+        probabilities: [0.75, 0.75],
+      });
+
+      await expect(verdict).resolves.toMatchObject({
+        value: {
+          isInterruption: true,
+          probability: 0.75,
+          speechInput: expect.any(Int16Array),
+        },
+      });
+    } finally {
+      await reader.cancel();
+      await stream.close();
+    }
+  });
+
+  it('ignores a late inference result from a previous agent speech', async () => {
+    const { stream, reader, ws } = await openStream();
+
+    try {
+      const oldRequestId = await startAgentOverlap(stream, ws, 1);
+      await endAgentOverlap(stream, reader);
+      const newRequestId = await startAgentOverlap(stream, ws, 2);
+
+      ws.simulateMessage({
+        type: 'inference_done',
+        created_at: oldRequestId,
+        probabilities: [0.99, 0.99],
+      });
+      ws.simulateMessage({
+        type: 'inference_done',
+        created_at: newRequestId,
+        probabilities: [0.25, 0.25],
+      });
+
+      const result = reader.read();
+      await stream.pushFrame(InterruptionStreamSentinel.overlapSpeechEnded(Date.now()));
+
+      await expect(result).resolves.toMatchObject({
+        value: {
+          isInterruption: false,
+          probability: 0.25,
+          speechInput: expect.any(Int16Array),
+        },
+      });
+    } finally {
+      await reader.cancel();
+      await stream.close();
+    }
+  });
+});

--- a/agents/src/inference/interruption/ws_transport.ts
+++ b/agents/src/inference/interruption/ws_transport.ts
@@ -280,19 +280,17 @@ export function createWsTransport(
               ? (performance.now() - existing.requestStartedAt) / 1000
               : (performance.now() - createdAt) / 1000;
 
-          const entry = state.cache.setOrUpdate(
-            createdAt,
-            () => new InterruptionCacheEntry({ createdAt }),
-            {
-              speechInput: existing?.speechInput,
-              requestStartedAt: existing?.requestStartedAt,
-              totalDurationInS,
-              probabilities: message.probabilities,
-              isInterruption: true,
-              predictionDurationInS: message.prediction_duration,
-              detectionDelayInS: (Date.now() - overlapSpeechStartedAt) / 1000,
-            },
-          );
+          const entry = state.cache.updateValue(createdAt, {
+            totalDurationInS,
+            probabilities: message.probabilities,
+            isInterruption: true,
+            predictionDurationInS: message.prediction_duration,
+            detectionDelayInS: (Date.now() - overlapSpeechStartedAt) / 1000,
+          });
+          if (!entry) {
+            logger.trace({ createdAt }, 'ignoring interruption verdict outside the current speech');
+            break;
+          }
 
           if (updateUserSpeakingSpan) {
             updateUserSpeakingSpan(entry);
@@ -346,19 +344,17 @@ export function createWsTransport(
             existing?.requestStartedAt !== undefined
               ? (performance.now() - existing.requestStartedAt) / 1000
               : (performance.now() - createdAt) / 1000;
-          const entry = state.cache.setOrUpdate(
-            createdAt,
-            () => new InterruptionCacheEntry({ createdAt }),
-            {
-              speechInput: existing?.speechInput,
-              requestStartedAt: existing?.requestStartedAt,
-              totalDurationInS,
-              predictionDurationInS: message.prediction_duration,
-              probabilities: message.probabilities,
-              isInterruption: message.is_bargein ?? false,
-              detectionDelayInS: (Date.now() - overlapSpeechStartedAt) / 1000,
-            },
-          );
+          const entry = state.cache.updateValue(createdAt, {
+            totalDurationInS,
+            predictionDurationInS: message.prediction_duration,
+            probabilities: message.probabilities,
+            isInterruption: message.is_bargein ?? false,
+            detectionDelayInS: (Date.now() - overlapSpeechStartedAt) / 1000,
+          });
+          if (!entry) {
+            logger.trace({ createdAt }, 'ignoring interruption result outside the current speech');
+            break;
+          }
 
           logger.debug(
             {


### PR DESCRIPTION
Late adaptive-interruption responses could outlive one agent speech and resolve an overlap in the next. A missing request-cache entry now invalidates both verdict and inference-result responses instead of recreating state.

Ports livekit/agents#6957. Supersedes #2306, whose author is credited as a co-author.
Fixes #2119
Addresses AGT-3235

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> Let's port over https://github.com/livekit/agents/pull/6957 and credit 2306 author as co-author.
>
> create the PR please

</details>