### PR TITLE
fix(cartesia): surface rejected /tts/bytes responses as APIStatusError

### DIFF
--- a/.changeset/cartesia-bytes-max-buffer-delay.md
+++ b/.changeset/cartesia-bytes-max-buffer-delay.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-cartesia': patch
+---
+
+Stop sending the websocket-only `max_buffer_delay_ms` field on `/tts/bytes` requests, which Cartesia rejects with HTTP 400.

--- a/.changeset/cartesia-bytes-status-errors.md
+++ b/.changeset/cartesia-bytes-status-errors.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-cartesia': patch
+---
+
+Surface rejected `/tts/bytes` responses as `APIStatusError` instead of ending with silent empty audio.

--- a/.changeset/chunked-stream-rejections.md
+++ b/.changeset/chunked-stream-rejections.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Stop failed `tts.ChunkedStream` requests from surfacing as unhandled promise rejections. The failure is already reported through the TTS `error` event.

--- a/agents/src/tts/tts.ts
+++ b/agents/src/tts/tts.ts
@@ -758,7 +758,15 @@ export abstract class ChunkedStream implements AsyncIterableIterator<Synthesized
     // is run **after** the constructor has finished. Otherwise we get
     // runtime error when trying to access class variables in the
     // `run` method.
-    ThrowsPromise.resolve().then(() => this.mainTask().finally(() => this.#metricsQueue.close()));
+    startSoon(async () => {
+      try {
+        await this.mainTask();
+      } catch {
+        // already surfaced via emitError; swallow to avoid unhandled rejection.
+      } finally {
+        this.#metricsQueue.close();
+      }
+    });
   }
 
   private drainAttemptQueue(attemptQueue: AsyncIterableQueue<SynthesizedAudio>): Promise<void> {

--- a/plugins/cartesia/src/tts.test.ts
+++ b/plugins/cartesia/src/tts.test.ts
@@ -477,7 +477,10 @@ describe('Cartesia /tts/bytes', () => {
       const error = errors[0]!.error;
       expect(error).toBeInstanceOf(APIStatusError);
       expect((error as APIStatusError).statusCode).toBe(400);
-      expect(error.message).toContain('max buffer delay is only supported for websocket requests');
+      expect(error.message).toBe('Cartesia /tts/bytes request failed with HTTP 400');
+      expect((error as APIStatusError).body).toEqual({
+        raw: expect.stringContaining('max buffer delay is only supported for websocket requests'),
+      });
       // A 4xx is not retried, so the default connect options made exactly one request.
       expect(requests).toHaveLength(1);
     } finally {

--- a/plugins/cartesia/src/tts.test.ts
+++ b/plugins/cartesia/src/tts.test.ts
@@ -13,7 +13,7 @@ import { tts as testTts } from '@livekit/agents-plugins-test';
 import { once } from 'node:events';
 import { type Server, type ServerResponse, createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { type WebSocket, WebSocketServer } from 'ws';
 import { TTS } from './tts.js';
 
@@ -430,15 +430,6 @@ describe('Cartesia streaming pool', () => {
 });
 
 describe('Cartesia /tts/bytes', () => {
-  // A failed ChunkedStream also rejects its background task; the error event is
-  // the surface under test here.
-  const swallowExpectedRejection = (reason: unknown) => {
-    if (reason instanceof APIStatusError) return;
-    throw reason;
-  };
-  beforeAll(() => process.on('unhandledRejection', swallowExpectedRejection));
-  afterAll(() => void process.off('unhandledRejection', swallowExpectedRejection));
-
   it('omits the websocket-only max_buffer_delay_ms field', async () => {
     const { server, baseURL, requests } = await startBytesServer((_body, res) => {
       res.writeHead(200, { 'content-type': 'audio/pcm' });

--- a/plugins/cartesia/src/tts.test.ts
+++ b/plugins/cartesia/src/tts.test.ts
@@ -13,7 +13,7 @@ import { tts as testTts } from '@livekit/agents-plugins-test';
 import { once } from 'node:events';
 import { type Server, type ServerResponse, createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { type WebSocket, WebSocketServer } from 'ws';
 import { TTS } from './tts.js';
 
@@ -430,6 +430,15 @@ describe('Cartesia streaming pool', () => {
 });
 
 describe('Cartesia /tts/bytes', () => {
+  // A failed ChunkedStream also rejects its background task; the error event is
+  // the surface under test here.
+  const swallowExpectedRejection = (reason: unknown) => {
+    if (reason instanceof APIStatusError) return;
+    throw reason;
+  };
+  beforeAll(() => process.on('unhandledRejection', swallowExpectedRejection));
+  afterAll(() => void process.off('unhandledRejection', swallowExpectedRejection));
+
   it('omits the websocket-only max_buffer_delay_ms field', async () => {
     const { server, baseURL, requests } = await startBytesServer((_body, res) => {
       res.writeHead(200, { 'content-type': 'audio/pcm' });
@@ -443,6 +452,60 @@ describe('Cartesia /tts/bytes', () => {
       expect(requests).toHaveLength(1);
       expect(requests[0]).toMatchObject({ transcript: 'hello.' });
       expect(requests[0]).not.toHaveProperty('max_buffer_delay_ms');
+    } finally {
+      await cartesia.close();
+      await closeBytesServer(server);
+    }
+  });
+
+  it('surfaces a rejected response as APIStatusError instead of silent empty audio', async () => {
+    const { server, baseURL, requests } = await startBytesServer((_body, res) => {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'Invalid request: max buffer delay is only supported for websocket requests',
+        }),
+      );
+    });
+
+    const cartesia = new TTS({ apiKey: 'test-key', baseUrl: baseURL });
+    const errors: { error: Error }[] = [];
+    cartesia.on('error', (error) => errors.push(error));
+    try {
+      expect(await synthesizeBytes(cartesia, 'hello.')).toHaveLength(0);
+      expect(errors).toHaveLength(1);
+      const error = errors[0]!.error;
+      expect(error).toBeInstanceOf(APIStatusError);
+      expect((error as APIStatusError).statusCode).toBe(400);
+      expect(error.message).toContain('max buffer delay is only supported for websocket requests');
+      // A 4xx is not retried, so the default connect options made exactly one request.
+      expect(requests).toHaveLength(1);
+    } finally {
+      await cartesia.close();
+      await closeBytesServer(server);
+    }
+  });
+
+  it('retries a 5xx response', async () => {
+    const { server, baseURL, requests } = await startBytesServer((_body, res) => {
+      if (requests.length === 1) {
+        res.writeHead(503);
+        res.end('upstream unavailable');
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'audio/pcm' });
+      res.end(CURRENT_CHUNK);
+    });
+
+    const cartesia = new TTS({ apiKey: 'test-key', baseUrl: baseURL });
+    try {
+      const events = await synthesizeBytes(cartesia, 'hello.', {
+        ...DEFAULT_API_CONNECT_OPTIONS,
+        maxRetry: 1,
+        retryIntervalMs: 0,
+      });
+      expect(events).not.toHaveLength(0);
+      expect(requests).toHaveLength(2);
     } finally {
       await cartesia.close();
       await closeBytesServer(server);

--- a/plugins/cartesia/src/tts.test.ts
+++ b/plugins/cartesia/src/tts.test.ts
@@ -11,6 +11,7 @@ import {
 import { STT } from '@livekit/agents-plugin-openai';
 import { tts as testTts } from '@livekit/agents-plugins-test';
 import { once } from 'node:events';
+import { type Server, type ServerResponse, createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { describe, expect, it } from 'vitest';
 import { type WebSocket, WebSocketServer } from 'ws';
@@ -45,6 +46,49 @@ async function closeWebSocketServer(wss: WebSocketServer): Promise<void> {
     client.close();
   }
   await new Promise<void>((resolve) => wss.close(() => resolve()));
+}
+
+// A minimal Cartesia /tts/bytes server. `onRequest` receives the parsed JSON
+// body and writes the response; the returned `requests` collects every body.
+async function startBytesServer(
+  onRequest: (body: Record<string, unknown>, res: ServerResponse) => void,
+): Promise<{ server: Server; baseURL: string; requests: Record<string, unknown>[] }> {
+  const requests: Record<string, unknown>[] = [];
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>;
+      requests.push(body);
+      onRequest(body, res);
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address() as AddressInfo;
+  return { server, baseURL: `http://127.0.0.1:${address.port}`, requests };
+}
+
+async function closeBytesServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function synthesizeBytes(
+  cartesia: TTS,
+  text: string,
+  connOptions?: APIConnectOptions,
+): Promise<tts.SynthesizedAudio[]> {
+  const stream = cartesia.synthesize(text, connOptions);
+  try {
+    const events: tts.SynthesizedAudio[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+    return events;
+  } finally {
+    stream.close();
+  }
 }
 
 async function waitFor<T>(promise: Promise<T>, timeoutMs = 1000): Promise<T> {
@@ -380,6 +424,48 @@ describe('Cartesia streaming pool', () => {
       );
       expect(wss.clients.size).toBe(0);
     } finally {
+      await closeWebSocketServer(wss);
+    }
+  });
+});
+
+describe('Cartesia /tts/bytes', () => {
+  it('omits the websocket-only max_buffer_delay_ms field', async () => {
+    const { server, baseURL, requests } = await startBytesServer((_body, res) => {
+      res.writeHead(200, { 'content-type': 'audio/pcm' });
+      res.end(CURRENT_CHUNK);
+    });
+
+    const cartesia = new TTS({ apiKey: 'test-key', baseUrl: baseURL });
+    try {
+      const events = await synthesizeBytes(cartesia, 'hello.');
+      expect(events).not.toHaveLength(0);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({ transcript: 'hello.' });
+      expect(requests[0]).not.toHaveProperty('max_buffer_delay_ms');
+    } finally {
+      await cartesia.close();
+      await closeBytesServer(server);
+    }
+  });
+
+  it('keeps max_buffer_delay_ms on websocket generations', async () => {
+    const { wss, baseURL } = await startWebSocketServer();
+    const packets: Record<string, unknown>[] = [];
+    wss.on('connection', (ws) => {
+      ws.on('message', (raw) => packets.push(JSON.parse(raw.toString())));
+    });
+    serveCartesia(wss);
+
+    const cartesia = new TTS({ apiKey: 'test-key', baseUrl: baseURL });
+    try {
+      expect(await synthesizeTurn(cartesia, 'hello.')).not.toHaveLength(0);
+      expect(packets.length).toBeGreaterThan(0);
+      for (const packet of packets) {
+        expect(packet).toMatchObject({ max_buffer_delay_ms: 0 });
+      }
+    } finally {
+      await cartesia.close();
       await closeWebSocketServer(wss);
     }
   });

--- a/plugins/cartesia/src/tts.ts
+++ b/plugins/cartesia/src/tts.ts
@@ -22,7 +22,8 @@ import {
   tts,
 } from '@livekit/agents';
 import type { AudioFrame } from '@livekit/rtc-node';
-import { request } from 'node:https';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
 import { type RawData, WebSocket } from 'ws';
 import {
   TTSDefaultVoiceId,
@@ -316,10 +317,11 @@ export class ChunkedStream extends tts.ChunkedStream {
     const baseUrl = new URL(this.#opts.baseUrl);
     const doneFut = new Future<void>();
 
-    const req = request(
+    const isHttps = baseUrl.protocol === 'https:';
+    const req = (isHttps ? httpsRequest : httpRequest)(
       {
         hostname: baseUrl.hostname,
-        port: parseInt(baseUrl.port) || (baseUrl.protocol === 'https:' ? 443 : 80),
+        port: parseInt(baseUrl.port) || (isHttps ? 443 : 80),
         path: '/tts/bytes',
         method: 'POST',
         headers: {
@@ -955,7 +957,6 @@ const toCartesiaOptions = (
       sample_rate: opts.sampleRate,
     },
     language: getBaseLanguage(opts.language),
-    max_buffer_delay_ms: 0,
   };
 
   if (opts.pronunciationDictId) {
@@ -978,8 +979,12 @@ const toCartesiaOptions = (
     }
   }
 
-  if (streaming && opts.wordTimestamps !== false) {
-    result.add_timestamps = true;
+  if (streaming) {
+    // Websocket-only: /tts/bytes rejects requests that carry it.
+    result.max_buffer_delay_ms = 0;
+    if (opts.wordTimestamps !== false) {
+      result.add_timestamps = true;
+    }
   }
 
   return result;

--- a/plugins/cartesia/src/tts.ts
+++ b/plugins/cartesia/src/tts.ts
@@ -357,8 +357,8 @@ export class ChunkedStream extends tts.ChunkedStream {
             if (!doneFut.done) {
               doneFut.reject(
                 new APIStatusError({
-                  message: `Cartesia /tts/bytes request failed: ${body || `HTTP ${statusCode}`}`,
-                  options: { statusCode },
+                  message: `Cartesia /tts/bytes request failed with HTTP ${statusCode}`,
+                  options: { statusCode, body: body ? { raw: body } : null },
                 }),
               );
             }

--- a/plugins/cartesia/src/tts.ts
+++ b/plugins/cartesia/src/tts.ts
@@ -316,6 +316,7 @@ export class ChunkedStream extends tts.ChunkedStream {
 
     const baseUrl = new URL(this.#opts.baseUrl);
     const doneFut = new Future<void>();
+    let responseReceived = false;
 
     const isHttps = baseUrl.protocol === 'https:';
     const req = (isHttps ? httpsRequest : httpRequest)(
@@ -331,7 +332,16 @@ export class ChunkedStream extends tts.ChunkedStream {
         signal: this.abortSignal,
       },
       (res) => {
-        res.on('data', (chunk) => {
+        responseReceived = true;
+        const statusCode = res.statusCode ?? 0;
+        const rejected = statusCode < 200 || statusCode >= 300;
+        const errorBody: Buffer[] = [];
+
+        res.on('data', (chunk: Buffer) => {
+          if (rejected) {
+            errorBody.push(chunk);
+            return;
+          }
           for (const frame of bstream.write(chunk)) {
             this.queue.put({
               requestId,
@@ -342,6 +352,18 @@ export class ChunkedStream extends tts.ChunkedStream {
           }
         });
         res.on('close', () => {
+          if (rejected) {
+            const body = Buffer.concat(errorBody).toString().trim();
+            if (!doneFut.done) {
+              doneFut.reject(
+                new APIStatusError({
+                  message: `Cartesia /tts/bytes request failed: ${body || `HTTP ${statusCode}`}`,
+                  options: { statusCode },
+                }),
+              );
+            }
+            return;
+          }
           for (const frame of bstream.flush()) {
             this.queue.put({
               requestId,
@@ -367,7 +389,7 @@ export class ChunkedStream extends tts.ChunkedStream {
       if (!doneFut.done) doneFut.reject(err);
     });
     req.on('close', () => {
-      if (!doneFut.done) doneFut.resolve();
+      if (!responseReceived && !doneFut.done) doneFut.resolve();
     });
     req.write(JSON.stringify(json));
     req.end();
@@ -377,6 +399,7 @@ export class ChunkedStream extends tts.ChunkedStream {
     } catch (e) {
       if (this.abortSignal.aborted) return;
       if (!this.queue.closed) this.queue.close();
+      if (e instanceof APIError) throw e;
       throw toRetryableConnectionError(e);
     }
   }


### PR DESCRIPTION
> **Stacked on #2442.** This branch is cut from that PR's branch, so the diff below currently shows both PRs' changes. Only the commits after a4a4f56b are new here: the `APIStatusError` handling, its two tests, and the base-class rejection fix. The first commit, the two http/https import lines, the `startBytesServer` harness, the `max_buffer_delay_ms` test and `.changeset/cartesia-bytes-max-buffer-delay.md` all belong to #2442. Once #2442 merges this diff collapses to roughly +110/-5. Review #2442 first.


## Description
`ChunkedStream.run()` never looks at `res.statusCode`. On a rejected response the error body is written into the `AudioByteStream`, is too short to fill a frame, and the stream completes successfully with zero audio. The caller only sees "no audio was received", never the reason, and a 401 or 400 is indistinguishable from an empty result.

Supersedes #1660, which stalled on two review points: the test needed a self-signed certificate, and (per the Devin review) every status was wrapped in `APIConnectionError`, so a 401 would be retried. This PR rejects with `APIStatusError` so retryability follows the status code, and tests against a plain HTTP server (protocol selection landed in #2442).

**Parity:** the Python plugin calls `resp.raise_for_status()` on `/tts/bytes` and maps the failure to `APIStatusError` ([tts.py#L380](https://github.com/livekit/agents/blob/614ef048fa17f8ed148eec6a663a237b3dda03eb/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py#L380), [tts.py#L395-L398](https://github.com/livekit/agents/blob/614ef048fa17f8ed148eec6a663a237b3dda03eb/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py#L395-L398)).

## Changes Made
- On a non-2xx response, buffer the body and reject with `APIStatusError`. The message carries only the status; Cartesia's response text goes in `error.body` per REVIEW.md, so it can be redacted from logs. 5xx and 429 stay retryable; other 4xx do not.
- `tts.ChunkedStream` (base class) now awaits its background task the same way `SynthesizeStream` already does, so a terminal failure no longer surfaces as an unhandled promise rejection. The failure is already reported through the TTS `error` event. This removes the need for the `unhandledRejection` suppression in the Cartesia test.
- Only resolve on request `close` when no response was received, so a late request close cannot beat the response handler's rejection.
- Rethrow `APIError` instances as-is in the catch instead of re-wrapping them as retryable connection errors, matching the websocket path.
- Tests: a 400 with a JSON body surfaces as `APIStatusError` with status 400, makes exactly one request under default connect options, and yields no audio; a 503 followed by 200 retries and yields audio.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title
- [ ] **Video demo**: n/a, error-path change covered by tests

## Testing
- [x] Automated tests added/updated
- [x] All tests pass
- [ ] `restaurant_agent.ts` / `realtime_agent.ts`: n/a, not a major change

```
pnpm build
pnpm vitest run plugins/cartesia/src/tts.test.ts   # 13 passed, 1 skipped (credential-gated)
pnpm exec eslint plugins/cartesia/src/tts.ts plugins/cartesia/src/tts.test.ts
pnpm exec prettier --check plugins/cartesia/src/tts.ts plugins/cartesia/src/tts.test.ts
```

## Additional Notes
Neuphonic and Resemble build their non-streaming request the same way and also never check the status. Left out of this PR to keep it to Cartesia; happy to follow up.

Co-authored-by: Jason Lernerman <jason.lernerman@livekit.io>
