### PR TITLE
fix: stop force interrupt inside a tool from crashing the process

### DIFF
--- a/.changeset/abort-listener-speech-handle.md
+++ b/.changeset/abort-listener-speech-handle.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Stop `session.interrupt({ force: true })` from crashing the process with `SpeechHandleCircularWaitError` when called inside a function tool.

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2294,9 +2294,8 @@ export class AgentActivity implements RecognitionHooks {
     });
 
     if (ownedSpeechHandle) {
-      // Return nothing: SpeechHandle is a thenable, and EventTarget calls `.then()` on a
-      // listener's return value. When the abort fires from inside the owning function tool,
-      // that `.then()` hits the circular-wait guard and crashes the process (#2435).
+      // Must not return the handle: SpeechHandle is a thenable, and EventTarget calls `.then()`
+      // on a listener's return value, which trips the circular-wait guard inside the owning tool.
       const interruptOwnedSpeech = () => {
         ownedSpeechHandle.interrupt(true);
       };

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -2294,7 +2294,12 @@ export class AgentActivity implements RecognitionHooks {
     });
 
     if (ownedSpeechHandle) {
-      const interruptOwnedSpeech = () => ownedSpeechHandle.interrupt(true);
+      // Return nothing: SpeechHandle is a thenable, and EventTarget calls `.then()` on a
+      // listener's return value. When the abort fires from inside the owning function tool,
+      // that `.then()` hits the circular-wait guard and crashes the process (#2435).
+      const interruptOwnedSpeech = () => {
+        ownedSpeechHandle.interrupt(true);
+      };
       taskController.signal.addEventListener('abort', interruptOwnedSpeech, { once: true });
       if (taskController.signal.aborted) {
         interruptOwnedSpeech();

--- a/agents/src/voice/agent_activity_speech_task_abort.test.ts
+++ b/agents/src/voice/agent_activity_speech_task_abort.test.ts
@@ -3,14 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Regression test for #2435.
- *
- * AgentActivity.createSpeechTask() registers an abort listener that interrupts the owned
- * SpeechHandle. SpeechHandle is a thenable, and Node's EventTarget calls `.then()` on any
- * thenable a listener returns. When the abort fires from inside the function tool that owns
- * the handle (for example `session.interrupt({ force: true })` in a tool), that `.then()` calls
- * `waitForPlayout()`, hits the circular-wait guard, and Node rethrows the rejection as an
- * uncaught exception. The listener must not return the handle.
+ * Cancelling a speech task from inside its owning function tool, as a tool calling
+ * `session.interrupt` with force does, must not crash the process with SpeechHandleCircularWaitError.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FunctionCall } from '../llm/chat_context.js';
@@ -49,8 +43,7 @@ describe('AgentActivity.createSpeechTask - abort listener', () => {
       args: '{}',
     });
 
-    // If the listener returns the handle, EventTarget calls `.then()` on it. Stub it so a
-    // regression fails this assertion instead of crashing the whole vitest worker.
+    // Stub `.then()` so a regression fails the assertion instead of crashing the vitest worker.
     const then = vi.spyOn(speechHandle, 'then').mockImplementation(() => Promise.resolve());
 
     const started = new Future<void>();
@@ -69,7 +62,7 @@ describe('AgentActivity.createSpeechTask - abort listener', () => {
     });
     await started.await;
 
-    // Same context as a tool calling `session.interrupt({ force: true })`.
+    // Same async context as a tool calling `session.interrupt({ force: true })`.
     functionCallStorage.run({ functionCall, speechHandle }, () => task.cancel());
     await task.result;
 

--- a/agents/src/voice/agent_activity_speech_task_abort.test.ts
+++ b/agents/src/voice/agent_activity_speech_task_abort.test.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression test for #2435.
+ *
+ * AgentActivity.createSpeechTask() registers an abort listener that interrupts the owned
+ * SpeechHandle. SpeechHandle is a thenable, and Node's EventTarget calls `.then()` on any
+ * thenable a listener returns. When the abort fires from inside the function tool that owns
+ * the handle (for example `session.interrupt({ force: true })` in a tool), that `.then()` calls
+ * `waitForPlayout()`, hits the circular-wait guard, and Node rethrows the rejection as an
+ * uncaught exception. The listener must not return the handle.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FunctionCall } from '../llm/chat_context.js';
+import { Future, type Task } from '../utils.js';
+import { functionCallStorage } from './agent.js';
+import { AgentActivity } from './agent_activity.js';
+import { SpeechHandle } from './speech_handle.js';
+
+type SpeechTaskFactory = (options: {
+  taskFn: (controller: AbortController) => Promise<void>;
+  ownedSpeechHandle?: SpeechHandle;
+  name?: string;
+}) => Task<void>;
+
+function makeActivity(): AgentActivity {
+  const activity = Object.create(AgentActivity.prototype) as AgentActivity;
+  Object.assign(activity, {
+    speechTasks: new Set(),
+    q_updated: new Future<void>(),
+    logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  });
+  return activity;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AgentActivity.createSpeechTask - abort listener', () => {
+  it('does not hand the owned SpeechHandle to EventTarget when cancelled from its own tool', async () => {
+    const activity = makeActivity();
+    const speechHandle = SpeechHandle.create();
+    const functionCall = FunctionCall.create({
+      callId: 'call_test',
+      name: 'example_tool',
+      args: '{}',
+    });
+
+    // If the listener returns the handle, EventTarget calls `.then()` on it. Stub it so a
+    // regression fails this assertion instead of crashing the whole vitest worker.
+    const then = vi.spyOn(speechHandle, 'then').mockImplementation(() => Promise.resolve());
+
+    const started = new Future<void>();
+    const createSpeechTask = (
+      activity as unknown as { createSpeechTask: SpeechTaskFactory }
+    ).createSpeechTask.bind(activity);
+    const task = createSpeechTask({
+      taskFn: async (controller) => {
+        started.resolve();
+        await new Promise<void>((resolve) => {
+          controller.signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      },
+      ownedSpeechHandle: speechHandle,
+      name: 'test_speech_task',
+    });
+    await started.await;
+
+    // Same context as a tool calling `session.interrupt({ force: true })`.
+    functionCallStorage.run({ functionCall, speechHandle }, () => task.cancel());
+    await task.result;
+
+    expect(speechHandle.interrupted).toBe(true);
+    expect(then).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #2435. Addresses AGT-3459.

Since 1.8.0 (#2372), the abort listener in `createSpeechTask` returned the `SpeechHandle` from `interrupt(true)`. `SpeechHandle` is a thenable, so `EventTarget` calls `.then()` on it, which runs `waitForPlayout()`. When a tool calls `session.interrupt({ force: true })`, the abort fires inside that tool's context, the circular-wait guard throws, and Node rethrows it as an uncaught exception that kills the job. The listener now returns nothing. The regression test cancels an owned speech task from its own tool context and asserts `.then()` is never touched.

<details>
<summary>Initial prompt and agent context</summary>

**Model:** Claude Fable 5.1

> can you take a look at issue 2435?

> okay, create a draft PR

</details>