### PR TITLE
fix(voice): commit interrupted speech before snapshotting the next turn

### DIFF
--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2959,13 +2959,28 @@ export class AgentActivity implements RecognitionHooks {
       this.realtimeSession?.interrupt();
     }
 
+    // The interrupted pipeline commits its spoken text before marking the generation done.
+    // Snapshot after that commit, including speech already interrupted by adaptive detection.
+    // Do not await the whole handle (which also owns tools), or an unauthorized generation.
+    if (
+      !(this.llm instanceof RealtimeModel) &&
+      currentSpeech?.interrupted &&
+      currentSpeech._hasGenerations
+    ) {
+      await currentSpeech._waitForGeneration();
+    }
+
     let userMessage: ChatMessage | undefined = ChatMessage.create({
       role: 'user',
       content: info.newTranscript,
       transcriptConfidence: info.transcriptConfidence,
     });
 
-    if (this.schedulingPaused || this.newTurnsBlocked) {
+    if (
+      this.schedulingPaused ||
+      this.newTurnsBlocked ||
+      (!(this.llm instanceof RealtimeModel) && this.agentSession._closing)
+    ) {
       this.logger.warn(
         { 'lk.pii.user_input': info.newTranscript },
         'skipping onUserTurnCompleted, speech scheduling is paused',

--- a/agents/src/voice/agent_activity_interrupted_context.test.ts
+++ b/agents/src/voice/agent_activity_interrupted_context.test.ts
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream } from 'node:stream/web';
+import { expect, it, vi } from 'vitest';
+import type { ChatContext } from '../llm/chat_context.js';
+import { tool } from '../llm/tool_context.js';
+import { Future } from '../utils.js';
+import { Agent, type AgentOptions } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AudioOutput } from './io.js';
+import { FakeLLM, type FakeLLMResponse } from './testing/fake_llm.js';
+
+const INITIAL = 'Find a time.';
+const CORRECTION = 'Actually, a different day.';
+const SPOKEN = 'The appointment is available';
+const UNSPOKEN = ' on Thursday at ten.';
+
+class CapturingLLM extends FakeLLM {
+  readonly requests: ChatContext[] = [];
+
+  constructor(
+    responses: FakeLLMResponse[] = [
+      { input: INITIAL, content: SPOKEN + UNSPOKEN },
+      { input: CORRECTION, content: 'Which day works?' },
+      { input: 'Friday instead.', content: 'Let me check Friday.' },
+    ],
+  ) {
+    super(responses);
+  }
+
+  override chat(options: Parameters<FakeLLM['chat']>[0]) {
+    this.requests.push(options.chatCtx.copy());
+    return super.chat(options);
+  }
+}
+
+class FrameAgent extends Agent {
+  constructor(tools?: AgentOptions['tools']) {
+    super({ instructions: 'Answer the caller.', tools });
+  }
+
+  override async ttsNode() {
+    return new ReadableStream<AudioFrame>({
+      start(controller) {
+        controller.enqueue(new AudioFrame(new Int16Array(480), 24_000, 1, 480));
+        controller.close();
+      },
+    });
+  }
+}
+
+class DelayedPlaybackOutput extends AudioOutput {
+  captured = false;
+  cleared = false;
+  released = false;
+
+  constructor(private readonly firstPlaybackStarts = true) {
+    super(24_000);
+  }
+
+  override async captureFrame(frame: AudioFrame) {
+    await super.captureFrame(frame);
+    this.captured = true;
+    if (this.firstPlaybackStarts || this.released) this.onPlaybackStarted(Date.now());
+  }
+
+  override flush() {
+    super.flush();
+    if (this.released) {
+      this.onPlaybackFinished({ playbackPosition: 0.02, interrupted: false });
+    }
+  }
+
+  override clearBuffer() {
+    this.cleared = true;
+    // Hold the completion event until the test explicitly releases it.
+  }
+
+  releasePlayback(interrupted = true) {
+    if (this.released) return;
+    this.released = true;
+    this.onPlaybackFinished({
+      playbackPosition: this.firstPlaybackStarts ? 0.02 : 0,
+      interrupted,
+      synchronizedTranscript: this.firstPlaybackStarts
+        ? interrupted
+          ? SPOKEN
+          : SPOKEN + UNSPOKEN
+        : undefined,
+    });
+    // A watchdog may authorize new audio before the old completion arrives.
+    // Finish any subsequently buffered segment too, as a real sink would.
+    while (this.pendingPlayoutSegments > 0) {
+      this.onPlaybackFinished({ playbackPosition: 0.02, interrupted: false });
+    }
+  }
+}
+
+function userTurn(newTranscript: string) {
+  return {
+    endOfUtteranceDelay: 0,
+    newTranscript,
+    startedSpeakingAt: undefined,
+    stoppedSpeakingAt: undefined,
+    transcriptionDelay: 0,
+    transcriptConfidence: 0.99,
+  };
+}
+
+function assistantText(context: ChatContext) {
+  return context.items.flatMap((item) =>
+    item.type === 'message' && item.role === 'assistant' ? [item.textContent ?? ''] : [],
+  );
+}
+
+async function startHarness({
+  preemptive = false,
+  llm = new CapturingLLM(),
+  output = new DelayedPlaybackOutput(),
+  agent = new FrameAgent(),
+} = {}) {
+  const session = new AgentSession({
+    llm,
+    turnHandling: { preemptiveGeneration: { enabled: preemptive } },
+  });
+  session.output.audio = output;
+  await session.start({ agent });
+  const activity = await session.waitForIdle();
+  return { session, activity, llm, output, agent };
+}
+
+const cases = [false, true].flatMap((preemptive) => [
+  { mode: 'interrupt_on_user_turn', preemptive },
+  { mode: 'interrupt_before_user_turn', preemptive },
+  { mode: 'completed_speech_control', preemptive },
+]);
+
+it.each(cases)(
+  'preserves prior spoken context: $mode / preemptive=$preemptive',
+  async ({ mode, preemptive }) => {
+    const { session, activity, llm, output, agent } = await startHarness({ preemptive });
+    try {
+      const firstReply = session.generateReply({ userInput: INITIAL });
+      await vi.waitFor(() => expect(output.captured).toBe(true));
+      if (mode === 'completed_speech_control') {
+        output.releasePlayback(false);
+        await firstReply.waitForPlayout();
+      } else if (mode === 'interrupt_before_user_turn') {
+        session.interrupt();
+        await vi.waitFor(() => expect(output.cleared).toBe(true));
+      }
+      if (preemptive) {
+        activity.onPreemptiveGeneration(userTurn(CORRECTION));
+        if (mode !== 'interrupt_on_user_turn') {
+          await vi.waitFor(() => expect(llm.requests.length).toBeGreaterThan(1));
+        }
+      }
+      await activity.onEndOfTurn(userTurn(CORRECTION));
+      if (mode !== 'completed_speech_control') {
+        await vi.waitFor(() => expect(output.cleared).toBe(true));
+      }
+      output.releasePlayback();
+      await session.waitForIdle();
+      expect(llm.requests.length).toBeGreaterThanOrEqual(2);
+      const nextRequest = assistantText(llm.requests.at(-1)!);
+      const finalHistory = assistantText(agent.chatCtx.copy());
+      const expected = mode === 'completed_speech_control' ? SPOKEN + UNSPOKEN : SPOKEN;
+      expect(finalHistory).toContain(expected);
+      expect(nextRequest).toContain(expected);
+      if (mode !== 'completed_speech_control') {
+        expect(nextRequest.some((text) => text.includes(UNSPOKEN))).toBe(false);
+      }
+      expect(nextRequest.filter((text) => text === expected)).toHaveLength(1);
+    } finally {
+      output.releasePlayback();
+      await session.close();
+    }
+  },
+);
+
+it('does not wait for an unauthorized generation or commit unplayed speech', async () => {
+  const { session, activity, llm, output, agent } = await startHarness();
+  try {
+    activity.pauseReplyAuthorization();
+    const first = session.generateReply({ userInput: INITIAL });
+    await vi.waitFor(() => expect(llm.requests).toHaveLength(1));
+    expect(first._hasGenerations).toBe(false);
+    await activity.onEndOfTurn(userTurn(CORRECTION));
+    await vi.waitFor(() => expect(llm.requests).toHaveLength(2));
+    activity.resumeReplyAuthorization();
+    output.released = true;
+    await session.waitForIdle();
+    expect(assistantText(llm.requests[1]!)).toEqual([]);
+    expect(assistantText(agent.chatCtx)).not.toContain(SPOKEN + UNSPOKEN);
+  } finally {
+    activity.resumeReplyAuthorization();
+    output.releasePlayback();
+    await session.close();
+  }
+});
+
+it('excludes a captured segment that never started playing', async () => {
+  const { session, activity, llm, output } = await startHarness({
+    output: new DelayedPlaybackOutput(false),
+  });
+  try {
+    session.generateReply({ userInput: INITIAL });
+    await vi.waitFor(() => expect(output.captured).toBe(true));
+    await activity.onEndOfTurn(userTurn(CORRECTION));
+    await vi.waitFor(() => expect(output.cleared).toBe(true));
+    output.releasePlayback();
+    await session.waitForIdle();
+    expect(assistantText(llm.requests.at(-1)!)).toEqual([]);
+  } finally {
+    output.releasePlayback();
+    await session.close();
+  }
+});
+
+it('keeps the next turn live when playback cleanup needs the interruption watchdog', async () => {
+  const { session, activity, llm, output } = await startHarness();
+  try {
+    session.generateReply({ userInput: INITIAL });
+    await vi.waitFor(() => expect(output.captured).toBe(true));
+    await activity.onEndOfTurn(userTurn(CORRECTION));
+    await vi.waitFor(() => expect(output.cleared).toBe(true));
+    // The sink withholds completion entirely. The existing watchdog must still
+    // release the generation wait; without playback metadata no exact prefix is known.
+    await vi.waitFor(() => expect(llm.requests).toHaveLength(2), { timeout: 8_000 });
+    output.releasePlayback();
+    await session.waitForIdle();
+  } finally {
+    output.releasePlayback();
+    await session.close();
+  }
+}, 15_000);
+
+it('can close while the next user turn awaits interrupted playback cleanup', async () => {
+  const { session, activity, llm, output, agent } = await startHarness();
+  try {
+    session.generateReply({ userInput: INITIAL });
+    await vi.waitFor(() => expect(output.captured).toBe(true));
+    await activity.onEndOfTurn(userTurn(CORRECTION));
+    await vi.waitFor(() => expect(output.cleared).toBe(true));
+    await session.close();
+    expect(llm.requests).toHaveLength(1);
+    expect(
+      agent.chatCtx.items.some(
+        (item) =>
+          item.type === 'message' && item.role === 'user' && item.textContent === CORRECTION,
+      ),
+    ).toBe(true);
+  } finally {
+    output.releasePlayback();
+    await session.close();
+  }
+});
+
+it('waits for speech commitment without waiting for an interrupted tool to settle', async () => {
+  const toolStarted = new Future<void>();
+  const toolResult = new Future<string>();
+  const { session, activity, llm, output } = await startHarness({
+    agent: new FrameAgent({
+      lookup: tool({
+        description: 'Look up a time',
+        execute: async () => {
+          toolStarted.resolve();
+          return toolResult.await;
+        },
+      }),
+    }),
+    llm: new CapturingLLM([
+      { input: INITIAL, content: SPOKEN + UNSPOKEN, toolCalls: [{ name: 'lookup', args: {} }] },
+      { input: CORRECTION, content: 'Which day works?' },
+    ]),
+  });
+  try {
+    session.generateReply({ userInput: INITIAL });
+    await vi.waitFor(() => expect(output.captured).toBe(true));
+    await toolStarted.await;
+    await activity.onEndOfTurn(userTurn(CORRECTION));
+    await vi.waitFor(() => expect(output.cleared).toBe(true));
+    output.releasePlayback();
+    await vi.waitFor(() => expect(llm.requests).toHaveLength(2));
+    expect(toolResult.done).toBe(false);
+    expect(assistantText(llm.requests[1]!)).toEqual([SPOKEN]);
+  } finally {
+    toolResult.resolve('Available');
+    output.releasePlayback();
+    await session.close();
+  }
+});
+
+it('preserves the committed prefix across consecutive caller corrections', async () => {
+  const { session, activity, llm, output } = await startHarness();
+  try {
+    session.generateReply({ userInput: INITIAL });
+    await vi.waitFor(() => expect(output.captured).toBe(true));
+    await activity.onEndOfTurn(userTurn(CORRECTION));
+    await vi.waitFor(() => expect(output.cleared).toBe(true));
+    await activity.onEndOfTurn(userTurn('Friday instead.'));
+    output.releasePlayback();
+    await session.waitForIdle();
+    const latest = llm.requests.at(-1)!;
+    expect(
+      latest.items.some(
+        (item) =>
+          item.type === 'message' && item.role === 'user' && item.textContent === 'Friday instead.',
+      ),
+    ).toBe(true);
+    expect(assistantText(latest).filter((text) => text === SPOKEN)).toHaveLength(1);
+  } finally {
+    output.releasePlayback();
+    await session.close();
+  }
+});


### PR DESCRIPTION
## Description
Interrupted pipeline speech can appear in final conversation history while being absent from the very next LLM request. `userTurnCompleted()` interrupts the current speech and copies `agent.chatCtx` before the interrupted pipeline has committed the spoken prefix. The next reply therefore uses stale context, even though inspecting history after the call looks correct.

This waits for the interrupted, authorized pipeline generation to complete before taking the next context snapshot. That boundary follows speech commitment and precedes settlement of interrupted tool executions. A shutdown check prevents the resumed turn from scheduling a new reply during session close while retaining the caller's message.

## Changes Made
- Await the existing generation-completion boundary before copying context, including when speech was already interrupted before end-of-turn handling.
- Skip this wait for unauthorized generations and realtime models. Keep the added shutdown guard within the pipeline path.
- Add 12 deterministic tests using a real `AgentSession`, `FakeLLM`, synthetic audio frames, and an output sink that controls playback completion. Capture each actual LLM input independently of final history.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Independent standards and behavior reviews completed; the realtime scope finding was fixed and re-reviewed.
- [x] **Changes explained**: Root cause, synchronization boundary, and regression evidence are documented here.
- [x] **Scope appropriate**: Only pipeline turn handling and its regression tests change; no new API, configuration, dependencies, or application policy.
- [ ] **Video demo**: Not applicable to this SDK context-ordering regression; the synthetic reproduction below is automated.

## Testing
- [x] Automated tests added/updated
- [x] All tests pass (core SDK suite; skips listed below)
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes): interactive examples were not run; no public API or realtime behavior changes.

### Reproducible before/after evidence

Base: upstream `main` at `64c0bf8f5f43edfcb287e21901046f0a568342f5` (`@livekit/agents` 1.8.0). Node 24.19.0, pnpm 11.13.1.

The synthetic assistant generates `The appointment is available on Thursday at ten.` Playback reports only `The appointment is available` as spoken. The caller then says `Actually, a different day.`

| Observation | Unmodified upstream | This change |
| --- | --- | --- |
| Spoken prefix eventually in final history | Present | Present |
| Spoken prefix in the next reply's LLM input | Missing | Present exactly once |
| Unspoken suffix in the next reply's LLM input | Absent | Absent |
| Same 12-test regression file | 5 passed, 7 failed | 12 passed |

Run the regression file against either runtime version:

```sh
LIVEKIT_INFERENCE_TESTS=0 pnpm test agents/src/voice/agent_activity_interrupted_context.test.ts
```

Coverage includes interruption at end of turn and before end of turn, with preemptive generation enabled/disabled; completed-speech controls; unauthorized and never-played speech; pending tools; consecutive caller corrections; session close while cleanup is pending; and progress through the existing interruption watchdog when the output never acknowledges completion. The pending-tool test checks that the next LLM input already contains the spoken prefix while the tool result is still unresolved.

Local validation on the final diff:

- `LIVEKIT_INFERENCE_TESTS=0 pnpm test agents --silent`: **152 files passed; 2,502 tests passed, 5 skipped**. Skips are three credential-gated inference integration suites and two existing Zod cases.
- `pnpm build`: **39 tasks passed**.
- `pnpm lint`: **39 tasks passed**.
- `pnpm typecheck`: **33 tasks passed**.
- `pnpm format:check`, `pnpm throws:check`, and `git diff --check`: **passed**.
- Required `pnpm -w format:write` and `pnpm -w lint:fix` were run; unrelated formatter output was excluded from this PR.

Live provider calls and interactive examples were not run.

## Additional Notes
- Uses the existing generation future and interruption watchdog; introduces no additional timeout. With a healthy output, the next context snapshot waits for playback cleanup to report what was spoken. If playback completion never arrives, the watchdog still permits progress; that case cannot guarantee an exact heard prefix without playback metadata.
- The already-interrupted case exercises event ordering after interruption, not the full adaptive detector's pause/resume behavior.
- Stale preemptive contexts are rejected by the existing context-equivalence check after the spoken prefix is committed.
- All examples and test inputs are synthetic. No production audio, transcripts, patient data, credentials, or private endpoints are included.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.
