### PR TITLE
fix(cartesia): stop sending max_buffer_delay_ms on /tts/bytes

### DIFF
--- a/.changeset/cartesia-bytes-max-buffer-delay.md
+++ b/.changeset/cartesia-bytes-max-buffer-delay.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-cartesia': patch
+---
+
+Stop sending the websocket-only `max_buffer_delay_ms` field on `/tts/bytes` requests, which Cartesia rejects with HTTP 400.

--- a/plugins/cartesia/src/tts.test.ts
+++ b/plugins/cartesia/src/tts.test.ts
@@ -11,6 +11,7 @@ import {
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts as testTts } from '@livekit/agents-plugins-test';
 import { once } from 'node:events';
+import { type Server, type ServerResponse, createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { describe, expect, it } from 'vitest';
 import { type WebSocket, WebSocketServer } from 'ws';
@@ -45,6 +46,49 @@ async function closeWebSocketServer(wss: WebSocketServer): Promise<void> {
     client.close();
   }
   await new Promise<void>((resolve) => wss.close(() => resolve()));
+}
+
+// A minimal Cartesia /tts/bytes server. `onRequest` receives the parsed JSON
+// body and writes the response; the returned `requests` collects every body.
+async function startBytesServer(
+  onRequest: (body: Record<string, unknown>, res: ServerResponse) => void,
+): Promise<{ server: Server; baseURL: string; requests: Record<string, unknown>[] }> {
+  const requests: Record<string, unknown>[] = [];
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>;
+      requests.push(body);
+      onRequest(body, res);
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address() as AddressInfo;
+  return { server, baseURL: `http://127.0.0.1:${address.port}`, requests };
+}
+
+async function closeBytesServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function synthesizeBytes(
+  cartesia: TTS,
+  text: string,
+  connOptions?: APIConnectOptions,
+): Promise<tts.SynthesizedAudio[]> {
+  const stream = cartesia.synthesize(text, connOptions);
+  try {
+    const events: tts.SynthesizedAudio[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+    return events;
+  } finally {
+    stream.close();
+  }
 }
 
 async function waitFor<T>(promise: Promise<T>, timeoutMs = 1000): Promise<T> {
@@ -380,6 +424,48 @@ describe('Cartesia streaming pool', () => {
       );
       expect(wss.clients.size).toBe(0);
     } finally {
+      await closeWebSocketServer(wss);
+    }
+  });
+});
+
+describe('Cartesia /tts/bytes', () => {
+  it('omits the websocket-only max_buffer_delay_ms field', async () => {
+    const { server, baseURL, requests } = await startBytesServer((_body, res) => {
+      res.writeHead(200, { 'content-type': 'audio/pcm' });
+      res.end(CURRENT_CHUNK);
+    });
+
+    const cartesia = new TTS({ apiKey: 'test-key', baseUrl: baseURL });
+    try {
+      const events = await synthesizeBytes(cartesia, 'hello.');
+      expect(events).not.toHaveLength(0);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({ transcript: 'hello.' });
+      expect(requests[0]).not.toHaveProperty('max_buffer_delay_ms');
+    } finally {
+      await cartesia.close();
+      await closeBytesServer(server);
+    }
+  });
+
+  it('keeps max_buffer_delay_ms on websocket generations', async () => {
+    const { wss, baseURL } = await startWebSocketServer();
+    const packets: Record<string, unknown>[] = [];
+    wss.on('connection', (ws) => {
+      ws.on('message', (raw) => packets.push(JSON.parse(raw.toString())));
+    });
+    serveCartesia(wss);
+
+    const cartesia = new TTS({ apiKey: 'test-key', baseUrl: baseURL });
+    try {
+      expect(await synthesizeTurn(cartesia, 'hello.')).not.toHaveLength(0);
+      expect(packets.length).toBeGreaterThan(0);
+      for (const packet of packets) {
+        expect(packet).toMatchObject({ max_buffer_delay_ms: 0 });
+      }
+    } finally {
+      await cartesia.close();
       await closeWebSocketServer(wss);
     }
   });

--- a/plugins/cartesia/src/tts.ts
+++ b/plugins/cartesia/src/tts.ts
@@ -22,7 +22,8 @@ import {
   tts,
 } from '@livekit/agents';
 import type { AudioFrame } from '@livekit/rtc-node';
-import { request } from 'node:https';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
 import { type RawData, WebSocket } from 'ws';
 import {
   TTSDefaultVoiceId,
@@ -316,10 +317,11 @@ export class ChunkedStream extends tts.ChunkedStream {
     const baseUrl = new URL(this.#opts.baseUrl);
     const doneFut = new Future<void>();
 
-    const req = request(
+    const isHttps = baseUrl.protocol === 'https:';
+    const req = (isHttps ? httpsRequest : httpRequest)(
       {
         hostname: baseUrl.hostname,
-        port: parseInt(baseUrl.port) || (baseUrl.protocol === 'https:' ? 443 : 80),
+        port: parseInt(baseUrl.port) || (isHttps ? 443 : 80),
         path: '/tts/bytes',
         method: 'POST',
         headers: {
@@ -955,7 +957,6 @@ const toCartesiaOptions = (
       sample_rate: opts.sampleRate,
     },
     language: getBaseLanguage(opts.language),
-    max_buffer_delay_ms: 0,
   };
 
   if (opts.pronunciationDictId) {
@@ -978,8 +979,12 @@ const toCartesiaOptions = (
     }
   }
 
-  if (streaming && opts.wordTimestamps !== false) {
-    result.add_timestamps = true;
+  if (streaming) {
+    // Websocket-only: /tts/bytes rejects requests that carry it.
+    result.max_buffer_delay_ms = 0;
+    if (opts.wordTimestamps !== false) {
+      result.add_timestamps = true;
+    }
   }
 
   return result;


### PR DESCRIPTION

## Description
`toCartesiaOptions` puts `max_buffer_delay_ms: 0` in the shared payload, so it goes out on `/tts/bytes` as well as the websocket. Cartesia rejects every non-streaming request with:

```
400 Invalid request: Your request was invalid: max buffer delay is only supported for websocket requests
```

#1107 added the field for the websocket message ("Add max_buffer_delay_ms = 0 to ws msg"); the placement made it apply to both paths. The main caller of `synthesize()` in a voice pipeline is the TTS `FallbackAdapter` recovery probe, so once a session fails over from Cartesia it can never recover to it. We observed one failover followed by 99 consecutive rejected recovery probes on a production call.

**Parity:** the Python plugin only adds `max_buffer_delay_ms` in the websocket sentence stream ([tts.py#L433-L434](https://github.com/livekit/agents/blob/614ef048fa17f8ed148eec6a663a237b3dda03eb/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py#L433-L434)) and never sends it on `/tts/bytes` ([tts.py#L366](https://github.com/livekit/agents/blob/614ef048fa17f8ed148eec6a663a237b3dda03eb/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py#L366)).

## Changes Made
- Move `max_buffer_delay_ms: 0` under the existing `streaming` guard in `toCartesiaOptions`, next to `add_timestamps`.
- Pick `node:http` or `node:https` from the base URL protocol in `ChunkedStream` (the port calculation already did), so the non-streaming path can be tested against a local plain-HTTP server the same way the websocket tests already are.
- Tests: the `/tts/bytes` payload has no `max_buffer_delay_ms`; websocket packets still carry it.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title
- [ ] **Video demo**: n/a, request-payload change covered by tests

## Testing
- [x] Automated tests added/updated
- [x] All tests pass
- [ ] `restaurant_agent.ts` / `realtime_agent.ts`: n/a, not a major change

```
pnpm build
pnpm vitest run plugins/cartesia/src/tts.test.ts   # 11 passed, 1 skipped (credential-gated)
pnpm exec eslint plugins/cartesia/src/tts.ts plugins/cartesia/src/tts.test.ts
pnpm exec prettier --check plugins/cartesia/src/tts.ts plugins/cartesia/src/tts.test.ts
```

## Additional Notes
The same handler never checks the response status, which is why this 400 showed up as silent empty audio rather than an error. That is a separate fix in #2443, which is stacked on this branch and should be reviewed after this one.
