### PR TITLE
fix: settle amd when session shutdown starts

### DIFF
--- a/.changeset/amd-session-close.md
+++ b/.changeset/amd-session-close.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Settle pending AMD detection when session shutdown starts, release waiting callbacks, and preserve results if interruption or reply authorization fails.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,8 @@ The framework uses Node.js `AsyncLocalStorage` for implicit context passing:
 
 ## Code Conventions
 
+- **Lifecycle changes**: Follow the [lifecycle review checklist](CONTRIBUTING.md#review-lifecycle-changes)
+  for session helpers, shutdown, and cleanup. Apply it to Python ports too.
 - **License header** required on every new file:
   ```
   // SPDX-FileCopyrightText: 2026 LiveKit, Inc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,19 @@ be approved:
 - There's no need to mess around with `CHANGELOG.md` or package manifests — we have a bot handle
   that for us. A maintainer will add the necessary notes before merging.
 
+### Review lifecycle changes
+
+For changes to session helpers, shutdown, or cleanup:
+
+- Identify the owner of each long-running operation and what settles it on success, failure,
+  cancellation, and shutdown.
+- Trace what teardown waits for. Release dependent work before draining the activity. A helper
+  must not depend on the session's `Close` event to release work that `Agent.onExit()` awaits.
+- Check synchronous throws and promise rejections separately. Keep promise settlement and local
+  state release independent of optional session calls. A throw inside `finally` skips later cleanup.
+- Use real session and activity objects to check lifecycle behavior. Mock external providers.
+- For Python ports, compare lifetime ownership and teardown order as well as method behavior.
+
 ## Assist others in the community
 
 If you can't contribute code, you can still help us greatly by helping out community members who

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -566,8 +566,7 @@ export class AgentSession<UserData = UnknownUserData> extends AgentSession_base 
     _recorderIO?: RecorderIO;
     // @internal
     _redactionEnabled: boolean;
-    // (undocumented)
-    resumeReplyAuthorization(): void;
+    resumeReplyAuthorization(): Throws<void, Error>;
     // @internal (undocumented)
     _roomIO?: RoomIO;
     // @internal (undocumented)
@@ -679,7 +678,6 @@ export enum AgentSessionEventTypes {
     AgentFalseInterruption = "agent_false_interruption",
     // (undocumented)
     AgentStateChanged = "agent_state_changed",
-    // (undocumented)
     Close = "close",
     // (undocumented)
     ConversationItemAdded = "conversation_item_added",
@@ -9699,15 +9697,15 @@ export const zipFunctionCallsAndOutputs: (event: FunctionToolsExecutedEvent) => 
 // src/stt/stt.ts:361:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "STT"
 // src/utils.ts:550:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "cancelled"
 // src/voice/agent_session.ts:380:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/voice/agent_session.ts:1004:5 - (ae-forgotten-export) The symbol "RecordingOptions" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1660:5 - (ae-forgotten-export) The symbol "STTError" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1660:5 - (ae-forgotten-export) The symbol "TTSError" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1660:5 - (ae-forgotten-export) The symbol "LLMError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1010:5 - (ae-forgotten-export) The symbol "RecordingOptions" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1670:5 - (ae-forgotten-export) The symbol "STTError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1670:5 - (ae-forgotten-export) The symbol "TTSError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1670:5 - (ae-forgotten-export) The symbol "LLMError" needs to be exported by the entry point index.d.ts
 // src/voice/amd.ts:313:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "waitForTrackPublication" has more than one declaration; you need to add a TSDoc member reference selector
 // src/voice/amd.ts:313:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
 // src/voice/amd.ts:321:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "aclose"
 // src/voice/amd.ts:515:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
-// src/voice/events.ts:423:3 - (ae-forgotten-export) The symbol "InterruptionDetectionError" needs to be exported by the entry point index.d.ts
+// src/voice/events.ts:424:3 - (ae-forgotten-export) The symbol "InterruptionDetectionError" needs to be exported by the entry point index.d.ts
 // src/voice/room_io/_output.ts:178:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "segmentTags"
 // src/voice/testing/run_result.ts:93:5 - (ae-forgotten-export) The symbol "OutputSchema" needs to be exported by the entry point index.d.ts
 

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -488,6 +488,8 @@ export class AgentSession<UserData = UnknownUserData> extends AgentSession_base 
     }): void;
     // @internal
     get _closing(): boolean;
+    // @internal
+    get _closingSignal(): AbortSignal;
     // (undocumented)
     commitUserTurn(): void;
     // Warning: (ae-incompatible-release-tags) The symbol "connOptions" is marked as @public, but its signature references "ResolvedSessionConnectOptions" which is marked as @internal
@@ -9697,14 +9699,14 @@ export const zipFunctionCallsAndOutputs: (event: FunctionToolsExecutedEvent) => 
 // src/stt/stt.ts:361:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "STT"
 // src/utils.ts:550:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "cancelled"
 // src/voice/agent_session.ts:380:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/voice/agent_session.ts:998:5 - (ae-forgotten-export) The symbol "RecordingOptions" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1651:5 - (ae-forgotten-export) The symbol "STTError" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1651:5 - (ae-forgotten-export) The symbol "TTSError" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1651:5 - (ae-forgotten-export) The symbol "LLMError" needs to be exported by the entry point index.d.ts
-// src/voice/amd.ts:314:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "waitForTrackPublication" has more than one declaration; you need to add a TSDoc member reference selector
-// src/voice/amd.ts:314:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
-// src/voice/amd.ts:322:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "aclose"
-// src/voice/amd.ts:511:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
+// src/voice/agent_session.ts:1004:5 - (ae-forgotten-export) The symbol "RecordingOptions" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1660:5 - (ae-forgotten-export) The symbol "STTError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1660:5 - (ae-forgotten-export) The symbol "TTSError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1660:5 - (ae-forgotten-export) The symbol "LLMError" needs to be exported by the entry point index.d.ts
+// src/voice/amd.ts:313:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "waitForTrackPublication" has more than one declaration; you need to add a TSDoc member reference selector
+// src/voice/amd.ts:313:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
+// src/voice/amd.ts:321:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "aclose"
+// src/voice/amd.ts:515:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
 // src/voice/events.ts:423:3 - (ae-forgotten-export) The symbol "InterruptionDetectionError" needs to be exported by the entry point index.d.ts
 // src/voice/room_io/_output.ts:178:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "segmentTags"
 // src/voice/testing/run_result.ts:93:5 - (ae-forgotten-export) The symbol "OutputSchema" needs to be exported by the entry point index.d.ts

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -531,6 +531,7 @@ export class AgentSession<
   private _output: AgentOutput;
 
   private closing = false;
+  private closingController = new AbortController();
   private closingTask: Promise<void> | null = null;
   private userAwayTimer: NodeJS.Timeout | null = null;
   private idleHolds = 0;
@@ -649,6 +650,11 @@ export class AgentSession<
   /** @internal - Whether the session is closing/draining. */
   get _closing(): boolean {
     return this.closing;
+  }
+
+  /** @internal Aborted when shutdown starts, before the activity drains. */
+  get _closingSignal(): AbortSignal {
+    return this.closingController.signal;
   }
 
   /** @internal - Current run state for testing */
@@ -1002,6 +1008,9 @@ export class AgentSession<
     }
 
     this.closing = false;
+    if (this.closingController.signal.aborted) {
+      this.closingController = new AbortController();
+    }
     this._usageCollector = new ModelUsageCollector();
 
     const ctx = getJobContext(false);
@@ -1921,6 +1930,9 @@ export class AgentSession<
     }
 
     this.closing = true;
+    // Set closingTask before listeners can call close() again.
+    await Promise.resolve();
+    this.closingController.abort();
     this._cancelUserAwayTimer();
     this._onAecWarmupExpired();
     this.off(AgentSessionEventTypes.UserInputTranscribed, this._onUserInputTranscribed);

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -10,7 +10,7 @@ import {
   type RemoteParticipant,
   type Room,
 } from '@livekit/rtc-node';
-import { ThrowsPromise } from '@livekit/throws-transformer/throws';
+import { type Throws, ThrowsPromise } from '@livekit/throws-transformer/throws';
 import type { TypedEventEmitter as TypedEmitter } from '@livekit/typed-emitter';
 import type { Context, Span } from '@opentelemetry/api';
 import { context as otelContext, trace } from '@opentelemetry/api';
@@ -652,7 +652,13 @@ export class AgentSession<
     return this.closing;
   }
 
-  /** @internal Aborted when shutdown starts, before the activity drains. */
+  /**
+   * Aborted when shutdown starts, before the activity drains or Agent.onExit() runs.
+   * Use this signal to release work that activity teardown can await.
+   * The Close event fires after activity teardown and cannot release those waits.
+   * The signal stays aborted after close; read it again when starting a new run.
+   * @internal
+   */
   get _closingSignal(): AbortSignal {
     return this.closingController.signal;
   }
@@ -1247,12 +1253,16 @@ export class AgentSession<
     this.activity.pauseReplyAuthorization();
   }
 
-  resumeReplyAuthorization(): void {
+  /**
+   * Resume automatic replies after pauseReplyAuthorization().
+   * @throws Error if the session is not running.
+   */
+  resumeReplyAuthorization(): Throws<void, Error> {
     if (!this.activity) {
       throw new Error('AgentSession is not running');
     }
 
-    this.activity.resumeReplyAuthorization();
+    return this.activity.resumeReplyAuthorization();
   }
 
   updateOptions(options: AgentSessionUpdateOptions = {}): void {

--- a/agents/src/voice/amd.test.ts
+++ b/agents/src/voice/amd.test.ts
@@ -90,6 +90,7 @@ class StaticLLM extends LLM {
 
 class MockSession extends EventEmitter {
   llm?: LLM;
+  readonly _closingSignal = new AbortController().signal;
   pauseReplyAuthorization = vi.fn();
   resumeReplyAuthorization = vi.fn();
   interrupt = vi.fn(() => ({ await: Promise.resolve() }));
@@ -143,6 +144,33 @@ describe('AMD', () => {
       type: 'amd_prediction',
       category: AMDCategory.MACHINE_VM,
     });
+  });
+
+  it.each(['sync', 'async'])('delivers a verdict after a %s interruption failure', async (mode) => {
+    const session = new MockSession();
+    session.interrupt.mockImplementation(() => {
+      const error = new Error('interruption failed');
+      if (mode === 'sync') throw error;
+      return { await: Promise.reject(error) };
+    });
+    const amd = new AMD(asAgentSession(session), {
+      llm: new StaticLLM(JSON.stringify({ category: AMDCategory.MACHINE_VM })),
+      machineSilenceThresholdMs: 0,
+      maxEndpointingDelayMs: 0,
+      suppressCompatibilityWarning: true,
+    });
+    const onPrediction = vi.fn();
+    amd.on('amd_prediction', onPrediction);
+    const prediction = amd.execute();
+    await waitForListening(amd);
+
+    speechStart(amd);
+    pushTranscript(amd, 'Please leave a message after the tone');
+    speechEnd(amd);
+
+    await expect(prediction).resolves.toMatchObject({ category: AMDCategory.MACHINE_VM });
+    expect(session.interrupt).toHaveBeenCalledWith({ force: true });
+    expect(onPrediction).toHaveBeenCalledTimes(1);
   });
 
   it('onEndOfTurn signals skip-reply after a machine verdict', async () => {

--- a/agents/src/voice/amd.ts
+++ b/agents/src/voice/amd.ts
@@ -422,13 +422,13 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
           return result;
         } finally {
           this.cleanup();
+          this.active = false;
+          this.span = undefined;
           try {
             this.session.resumeReplyAuthorization();
           } catch (err) {
             this._log.debug({ err }, 'AMD: could not resume reply authorization');
           }
-          this.active = false;
-          this.span = undefined;
         }
       },
       {
@@ -816,6 +816,7 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
       return;
     }
     this.settled = true;
+    this.resolveRun?.(result);
     this.cleanup();
     this.setSpanAttributes(result);
     this._log.info(
@@ -836,8 +837,6 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
         this._log.debug({ err }, 'AMD: could not interrupt session');
       }
     }
-    this.resolveRun?.(result);
-
     // Mirrors python detector.py: forward the prediction to the SessionHost
     // (so a connected `RemoteSession` peer receives an `amd_prediction`
     // event) and then emit on this `AMD` instance for direct listeners.

--- a/agents/src/voice/amd.ts
+++ b/agents/src/voice/amd.ts
@@ -27,7 +27,6 @@ import {
 } from '../utils.js';
 import type { AgentSession } from './agent_session.js';
 import type { EndOfTurnInfo } from './audio_recognition.js';
-import { AgentSessionEventTypes } from './events.js';
 import { setParticipantSpanAttributes } from './utils.js';
 
 export enum AMDCategory {
@@ -324,6 +323,7 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
   private resolveRun: ((value: AMDPredictionEvent) => void) | undefined;
   private rejectRun: ((reason?: unknown) => void) | undefined;
   private span: Span | undefined;
+  private sessionClosingSignal: AbortSignal | undefined;
 
   constructor(
     private readonly session: AgentSession,
@@ -400,7 +400,6 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
         this.resetState();
         this.active = true;
         this.span = span;
-        this.session.pauseReplyAuthorization();
 
         span.setAttribute(traceTypes.ATTR_AMD_INTERRUPT_ON_MACHINE, this.interruptOnMachine);
         span.setAttribute(traceTypes.ATTR_GEN_AI_OPERATION_NAME, 'classification');
@@ -415,13 +414,19 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
             this.resolveRun = resolve;
             this.rejectRun = reject;
             this.subscribe();
+            if (this.settled) return;
+            this.session.pauseReplyAuthorization();
             this.gateListening();
             this.startSTTPump();
           });
           return result;
         } finally {
           this.cleanup();
-          this.session.resumeReplyAuthorization();
+          try {
+            this.session.resumeReplyAuthorization();
+          } catch (err) {
+            this._log.debug({ err }, 'AMD: could not resume reply authorization');
+          }
           this.active = false;
           this.span = undefined;
         }
@@ -495,12 +500,11 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
   }
 
   private subscribe(): void {
-    // Speech boundaries and transcripts are delivered via the public hook
-    // methods ({@link onUserSpeechStarted}/{@link onUserSpeechEnded}/{@link onTranscript}),
-    // which `AgentActivity` invokes from its recognition hooks — mirroring how
-    // python `AudioRecognition` drives `_AMDClassifier`. Only the session-close
-    // lifecycle signal is consumed as an event here.
-    this.session.on(AgentSessionEventTypes.Close, this.handleClose);
+    this.sessionClosingSignal = this.session._closingSignal;
+    this.sessionClosingSignal.addEventListener('abort', this.handleSessionClosing, { once: true });
+    if (this.sessionClosingSignal.aborted) {
+      this.handleSessionClosing();
+    }
   }
 
   /**
@@ -727,7 +731,8 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
     this.clearTimer('silence');
     this.clearTimer('eot');
     this.listening = false;
-    this.session.off(AgentSessionEventTypes.Close, this.handleClose);
+    this.sessionClosingSignal?.removeEventListener('abort', this.handleSessionClosing);
+    this.sessionClosingSignal = undefined;
 
     // Detach the track-publication listener — without this, a run that
     // settled via `detectionTimer` before the participant track was ever
@@ -824,8 +829,12 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
       },
       'amd prediction',
     );
-    if (result.isMachine && this.interruptOnMachine) {
-      this.session.interrupt({ force: true }).await.catch(() => {});
+    if (result.isMachine && this.interruptOnMachine && !this.session._closing) {
+      try {
+        this.session.interrupt({ force: true }).await.catch(() => {});
+      } catch (err) {
+        this._log.debug({ err }, 'AMD: could not interrupt session');
+      }
     }
     this.resolveRun?.(result);
 
@@ -1063,7 +1072,7 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
     this.scheduleLLMClassification();
   }
 
-  private readonly handleClose = (): void => {
+  private readonly handleSessionClosing = (): void => {
     if (this.settled) return;
     // The session is closing — force a settle regardless of the emission gates
     // (open the end-of-turn gate so a non-human fallback can release immediately).

--- a/agents/src/voice/amd.ts
+++ b/agents/src/voice/amd.ts
@@ -1076,7 +1076,12 @@ export class AMD extends (EventEmitter as new () => TypedEmitter<AMDCallbacks>) 
     // The session is closing — force a settle regardless of the emission gates
     // (open the end-of-turn gate so a non-human fallback can release immediately).
     this.eotReached = true;
-    this.settle(AMDCategory.UNCERTAIN, 'session_closed');
+    // AbortSignal rethrows listener errors outside the close promise.
+    try {
+      this.settle(AMDCategory.UNCERTAIN, 'session_closed');
+    } catch (err) {
+      this._log.error({ err }, 'AMD: error while handling session shutdown');
+    }
   };
 
   // ─── LLM classification ─────────────────────────────────────────────────────

--- a/agents/src/voice/amd_session_close.test.ts
+++ b/agents/src/voice/amd_session_close.test.ts
@@ -1,12 +1,58 @@
 // SPDX-FileCopyrightText: 2026 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Agent } from './agent.js';
 import { AgentSession } from './agent_session.js';
 import { AMD, AMDCategory, type AMDPredictionEvent } from './amd.js';
 import { AgentSessionEventTypes } from './events.js';
 import { FakeLLM } from './testing/fake_llm.js';
+
+it('the built SDK survives a prediction listener throwing during session shutdown', async () => {
+  const entrypoint = new URL('../../dist/index.js', import.meta.url).href;
+  const { stdout } = await promisify(execFile)(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `
+        import assert from 'node:assert/strict';
+        import { Agent, AgentSession, initializeLogger, voice } from ${JSON.stringify(entrypoint)};
+
+        initializeLogger({ pretty: false, level: 'silent' });
+        const session = new AgentSession({ llm: new voice.testing.FakeLLM(), turnDetection: 'manual' });
+        await session.start({ agent: new Agent({ instructions: 'Help the caller.' }) });
+        const amd = new voice.AMD(session, {
+          llm: new voice.testing.FakeLLM(),
+          suppressCompatibilityWarning: true,
+        });
+        let predictions = 0;
+        let closed = false;
+        amd.on('amd_prediction', () => {
+          predictions += 1;
+          throw new Error('prediction listener failed');
+        });
+        session.on(voice.AgentSessionEventTypes.Close, () => { closed = true; });
+        const detection = amd.execute();
+        void detection.catch(() => {});
+
+        await session.close();
+        const result = await detection;
+        assert.equal(result.category, voice.AMDCategory.UNCERTAIN);
+        assert.equal(result.reason, 'session_closed');
+        assert.equal(predictions, 1);
+        assert.equal(closed, true);
+        await amd.aclose();
+        await new Promise(setImmediate);
+        console.log('shutdown completed');
+      `,
+    ],
+    { env: { ...process.env, LIVEKIT_URL: '' }, timeout: 10_000 },
+  );
+  expect(stdout).toBe('shutdown completed\n');
+}, 15_000);
 
 describe('AMD session shutdown', () => {
   let session: AgentSession;

--- a/agents/src/voice/amd_session_close.test.ts
+++ b/agents/src/voice/amd_session_close.test.ts
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Agent } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AMD, AMDCategory, type AMDPredictionEvent } from './amd.js';
+import { AgentSessionEventTypes } from './events.js';
+import { FakeLLM } from './testing/fake_llm.js';
+
+describe('AMD session shutdown', () => {
+  let session: AgentSession;
+  let amd: AMD;
+  let detection: Promise<AMDPredictionEvent>;
+  const transcript = 'Please leave a message after the tone.';
+
+  beforeEach(() => {
+    vi.stubEnv('LIVEKIT_URL', '');
+  });
+
+  afterEach(async () => {
+    await amd?.aclose();
+    await detection?.catch(() => {});
+    await session?.close().catch(() => {});
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  async function startDetection(category?: AMDCategory): Promise<void> {
+    session = new AgentSession({ llm: new FakeLLM(), turnDetection: 'manual' });
+    await session.start({ agent: new Agent({ instructions: 'Help the caller.' }) });
+    amd = new AMD(session, {
+      llm: new FakeLLM(
+        category
+          ? [
+              {
+                input: transcript,
+                toolCalls: [{ name: 'save_prediction', args: { label: category } }],
+              },
+            ]
+          : [],
+      ),
+      humanSilenceThresholdMs: 60_000,
+      machineSilenceThresholdMs: 60_000,
+      maxEndpointingDelayMs: 60_000,
+      detectionTimeoutMs: 60_000,
+      suppressCompatibilityWarning: true,
+    });
+    detection = amd.execute();
+    void detection.catch(() => {});
+    if (category) {
+      amd.onUserSpeechStarted();
+      amd.onTranscript(transcript, 'stt');
+      await vi.waitFor(() => {
+        expect(amd).toMatchObject({ verdictResult: { category }, settled: false });
+      });
+    }
+  }
+
+  it.each([
+    AMDCategory.MACHINE_VM,
+    AMDCategory.MACHINE_IVR,
+    AMDCategory.MACHINE_UNAVAILABLE,
+    AMDCategory.HUMAN,
+  ])('delivers a pending %s verdict exactly once when the session closes', async (category) => {
+    await startDetection(category);
+    const onPrediction = vi.fn();
+    const onClose = vi.fn();
+    amd.on('amd_prediction', onPrediction);
+    session.on(AgentSessionEventTypes.Close, onClose);
+
+    await expect(session.close()).resolves.toBeUndefined();
+    await expect(detection).resolves.toMatchObject({ category });
+    await session.close();
+
+    expect(onPrediction).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(amd).toMatchObject({ active: false, span: undefined });
+  });
+
+  it('releases a caller waiting for detection when the session closes before any speech', async () => {
+    await startDetection();
+    const onPrediction = vi.fn();
+    amd.on('amd_prediction', onPrediction);
+
+    await expect(session.close()).resolves.toBeUndefined();
+    await expect(detection).resolves.toMatchObject({
+      category: AMDCategory.UNCERTAIN,
+      reason: 'session_closed',
+    });
+    expect(onPrediction).toHaveBeenCalledTimes(1);
+    expect(amd).toMatchObject({ active: false, span: undefined });
+  });
+
+  it.each(['close', 'shutdown'] as const)(
+    'releases an onExit handler waiting for detection during %s',
+    async (method) => {
+      await startDetection();
+      const onExitResult = vi.fn();
+      vi.spyOn(session.currentAgent, 'onExit').mockImplementation(async () => {
+        onExitResult(await detection);
+      });
+
+      if (method === 'shutdown') session.shutdown();
+      await expect(session.close()).resolves.toBeUndefined();
+      expect(onExitResult).toHaveBeenCalledWith(
+        expect.objectContaining({ category: AMDCategory.UNCERTAIN, reason: 'session_closed' }),
+      );
+    },
+  );
+
+  it('joins shutdown when a prediction listener calls close again', async () => {
+    await startDetection();
+    const onExit = vi.spyOn(session.currentAgent, 'onExit');
+    let repeatedClose: Promise<void> | undefined;
+    amd.on('amd_prediction', () => {
+      repeatedClose = session.close();
+    });
+
+    await session.close();
+    await repeatedClose;
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles immediately when execution starts after the session has closed', async () => {
+    await startDetection();
+    await session.close();
+    await detection;
+
+    await expect(amd.execute()).resolves.toMatchObject({
+      category: AMDCategory.UNCERTAIN,
+      reason: 'session_closed',
+    });
+    expect(amd).toMatchObject({ active: false, span: undefined });
+  });
+
+  it('can detect again after the session restarts', async () => {
+    await startDetection();
+    await session.close();
+    await detection;
+    await session.start({ agent: new Agent({ instructions: 'Help the caller.' }) });
+    detection = amd.execute();
+    void detection.catch(() => {});
+    const onPrediction = vi.fn();
+    amd.on('amd_prediction', onPrediction);
+
+    await new Promise(setImmediate);
+    expect(onPrediction).not.toHaveBeenCalled();
+    await session.close();
+    await expect(detection).resolves.toMatchObject({
+      category: AMDCategory.UNCERTAIN,
+      reason: 'session_closed',
+    });
+    expect(onPrediction).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the result and clears state if reply authorization cannot resume', async () => {
+    await startDetection();
+    vi.spyOn(session, 'resumeReplyAuthorization').mockImplementation(() => {
+      throw new Error('AgentSession is not running');
+    });
+
+    await session.close();
+    await expect(detection).resolves.toMatchObject({ category: AMDCategory.UNCERTAIN });
+    expect(amd).toMatchObject({ active: false, span: undefined });
+  });
+
+  it('still interrupts queued speech when a machine verdict arrives during a live session', async () => {
+    await startDetection(AMDCategory.MACHINE_VM);
+    const speech = session.generateReply({ userInput: 'Hello', allowInterruptions: false });
+    expect(speech.interrupted).toBe(false);
+    expect(speech.done()).toBe(false);
+
+    amd.onUserSpeechEnded(60_001);
+    amd.onEndOfTurn({
+      newTranscript: transcript,
+      transcriptConfidence: 1,
+      transcriptionDelay: 0,
+      endOfUtteranceDelay: 0,
+      startedSpeakingAt: undefined,
+      stoppedSpeakingAt: undefined,
+    });
+
+    await expect(detection).resolves.toMatchObject({ category: AMDCategory.MACHINE_VM });
+    expect(speech.interrupted).toBe(true);
+    expect(amd).toMatchObject({ active: false, span: undefined });
+  });
+});

--- a/agents/src/voice/events.ts
+++ b/agents/src/voice/events.ts
@@ -38,6 +38,7 @@ export enum AgentSessionEventTypes {
   /** Audio EOT detector emitted a per-turn prediction. */
   EotPrediction = 'eot_prediction',
   Error = 'error',
+  /** Emitted after activity teardown, when the session is no longer running. */
   Close = 'close',
 }
 

--- a/plugins/anam/etc/agents-plugin-anam.api.md
+++ b/plugins/anam/etc/agents-plugin-anam.api.md
@@ -26,6 +26,7 @@ import { Room } from '@livekit/rtc-node';
 import { RpcInvocationData } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackKind } from '@livekit/rtc-node';
 import { TrackPublishOptions } from '@livekit/rtc-node';

--- a/plugins/anthropic/etc/agents-plugin-anthropic.api.md
+++ b/plugins/anthropic/etc/agents-plugin-anthropic.api.md
@@ -24,6 +24,7 @@ import { RemoteParticipant } from '@livekit/rtc-node';
 import { Room } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackPublishOptions } from '@livekit/rtc-node';
 import { TransformStream as TransformStream_2 } from 'node:stream/web';

--- a/plugins/baseten/etc/agents-plugin-baseten.api.md
+++ b/plugins/baseten/etc/agents-plugin-baseten.api.md
@@ -25,6 +25,7 @@ import { RemoteParticipant } from '@livekit/rtc-node';
 import { Room } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackPublishOptions } from '@livekit/rtc-node';
 import { TransformStream as TransformStream_2 } from 'node:stream/web';

--- a/plugins/bey/etc/agents-plugin-bey.api.md
+++ b/plugins/bey/etc/agents-plugin-bey.api.md
@@ -26,6 +26,7 @@ import { Room } from '@livekit/rtc-node';
 import { RpcInvocationData } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackKind } from '@livekit/rtc-node';
 import { TrackPublishOptions } from '@livekit/rtc-node';

--- a/plugins/cerebras/etc/agents-plugin-cerebras.api.md
+++ b/plugins/cerebras/etc/agents-plugin-cerebras.api.md
@@ -25,6 +25,7 @@ import { RemoteParticipant } from '@livekit/rtc-node';
 import { Room } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackPublishOptions } from '@livekit/rtc-node';
 import { TransformStream as TransformStream_2 } from 'node:stream/web';

--- a/plugins/did/etc/agents-plugin-did.api.md
+++ b/plugins/did/etc/agents-plugin-did.api.md
@@ -26,6 +26,7 @@ import { Room } from '@livekit/rtc-node';
 import { RpcInvocationData } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackKind } from '@livekit/rtc-node';
 import { TrackPublishOptions } from '@livekit/rtc-node';

--- a/plugins/google/etc/agents-plugin-google.api.md
+++ b/plugins/google/etc/agents-plugin-google.api.md
@@ -34,6 +34,7 @@ import { RemoteParticipant } from '@livekit/rtc-node';
 import { Room } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackPublishOptions } from '@livekit/rtc-node';
 import { TransformStream as TransformStream_2 } from 'node:stream/web';

--- a/plugins/lemonslice/etc/agents-plugin-lemonslice.api.md
+++ b/plugins/lemonslice/etc/agents-plugin-lemonslice.api.md
@@ -26,6 +26,7 @@ import { Room } from '@livekit/rtc-node';
 import { RpcInvocationData } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackKind } from '@livekit/rtc-node';
 import { TrackPublishOptions } from '@livekit/rtc-node';

--- a/plugins/liveavatar/etc/agents-plugin-liveavatar.api.md
+++ b/plugins/liveavatar/etc/agents-plugin-liveavatar.api.md
@@ -26,6 +26,7 @@ import { Room } from '@livekit/rtc-node';
 import { RpcInvocationData } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackKind } from '@livekit/rtc-node';
 import { TrackPublishOptions } from '@livekit/rtc-node';

--- a/plugins/livekit/etc/agents-plugin-livekit.api.md
+++ b/plugins/livekit/etc/agents-plugin-livekit.api.md
@@ -24,6 +24,7 @@ import type { RepoDesignation } from '@huggingface/hub';
 import { Room } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackPublishOptions } from '@livekit/rtc-node';
 import { TransformStream as TransformStream_2 } from 'node:stream/web';

--- a/plugins/mistralai/etc/agents-plugin-mistralai.api.md
+++ b/plugins/mistralai/etc/agents-plugin-mistralai.api.md
@@ -24,6 +24,7 @@ import { RemoteParticipant } from '@livekit/rtc-node';
 import { Room } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackPublishOptions } from '@livekit/rtc-node';
 import { TransformStream as TransformStream_2 } from 'node:stream/web';

--- a/plugins/openai/etc/agents-plugin-openai.api.md
+++ b/plugins/openai/etc/agents-plugin-openai.api.md
@@ -25,6 +25,7 @@ import { RemoteParticipant } from '@livekit/rtc-node';
 import { Room } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackPublishOptions } from '@livekit/rtc-node';
 import { TransformStream as TransformStream_2 } from 'node:stream/web';

--- a/plugins/perplexity/etc/agents-plugin-perplexity.api.md
+++ b/plugins/perplexity/etc/agents-plugin-perplexity.api.md
@@ -25,6 +25,7 @@ import { RemoteParticipant } from '@livekit/rtc-node';
 import { Room } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackPublishOptions } from '@livekit/rtc-node';
 import { TransformStream as TransformStream_2 } from 'node:stream/web';

--- a/plugins/phonic/etc/agents-plugin-phonic.api.md
+++ b/plugins/phonic/etc/agents-plugin-phonic.api.md
@@ -24,6 +24,7 @@ import { RemoteParticipant } from '@livekit/rtc-node';
 import { Room } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackPublishOptions } from '@livekit/rtc-node';
 import { TransformStream as TransformStream_2 } from 'node:stream/web';

--- a/plugins/protoface/etc/agents-plugin-protoface.api.md
+++ b/plugins/protoface/etc/agents-plugin-protoface.api.md
@@ -26,6 +26,7 @@ import { Room } from '@livekit/rtc-node';
 import { RpcInvocationData } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackKind } from '@livekit/rtc-node';
 import { TrackPublishOptions } from '@livekit/rtc-node';

--- a/plugins/runway/etc/agents-plugin-runway.api.md
+++ b/plugins/runway/etc/agents-plugin-runway.api.md
@@ -26,6 +26,7 @@ import { Room } from '@livekit/rtc-node';
 import { RpcInvocationData } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackKind } from '@livekit/rtc-node';
 import { TrackPublishOptions } from '@livekit/rtc-node';

--- a/plugins/tavus/etc/agents-plugin-tavus.api.md
+++ b/plugins/tavus/etc/agents-plugin-tavus.api.md
@@ -26,6 +26,7 @@ import { Room } from '@livekit/rtc-node';
 import { RpcInvocationData } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackKind } from '@livekit/rtc-node';
 import { TrackPublishOptions } from '@livekit/rtc-node';

--- a/plugins/trugen/etc/agents-plugin-trugen.api.md
+++ b/plugins/trugen/etc/agents-plugin-trugen.api.md
@@ -26,6 +26,7 @@ import { Room } from '@livekit/rtc-node';
 import { RpcInvocationData } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackKind } from '@livekit/rtc-node';
 import { TrackPublishOptions } from '@livekit/rtc-node';

--- a/plugins/xai/etc/agents-plugin-xai.api.md
+++ b/plugins/xai/etc/agents-plugin-xai.api.md
@@ -23,6 +23,7 @@ import { RemoteParticipant } from '@livekit/rtc-node';
 import { Room } from '@livekit/rtc-node';
 import type { Span } from '@opentelemetry/api';
 import type { TextStreamInfo } from '@livekit/rtc-node';
+import { Throws } from '@livekit/throws-transformer/throws';
 import { ThrowsPromise } from '@livekit/throws-transformer/throws';
 import { TrackPublishOptions } from '@livekit/rtc-node';
 import { TransformStream as TransformStream_2 } from 'node:stream/web';


### PR DESCRIPTION
Session shutdown could strand `AMD.execute()` or replace its verdict with a cleanup error. Signal shutdown before activity drain to release waiting `onExit()` handlers with the stored verdict, or uncertain.

Settle AMD and clear local state before optional session calls. Contain prediction listener errors, check reply authorization errors in CI, and document lifecycle review rules.

The workspace API check reports existing Phonic/Rime snapshot mismatches.

Addresses #2445.
Addresses AGT-3461.

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-6

> can you review https://github.com/livekit/agents-js/issues/2445

> okay, let's create a draft PR for this

> because AMD lives outside the session, we should also add a hook to track session close and unblock downstream code.

> Release AMD when shutdown starts (Recommended)

> my next question is how come we didn't catch this previously? What can we do to prevent this in the future, in addition to regression tests?

> okay, what else we can do in this PR to help that?

> run a subagent for code review

Approved fixing the shutdown listener error found in that review:

> yes please

</details>
