### PR TITLE
fix: preserve empty transcripts on interruption

### DIFF
--- a/.changeset/six-mugs-chew.md
+++ b/.changeset/six-mugs-chew.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Respect empty synchronized transcripts when committing interrupted replies to chat history.

--- a/agents/src/voice/agent_activity_interrupted_commit.test.ts
+++ b/agents/src/voice/agent_activity_interrupted_commit.test.ts
@@ -17,12 +17,10 @@ function frame(durationMs = 20, sampleRate = 24000): AudioFrame {
   return new AudioFrame(new Int16Array(samples), sampleRate, 1, samples);
 }
 
-// Audio sink that reports the first frame as played, then (on the interruption's
-// clearBuffer) reports a partial playout WITHOUT a synchronized transcript —
-// the case an avatar / non-aligned output produces. Calls `onFirstFrame` once
-// the first frame is captured so the test can interrupt mid-playout.
+// Reports the first frame as played, then waits for interruption to finish playout.
 class InterruptibleOutput extends AudioOutput {
   onFirstFrame?: () => void;
+  synchronizedTranscript?: string;
   private started = false;
   constructor() {
     super(24000);
@@ -39,7 +37,11 @@ class InterruptibleOutput extends AudioOutput {
     super.flush();
   }
   clearBuffer(): void {
-    this.onPlaybackFinished({ playbackPosition: 0.02, interrupted: true });
+    this.onPlaybackFinished({
+      playbackPosition: 0.02,
+      interrupted: true,
+      synchronizedTranscript: this.synchronizedTranscript,
+    });
   }
 }
 
@@ -307,6 +309,35 @@ describe('AgentActivity interrupted-speech commit', () => {
       expect(msg.interrupted).toBe(true);
       expect(msg.content.length).toBeGreaterThan(0);
       expect('A fairly long spoken reply.'.startsWith(msg.content)).toBe(true);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it.each([
+    { name: 'empty', transcript: '', expected: [] },
+    { name: 'partial', transcript: 'A fairly', expected: ['A fairly'] },
+  ])('uses the $name synchronized transcript on interruption', async ({ transcript, expected }) => {
+    const session = new AgentSession({
+      llm: new FakeLLM([{ input: 'hello', content: 'A fairly long spoken reply.' }]),
+    });
+    const audioOut = new InterruptibleOutput();
+    audioOut.synchronizedTranscript = transcript;
+    audioOut.onFirstFrame = () => session.interrupt({ force: true });
+    session.output.audio = audioOut;
+    const agent = new FrameAgent();
+
+    await session.start({ agent });
+    try {
+      await session.generateReply({ userInput: 'hello' }).waitForPlayout();
+      await session.close();
+
+      for (const chatCtx of [agent.chatCtx, session.history]) {
+        const assistantMessages = chatCtx.items
+          .filter((item) => item.type === 'message' && item.role === 'assistant')
+          .map((item) => item.textContent);
+        expect(assistantMessages).toEqual(expected);
+      }
     } finally {
       await session.close();
     }

--- a/agents/src/voice/generation.ts
+++ b/agents/src/voice/generation.ts
@@ -1079,7 +1079,7 @@ export interface _AudioOut {
  */
 export function forwardedTextFor(output: ForwardOutput): string {
   if (output.played === 'skipped') return '';
-  if (output.played === 'partial' && output.synchronizedTranscript) {
+  if (output.played === 'partial' && output.synchronizedTranscript !== undefined) {
     return output.synchronizedTranscript;
   }
   return output.textOut?.text ?? '';


### PR DESCRIPTION
An interrupted reply with an empty synchronized transcript currently saves generated text that was not spoken. Preserve the empty transcript and retain the fallback when synchronization is unavailable.

@berk-h identified the affected code and proposed following [Python #2095](https://github.com/livekit/agents/pull/2095) in [#2457](https://github.com/livekit/agents-js/issues/2457). This change restores its distinction between empty and missing transcripts.

Regression tests cover empty and partial transcripts in agent and session history.

Addresses AGT-3471

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-6

> Can you investigate linear AGT-3471?

> okay, let's create a draft PR

> did you mention the original github issue and if there was a proposed solution and we should credit them with co-author if appropriate?

</details>
