### PR TITLE
fix(llm): attribute fallback inference telemetry to providers

### DIFF
--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -4420,6 +4420,7 @@ interface InferenceLLMOptions {
 //
 // @public (undocumented)
 interface InferenceMarker {
+    hasAdapter?: boolean;
     // (undocumented)
     recorded: boolean;
 }
@@ -5202,6 +5203,7 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
     });
     // (undocumented)
     protected abortController: AbortController;
+    protected get adapterSpanName(): string | undefined;
     get chatCtx(): ChatContext;
     // (undocumented)
     close(): void;
@@ -5329,7 +5331,9 @@ export function loopAudioFramesFromFile(filePath: string, options?: AudioDecodeO
 // Warning: (ae-missing-release-tag) "markInferenceSpanRecorded" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-function markInferenceSpanRecorded(): void;
+function markInferenceSpanRecorded(options?: {
+    adapter?: boolean;
+}): void;
 
 // Warning: (ae-missing-release-tag) "MarkupInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/agents/src/llm/fallback_adapter.ts
+++ b/agents/src/llm/fallback_adapter.ts
@@ -148,6 +148,10 @@ export class FallbackAdapter extends LLM {
  * Handles fallback logic between multiple LLM providers.
  */
 class FallbackLLMStream extends LLMStream {
+  protected override get adapterSpanName(): string {
+    return 'llm_fallback_adapter';
+  }
+
   private adapter: FallbackAdapter;
   private parallelToolCalls?: boolean;
   private toolChoice?: ToolChoice;

--- a/agents/src/llm/fallback_adapter_telemetry.test.ts
+++ b/agents/src/llm/fallback_adapter_telemetry.test.ts
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { ReadableStream } from 'node:stream/web';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { APIConnectionError, APIError } from '../_exceptions.js';
+import type { LLMMetrics } from '../metrics/base.js';
+import { ModelUsageCollector } from '../metrics/model_usage.js';
+import { setTracerProvider, traceTypes } from '../telemetry/index.js';
+import { DEFAULT_API_CONNECT_OPTIONS } from '../types.js';
+import { Agent } from '../voice/agent.js';
+import { AgentSession } from '../voice/agent_session.js';
+import { performLLMInference } from '../voice/generation.js';
+import { ChatContext } from './chat_context.js';
+import { FallbackAdapter } from './fallback_adapter.js';
+import { type ChatChunk, LLM, LLMStream } from './llm.js';
+import { ToolContext } from './tool_context.js';
+
+class TestLLM extends LLM {
+  constructor(
+    private modelName: string,
+    private providerName: string,
+    readonly fails = false,
+  ) {
+    super();
+  }
+
+  get model(): string {
+    return this.modelName;
+  }
+
+  get provider(): string {
+    return this.providerName;
+  }
+
+  label(): string {
+    return `${this.provider}.LLM`;
+  }
+
+  chat(opts: Parameters<LLM['chat']>[0]): LLMStream {
+    return new TestStream(this, {
+      ...opts,
+      connOptions: opts.connOptions ?? DEFAULT_API_CONNECT_OPTIONS,
+    });
+  }
+}
+
+class TestStream extends LLMStream {
+  constructor(
+    private llm: TestLLM,
+    opts: ConstructorParameters<typeof LLMStream>[1],
+  ) {
+    super(llm, opts);
+  }
+
+  protected async run(): Promise<void> {
+    if (this.llm.fails) throw new APIError('test provider unavailable');
+    this.queue.put({
+      id: this.llm.model,
+      delta: { role: 'assistant', content: 'hello' },
+      usage: { promptTokens: 10, promptCachedTokens: 0, completionTokens: 2, totalTokens: 12 },
+    });
+  }
+}
+
+const exporter = new InMemorySpanExporter();
+const provider = new NodeTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+
+describe('FallbackAdapter telemetry', () => {
+  beforeAll(() => {
+    provider.register();
+    setTracerProvider(provider);
+  });
+  beforeEach(() => exporter.reset());
+  afterAll(() => provider.shutdown());
+
+  async function run(adapter: FallbackAdapter) {
+    const metrics: LLMMetrics[] = [];
+    const childMetrics: LLMMetrics[] = [];
+    adapter.on('metrics_collected', (event) => metrics.push(event));
+    for (const child of adapter.llms) {
+      child.on('metrics_collected', (event) => childMetrics.push(event));
+    }
+    const chunks: ChatChunk[] = [];
+    for await (const chunk of adapter.chat({ chatCtx: ChatContext.empty() })) chunks.push(chunk);
+    await Promise.all(adapter._status.map((status) => status.recoveringTask));
+    await provider.forceFlush();
+    return { metrics, childMetrics, chunks };
+  }
+
+  it('reports only the primary model request and counts its tokens once', async () => {
+    const primary = new TestLLM('primary-model', 'primary-provider');
+    const backup = new TestLLM('backup-model', 'backup-provider');
+    const { metrics, childMetrics, chunks } = await run(
+      new FallbackAdapter({ llms: [primary, backup] }),
+    );
+
+    expect(chunks).toHaveLength(1);
+    expect(metrics).toEqual(childMetrics);
+    expect(metrics).toHaveLength(1);
+    const usage = new ModelUsageCollector();
+    metrics.forEach((event) => usage.collect(event));
+    expect(usage.flatten()).toEqual([
+      expect.objectContaining({
+        model: 'primary-model',
+        provider: 'primary-provider',
+        inputTokens: 10,
+        outputTokens: 2,
+      }),
+    ]);
+  });
+
+  it('keeps an orchestration span without reporting the adapter as an inference model', async () => {
+    await run(new FallbackAdapter({ llms: [new TestLLM('primary-model', 'primary-provider')] }));
+    const spans = exporter.getFinishedSpans();
+    const requests = spans.filter((span) => span.name === 'llm_request');
+    expect(requests.map((span) => span.attributes['gen_ai.request.model'])).toEqual([
+      'primary-model',
+    ]);
+    const adapter = spans.find((span) => span.name === 'llm_fallback_adapter');
+    expect(adapter).toBeDefined();
+    expect(Object.keys(adapter!.attributes).filter((key) => key.startsWith('gen_ai.'))).toEqual([]);
+    expect(adapter!.attributes[traceTypes.ATTR_LLM_METRICS]).toBeUndefined();
+    const attempt = spans.find(
+      (span) => span.spanContext().spanId === requests[0]!.parentSpanContext?.spanId,
+    );
+    expect(attempt!.parentSpanContext?.spanId).toBe(adapter!.spanContext().spanId);
+    expect(requests[0]!.attributes['gen_ai.usage.input_tokens']).toBe(10);
+    expect(requests[0]!.attributes['gen_ai.usage.output_tokens']).toBe(2);
+  });
+
+  it('preserves the real provider attribution after failover', async () => {
+    const { metrics, childMetrics, chunks } = await run(
+      new FallbackAdapter({
+        llms: [
+          new TestLLM('primary-model', 'primary-provider', true),
+          new TestLLM('backup-model', 'backup-provider'),
+        ],
+      }),
+    );
+    expect(chunks.map((chunk) => chunk.id)).toEqual(['backup-model']);
+    expect(metrics).toEqual(childMetrics);
+    expect(metrics.filter((event) => event.totalTokens > 0)).toEqual([
+      expect.objectContaining({
+        metadata: { modelName: 'backup-model', modelProvider: 'backup-provider' },
+        totalTokens: 12,
+      }),
+    ]);
+    expect(
+      exporter
+        .getFinishedSpans()
+        .filter((span) => span.name === 'llm_request')
+        .every((span) => span.attributes['gen_ai.request.model'] !== 'FallbackAdapter'),
+    ).toBe(true);
+  });
+
+  it('does not multiply usage through nested fallback adapters', async () => {
+    const child = new FallbackAdapter({ llms: [new TestLLM('primary-model', 'primary-provider')] });
+    const { metrics, chunks } = await run(new FallbackAdapter({ llms: [child] }));
+    expect(chunks).toHaveLength(1);
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0]!.metadata?.modelName).toBe('primary-model');
+    expect(
+      exporter.getFinishedSpans().filter((span) => span.name === 'llm_fallback_adapter'),
+    ).toHaveLength(2);
+  });
+
+  it('ends the orchestration span and preserves the error when all providers fail', async () => {
+    const adapter = new FallbackAdapter({
+      llms: [new TestLLM('primary-model', 'primary-provider', true)],
+    });
+    const onError = vi.fn();
+    adapter.on('error', onError);
+    const { metrics, childMetrics, chunks } = await run(adapter);
+    expect(chunks).toEqual([]);
+    expect(metrics).toEqual(childMetrics);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(APIConnectionError), recoverable: false }),
+    );
+    expect(
+      exporter.getFinishedSpans().filter((span) => span.name === 'llm_fallback_adapter'),
+    ).toHaveLength(1);
+  });
+
+  it('ends the orchestration span when the consumer closes the stream', async () => {
+    const adapter = new FallbackAdapter({
+      llms: [new TestLLM('primary-model', 'primary-provider')],
+    });
+    const metrics: LLMMetrics[] = [];
+    adapter.on('metrics_collected', (event) => metrics.push(event));
+    const stream = adapter.chat({ chatCtx: ChatContext.empty() });
+    stream.close();
+    expect(await stream.next()).toMatchObject({ done: true });
+    await vi.waitFor(() => {
+      expect(
+        exporter.getFinishedSpans().filter((span) => span.name === 'llm_fallback_adapter'),
+      ).toHaveLength(1);
+    });
+    expect(metrics.every((event) => event.metadata?.modelName === 'primary-model')).toBe(true);
+  });
+
+  it.each([false, true])(
+    'does not credit the configured wrapper on llm_node (failover=%s)',
+    async (fails) => {
+      const adapter = new FallbackAdapter({
+        llms: [
+          new TestLLM('primary-model', 'primary-provider', fails),
+          new TestLLM('backup-model', 'backup-provider'),
+        ],
+      });
+      const [task, data] = performLLMInference(
+        async (chatCtx) => ReadableStream.from(adapter.chat({ chatCtx })),
+        ChatContext.empty(),
+        ToolContext.empty(),
+        {},
+        new AbortController(),
+        adapter.model,
+        adapter.provider,
+      );
+      const drain = async (stream: ReadableStream<unknown>) => {
+        for await (const _ of stream) {
+          /* consume */
+        }
+      };
+      await Promise.all([task.result, drain(data.textStream), drain(data.toolCallStream)]);
+      await Promise.all(adapter._status.map((status) => status.recoveringTask));
+      const node = exporter.getFinishedSpans().find((span) => span.name === 'llm_node');
+      expect(node).toBeDefined();
+      expect(node!.attributes['gen_ai.request.model']).toBeUndefined();
+      const request = exporter
+        .getFinishedSpans()
+        .find(
+          (span) =>
+            span.name === 'llm_request' && span.attributes['gen_ai.usage.output_tokens'] === 2,
+        );
+      expect(request!.attributes['gen_ai.request.model']).toBe(
+        fails ? 'backup-model' : 'primary-model',
+      );
+    },
+  );
+
+  it('describes the configured primary model when starting an agent with nested adapters', async () => {
+    const primary = new TestLLM('primary-model', 'primary-provider');
+    const adapter = new FallbackAdapter({ llms: [new FallbackAdapter({ llms: [primary] })] });
+    const session = new AgentSession({ llm: adapter, turnDetection: 'manual' });
+    try {
+      await session.start({ agent: new Agent({ instructions: 'test' }) });
+      const start = exporter
+        .getFinishedSpans()
+        .find((span) => span.name === 'start_agent_activity');
+      expect(start!.attributes['gen_ai.request.model']).toBe('primary-model');
+      expect(start!.attributes['gen_ai.provider.name']).toBe('primary-provider');
+    } finally {
+      await session.close();
+    }
+  });
+});

--- a/agents/src/llm/llm.ts
+++ b/agents/src/llm/llm.ts
@@ -194,6 +194,14 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
   // attempt; reset before each retry and written to the `llm_request_run` span.
   #providerRequestIds: string[] = [];
 
+  /**
+   * Override for adapters that orchestrate instrumented child streams. The named span tracks
+   * orchestration only; child streams own inference attributes and metrics.
+   */
+  protected get adapterSpanName(): string | undefined {
+    return undefined;
+  }
+
   constructor(
     llm: LLM,
     {
@@ -220,7 +228,7 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
     // tells an enclosing `llm_node` span that this call is instrumented, so it does not
     // record the convention's attributes a second time. Read here rather than in mainTask,
     // which startSoon defers out of the node's context.
-    genAI.markInferenceSpanRecorded();
+    genAI.markInferenceSpanRecorded({ adapter: this.adapterSpanName !== undefined });
 
     // this is a hack to immitate asyncio.create_task so that mainTask
     // is run **after** the constructor has finished. Otherwise we get
@@ -255,8 +263,10 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
 
   private _mainTaskImpl = async (span: Span) => {
     this.#llmRequestSpan = span;
-    span.setAttribute(traceTypes.ATTR_GEN_AI_REQUEST_MODEL, this.#llm.model);
-    this.recordGenAIRequest(span);
+    if (this.adapterSpanName === undefined) {
+      span.setAttribute(traceTypes.ATTR_GEN_AI_REQUEST_MODEL, this.#llm.model);
+      this.recordGenAIRequest(span);
+    }
 
     for (let i = 0; i < this._connOptions.maxRetry + 1; i++) {
       try {
@@ -316,7 +326,7 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
 
   private mainTask = async () => {
     return tracer.startActiveSpan(async (span) => this._mainTaskImpl(span), {
-      name: 'llm_request',
+      name: this.adapterSpanName ?? 'llm_request',
       endOnExit: false,
     });
   };
@@ -346,6 +356,7 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
         break;
       }
       this.output.put(ev);
+      if (this.adapterSpanName !== undefined) continue;
       requestId = ev.id;
       if (requestId && !this.#providerRequestIds.includes(requestId)) {
         this.#providerRequestIds.push(requestId);
@@ -367,6 +378,11 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
       }
     }
     this.output.close();
+
+    if (this.adapterSpanName !== undefined) {
+      this.#llmRequestSpan?.end();
+      return;
+    }
 
     const duration = process.hrtime.bigint() - startTime;
     const durationMs = Math.trunc(Number(duration / BigInt(1000000)));

--- a/agents/src/telemetry/gen_ai.ts
+++ b/agents/src/telemetry/gen_ai.ts
@@ -76,6 +76,8 @@ const INFERENCE_RECORDED = Symbol('lkInferenceRecorded');
 
 export interface InferenceMarker {
   recorded: boolean;
+  /** A wrapper served this node; configured model identity is not an inference model. */
+  hasAdapter?: boolean;
 }
 
 /** Runs `fn` with a marker that fills in if an `llm_request` span is created inside it. */
@@ -87,9 +89,12 @@ export function withInferenceTracking<T>(fn: (marker: InferenceMarker) => T): T 
 }
 
 /** Called where an `llm_request` span is created, so the enclosing node stands down. */
-export function markInferenceSpanRecorded(): void {
+export function markInferenceSpanRecorded(options?: { adapter?: boolean }): void {
   const marker = otelContext.active().getValue(INFERENCE_RECORDED) as InferenceMarker | undefined;
-  if (marker) marker.recorded = true;
+  if (marker) {
+    marker.recorded = true;
+    if (options?.adapter) marker.hasAdapter = true;
+  }
 }
 
 function textPart(content: string): MessagePart {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -28,7 +28,7 @@ import {
   instructionsEqual,
   renderInstructions,
 } from '../llm/chat_context.js';
-import { AsyncToolset, type Toolset } from '../llm/index.js';
+import { AsyncToolset, FallbackAdapter, type Toolset } from '../llm/index.js';
 import {
   type ChatItem,
   type FunctionCall,
@@ -599,11 +599,13 @@ export class AgentActivity implements RecognitionHooks {
       attributes: { [traceTypes.ATTR_AGENT_LABEL]: this.agent.id },
       context: this.agentSession.rootSpanContext ?? ROOT_CONTEXT,
     });
+    let configuredLLM = this.llm;
+    while (configuredLLM instanceof FallbackAdapter) configuredLLM = configuredLLM.llms[0];
     genAI.setAgentAttributes(startSpan, {
       operation: traceTypes.GenAIOperationName.CREATE_AGENT,
       agentName: this.agent.id,
-      model: this.llm?.model,
-      provider: this.llm?.provider,
+      model: configuredLLM?.model,
+      provider: configuredLLM?.provider,
     });
 
     this.agent._agentActivity = this;

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -774,7 +774,7 @@ export function performLLMInference(
       // a custom node may have generated this itself, with no nested `llm_request` span to
       // carry the convention's attributes; when there was one, they are already recorded
       if (inference.recorded) {
-        recordConfiguredModel();
+        if (!inference.hasAdapter) recordConfiguredModel();
       } else {
         // a third-party engine served this, so the configured model and provider are left
         // off rather than crediting it with a call it never made


### PR DESCRIPTION
## Description

An LLM `FallbackAdapter` currently reports a second `llm_request` and `llm_metrics` record alongside the real provider request. For example, one primary request using 10 input and 2 output tokens produces another identical usage record for model `FallbackAdapter`, provider `unknown`. The enclosing `llm_node` also copies the wrapper model name into its inference attributes.

Keep fallback orchestration visible while attributing inference and usage to the actual providers. Agent-start metadata describes the configured primary; individual request spans retain the actual primary or backup model used.

## Changes Made

- Add an `LLMStream` adapter-span hook and use `llm_fallback_adapter` for the fallback stream. Forward its chunks without emitting another inference metrics record or duplicating GenAI attributes.
- Mark adapter orchestration in the existing inference context so `llm_node` does not claim the configured wrapper as a model. Resolve nested adapters to their configured primary for agent-start metadata.
- Regenerate the API report and add nine regression cases covering primary use, failover, token aggregation, span hierarchy, nested adapters, failure, cancellation, voice generation, and agent startup.

## Pre-Review Checklist

- [x] **Build passes**: Agents package build/typecheck, workspace lint, formatting, and API check pass locally.
- [x] **AI-generated code reviewed**: Standards and spec reviews completed; remaining wrapper attribution found during review was fixed and regression-tested.
- [x] **Changes explained**: Behavior and validation described here.
- [x] **Scope appropriate**: Changes address fallback model attribution and duplicate inference accounting.
- [ ] **Video demo**: Not applicable; this is a telemetry change, verified with in-memory traces and synthetic providers.

## Testing

- [x] Automated tests added. The original primary/failover tests failed with extra `FallbackAdapter` usage records and request spans before the fix. Voice-generation and agent-start tests separately reproduced the remaining wrapper attribution before its fix.
- [x] `pnpm test agents --silent`: 2,499 passed, 5 skipped.
- [x] `pnpm --filter @livekit/agents build`
- [x] `pnpm --filter @livekit/agents typecheck`
- [x] `pnpm --filter @livekit/agents api:check`
- [x] `pnpm -w lint:fix` and `pnpm format:check` (existing lint warnings only).
- [ ] Restaurant/realtime agent demos: Not run; no credentials or live provider calls are needed for these regression tests.

## Additional Notes

`FallbackAdapter.model` and `label()` retain their wrapper identity. Retry order and provider error behavior are unchanged. Consumers that counted wrapper-generated metrics will see those duplicate records disappear. Live Cloud analytics UI behavior has not been independently verified; this PR verifies the emitted telemetry and usage collector inputs.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.
