### PR TITLE
feat(agents): force low inference priority for text simulation jobs

### DIFF
--- a/.changeset/quiet-simulations-yield.md
+++ b/.changeset/quiet-simulations-yield.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Text-mode simulation jobs now send `X-LiveKit-Inference-Priority: low` on every inference request, overriding the model's configured `inferenceClass`, so simulation runs are paced into spare quota instead of competing with live voice traffic. Matches the Python SDK.

--- a/agents/src/inference/llm.test.ts
+++ b/agents/src/inference/llm.test.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import * as agents from '../index.js';
+import { type JobContext, runWithJobContextAsync } from '../job.js';
 import { ChatContext } from '../llm/index.js';
 import { initializeLogger } from '../log.js';
 import type { LLMMetrics } from '../metrics/base.js';
@@ -62,7 +63,12 @@ describe('inference.LLM prewarm', () => {
 async function captureHeaders(opts: {
   ctor?: InferenceClass;
   perCall?: InferenceClass;
+  jobCtx?: JobContext;
 }): Promise<CapturedHeaders> {
+  if (opts.jobCtx) {
+    const { jobCtx, ...rest } = opts;
+    return runWithJobContextAsync(jobCtx, () => captureHeaders(rest));
+  }
   const llm = new LLM({
     model: 'openai/gpt-4o-mini',
     apiKey: 'test-key',
@@ -393,6 +399,18 @@ describe('inference.LLM X-LiveKit-Inference-Priority header', () => {
   it("per-call 'priority' overrides constructor 'standard'", async () => {
     const headers = await captureHeaders({ ctor: 'standard', perCall: 'priority' });
     expect(headers['X-LiveKit-Inference-Priority']).toBe('priority');
+  });
+
+  // --- job context overrides everything ---
+
+  it("a text simulation job's 'low' overrides per-call 'priority'", async () => {
+    const jobCtx = {
+      job: { id: 'job-id', room: { sid: 'RM_1' } },
+      room: { isConnected: false },
+      inferenceHeaders: { 'X-LiveKit-Inference-Priority': 'low' },
+    } as unknown as JobContext;
+    const headers = await captureHeaders({ ctor: 'standard', perCall: 'priority', jobCtx });
+    expect(headers['X-LiveKit-Inference-Priority']).toBe('low');
   });
 });
 

--- a/agents/src/inference/llm.ts
+++ b/agents/src/inference/llm.ts
@@ -478,7 +478,6 @@ export class LLMStream extends llm.LLMStream {
       }
 
       const extraHeaders: Record<string, string> = {
-        ...buildMetadataHeaders(),
         ...((requestOptions.extra_headers as Record<string, string> | undefined) ?? {}),
       };
       const extraBody = requestOptions.extra_body as Record<string, unknown> | undefined;
@@ -489,6 +488,9 @@ export class LLMStream extends llm.LLMStream {
       if (this.inferenceClass !== undefined) {
         extraHeaders[INFERENCE_PRIORITY_HEADER] = this.inferenceClass;
       }
+      // Job metadata is merged last so a job's own assertions (e.g. a text
+      // simulation forcing low priority) outrank the model's configured class.
+      Object.assign(extraHeaders, buildMetadataHeaders());
       delete requestOptions.extra_headers;
       delete requestOptions.extra_body;
       delete requestOptions.extra_query;

--- a/agents/src/inference/utils.ts
+++ b/agents/src/inference/utils.ts
@@ -58,6 +58,7 @@ export async function createAccessToken(
  * Build metadata headers for inference requests.
  * Includes SDK version/platform, and optionally room/job/agent IDs from the current job context.
  * Includes X-LiveKit-Worker-Token when LIVEKIT_WORKER_TOKEN is set (hosted agents).
+ * The job context's {@link JobContext.inferenceHeaders} are merged last and win.
  */
 export function buildMetadataHeaders(): Record<string, string> {
   const headers: Record<string, string> = {
@@ -84,6 +85,9 @@ export function buildMetadataHeaders(): Record<string, string> {
     if (ctx.room.isConnected && agentSid) {
       headers['X-LiveKit-Agent-Id'] = agentSid;
     }
+    // merged last: what the job asserts about itself outranks what an individual
+    // model was configured with.
+    Object.assign(headers, ctx.inferenceHeaders);
   }
 
   return headers;

--- a/agents/src/job.test.ts
+++ b/agents/src/job.test.ts
@@ -242,6 +242,32 @@ describe('JobContext.simulationContext', () => {
   });
 });
 
+describe('JobContext.inferenceHeaders', () => {
+  const dispatch = (mode: string) =>
+    JSON.stringify({ simulationRunId: 'SR_1', scenario: { label: 's' }, mode });
+
+  it('forces low inference priority under a text simulation', () => {
+    const { ctx } = createJobContextWithRoom(
+      {},
+      { attributes: { 'lk.simulator.dispatch': dispatch('SIMULATION_MODE_TEXT') } },
+    );
+    expect(ctx.inferenceHeaders).toEqual({ 'X-LiveKit-Inference-Priority': 'low' });
+  });
+
+  it('leaves audio simulations at their configured priority', () => {
+    const { ctx } = createJobContextWithRoom(
+      {},
+      { attributes: { 'lk.simulator.dispatch': dispatch('SIMULATION_MODE_AUDIO') } },
+    );
+    expect(ctx.inferenceHeaders).toEqual({});
+  });
+
+  it('is empty for an ordinary job', () => {
+    const { ctx } = createJobContextWithRoom();
+    expect(ctx.inferenceHeaders).toEqual({});
+  });
+});
+
 describe('simulator participant lifecycle', () => {
   it('shuts the job down when a participant with lk.simulator disconnects', () => {
     const { handlers, onShutdown } = createJobContextWithRoom();

--- a/agents/src/job.ts
+++ b/agents/src/job.ts
@@ -18,9 +18,10 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { Logger } from 'pino';
+import { INFERENCE_PRIORITY_HEADER } from './inference/utils.js';
 import type { InferenceExecutor } from './ipc/inference_executor.js';
 import { log } from './log.js';
-import { SimulationContext, parseSimulationDispatch } from './simulation.js';
+import { SimulationContext, SimulationMode, parseSimulationDispatch } from './simulation.js';
 import { setupCloudTracer, uploadSessionReport } from './telemetry/index.js';
 import {
   ATTRIBUTE_REDACTION_ENABLED,
@@ -263,6 +264,27 @@ export class JobContext<ProcessUserData = Record<string, unknown>> {
       this as JobContext<unknown> as JobContext,
     );
     return this.#simulationCtx;
+  }
+
+  /** Headers this job asserts about itself on every inference request.
+   *
+   * Merged last by `buildMetadataHeaders`, so what the job asserts about
+   * itself outranks what an individual model was configured with. Empty for
+   * an ordinary job. */
+  get inferenceHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {};
+
+    // A text simulation is batch load: a run fans out many jobs at once and nobody
+    // is waiting on the answers, so it must not compete with live traffic for
+    // gateway capacity, and it must not be able to ask for priority either. Audio
+    // simulations are excluded: they run in real time against the audio pipeline,
+    // so their latency has to stay representative of production.
+    const sim = this.simulationContext();
+    if (sim !== undefined && sim.simulationMode === SimulationMode.TEXT) {
+      headers[INFERENCE_PRIORITY_HEADER] = 'low';
+    }
+
+    return headers;
   }
 
   get workerId(): string {


### PR DESCRIPTION
## Summary

Python agents running under a text-mode simulation already stamp `X-LiveKit-Inference-Priority: low` on every inference request ([job.py](https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/job.py#L534-L542)), so agent-gateway paces them into spare quota instead of letting them compete with live voice sessions. agents-js had the `inferenceClass` option but never set it for simulations, so a JS agent under simulation ran at standard priority against production traffic.

This brings agents-js to parity:

- `JobContext.inferenceHeaders` returns `{ 'X-LiveKit-Inference-Priority': 'low' }` when the job is a text-mode simulation, `{}` otherwise. Audio simulations are excluded on purpose: they run in real time against the audio pipeline, so their latency has to stay representative of production.
- `buildMetadataHeaders()` merges `ctx.inferenceHeaders` last, so what the job asserts about itself outranks what an individual model was configured with. This is the same precedence Python uses in `get_inference_headers`.
- `inference.LLM` now applies `buildMetadataHeaders()` after the constructor / per-call `inferenceClass`, so the job's `low` wins over a model configured as `priority`.

Docs in livekit/web#5978 describe this behavior for both SDKs, so this closes the gap the docs would otherwise overstate.

## Test plan

- [x] `agents/src/job.test.ts`: text sim → `low`, audio sim → `{}`, ordinary job → `{}`
- [x] `agents/src/inference/llm.test.ts`: a job context's `low` overrides constructor `standard` + per-call `priority`
- [x] Full `agents` vitest suite: 149 files / 2435 tests pass
- [x] `tsc --noEmit`, eslint clean