### PR TITLE
feat(agents): add sampleRate option to OpenAI.TTS

### DIFF
--- a/.changeset/five-nights-ring.md
+++ b/.changeset/five-nights-ring.md
@@ -1,0 +1,5 @@
+---
+"@livekit/agents-plugin-openai": patch
+---
+
+feat(agents): add sampleRate option to OpenAI.TTS

--- a/plugins/openai/src/tts.ts
+++ b/plugins/openai/src/tts.ts
@@ -6,8 +6,8 @@ import type { AudioFrame } from '@livekit/rtc-node';
 import { OpenAI } from 'openai';
 import type { TTSModels, TTSVoices } from './models.js';
 
-const OPENAI_TTS_SAMPLE_RATE = 24000;
 const OPENAI_TTS_CHANNELS = 1;
+const OPENAI_TTS_SAMPLE_RATE = 24000;
 
 export interface TTSOptions {
   model: TTSModels | string;
@@ -17,6 +17,7 @@ export interface TTSOptions {
   baseURL?: string;
   client?: OpenAI;
   apiKey?: string;
+  sampleRate?: number;
 }
 
 const defaultTTSOptions: TTSOptions = {
@@ -24,6 +25,7 @@ const defaultTTSOptions: TTSOptions = {
   model: 'tts-1',
   voice: 'alloy',
   speed: 1,
+  sampleRate: OPENAI_TTS_SAMPLE_RATE,
 };
 
 export class TTS extends tts.TTS {
@@ -53,7 +55,7 @@ export class TTS extends tts.TTS {
    * `OPENAI_API_KEY` environment variable.
    */
   constructor(opts: Partial<TTSOptions> = defaultTTSOptions) {
-    super(OPENAI_TTS_SAMPLE_RATE, OPENAI_TTS_CHANNELS, { streaming: false });
+    super(opts.sampleRate ?? OPENAI_TTS_SAMPLE_RATE, OPENAI_TTS_CHANNELS, { streaming: false });
 
     this.#opts = { ...defaultTTSOptions, ...opts };
     if (this.#opts.apiKey === undefined && !this.#opts.client) {
@@ -95,6 +97,7 @@ export class TTS extends tts.TTS {
         },
         { signal },
       ),
+      this.#opts.sampleRate!,
       connOptions,
       signal,
     );
@@ -112,24 +115,27 @@ export class TTS extends tts.TTS {
 export class ChunkedStream extends tts.ChunkedStream {
   label = 'openai.ChunkedStream';
   private stream: Promise<any>;
+  private sampleRate: number;
 
   // set Promise<T> to any because OpenAI returns an annoying Response type
   constructor(
     tts: TTS,
     text: string,
     stream: Promise<any>,
+    sampleRate: number,
     connOptions?: APIConnectOptions,
     abortSignal?: AbortSignal,
   ) {
     super(text, tts, connOptions, abortSignal);
     this.stream = stream;
+    this.sampleRate = sampleRate;
   }
 
   protected async run() {
     try {
       const buffer = await this.stream.then((r) => r.arrayBuffer());
       const requestId = shortuuid();
-      const audioByteStream = new AudioByteStream(OPENAI_TTS_SAMPLE_RATE, OPENAI_TTS_CHANNELS);
+      const audioByteStream = new AudioByteStream(this.sampleRate, OPENAI_TTS_CHANNELS);
       const frames = audioByteStream.write(buffer);
 
       let lastFrame: AudioFrame | undefined;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR does -->
Currently, the `OpenAI.TTS` class hardcodes a sample rate of 24000 hz.

Some models, such as FishAudio S2 Pro, are using a different one, such as 44100 hz.
This PR adds the ability to override the sample rate as part of the constructor, which falls back to 24000 hz as before if not supplied.

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [ ] **Changes explained**: All changes are properly documented and justified above
	- No docs yet!
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included
- [ ] **Video demo**: A small video demo showing changes works as expected and did not break any existing functionality using [Agent Playground](https://agents-playground.livekit.io/#cam=0&mic=1&screen=1&video=1&audio=1&chat=1&theme_color=green) (if applicable) 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Automated tests added/updated (if applicable)
- [x] All tests pass
- [ ] Make sure both `restaurant_agent.ts` and `realtime_agent.ts` work properly (for major changes)

## Additional Notes
<!-- Any additional context, screenshots, or information that reviewers should know -->

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.

Please tell me what I can do to get this merged asap!