### PR TITLE
feat(phonic): export LiveKit tools for the Responses API

### DIFF
--- a/.changeset/phonic-responses-tool-definitions.md
+++ b/.changeset/phonic-responses-tool-definitions.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-phonic': patch
+---
+
+Add a helper for converting a LiveKit `ToolContext` into the tool definitions accepted by Phonic's Responses API.

--- a/plugins/phonic/README.md
+++ b/plugins/phonic/README.md
@@ -59,6 +59,20 @@ export default defineAgent({
 cli.runApp(new ServerOptions({ agent: fileURLToPath(import.meta.url) }));
 ```
 
+### Reusing tools with Phonic Responses
+
+Convert an existing LiveKit `ToolContext` into the schema-only definitions accepted by Phonic's
+Responses API:
+
+```typescript
+import * as phonic from '@livekit/agents-plugin-phonic';
+
+const toolDefinitions = phonic.realtime.toPhonicToolDefinitions(toolContext);
+```
+
+The executable functions remain in the `ToolContext`; only their names, descriptions, and parameter
+schemas are returned.
+
 ## Configuration
 
 Set the `PHONIC_API_KEY` environment variable, or pass `apiKey` directly to `RealtimeModel`. All other options are optional.

--- a/plugins/phonic/etc/agents-plugin-phonic.api.md
+++ b/plugins/phonic/etc/agents-plugin-phonic.api.md
@@ -55,12 +55,23 @@ interface PhonicToolConfig {
     speech_before_tool_call?: string;
 }
 
+// Warning: (ae-missing-release-tag) "PhonicToolDefinition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+interface PhonicToolDefinition {
+    description: string;
+    name: string;
+    parameters: Record<string, unknown>;
+}
+
 declare namespace realtime {
     export {
         RealtimeModel,
         RealtimeModelOptions,
         PhonicToolConfig,
         PhonicConfig,
+        PhonicToolDefinition,
+        toPhonicToolDefinitions,
         Voice
     }
 }
@@ -215,6 +226,11 @@ interface RealtimeModelOptions {
     welcomeMessage?: string;
 }
 
+// Warning: (ae-missing-release-tag) "toPhonicToolDefinitions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function toPhonicToolDefinitions(toolContext: llm.ToolContext): PhonicToolDefinition[];
+
 // Warning: (ae-missing-release-tag) "Voice" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -222,7 +238,7 @@ type Voice = 'sabrina' | 'grant' | 'virginia' | 'landon' | 'eleanor' | 'shelby' 
 
 // Warnings were encountered during analysis:
 //
-// src/realtime/realtime_model.ts:294:7 - (ae-forgotten-export) The symbol "APIConnectOptions" needs to be exported by the entry point index.d.ts
+// src/realtime/realtime_model.ts:322:7 - (ae-forgotten-export) The symbol "APIConnectOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/plugins/phonic/etc/agents-plugin-phonic.api.md
+++ b/plugins/phonic/etc/agents-plugin-phonic.api.md
@@ -55,22 +55,12 @@ interface PhonicToolConfig {
     speech_before_tool_call?: string;
 }
 
-// Warning: (ae-missing-release-tag) "PhonicToolDefinition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
-interface PhonicToolDefinition {
-    description: string;
-    name: string;
-    parameters: Record<string, unknown>;
-}
-
 declare namespace realtime {
     export {
         RealtimeModel,
         RealtimeModelOptions,
         PhonicToolConfig,
         PhonicConfig,
-        PhonicToolDefinition,
         toPhonicToolDefinitions,
         Voice
     }
@@ -229,7 +219,7 @@ interface RealtimeModelOptions {
 // Warning: (ae-missing-release-tag) "toPhonicToolDefinitions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-function toPhonicToolDefinitions(toolContext: llm.ToolContext): PhonicToolDefinition[];
+function toPhonicToolDefinitions(toolContext: llm.ToolContext): Phonic.ResponsesToolDefinition[];
 
 // Warning: (ae-missing-release-tag) "Voice" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -238,7 +228,7 @@ type Voice = 'sabrina' | 'grant' | 'virginia' | 'landon' | 'eleanor' | 'shelby' 
 
 // Warnings were encountered during analysis:
 //
-// src/realtime/realtime_model.ts:322:7 - (ae-forgotten-export) The symbol "APIConnectOptions" needs to be exported by the entry point index.d.ts
+// src/realtime/realtime_model.ts:314:7 - (ae-forgotten-export) The symbol "APIConnectOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/plugins/phonic/package.json
+++ b/plugins/phonic/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "phonic": "^0.32.15"
+    "phonic": "^0.32.21"
   },
   "peerDependencies": {
     "@livekit/agents": "workspace:*",

--- a/plugins/phonic/src/realtime/index.ts
+++ b/plugins/phonic/src/realtime/index.ts
@@ -6,7 +6,6 @@ export {
   type RealtimeModelOptions,
   type PhonicToolConfig,
   type PhonicConfig,
-  type PhonicToolDefinition,
   toPhonicToolDefinitions,
 } from './realtime_model.js';
 export type { Voice } from './api_proto.js';

--- a/plugins/phonic/src/realtime/index.ts
+++ b/plugins/phonic/src/realtime/index.ts
@@ -6,5 +6,7 @@ export {
   type RealtimeModelOptions,
   type PhonicToolConfig,
   type PhonicConfig,
+  type PhonicToolDefinition,
+  toPhonicToolDefinitions,
 } from './realtime_model.js';
 export type { Voice } from './api_proto.js';

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -110,6 +110,34 @@ export interface PhonicToolConfig {
   speech_before_tool_call?: string; // keypad_input / natural_conversation_ending: required|optional|suppressed
 }
 
+/** Tool schema accepted by Phonic's Responses API. */
+export interface PhonicToolDefinition {
+  /** Name used to identify the tool. */
+  name: string;
+  /** Description the model uses to decide when to call the tool. */
+  description: string;
+  /** JSON Schema describing the tool's arguments. */
+  parameters: Record<string, unknown>;
+}
+
+function toPhonicToolDefinition(tool: llm.FunctionTool): PhonicToolDefinition {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters: llm.toJsonSchema(tool.parameters) as Record<string, unknown>,
+  };
+}
+
+/**
+ * Convert LiveKit function tools to Phonic Responses API definitions.
+ *
+ * The returned values contain schemas only; executable functions remain in the
+ * `ToolContext` for the caller to invoke when Phonic returns a tool call.
+ */
+export function toPhonicToolDefinitions(toolContext: llm.ToolContext): PhonicToolDefinition[] {
+  return toolContext.flatten().filter(llm.isFunctionTool).map(toPhonicToolDefinition);
+}
+
 export class RealtimeModel extends llm.RealtimeModel {
   /** @internal */
   _options: RealtimeModelOptions;
@@ -596,15 +624,15 @@ export class RealtimeSession extends llm.RealtimeSession {
       .flatten()
       .filter(llm.isFunctionTool)
       .map((t) => {
-        const cfg = this.configsForTools.get(t.name);
+        const definition = toPhonicToolDefinition(t);
+        const cfg = this.configsForTools.get(definition.name);
         return {
           type: 'custom_websocket',
           tool_schema: {
             type: 'function',
             function: {
-              name: t.name,
-              description: t.description,
-              parameters: llm.toJsonSchema(t.parameters) as Phonic.OpenAiFunctionParameters,
+              ...definition,
+              parameters: definition.parameters as Phonic.OpenAiFunctionParameters,
               strict: true,
             },
           },

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -110,21 +110,11 @@ export interface PhonicToolConfig {
   speech_before_tool_call?: string; // keypad_input / natural_conversation_ending: required|optional|suppressed
 }
 
-/** Tool schema accepted by Phonic's Responses API. */
-export interface PhonicToolDefinition {
-  /** Name used to identify the tool. */
-  name: string;
-  /** Description the model uses to decide when to call the tool. */
-  description: string;
-  /** JSON Schema describing the tool's arguments. */
-  parameters: Record<string, unknown>;
-}
-
-function toPhonicToolDefinition(tool: llm.FunctionTool): PhonicToolDefinition {
+function toPhonicToolDefinition(tool: llm.FunctionTool): Phonic.ResponsesToolDefinition {
   return {
     name: tool.name,
     description: tool.description,
-    parameters: llm.toJsonSchema(tool.parameters) as Record<string, unknown>,
+    parameters: llm.toJsonSchema(tool.parameters) as Phonic.ToolParametersJsonSchema,
   };
 }
 
@@ -134,7 +124,9 @@ function toPhonicToolDefinition(tool: llm.FunctionTool): PhonicToolDefinition {
  * The returned values contain schemas only; executable functions remain in the
  * `ToolContext` for the caller to invoke when Phonic returns a tool call.
  */
-export function toPhonicToolDefinitions(toolContext: llm.ToolContext): PhonicToolDefinition[] {
+export function toPhonicToolDefinitions(
+  toolContext: llm.ToolContext,
+): Phonic.ResponsesToolDefinition[] {
   return toolContext.flatten().filter(llm.isFunctionTool).map(toPhonicToolDefinition);
 }
 
@@ -632,7 +624,7 @@ export class RealtimeSession extends llm.RealtimeSession {
             type: 'function',
             function: {
               ...definition,
-              parameters: definition.parameters as Phonic.OpenAiFunctionParameters,
+              parameters: { ...definition.parameters },
               strict: true,
             },
           },

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -616,15 +616,15 @@ export class RealtimeSession extends llm.RealtimeSession {
       .flatten()
       .filter(llm.isFunctionTool)
       .map((t) => {
-        const definition = toPhonicToolDefinition(t);
-        const cfg = this.configsForTools.get(definition.name);
+        const cfg = this.configsForTools.get(t.name);
         return {
           type: 'custom_websocket',
           tool_schema: {
             type: 'function',
             function: {
-              ...definition,
-              parameters: { ...definition.parameters },
+              name: t.name,
+              description: t.description,
+              parameters: llm.toJsonSchema(t.parameters) as Phonic.OpenAiFunctionParameters,
               strict: true,
             },
           },

--- a/plugins/phonic/src/realtime/tool_definitions.test.ts
+++ b/plugins/phonic/src/realtime/tool_definitions.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { llm } from '@livekit/agents';
+import { describe, expect, it } from 'vitest';
+import { toPhonicToolDefinitions } from './realtime_model.js';
+
+describe('toPhonicToolDefinitions', () => {
+  it('converts function tools without exposing their executors', () => {
+    const searchPizzaShopRecs = llm.tool({
+      name: 'search_pizza_shop_recs',
+      description: 'Search for pizza shop recommendations in a location.',
+      parameters: {
+        type: 'object',
+        properties: {
+          location: { type: 'string' },
+        },
+        required: ['location'],
+        additionalProperties: false,
+      },
+      execute: async ({ location }) => location,
+    });
+
+    const definitions = toPhonicToolDefinitions(new llm.ToolContext([searchPizzaShopRecs]));
+
+    expect(definitions).toEqual([
+      {
+        name: 'search_pizza_shop_recs',
+        description: 'Search for pizza shop recommendations in a location.',
+        parameters: {
+          type: 'object',
+          properties: {
+            location: { type: 'string' },
+          },
+          required: ['location'],
+          additionalProperties: false,
+        },
+      },
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1191,8 +1191,8 @@ importers:
   plugins/phonic:
     dependencies:
       phonic:
-        specifier: ^0.32.15
-        version: 0.32.15
+        specifier: ^0.32.21
+        version: 0.32.21
     devDependencies:
       '@livekit/agents':
         specifier: workspace:*
@@ -4678,8 +4678,8 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  phonic@0.32.15:
-    resolution: {integrity: sha512-RP2l67N/wSaAkLfwK1OS6q7OvZY51OJAGfqqcISJiec967gOkBQlk1IJGGg9gDMZL9OL5275VNytD7V/VLoRqA==}
+  phonic@0.32.21:
+    resolution: {integrity: sha512-y54bOnBBcRaJQV1mJBUdQdBtPMCejJFcN9Ko7gApzgx0qj+0v5zGNuRHMrf+EN9ClafDztSVpFhJNuWfWx2JuA==}
     engines: {node: '>=18.0.0'}
 
   picocolors@1.1.1:
@@ -8757,7 +8757,7 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  phonic@0.32.15:
+  phonic@0.32.21:
     dependencies:
       ws: 8.21.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,8 @@ packages:
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   - '@livekit/*'
-  # choose_not_to_respond respond_after_sec built-in tool config
-  - phonic@0.32.15
+  # Responses API tool definition type
+  - phonic@0.32.21
   # Renovate security update: vite@7.3.2 || 7.3.5
   - vite@7.3.2 || 7.3.5
   # Renovate security update: ws@8.20.1


### PR DESCRIPTION
## Motivation

LiveKit's generation APIs operate within an active agent or realtime session.
Phonic's Responses API supports a complementary use case: generating the next
assistant turn from supplied conversation history without starting a live
session.

From our understanding, LiveKit does not currently expose an equivalent
stateless generation endpoint. Applications using this capability should still
be able to reuse the tools already defined in their LiveKit `ToolContext`,
rather than maintaining a second set of tool schemas.

## Change

Add `toPhonicToolDefinitions()`, a small adapter that converts a LiveKit
`ToolContext` into the schema-only definitions accepted by Phonic's Responses
API.

The helper:

- uses the same strict serialization path as the existing Phonic realtime plugin
- returns each tool's name, description, and parameter schema
- keeps executable functions in LiveKit so the application remains responsible
  for executing returned tool calls

This adds support for stateless generation without introducing another
generation or tool-execution path inside LiveKit.

## Usage

```typescript
import * as phonic from '@livekit/agents-plugin-phonic';

const toolDefinitions = phonic.realtime.toPhonicToolDefinitions(toolContext);
```

## Validation

- Added focused unit coverage for tool-schema conversion
- Workspace formatting and lint pass
- Phonic plugin build and API Extractor checks pass
