### PR TITLE
fix(assemblyai): validate live options and preserve Unicode context

### DIFF
--- a/.changeset/tidy-voices-validate.md
+++ b/.changeset/tidy-voices-validate.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-assemblyai': patch
+---
+
+Validate live AssemblyAI options before mutating configuration, normalize regional language codes, and count and truncate agent context by Unicode code points. Model changes via updateOptions now fail explicitly; create a new STT instance to select a different model.

--- a/plugins/assemblyai/etc/agents-plugin-assemblyai.api.md
+++ b/plugins/assemblyai/etc/agents-plugin-assemblyai.api.md
@@ -111,7 +111,6 @@ export interface STTOptions {
     // (undocumented)
     sampleRate: number;
     speakerLabels?: boolean;
-    // (undocumented)
     speechModel: STTModels;
     // (undocumented)
     vadThreshold?: number;

--- a/plugins/assemblyai/src/stt-options.test.ts
+++ b/plugins/assemblyai/src/stt-options.test.ts
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { ChatMessage } from '@livekit/agents';
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
+import { describe, expect, it } from 'vitest';
+import { WebSocketServer } from 'ws';
+import { STT, type STTOptions, type SpeechStream } from './stt.js';
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1500;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error('timed out waiting for provider message');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+async function withProvider(
+  opts: Partial<STTOptions>,
+  check: (
+    provider: STT,
+    query: URLSearchParams,
+    messages: Record<string, unknown>[],
+    stream: SpeechStream,
+  ) => Promise<void>,
+): Promise<void> {
+  const wss = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  await once(wss, 'listening');
+  const address = wss.address() as AddressInfo;
+  let query: URLSearchParams | undefined;
+  const messages: Record<string, unknown>[] = [];
+  wss.on('connection', (socket, request) => {
+    query = new URL(request.url!, 'ws://localhost').searchParams;
+    socket.on('message', (data, binary) => {
+      if (!binary) messages.push(JSON.parse(data.toString()));
+    });
+  });
+  const provider = new STT({
+    apiKey: 'test-key',
+    baseUrl: `ws://127.0.0.1:${address.port}`,
+    ...opts,
+  });
+  const stream = provider.stream();
+  try {
+    await waitUntil(() => query !== undefined);
+    await check(provider, query!, messages, stream);
+  } finally {
+    stream.close();
+    for (const socket of wss.clients) socket.terminate();
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+  }
+}
+
+describe('AssemblyAI streaming configuration', () => {
+  it('preserves omitted provider defaults', async () => {
+    await withProvider({}, async (_provider, query) => {
+      expect(query.has('continuous_partials')).toBe(false);
+      expect(query.has('interruption_delay')).toBe(false);
+    });
+  });
+
+  it('preserves explicit false and zero on connection', async () => {
+    await withProvider({ continuousPartials: false, interruptionDelay: 0 }, async (_p, query) => {
+      expect(query.get('continuous_partials')).toBe('false');
+      expect(query.get('interruption_delay')).toBe('0');
+    });
+  });
+
+  it('sends both partial controls in a live update', async () => {
+    await withProvider({}, async (provider, _query, messages) => {
+      provider.updateOptions({ continuousPartials: false, interruptionDelay: 0 });
+      await waitUntil(() => messages.some((message) => message.type === 'UpdateConfiguration'));
+      expect(messages.find((message) => message.type === 'UpdateConfiguration')).toEqual({
+        type: 'UpdateConfiguration',
+        continuous_partials: false,
+        interruption_delay: 0,
+      });
+    });
+  });
+
+  it('normalizes names and clears language steering in a live update', async () => {
+    await withProvider(
+      { languageCodes: ['English', 'en-US', 'Spanish'] },
+      async (p, q, messages) => {
+        expect(JSON.parse(q.get('language_codes')!)).toEqual(['en', 'es']);
+        p.updateOptions({ languageCodes: [] });
+        await waitUntil(() => messages.some((message) => message.type === 'UpdateConfiguration'));
+        expect(messages.find((message) => message.type === 'UpdateConfiguration')).toEqual({
+          type: 'UpdateConfiguration',
+          language_codes: [],
+        });
+      },
+    );
+  });
+
+  it('enables carryover for the existing default model, with explicit opt-out', () => {
+    expect(new STT({ apiKey: 'test' }).capabilities.chatContext).toBe(true);
+    expect(new STT({ apiKey: 'test', agentContextCarryover: false }).capabilities.chatContext).toBe(
+      false,
+    );
+  });
+});
+
+describe('AssemblyAI option validation', () => {
+  it('does not clear the model when an update contains undefined', async () => {
+    await withProvider({}, async (provider, _query, messages, stream) => {
+      provider.updateOptions({ speechModel: undefined });
+      stream.updateOptions({ speechModel: undefined });
+      expect(provider.model).toBe('universal-3-5-pro');
+      provider.updateOptions({ interruptionDelay: 0 });
+      await waitUntil(() => messages.length > 0);
+      expect(messages).toEqual([{ type: 'UpdateConfiguration', interruption_delay: 0 }]);
+    });
+  });
+
+  for (const speechModel of [
+    'universal-streaming-english',
+    'universal-streaming-multilingual',
+  ] as const) {
+    for (const option of [{ continuousPartials: false }, { interruptionDelay: 0 }] as const) {
+      it.each(['provider', 'stream'] as const)(
+        `rejects ${Object.keys(option)[0]} on ${speechModel} via %s`,
+        async (target) => {
+          expect(() => new STT({ apiKey: 'test', speechModel, ...option })).toThrow(
+            /only supported/,
+          );
+          await withProvider({ speechModel }, async (provider, _q, messages, stream) => {
+            const updatable = target === 'provider' ? provider : stream;
+            expect(() => updatable.updateOptions(option)).toThrow(/only supported/);
+            updatable.updateOptions({ minTurnSilence: 250 });
+            await waitUntil(() => messages.length > 0);
+            expect(messages).toEqual([{ type: 'UpdateConfiguration', min_turn_silence: 250 }]);
+          });
+        },
+      );
+    }
+  }
+
+  it('rejects a combined model update before changing parent state or keyterms', async () => {
+    await withProvider(
+      { speechModel: 'universal-streaming-english', keytermsPrompt: ['original'] },
+      async (provider, _q, messages) => {
+        expect(() =>
+          provider.updateOptions({
+            speechModel: 'universal-3-6-pro',
+            languageCodes: ['en'],
+            keytermsPrompt: ['rejected'],
+          }),
+        ).toThrow(/create a new STT/);
+        expect(provider.model).toBe('universal-streaming-english');
+        provider._updateSessionKeyterms(['session']);
+        await waitUntil(() => messages.length > 0);
+        expect(messages).toEqual([
+          { type: 'UpdateConfiguration', keyterms_prompt: ['original', 'session'] },
+        ]);
+      },
+    );
+  });
+
+  it.each(['provider', 'stream'] as const)(
+    'rejects model changes via %s without queuing Pro options',
+    async (target) => {
+      await withProvider(
+        { speechModel: 'universal-streaming-english' },
+        async (provider, _q, messages, stream) => {
+          const updatable = target === 'provider' ? provider : stream;
+          expect(() =>
+            updatable.updateOptions({ speechModel: 'universal-3-6-pro', languageCodes: ['en'] }),
+          ).toThrow(/create a new STT/);
+          expect(() => updatable.updateOptions({ interruptionDelay: 0 })).toThrow(/only supported/);
+          updatable.updateOptions({ minTurnSilence: 250 });
+          await waitUntil(() => messages.length > 0);
+          expect(messages).toEqual([{ type: 'UpdateConfiguration', min_turn_silence: 250 }]);
+        },
+      );
+    },
+  );
+
+  it.each(['provider', 'stream'] as const)(
+    'accepts the existing model alias via %s without mutating input',
+    async (target) => {
+      await withProvider(
+        { speechModel: 'universal-3-5-pro' },
+        async (provider, _q, messages, stream) => {
+          const opts = Object.freeze({
+            speechModel: 'u3-pro' as const,
+            languageCodes: 'eng-US',
+            interruptionDelay: 0,
+          });
+          (target === 'provider' ? provider : stream).updateOptions(opts);
+          await waitUntil(() => messages.length > 0);
+          expect(messages).toEqual([
+            { type: 'UpdateConfiguration', language_codes: ['en'], interruption_delay: 0 },
+          ]);
+          expect(opts.languageCodes).toBe('eng-US');
+          expect(opts.speechModel).toBe('u3-pro');
+        },
+      );
+    },
+  );
+
+  it('normalizes regional ISO-639-3 codes on connection', async () => {
+    await withProvider(
+      { languageCodes: ['eng-US', 'spa-ES', 'cmn-Hans-CN', 'en'] },
+      async (_provider, query) => {
+        expect(JSON.parse(query.get('language_codes')!)).toEqual(['en', 'es', 'zh']);
+      },
+    );
+  });
+
+  it.each(['provider', 'stream'] as const)(
+    'normalizes regional ISO-639-3 codes on %s updates',
+    async (target) => {
+      await withProvider({}, async (provider, _q, messages, stream) => {
+        (target === 'provider' ? provider : stream).updateOptions({
+          languageCodes: ['eng-US', 'spa-ES', 'cmn-Hans-CN', 'en'],
+        });
+        await waitUntil(() => messages.length > 0);
+        expect(messages).toEqual([
+          { type: 'UpdateConfiguration', language_codes: ['en', 'es', 'zh'] },
+        ]);
+      });
+    },
+  );
+
+  it('accepts explicit context below the 1750-character provider limit', () => {
+    const context = '😀'.repeat(900);
+    expect(Array.from(context)).toHaveLength(900);
+    expect(() => new STT({ apiKey: 'test', agentContext: context })).not.toThrow();
+  });
+
+  it('checks the Unicode code-point limit at construction', () => {
+    expect(() => new STT({ apiKey: 'test', agentContext: '😀'.repeat(1750) })).not.toThrow();
+    expect(() => new STT({ apiKey: 'test', agentContext: '😀'.repeat(1751) })).toThrow(/got 1751/);
+  });
+
+  it.each(['provider', 'stream'] as const)(
+    'checks Unicode limits before changing %s configuration',
+    async (target) => {
+      await withProvider({}, async (provider, _q, messages, stream) => {
+        const updatable = target === 'provider' ? provider : stream;
+        expect(() => updatable.updateOptions({ agentContext: '😀'.repeat(1751) })).toThrow(
+          /got 1751/,
+        );
+        const context = '😀'.repeat(1750);
+        updatable.updateOptions({ agentContext: context });
+        await waitUntil(() => messages.length > 0);
+        expect(messages).toEqual([{ type: 'UpdateConfiguration', agent_context: context }]);
+      });
+    },
+  );
+
+  it('does not split a Unicode character when truncating carried-over text', async () => {
+    await withProvider({}, async (provider, _query, messages) => {
+      const reply = '😀'.repeat(900) + 'a';
+      provider._pushConversationItem({
+        type: 'conversation_item_added',
+        createdAt: Date.now(),
+        item: new ChatMessage({ role: 'assistant', content: reply }),
+      });
+      await waitUntil(() => messages.some((message) => message.type === 'UpdateConfiguration'));
+      const context = messages.find(
+        (message) => message.type === 'UpdateConfiguration',
+      )?.agent_context;
+      expect(context).toBe(reply);
+    });
+  });
+
+  it('keeps the last 1750 Unicode code points of long carried-over text', async () => {
+    await withProvider({}, async (provider, _query, messages) => {
+      const reply = '😀'.repeat(1900) + 'a';
+      provider._pushConversationItem({
+        type: 'conversation_item_added',
+        createdAt: Date.now(),
+        item: new ChatMessage({ role: 'assistant', content: reply }),
+      });
+      await waitUntil(() => messages.length > 0);
+      expect(messages).toEqual([
+        { type: 'UpdateConfiguration', agent_context: '😀'.repeat(1749) + 'a' },
+      ]);
+    });
+  });
+});

--- a/plugins/assemblyai/src/stt.ts
+++ b/plugins/assemblyai/src/stt.ts
@@ -12,6 +12,7 @@ import {
   Task,
   createTimedString,
   delay,
+  getBaseLanguage,
   log,
   normalizeLanguage,
   stt,
@@ -49,12 +50,21 @@ function isU3ProModel(model: STTModels): boolean {
   return U3_PRO_MODELS.includes(model as (typeof U3_PRO_MODELS)[number]);
 }
 
+function validateModelOptions(opts: Partial<STTOptions>, speechModel: STTModels): void {
+  if (isU3ProModel(speechModel)) return;
+  for (const param of U3_PRO_ONLY_PARAMS) {
+    if (opts[param] !== undefined) {
+      throw new Error(
+        `The '${param}' parameter is only supported with the ${U3_PRO_MODELS.join(', ')} models.`,
+      );
+    }
+  }
+}
+
 function normalizeLanguageCodes(languageCodes: string | string[]): string[] {
   const codes =
     typeof languageCodes === 'string' ? (languageCodes ? [languageCodes] : []) : languageCodes;
-  const normalized = [
-    ...new Set(codes.map((code) => normalizeLanguage(code).split('-')[0] as string)),
-  ];
+  const normalized = [...new Set(codes.map(getBaseLanguage))];
   if (normalized.length > MAX_LANGUAGE_CODES) {
     throw new Error(
       `languageCodes accepts at most ${MAX_LANGUAGE_CODES} codes (got ${normalized.length} after normalization)`,
@@ -69,11 +79,31 @@ function normalizeLanguageCodes(languageCodes: string | string[]): string[] {
 }
 
 function validateAgentContext(agentContext: string | undefined): void {
-  if (agentContext !== undefined && agentContext.length > MAX_AGENT_CONTEXT_CHARS) {
+  const length = agentContext === undefined ? 0 : Array.from(agentContext).length;
+  if (length > MAX_AGENT_CONTEXT_CHARS) {
     throw new Error(
-      `agentContext exceeds maximum length of ${MAX_AGENT_CONTEXT_CHARS} characters (got ${agentContext.length})`,
+      `agentContext exceeds maximum length of ${MAX_AGENT_CONTEXT_CHARS} characters (got ${length})`,
     );
   }
+}
+
+function normalizeUpdateOptions(
+  opts: Partial<STTOptions>,
+  speechModel: STTModels,
+): Partial<STTOptions> {
+  const nextOpts = { ...opts };
+  if (nextOpts.speechModel === 'u3-pro') nextOpts.speechModel = 'universal-3-5-pro';
+  // UpdateConfiguration cannot change the model of an existing provider session.
+  if (nextOpts.speechModel !== undefined && nextOpts.speechModel !== speechModel) {
+    throw new Error('speechModel cannot be changed via updateOptions; create a new STT instead.');
+  }
+  delete nextOpts.speechModel;
+  validateModelOptions(nextOpts, speechModel);
+  validateAgentContext(nextOpts.agentContext);
+  if (nextOpts.languageCodes !== undefined) {
+    nextOpts.languageCodes = normalizeLanguageCodes(nextOpts.languageCodes);
+  }
+  return nextOpts;
 }
 
 // AssemblyAI Universal-Streaming (v3) message envelope. All fields are optional
@@ -126,6 +156,7 @@ export interface STTOptions {
    */
   bufferSizeMs: number;
   encoding: STTEncoding;
+  /** Model selected at construction. Create a new STT to switch models. */
   speechModel: STTModels;
   languageDetection?: boolean;
   /**
@@ -237,15 +268,7 @@ export class STT extends stt.STT {
     }
 
     const speechModel = opts.speechModel ?? defaultSTTOptions.speechModel;
-    if (!isU3ProModel(speechModel)) {
-      for (const param of U3_PRO_ONLY_PARAMS) {
-        if (opts[param] !== undefined) {
-          throw new Error(
-            `The '${param}' parameter is only supported with the ${U3_PRO_MODELS.join(', ')} models.`,
-          );
-        }
-      }
-    }
+    validateModelOptions(opts, speechModel);
 
     const apiKey = opts.apiKey ?? defaultSTTOptions.apiKey;
     if (!apiKey) {
@@ -272,19 +295,7 @@ export class STT extends stt.STT {
   }
 
   updateOptions(opts: Partial<STTOptions>) {
-    validateAgentContext(opts.agentContext);
-
-    // session keyterms so a user update doesn't drop them)
-    const nextOpts = { ...opts };
-    if (nextOpts.languageCodes !== undefined) {
-      const speechModel = nextOpts.speechModel ?? this.#opts.speechModel;
-      if (!isU3ProModel(speechModel)) {
-        throw new Error(
-          `The 'languageCodes' parameter is only supported with the ${U3_PRO_MODELS.join(', ')} models.`,
-        );
-      }
-      nextOpts.languageCodes = normalizeLanguageCodes(nextOpts.languageCodes);
-    }
+    const nextOpts = normalizeUpdateOptions(opts, this.#opts.speechModel);
     if (nextOpts.keytermsPrompt !== undefined) {
       this.#userKeyterms = [...nextOpts.keytermsPrompt];
       nextOpts.keytermsPrompt = [...new Set([...this.#userKeyterms, ...this.#sessionKeyterms])];
@@ -324,7 +335,9 @@ export class STT extends stt.STT {
   override _pushConversationItem(ev: ConversationItemAddedEvent): void {
     const chatItem = ev.item;
     if (chatItem instanceof ChatMessage && chatItem.role === 'assistant' && chatItem.textContent) {
-      this.updateOptions({ agentContext: chatItem.textContent.slice(-MAX_AGENT_CONTEXT_CHARS) });
+      this.updateOptions({
+        agentContext: Array.from(chatItem.textContent).slice(-MAX_AGENT_CONTEXT_CHARS).join(''),
+      });
     }
   }
 
@@ -372,16 +385,7 @@ export class SpeechStream extends stt.SpeechStream {
   }
 
   updateOptions(opts: Partial<STTOptions>) {
-    validateAgentContext(opts.agentContext);
-    if (opts.languageCodes !== undefined) {
-      if (!isU3ProModel(this.#opts.speechModel)) {
-        throw new Error(
-          `The 'languageCodes' parameter is only supported with the ${U3_PRO_MODELS.join(', ')} models.`,
-        );
-      }
-      opts.languageCodes = normalizeLanguageCodes(opts.languageCodes);
-    }
-
+    opts = normalizeUpdateOptions(opts, this.#opts.speechModel);
     this.#opts = { ...this.#opts, ...opts };
 
     const configMsg: Record<string, unknown> = { type: 'UpdateConfiguration' };


### PR DESCRIPTION
## Description

Focused fixes for the AssemblyAI option handling introduced in #2409. This PR is intentionally stacked on `incubate-warhead-talon`, rather than `main`, so the diff contains only the fixes and regression tests. Maintainers can merge it into #2409 or cherry-pick the commit; it can be rebased onto main after #2409 lands.

## Changes Made

- Reuse a single Pro-family validation gate at construction and on both public update paths. Unsupported partial-transcript controls fail before configuration or keyterms are mutated or a provider message is queued.
- Reject model changes through `updateOptions` before mutating state. `speech_model` is not an [AssemblyAI UpdateConfiguration field](https://assemblyai.github.io/assemblyai-node-sdk/types/StreamingUpdateConfiguration.html); merely validating against the requested model would still send Pro-only options to the old server-side model. Create a new STT instance to change models. Repeating the current model, its equivalent alias, or an undefined model remains safe.
- Use the framework's `getBaseLanguage` helper so regional ISO-639-3 tags normalize and deduplicate correctly (for example, `eng-US` -> `en`, `cmn-Hans-CN` -> `zh`).
- Validate and truncate agent context using Unicode code points, matching the Python implementation and avoiding split surrogate pairs.
- Add mock-WebSocket regression tests for both update APIs, model/state preservation, language normalization, Unicode boundaries, and explicit false/zero values.

The context-carryover default introduced in #2409 is unchanged. No core interruption or endpointing policy is changed.

## Pre-Review Checklist

- [x] Build passes locally: `pnpm build` (40 tasks).
- [x] AI-generated code reviewed; deslop pass completed.
- [x] Changes and the explicit model-update rejection are explained above and in the changeset.
- [x] Scope limited to AssemblyAI option handling, its API report, tests, and changeset.
- [x] No file crosses 1000 lines; production `stt.ts` changes from 802 to 806 lines.
- [x] Shared validation replaces duplicated checks; existing language utility reused.
- [ ] Video demo / Agent Playground: not run; this is a provider-configuration fix tested with local WebSocket servers.

## Testing

- `ASSEMBLYAI_API_KEY= pnpm exec vitest run plugins/assemblyai agents/src/language.test.ts`: 50 passed, 1 credential-dependent skip.
- `pnpm build`: passed.
- `pnpm -w format:write` and `pnpm -w lint:fix`: completed; an unrelated Cartesia import autofix was excluded from this PR.
- Focused Prettier check, AssemblyAI lint, and `api:check`: passed.
- `git diff --check`: passed.

The local review first reproduced six failing assertions across the four issues; the regression suite now passes. No credentialed AssemblyAI integration or real audio call was run. The full monorepo test suite was not run.
