### PR TITLE
fix: preserve final inference STT transcripts

### DIFF
--- a/.changeset/finish-inference-stt.md
+++ b/.changeset/finish-inference-stt.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Preserve trailing inference STT transcripts before closing sessions, and close sessions when providers omit finalization acknowledgments.

--- a/.changeset/finish-inference-stt.md
+++ b/.changeset/finish-inference-stt.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-Preserve trailing inference STT transcripts until transcript inactivity or socket closure, independent of provider lifecycle acknowledgments.
+Preserve trailing inference STT transcripts by finalizing input before requesting session closure, then wait for closure before ending the stream.

--- a/.changeset/finish-inference-stt.md
+++ b/.changeset/finish-inference-stt.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-Preserve trailing inference STT transcripts by finalizing input before requesting session closure, then wait for closure before ending the stream.
+Preserve trailing inference STT transcripts until transcript inactivity, session closure, or socket closure after input ends.

--- a/.changeset/finish-inference-stt.md
+++ b/.changeset/finish-inference-stt.md
@@ -2,4 +2,4 @@
 '@livekit/agents': patch
 ---
 
-Preserve trailing inference STT transcripts before closing sessions, and close sessions when providers omit finalization acknowledgments.
+Preserve trailing inference STT transcripts until transcript inactivity or socket closure, independent of provider lifecycle acknowledgments.

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -607,7 +607,7 @@ describe('STT VAD handling for Speechmatics models', () => {
 });
 
 describe('Inference STT connection lifecycle', () => {
-  it('includes the model in the dial and closes the session after input ends', async () => {
+  it('includes the model and waits for trailing transcripts before closing', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     await once(server, 'listening');
     const address = server.address() as AddressInfo;
@@ -628,7 +628,9 @@ describe('Inference STT connection lifecycle', () => {
         const event = JSON.parse(raw.toString()) as { type: string };
         messageTypes.push(event.type);
         if (event.type === 'session.finalize') {
+          socket.send(JSON.stringify({ type: 'session.finalized' }));
           setTimeout(() => {
+            if (socket.readyState !== 1) return;
             socket.send(
               JSON.stringify({
                 type: 'final_transcript',

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -904,7 +904,7 @@ describe('Inference STT connection lifecycle', () => {
       vi.useFakeTimers();
       stream.endInput();
       await transcriptReceived;
-      await vi.advanceTimersByTimeAsync(20_000);
+      await vi.advanceTimersByTimeAsync(30_000);
       await outputTask;
 
       expect(messageTypes).toEqual(['session.create', 'session.finalize', 'session.close']);

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -607,19 +607,23 @@ describe('STT VAD handling for Speechmatics models', () => {
 });
 
 describe('Inference STT connection lifecycle', () => {
-  it('waits for session.finalized and session.closed before closing the socket', async () => {
+  it('keeps receiving transcripts after session.finalized', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     await once(server, 'listening');
     const address = server.address() as AddressInfo;
     const messageTypes: string[] = [];
     const transcripts: string[] = [];
-    let closeBeforeFinalized = false;
     let closeBeforeTranscript = false;
-    let sessionFinalizedSent = false;
     let transcriptSent = false;
-    let socketClosedBeforeSessionClosed = false;
-    let sessionClosedSent = false;
     let requestUrl: string | undefined;
+    let resolveSessionCreated!: () => void;
+    const sessionCreated = new Promise<void>((resolve) => {
+      resolveSessionCreated = resolve;
+    });
+    let resolveFinalizeReceived!: () => void;
+    const finalizeReceived = new Promise<void>((resolve) => {
+      resolveFinalizeReceived = resolve;
+    });
     let resolveSocketClosed!: () => void;
     const socketClosed = new Promise<void>((resolve) => {
       resolveSocketClosed = resolve;
@@ -627,6 +631,90 @@ describe('Inference STT connection lifecycle', () => {
 
     server.on('connection', (socket, request) => {
       requestUrl = request.url;
+      socket.on('close', resolveSocketClosed);
+      socket.on('message', (raw) => {
+        const event = JSON.parse(raw.toString()) as { type: string };
+        messageTypes.push(event.type);
+        if (event.type === 'session.create') resolveSessionCreated();
+        if (event.type === 'session.finalize') {
+          resolveFinalizeReceived();
+          socket.send(JSON.stringify({ type: 'session.finalized' }));
+          setTimeout(() => {
+            if (socket.readyState !== 1) return;
+            socket.send(
+              JSON.stringify({
+                type: 'final_transcript',
+                transcript: 'final words',
+                language: 'en',
+              }),
+            );
+            transcriptSent = true;
+          }, 25);
+        }
+        if (event.type === 'session.close') {
+          closeBeforeTranscript = !transcriptSent;
+        }
+      });
+    });
+
+    const stt = makeStt({
+      model: 'deepgram/nova-3',
+      baseURL: `http://127.0.0.1:${address.port}`,
+      connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1_000 },
+    });
+    const stream = stt.stream();
+    let resolveTranscript!: () => void;
+    const transcriptReceived = new Promise<void>((resolve) => {
+      resolveTranscript = resolve;
+    });
+    const outputTask = (async () => {
+      for await (const event of stream) {
+        if (event.type === SpeechEventType.FINAL_TRANSCRIPT) {
+          transcripts.push(event.alternatives![0].text);
+          resolveTranscript();
+        }
+      }
+    })();
+
+    try {
+      await sessionCreated;
+      vi.useFakeTimers();
+      stream.endInput();
+      await finalizeReceived;
+      await vi.advanceTimersByTimeAsync(25);
+      await transcriptReceived;
+      await vi.advanceTimersByTimeAsync(3_000);
+      await outputTask;
+      await socketClosed;
+
+      expect(new URL(requestUrl!, 'ws://127.0.0.1').searchParams.get('model')).toBe(
+        'deepgram/nova-3',
+      );
+      expect(messageTypes).toEqual(['session.create', 'session.finalize', 'session.close']);
+      expect(transcripts).toEqual(['final words']);
+      expect(closeBeforeTranscript).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      stream.close();
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('finishes when session.closed follows input end', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    const address = server.address() as AddressInfo;
+    const messageTypes: string[] = [];
+    const transcripts: string[] = [];
+    let sessionClosedSent = false;
+    let socketClosedBeforeSessionClosed = false;
+    let resolveSocketClosed!: () => void;
+    const socketClosed = new Promise<void>((resolve) => {
+      resolveSocketClosed = resolve;
+    });
+
+    server.on('connection', (socket) => {
       socket.on('close', () => {
         socketClosedBeforeSessionClosed = !sessionClosedSent;
         resolveSocketClosed();
@@ -634,35 +722,20 @@ describe('Inference STT connection lifecycle', () => {
       socket.on('message', (raw) => {
         const event = JSON.parse(raw.toString()) as { type: string };
         messageTypes.push(event.type);
-        if (event.type === 'session.finalize') {
-          socket.send(
-            JSON.stringify({
-              type: 'final_transcript',
-              transcript: 'final words',
-              language: 'en',
-            }),
-          );
-          transcriptSent = true;
-          setTimeout(() => {
-            if (socket.readyState !== 1) return;
-            sessionFinalizedSent = true;
-            socket.send(JSON.stringify({ type: 'session.finalized' }));
-          }, 25);
-        }
-        if (event.type === 'session.close') {
-          closeBeforeFinalized = !sessionFinalizedSent;
-          closeBeforeTranscript = !transcriptSent;
-          setTimeout(() => {
-            if (socket.readyState !== 1) return;
-            sessionClosedSent = true;
-            socket.send(JSON.stringify({ type: 'session.closed' }));
-          }, 25);
-        }
+        if (event.type !== 'session.finalize') return;
+        socket.send(
+          JSON.stringify({
+            type: 'final_transcript',
+            transcript: 'final words',
+            language: 'en',
+          }),
+        );
+        sessionClosedSent = true;
+        socket.send(JSON.stringify({ type: 'session.closed' }));
       });
     });
 
     const stt = makeStt({
-      model: 'deepgram/nova-3',
       baseURL: `http://127.0.0.1:${address.port}`,
       connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1_000 },
     });
@@ -677,13 +750,8 @@ describe('Inference STT connection lifecycle', () => {
       }
       await socketClosed;
 
-      expect(new URL(requestUrl!, 'ws://127.0.0.1').searchParams.get('model')).toBe(
-        'deepgram/nova-3',
-      );
-      expect(messageTypes).toEqual(['session.create', 'session.finalize', 'session.close']);
+      expect(messageTypes).toEqual(['session.create', 'session.finalize']);
       expect(transcripts).toEqual(['final words']);
-      expect(closeBeforeFinalized).toBe(false);
-      expect(closeBeforeTranscript).toBe(false);
       expect(socketClosedBeforeSessionClosed).toBe(false);
     } finally {
       stream.close();
@@ -756,9 +824,6 @@ describe('Inference STT connection lifecycle', () => {
               language: 'en',
             }),
           );
-          socket.send(JSON.stringify({ type: 'session.finalized' }));
-        }
-        if (connection === 2 && event.type === 'session.close') {
           socket.send(JSON.stringify({ type: 'session.closed' }));
         }
       });
@@ -815,9 +880,6 @@ describe('Inference STT connection lifecycle', () => {
               language: 'en',
             }),
           );
-        }
-        if (event.type === 'session.close') {
-          socket.send(JSON.stringify({ type: 'session.closed' }));
         }
       });
     });

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -613,9 +613,17 @@ describe('Inference STT connection lifecycle', () => {
     const address = server.address() as AddressInfo;
     const messageTypes: string[] = [];
     const transcripts: string[] = [];
-    let closeBeforeFinalized = false;
-    let finalized = false;
+    let closeBeforeTranscript = false;
+    let transcriptSent = false;
     let requestUrl: string | undefined;
+    let resolveSessionCreated!: () => void;
+    const sessionCreated = new Promise<void>((resolve) => {
+      resolveSessionCreated = resolve;
+    });
+    let resolveFinalizeReceived!: () => void;
+    const finalizeReceived = new Promise<void>((resolve) => {
+      resolveFinalizeReceived = resolve;
+    });
     let resolveSocketClosed!: () => void;
     const socketClosed = new Promise<void>((resolve) => {
       resolveSocketClosed = resolve;
@@ -627,7 +635,9 @@ describe('Inference STT connection lifecycle', () => {
       socket.on('message', (raw) => {
         const event = JSON.parse(raw.toString()) as { type: string };
         messageTypes.push(event.type);
+        if (event.type === 'session.create') resolveSessionCreated();
         if (event.type === 'session.finalize') {
+          resolveFinalizeReceived();
           socket.send(JSON.stringify({ type: 'session.finalized' }));
           setTimeout(() => {
             if (socket.readyState !== 1) return;
@@ -638,16 +648,15 @@ describe('Inference STT connection lifecycle', () => {
                 language: 'en',
               }),
             );
-            finalized = true;
-            socket.send(JSON.stringify({ type: 'session.finalized' }));
-            if (closeBeforeFinalized) {
+            transcriptSent = true;
+            if (closeBeforeTranscript) {
               socket.send(JSON.stringify({ type: 'session.closed' }));
             }
           }, 25);
         }
         if (event.type === 'session.close') {
-          closeBeforeFinalized = !finalized;
-          if (finalized) socket.send(JSON.stringify({ type: 'session.closed' }));
+          closeBeforeTranscript = !transcriptSent;
+          if (transcriptSent) socket.send(JSON.stringify({ type: 'session.closed' }));
         }
       });
     });
@@ -658,14 +667,28 @@ describe('Inference STT connection lifecycle', () => {
       connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1_000 },
     });
     const stream = stt.stream();
-
-    try {
-      stream.endInput();
+    let resolveTranscript!: () => void;
+    const transcriptReceived = new Promise<void>((resolve) => {
+      resolveTranscript = resolve;
+    });
+    const outputTask = (async () => {
       for await (const event of stream) {
         if (event.type === SpeechEventType.FINAL_TRANSCRIPT) {
           transcripts.push(event.alternatives![0].text);
+          resolveTranscript();
         }
       }
+    })();
+
+    try {
+      await sessionCreated;
+      vi.useFakeTimers();
+      stream.endInput();
+      await finalizeReceived;
+      await vi.advanceTimersByTimeAsync(25);
+      await transcriptReceived;
+      await vi.advanceTimersByTimeAsync(3_000);
+      await outputTask;
       await socketClosed;
 
       expect(new URL(requestUrl!, 'ws://127.0.0.1').searchParams.get('model')).toBe(
@@ -673,15 +696,16 @@ describe('Inference STT connection lifecycle', () => {
       );
       expect(messageTypes).toEqual(['session.create', 'session.finalize', 'session.close']);
       expect(transcripts).toEqual(['final words']);
-      expect(closeBeforeFinalized).toBe(false);
+      expect(closeBeforeTranscript).toBe(false);
     } finally {
+      vi.useRealTimers();
       stream.close();
       for (const client of server.clients) client.terminate();
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
 
-  it('reports a disconnect before finalization completes after input ends', async () => {
+  it('accepts a socket close after input ends', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     await once(server, 'listening');
     const address = server.address() as AddressInfo;
@@ -710,8 +734,7 @@ describe('Inference STT connection lifecycle', () => {
       }
 
       expect(connectionCount).toBe(1);
-      expect(errors).toHaveLength(1);
-      expect(errors[0]).toMatchObject({ retryable: false, statusCode: 1011 });
+      expect(errors).toHaveLength(0);
     } finally {
       stream.close();
       for (const client of server.clients) client.terminate();
@@ -719,20 +742,92 @@ describe('Inference STT connection lifecycle', () => {
     }
   });
 
-  it('reconnects when the session closes before input ends', async () => {
+  it('ignores session.closed while the socket remains open', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     await once(server, 'listening');
     const address = server.address() as AddressInfo;
     let connectionCount = 0;
-    let resolveFirstSocketClosed!: () => void;
-    const firstSocketClosed = new Promise<void>((resolve) => {
-      resolveFirstSocketClosed = resolve;
+
+    server.on('connection', (socket) => {
+      connectionCount += 1;
+      socket.on('message', (raw) => {
+        const event = JSON.parse(raw.toString()) as { type: string };
+        if (event.type === 'session.create') {
+          socket.send(JSON.stringify({ type: 'session.closed' }));
+          socket.send(
+            JSON.stringify({
+              type: 'final_transcript',
+              transcript: 'final words',
+              language: 'en',
+            }),
+          );
+        }
+        if (event.type === 'session.finalize') socket.close();
+      });
+    });
+
+    const stt = makeStt({
+      baseURL: `http://127.0.0.1:${address.port}`,
+      connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1_000 },
+    });
+    const errors: Error[] = [];
+    let resolveError!: () => void;
+    const errorReceived = new Promise<void>((resolve) => {
+      resolveError = resolve;
+    });
+    stt.on('error', ({ error }) => {
+      errors.push(error);
+      resolveError();
+    });
+    const stream = stt.stream();
+    const transcripts: string[] = [];
+    let resolveTranscript!: () => void;
+    const transcriptReceived = new Promise<void>((resolve) => {
+      resolveTranscript = resolve;
+    });
+    const outputTask = (async () => {
+      for await (const event of stream) {
+        if (event.type === SpeechEventType.FINAL_TRANSCRIPT) {
+          transcripts.push(event.alternatives![0].text);
+          resolveTranscript();
+        }
+      }
+    })();
+
+    try {
+      const outcome = await Promise.race([
+        transcriptReceived.then(() => 'transcript'),
+        errorReceived.then(() => 'error'),
+      ]);
+      expect(outcome).toBe('transcript');
+
+      stream.endInput();
+      await outputTask;
+
+      expect(connectionCount).toBe(1);
+      expect(errors).toHaveLength(0);
+      expect(transcripts).toEqual(['final words']);
+    } finally {
+      stream.close();
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('reconnects when the socket closes before input ends', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    const address = server.address() as AddressInfo;
+    let connectionCount = 0;
+    let resolveSecondConnection!: () => void;
+    const secondConnection = new Promise<void>((resolve) => {
+      resolveSecondConnection = resolve;
     });
 
     server.on('connection', (socket) => {
       connectionCount += 1;
       const connection = connectionCount;
-      if (connection === 1) socket.once('close', resolveFirstSocketClosed);
+      if (connection === 2) resolveSecondConnection();
       socket.on('message', (raw) => {
         const event = JSON.parse(raw.toString()) as { type: string };
         if (connection === 1 && event.type === 'session.create') {
@@ -746,10 +841,7 @@ describe('Inference STT connection lifecycle', () => {
               language: 'en',
             }),
           );
-          socket.send(JSON.stringify({ type: 'session.finalized' }));
-        }
-        if (connection === 2 && event.type === 'session.close') {
-          socket.send(JSON.stringify({ type: 'session.closed' }));
+          socket.send(JSON.stringify({ type: 'session.finalized' }), () => socket.close());
         }
       });
     });
@@ -769,7 +861,7 @@ describe('Inference STT connection lifecycle', () => {
     })();
 
     try {
-      await firstSocketClosed;
+      await secondConnection;
       stream.endInput();
       await outputTask;
 
@@ -1000,7 +1092,7 @@ describeLiveKitInference('LiveKit Inference STT integration', agents, async (har
     'assemblyai/universal-streaming',
     'xai/stt-1',
   ] as const) {
-    describe(model, { retry: model === 'xai/stt-1' ? 1 : 0 }, async () => {
+    describe(model, { retry: 1 }, async () => {
       const stt =
         model === 'assemblyai/universal-streaming'
           ? new STT({ model, modelOptions: { format_turns: true } })

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -719,6 +719,69 @@ describe('Inference STT connection lifecycle', () => {
     }
   });
 
+  it('reconnects when the session closes before input ends', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    const address = server.address() as AddressInfo;
+    let connectionCount = 0;
+    let resolveFirstSocketClosed!: () => void;
+    const firstSocketClosed = new Promise<void>((resolve) => {
+      resolveFirstSocketClosed = resolve;
+    });
+
+    server.on('connection', (socket) => {
+      connectionCount += 1;
+      const connection = connectionCount;
+      if (connection === 1) socket.once('close', resolveFirstSocketClosed);
+      socket.on('message', (raw) => {
+        const event = JSON.parse(raw.toString()) as { type: string };
+        if (connection === 1 && event.type === 'session.create') {
+          socket.send(JSON.stringify({ type: 'session.closed' }), () => socket.close());
+        }
+        if (connection === 2 && event.type === 'session.finalize') {
+          socket.send(
+            JSON.stringify({
+              type: 'final_transcript',
+              transcript: 'final words',
+              language: 'en',
+            }),
+          );
+          socket.send(JSON.stringify({ type: 'session.finalized' }));
+        }
+        if (connection === 2 && event.type === 'session.close') {
+          socket.send(JSON.stringify({ type: 'session.closed' }));
+        }
+      });
+    });
+
+    const stt = makeStt({
+      baseURL: `http://127.0.0.1:${address.port}`,
+      connOptions: { maxRetry: 1, retryIntervalMs: 1, timeoutMs: 1_000 },
+    });
+    const stream = stt.stream();
+    const transcripts: string[] = [];
+    const outputTask = (async () => {
+      for await (const event of stream) {
+        if (event.type === SpeechEventType.FINAL_TRANSCRIPT) {
+          transcripts.push(event.alternatives![0].text);
+        }
+      }
+    })();
+
+    try {
+      await firstSocketClosed;
+      stream.endInput();
+      await outputTask;
+
+      expect(connectionCount).toBe(2);
+      expect(transcripts).toEqual(['final words']);
+    } finally {
+      stream.close();
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it('closes the session after transcript inactivity without a finalization ack', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     await once(server, 'listening');

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -857,7 +857,7 @@ describe('Inference STT connection lifecycle', () => {
     }
   });
 
-  it('closes the session after transcript inactivity without a finalization ack', async () => {
+  it('does not require a final transcript after an interim', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     await once(server, 'listening');
     const address = server.address() as AddressInfo;
@@ -875,8 +875,8 @@ describe('Inference STT connection lifecycle', () => {
         if (event.type === 'session.finalize') {
           socket.send(
             JSON.stringify({
-              type: 'final_transcript',
-              transcript: 'final words',
+              type: 'interim_transcript',
+              transcript: 'interim words',
               language: 'en',
             }),
           );
@@ -895,7 +895,7 @@ describe('Inference STT connection lifecycle', () => {
     });
     const outputTask = (async () => {
       for await (const event of stream) {
-        if (event.type === SpeechEventType.FINAL_TRANSCRIPT) resolveTranscript();
+        if (event.type === SpeechEventType.INTERIM_TRANSCRIPT) resolveTranscript();
       }
     })();
 
@@ -904,7 +904,7 @@ describe('Inference STT connection lifecycle', () => {
       vi.useFakeTimers();
       stream.endInput();
       await transcriptReceived;
-      await vi.advanceTimersByTimeAsync(3_000);
+      await vi.advanceTimersByTimeAsync(20_000);
       await outputTask;
 
       expect(messageTypes).toEqual(['session.create', 'session.finalize', 'session.close']);

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -607,23 +607,19 @@ describe('STT VAD handling for Speechmatics models', () => {
 });
 
 describe('Inference STT connection lifecycle', () => {
-  it('includes the model and waits for trailing transcripts before closing', async () => {
+  it('waits for session.finalized and session.closed before closing the socket', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     await once(server, 'listening');
     const address = server.address() as AddressInfo;
     const messageTypes: string[] = [];
     const transcripts: string[] = [];
+    let closeBeforeFinalized = false;
     let closeBeforeTranscript = false;
+    let sessionFinalizedSent = false;
     let transcriptSent = false;
+    let socketClosedBeforeSessionClosed = false;
+    let sessionClosedSent = false;
     let requestUrl: string | undefined;
-    let resolveSessionCreated!: () => void;
-    const sessionCreated = new Promise<void>((resolve) => {
-      resolveSessionCreated = resolve;
-    });
-    let resolveFinalizeReceived!: () => void;
-    const finalizeReceived = new Promise<void>((resolve) => {
-      resolveFinalizeReceived = resolve;
-    });
     let resolveSocketClosed!: () => void;
     const socketClosed = new Promise<void>((resolve) => {
       resolveSocketClosed = resolve;
@@ -631,32 +627,36 @@ describe('Inference STT connection lifecycle', () => {
 
     server.on('connection', (socket, request) => {
       requestUrl = request.url;
-      socket.on('close', resolveSocketClosed);
+      socket.on('close', () => {
+        socketClosedBeforeSessionClosed = !sessionClosedSent;
+        resolveSocketClosed();
+      });
       socket.on('message', (raw) => {
         const event = JSON.parse(raw.toString()) as { type: string };
         messageTypes.push(event.type);
-        if (event.type === 'session.create') resolveSessionCreated();
         if (event.type === 'session.finalize') {
-          resolveFinalizeReceived();
-          socket.send(JSON.stringify({ type: 'session.finalized' }));
+          socket.send(
+            JSON.stringify({
+              type: 'final_transcript',
+              transcript: 'final words',
+              language: 'en',
+            }),
+          );
+          transcriptSent = true;
           setTimeout(() => {
             if (socket.readyState !== 1) return;
-            socket.send(
-              JSON.stringify({
-                type: 'final_transcript',
-                transcript: 'final words',
-                language: 'en',
-              }),
-            );
-            transcriptSent = true;
-            if (closeBeforeTranscript) {
-              socket.send(JSON.stringify({ type: 'session.closed' }));
-            }
+            sessionFinalizedSent = true;
+            socket.send(JSON.stringify({ type: 'session.finalized' }));
           }, 25);
         }
         if (event.type === 'session.close') {
+          closeBeforeFinalized = !sessionFinalizedSent;
           closeBeforeTranscript = !transcriptSent;
-          if (transcriptSent) socket.send(JSON.stringify({ type: 'session.closed' }));
+          setTimeout(() => {
+            if (socket.readyState !== 1) return;
+            sessionClosedSent = true;
+            socket.send(JSON.stringify({ type: 'session.closed' }));
+          }, 25);
         }
       });
     });
@@ -667,28 +667,14 @@ describe('Inference STT connection lifecycle', () => {
       connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1_000 },
     });
     const stream = stt.stream();
-    let resolveTranscript!: () => void;
-    const transcriptReceived = new Promise<void>((resolve) => {
-      resolveTranscript = resolve;
-    });
-    const outputTask = (async () => {
+
+    try {
+      stream.endInput();
       for await (const event of stream) {
         if (event.type === SpeechEventType.FINAL_TRANSCRIPT) {
           transcripts.push(event.alternatives![0].text);
-          resolveTranscript();
         }
       }
-    })();
-
-    try {
-      await sessionCreated;
-      vi.useFakeTimers();
-      stream.endInput();
-      await finalizeReceived;
-      await vi.advanceTimersByTimeAsync(25);
-      await transcriptReceived;
-      await vi.advanceTimersByTimeAsync(3_000);
-      await outputTask;
       await socketClosed;
 
       expect(new URL(requestUrl!, 'ws://127.0.0.1').searchParams.get('model')).toBe(
@@ -696,9 +682,10 @@ describe('Inference STT connection lifecycle', () => {
       );
       expect(messageTypes).toEqual(['session.create', 'session.finalize', 'session.close']);
       expect(transcripts).toEqual(['final words']);
+      expect(closeBeforeFinalized).toBe(false);
       expect(closeBeforeTranscript).toBe(false);
+      expect(socketClosedBeforeSessionClosed).toBe(false);
     } finally {
-      vi.useRealTimers();
       stream.close();
       for (const client of server.clients) client.terminate();
       await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -742,78 +729,6 @@ describe('Inference STT connection lifecycle', () => {
     }
   });
 
-  it('ignores session.closed while the socket remains open', async () => {
-    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
-    await once(server, 'listening');
-    const address = server.address() as AddressInfo;
-    let connectionCount = 0;
-
-    server.on('connection', (socket) => {
-      connectionCount += 1;
-      socket.on('message', (raw) => {
-        const event = JSON.parse(raw.toString()) as { type: string };
-        if (event.type === 'session.create') {
-          socket.send(JSON.stringify({ type: 'session.closed' }));
-          socket.send(
-            JSON.stringify({
-              type: 'final_transcript',
-              transcript: 'final words',
-              language: 'en',
-            }),
-          );
-        }
-        if (event.type === 'session.finalize') socket.close();
-      });
-    });
-
-    const stt = makeStt({
-      baseURL: `http://127.0.0.1:${address.port}`,
-      connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1_000 },
-    });
-    const errors: Error[] = [];
-    let resolveError!: () => void;
-    const errorReceived = new Promise<void>((resolve) => {
-      resolveError = resolve;
-    });
-    stt.on('error', ({ error }) => {
-      errors.push(error);
-      resolveError();
-    });
-    const stream = stt.stream();
-    const transcripts: string[] = [];
-    let resolveTranscript!: () => void;
-    const transcriptReceived = new Promise<void>((resolve) => {
-      resolveTranscript = resolve;
-    });
-    const outputTask = (async () => {
-      for await (const event of stream) {
-        if (event.type === SpeechEventType.FINAL_TRANSCRIPT) {
-          transcripts.push(event.alternatives![0].text);
-          resolveTranscript();
-        }
-      }
-    })();
-
-    try {
-      const outcome = await Promise.race([
-        transcriptReceived.then(() => 'transcript'),
-        errorReceived.then(() => 'error'),
-      ]);
-      expect(outcome).toBe('transcript');
-
-      stream.endInput();
-      await outputTask;
-
-      expect(connectionCount).toBe(1);
-      expect(errors).toHaveLength(0);
-      expect(transcripts).toEqual(['final words']);
-    } finally {
-      stream.close();
-      for (const client of server.clients) client.terminate();
-      await new Promise<void>((resolve) => server.close(() => resolve()));
-    }
-  });
-
   it('reconnects when the socket closes before input ends', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     await once(server, 'listening');
@@ -841,7 +756,10 @@ describe('Inference STT connection lifecycle', () => {
               language: 'en',
             }),
           );
-          socket.send(JSON.stringify({ type: 'session.finalized' }), () => socket.close());
+          socket.send(JSON.stringify({ type: 'session.finalized' }));
+        }
+        if (connection === 2 && event.type === 'session.close') {
+          socket.send(JSON.stringify({ type: 'session.closed' }));
         }
       });
     });
@@ -897,6 +815,9 @@ describe('Inference STT connection lifecycle', () => {
               language: 'en',
             }),
           );
+        }
+        if (event.type === 'session.close') {
+          socket.send(JSON.stringify({ type: 'session.closed' }));
         }
       });
     });

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { once } from 'node:events';
 import type { AddressInfo } from 'node:net';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { WebSocketServer } from 'ws';
 import { APIStatusError } from '../_exceptions.js';
 import * as agents from '../index.js';
@@ -613,6 +613,8 @@ describe('Inference STT connection lifecycle', () => {
     const address = server.address() as AddressInfo;
     const messageTypes: string[] = [];
     const transcripts: string[] = [];
+    let closeBeforeFinalized = false;
+    let finalized = false;
     let requestUrl: string | undefined;
     let resolveSocketClosed!: () => void;
     const socketClosed = new Promise<void>((resolve) => {
@@ -625,15 +627,25 @@ describe('Inference STT connection lifecycle', () => {
       socket.on('message', (raw) => {
         const event = JSON.parse(raw.toString()) as { type: string };
         messageTypes.push(event.type);
+        if (event.type === 'session.finalize') {
+          setTimeout(() => {
+            socket.send(
+              JSON.stringify({
+                type: 'final_transcript',
+                transcript: 'final words',
+                language: 'en',
+              }),
+            );
+            finalized = true;
+            socket.send(JSON.stringify({ type: 'session.finalized' }));
+            if (closeBeforeFinalized) {
+              socket.send(JSON.stringify({ type: 'session.closed' }));
+            }
+          }, 25);
+        }
         if (event.type === 'session.close') {
-          socket.send(
-            JSON.stringify({
-              type: 'final_transcript',
-              transcript: 'final words',
-              language: 'en',
-            }),
-          );
-          socket.send(JSON.stringify({ type: 'session.closed' }));
+          closeBeforeFinalized = !finalized;
+          if (finalized) socket.send(JSON.stringify({ type: 'session.closed' }));
         }
       });
     });
@@ -659,6 +671,7 @@ describe('Inference STT connection lifecycle', () => {
       );
       expect(messageTypes).toEqual(['session.create', 'session.finalize', 'session.close']);
       expect(transcripts).toEqual(['final words']);
+      expect(closeBeforeFinalized).toBe(false);
     } finally {
       stream.close();
       for (const client of server.clients) client.terminate();
@@ -666,7 +679,7 @@ describe('Inference STT connection lifecycle', () => {
     }
   });
 
-  it('reports a disconnect before session.closed after input ends', async () => {
+  it('reports a disconnect before finalization completes after input ends', async () => {
     const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     await once(server, 'listening');
     const address = server.address() as AddressInfo;
@@ -676,7 +689,7 @@ describe('Inference STT connection lifecycle', () => {
       connectionCount += 1;
       socket.on('message', (raw) => {
         const event = JSON.parse(raw.toString()) as { type: string };
-        if (event.type === 'session.close') socket.close(1011, 'missing session.closed');
+        if (event.type === 'session.finalize') socket.close(1011, 'finalization interrupted');
       });
     });
 
@@ -698,6 +711,65 @@ describe('Inference STT connection lifecycle', () => {
       expect(errors).toHaveLength(1);
       expect(errors[0]).toMatchObject({ retryable: false, statusCode: 1011 });
     } finally {
+      stream.close();
+      for (const client of server.clients) client.terminate();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('closes the session after transcript inactivity without a finalization ack', async () => {
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+    const address = server.address() as AddressInfo;
+    const messageTypes: string[] = [];
+    let resolveSessionCreated!: () => void;
+    const sessionCreated = new Promise<void>((resolve) => {
+      resolveSessionCreated = resolve;
+    });
+
+    server.on('connection', (socket) => {
+      socket.on('message', (raw) => {
+        const event = JSON.parse(raw.toString()) as { type: string };
+        messageTypes.push(event.type);
+        if (event.type === 'session.create') resolveSessionCreated();
+        if (event.type === 'session.finalize') {
+          socket.send(
+            JSON.stringify({
+              type: 'final_transcript',
+              transcript: 'final words',
+              language: 'en',
+            }),
+          );
+        }
+      });
+    });
+
+    const stt = makeStt({
+      baseURL: `http://127.0.0.1:${address.port}`,
+      connOptions: { maxRetry: 0, retryIntervalMs: 1, timeoutMs: 1_000 },
+    });
+    const stream = stt.stream();
+    let resolveTranscript!: () => void;
+    const transcriptReceived = new Promise<void>((resolve) => {
+      resolveTranscript = resolve;
+    });
+    const outputTask = (async () => {
+      for await (const event of stream) {
+        if (event.type === SpeechEventType.FINAL_TRANSCRIPT) resolveTranscript();
+      }
+    })();
+
+    try {
+      await sessionCreated;
+      vi.useFakeTimers();
+      stream.endInput();
+      await transcriptReceived;
+      await vi.advanceTimersByTimeAsync(3_000);
+      await outputTask;
+
+      expect(messageTypes).toEqual(['session.create', 'session.finalize', 'session.close']);
+    } finally {
+      vi.useRealTimers();
       stream.close();
       for (const client of server.clients) client.terminate();
       await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -864,7 +936,11 @@ describeLiveKitInference('LiveKit Inference STT integration', agents, async (har
     'xai/stt-1',
   ] as const) {
     describe(model, async () => {
-      await harness.stt(new STT({ model }), new InferenceVAD(), {
+      const stt =
+        model === 'assemblyai/universal-streaming'
+          ? new STT({ model, modelOptions: { format_turns: true } })
+          : new STT({ model });
+      await harness.stt(stt, new InferenceVAD(), {
         nonStreaming: false,
       });
     });

--- a/agents/src/inference/stt.test.ts
+++ b/agents/src/inference/stt.test.ts
@@ -1000,7 +1000,7 @@ describeLiveKitInference('LiveKit Inference STT integration', agents, async (har
     'assemblyai/universal-streaming',
     'xai/stt-1',
   ] as const) {
-    describe(model, async () => {
+    describe(model, { retry: model === 'xai/stt-1' ? 1 : 0 }, async () => {
       const stt =
         model === 'assemblyai/universal-streaming'
           ? new STT({ model, modelOptions: { format_turns: true } })

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -421,8 +421,7 @@ const DEFAULT_ENCODING: STTEncoding = 'pcm_s16le';
 const DEFAULT_SAMPLE_RATE = 16000;
 const DEFAULT_CANCEL_TIMEOUT = 5000;
 const INACTIVITY_TIMEOUT_ERROR_CODE = 2007;
-const FIRST_TRANSCRIPT_TIMEOUT_MS = 30_000;
-const INTERIM_TRANSCRIPT_INACTIVITY_TIMEOUT_MS = 20_000;
+const FINALIZATION_TIMEOUT_MS = 30_000;
 const FINAL_TRANSCRIPT_INACTIVITY_TIMEOUT_MS = 3_000;
 
 export interface InferenceSTTOptions<TModel extends STTModels> {
@@ -820,7 +819,6 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       let ws: WebSocket | null = null;
       let inputEnded = false;
       let cleanedUp = false;
-      let transcriptReceived = false;
       let finalTranscriptReceived = false;
       let finalizationComplete = false;
       let sessionClosedReceived = false;
@@ -879,9 +877,10 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
         }
         if (finalizationTimeout) clearTimeout(finalizationTimeout);
         // Lifecycle acknowledgments are optional and may precede trailing transcripts.
-        let timeout = FIRST_TRANSCRIPT_TIMEOUT_MS;
-        if (transcriptReceived) timeout = INTERIM_TRANSCRIPT_INACTIVITY_TIMEOUT_MS;
-        if (finalTranscriptReceived) timeout = FINAL_TRANSCRIPT_INACTIVITY_TIMEOUT_MS;
+        // ponytail: Add an interim-specific deadline only if shutdown latency requires it.
+        const timeout = finalTranscriptReceived
+          ? FINAL_TRANSCRIPT_INACTIVITY_TIMEOUT_MS
+          : FINALIZATION_TIMEOUT_MS;
         finalizationTimeout = setTimeout(finishFinalization, timeout);
       };
 
@@ -904,7 +903,6 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
               json.type === 'final_transcript' ||
               json.type === 'preflight_transcript'
             ) {
-              transcriptReceived = true;
               scheduleFinalizationTimeout();
             }
             void eventChannel.write(json).catch((error) => {

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -909,7 +909,11 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
           });
 
           ws.on('close', (code: number) => {
-            const expectedClose = sessionClosedReceived || finalizationComplete || signal.aborted;
+            const expectedClose =
+              signal.aborted ||
+              finalizationComplete ||
+              sessionCloseSent ||
+              (sessionClosedReceived && inputEnded);
             resourceCleanup();
 
             if (expectedClose) return resolve();
@@ -1051,6 +1055,12 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
                 }
                 break;
               case 'session.closed':
+                if (!inputEnded && !sessionCloseSent) {
+                  throw new APIStatusError({
+                    message: 'LiveKit STT session closed before input ended',
+                    options: { statusCode: -1, retryable: true },
+                  });
+                }
                 finishFinalization();
                 break;
               case 'start_of_speech':

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -422,7 +422,8 @@ const DEFAULT_SAMPLE_RATE = 16000;
 const DEFAULT_CANCEL_TIMEOUT = 5000;
 const INACTIVITY_TIMEOUT_ERROR_CODE = 2007;
 const FIRST_TRANSCRIPT_TIMEOUT_MS = 30_000;
-const TRANSCRIPT_INACTIVITY_TIMEOUT_MS = 3_000;
+const INTERIM_TRANSCRIPT_INACTIVITY_TIMEOUT_MS = 20_000;
+const FINAL_TRANSCRIPT_INACTIVITY_TIMEOUT_MS = 3_000;
 
 export interface InferenceSTTOptions<TModel extends STTModels> {
   model?: TModel;
@@ -819,6 +820,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       let ws: WebSocket | null = null;
       let inputEnded = false;
       let cleanedUp = false;
+      let transcriptReceived = false;
       let finalTranscriptReceived = false;
       let finalizationComplete = false;
       let sessionClosedReceived = false;
@@ -877,10 +879,10 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
         }
         if (finalizationTimeout) clearTimeout(finalizationTimeout);
         // Lifecycle acknowledgments are optional and may precede trailing transcripts.
-        finalizationTimeout = setTimeout(
-          finishFinalization,
-          finalTranscriptReceived ? TRANSCRIPT_INACTIVITY_TIMEOUT_MS : FIRST_TRANSCRIPT_TIMEOUT_MS,
-        );
+        let timeout = FIRST_TRANSCRIPT_TIMEOUT_MS;
+        if (transcriptReceived) timeout = INTERIM_TRANSCRIPT_INACTIVITY_TIMEOUT_MS;
+        if (finalTranscriptReceived) timeout = FINAL_TRANSCRIPT_INACTIVITY_TIMEOUT_MS;
+        finalizationTimeout = setTimeout(finishFinalization, timeout);
       };
 
       const createWsListener = async (ws: WebSocket, signal: AbortSignal) => {
@@ -894,7 +896,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
 
           ws.on('message', (data) => {
             const json = JSON.parse(data.toString()) as SttServerEvent;
-            if (json.type === 'final_transcript' && json.transcript) {
+            if (json.type === 'final_transcript') {
               finalTranscriptReceived = true;
             }
             if (
@@ -902,6 +904,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
               json.type === 'final_transcript' ||
               json.type === 'preflight_transcript'
             ) {
+              transcriptReceived = true;
               scheduleFinalizationTimeout();
             }
             void eventChannel.write(json).catch((error) => {

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -820,6 +820,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       let inputEnded = false;
       let cleanedUp = false;
       let finalTranscriptReceived = false;
+      let finalTranscriptReceivedAfterInputEnd = false;
       let finalizationComplete = false;
       let sessionClosedReceived = false;
       let sessionCloseSent = false;
@@ -1040,7 +1041,14 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
                 break;
               case 'session.finalized':
                 pendingFinalizations = Math.max(0, pendingFinalizations - 1);
-                if (inputEnded && pendingFinalizations === 0) finishFinalization();
+                // xAI acknowledges finalize before endpointing emits its trailing transcript.
+                if (
+                  inputEnded &&
+                  pendingFinalizations === 0 &&
+                  finalTranscriptReceivedAfterInputEnd
+                ) {
+                  finishFinalization();
+                }
                 break;
               case 'session.closed':
                 finishFinalization();
@@ -1052,6 +1060,9 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
                 this.processTranscript(event, SpeechEventType.INTERIM_TRANSCRIPT);
                 break;
               case 'final_transcript':
+                if (inputEnded && event.transcript) {
+                  finalTranscriptReceivedAfterInputEnd = true;
+                }
                 this.processTranscript(event, SpeechEventType.FINAL_TRANSCRIPT);
                 break;
               case 'preflight_transcript':

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -421,6 +421,8 @@ const DEFAULT_ENCODING: STTEncoding = 'pcm_s16le';
 const DEFAULT_SAMPLE_RATE = 16000;
 const DEFAULT_CANCEL_TIMEOUT = 5000;
 const INACTIVITY_TIMEOUT_ERROR_CODE = 2007;
+const FIRST_TRANSCRIPT_TIMEOUT_MS = 30_000;
+const TRANSCRIPT_INACTIVITY_TIMEOUT_MS = 3_000;
 
 export interface InferenceSTTOptions<TModel extends STTModels> {
   model?: TModel;
@@ -817,8 +819,13 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       let ws: WebSocket | null = null;
       let inputEnded = false;
       let cleanedUp = false;
-      let finalReceived = false;
+      let finalTranscriptReceived = false;
+      let finalizationComplete = false;
+      let sessionClosedReceived = false;
       let sessionCloseSent = false;
+      // Acks have no IDs. Count them so a VAD-turn ack cannot close ended input early.
+      let pendingFinalizations = 0;
+      let finalizationTimeout: ReturnType<typeof setTimeout> | undefined;
       let vadStream: VADStream | null = null;
 
       const eventChannel = createStreamChannel<SttServerEvent>();
@@ -829,9 +836,15 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
         socket.send(JSON.stringify({ type: 'session.close' }));
       };
 
+      const sendSessionFinalize = (socket: WebSocket) => {
+        pendingFinalizations += 1;
+        socket.send(JSON.stringify({ type: 'session.finalize' }));
+      };
+
       const resourceCleanup = () => {
         if (cleanedUp) return;
         cleanedUp = true;
+        if (finalizationTimeout) clearTimeout(finalizationTimeout);
         void eventChannel.close().catch((error) => {
           this.#logger.debug({ error }, 'Failed to close STT event channel');
         });
@@ -845,6 +858,22 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
         }
       };
 
+      const finishFinalization = () => {
+        if (finalizationComplete) return;
+        finalizationComplete = true;
+        resourceCleanup();
+      };
+
+      const scheduleFinalizationTimeout = () => {
+        if (!inputEnded || finalizationComplete || cleanedUp) return;
+        if (finalizationTimeout) clearTimeout(finalizationTimeout);
+        // Some providers omit the ack. End the session after transcript inactivity.
+        finalizationTimeout = setTimeout(
+          finishFinalization,
+          finalTranscriptReceived ? TRANSCRIPT_INACTIVITY_TIMEOUT_MS : FIRST_TRANSCRIPT_TIMEOUT_MS,
+        );
+      };
+
       const createWsListener = async (ws: WebSocket, signal: AbortSignal) => {
         return new ThrowsPromise<void, Error | APIStatusError>((resolve, reject) => {
           const onAbort = () => {
@@ -856,6 +885,17 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
 
           ws.on('message', (data) => {
             const json = JSON.parse(data.toString()) as SttServerEvent;
+            if (json.type === 'final_transcript' && json.transcript) {
+              finalTranscriptReceived = true;
+            }
+            if (json.type === 'session.closed') sessionClosedReceived = true;
+            if (
+              json.type === 'interim_transcript' ||
+              json.type === 'final_transcript' ||
+              json.type === 'preflight_transcript'
+            ) {
+              scheduleFinalizationTimeout();
+            }
             void eventChannel.write(json).catch((error) => {
               this.#logger.debug({ error }, 'Failed to queue STT server event');
             });
@@ -868,7 +908,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
           });
 
           ws.on('close', (code: number) => {
-            const expectedClose = finalReceived || signal.aborted;
+            const expectedClose = sessionClosedReceived || finalizationComplete || signal.aborted;
             resourceCleanup();
 
             if (expectedClose) return resolve();
@@ -929,8 +969,8 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
 
           inputEnded = true;
           vadStream?.endInput();
-          socket.send(JSON.stringify({ type: 'session.finalize' }));
-          sendSessionClose(socket);
+          sendSessionFinalize(socket);
+          scheduleFinalizationTimeout();
         } catch (e) {
           if ((e as Error).message === 'Send aborted') {
             // Expected abort, don't log
@@ -956,7 +996,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
             if (result.done) break;
             if (result.value.type !== VADEventType.END_OF_SPEECH) continue;
             if (socket.readyState !== 1) return;
-            socket.send(JSON.stringify({ type: 'session.finalize' }));
+            sendSessionFinalize(socket);
           }
         } catch (e) {
           if ((e as Error).message === 'VAD aborted') return;
@@ -997,11 +1037,13 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
 
             switch (event.type) {
               case 'session.created':
+                break;
               case 'session.finalized':
+                pendingFinalizations = Math.max(0, pendingFinalizations - 1);
+                if (inputEnded && pendingFinalizations === 0) finishFinalization();
                 break;
               case 'session.closed':
-                finalReceived = true;
-                resourceCleanup();
+                finishFinalization();
                 break;
               case 'start_of_speech':
                 this.processStartOfSpeech();

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -821,19 +821,26 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       let cleanedUp = false;
       let finalTranscriptReceived = false;
       let finalizationComplete = false;
+      let sessionClosedReceived = false;
       let sessionCloseSent = false;
+      let pendingFinalizations = 0;
       let finalizationTimeout: ReturnType<typeof setTimeout> | undefined;
       let vadStream: VADStream | null = null;
 
       const eventChannel = createStreamChannel<SttServerEvent>();
 
       const sendSessionClose = (socket: WebSocket) => {
-        if (sessionCloseSent || socket.readyState !== 1) return;
+        if (sessionCloseSent || sessionClosedReceived || socket.readyState !== 1) return;
         sessionCloseSent = true;
+        if (finalizationTimeout) {
+          clearTimeout(finalizationTimeout);
+          finalizationTimeout = undefined;
+        }
         socket.send(JSON.stringify({ type: 'session.close' }));
       };
 
       const sendSessionFinalize = (socket: WebSocket) => {
+        pendingFinalizations += 1;
         socket.send(JSON.stringify({ type: 'session.finalize' }));
       };
 
@@ -861,11 +868,21 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       };
 
       const scheduleFinalizationTimeout = () => {
-        if (!inputEnded || finalizationComplete || cleanedUp) return;
+        if (
+          !inputEnded ||
+          finalizationComplete ||
+          sessionCloseSent ||
+          sessionClosedReceived ||
+          cleanedUp
+        ) {
+          return;
+        }
         if (finalizationTimeout) clearTimeout(finalizationTimeout);
-        // Lifecycle acknowledgements are not transcript barriers. End after transcript inactivity.
+        // Some providers omit session.finalized. Request closure after transcript inactivity.
         finalizationTimeout = setTimeout(
-          finishFinalization,
+          () => {
+            if (ws) sendSessionClose(ws);
+          },
           finalTranscriptReceived ? TRANSCRIPT_INACTIVITY_TIMEOUT_MS : FIRST_TRANSCRIPT_TIMEOUT_MS,
         );
       };
@@ -1035,8 +1052,18 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
               case 'session.created':
                 break;
               case 'session.finalized':
+                pendingFinalizations = Math.max(0, pendingFinalizations - 1);
+                if (inputEnded && pendingFinalizations === 0 && ws) sendSessionClose(ws);
                 break;
               case 'session.closed':
+                if (!inputEnded && !sessionCloseSent) {
+                  throw new APIStatusError({
+                    message: 'LiveKit STT session closed before input ended',
+                    options: { statusCode: -1, retryable: true },
+                  });
+                }
+                sessionClosedReceived = true;
+                finishFinalization();
                 break;
               case 'start_of_speech':
                 this.processStartOfSpeech();

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -823,7 +823,6 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       let finalizationComplete = false;
       let sessionClosedReceived = false;
       let sessionCloseSent = false;
-      let pendingFinalizations = 0;
       let finalizationTimeout: ReturnType<typeof setTimeout> | undefined;
       let vadStream: VADStream | null = null;
 
@@ -840,7 +839,6 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       };
 
       const sendSessionFinalize = (socket: WebSocket) => {
-        pendingFinalizations += 1;
         socket.send(JSON.stringify({ type: 'session.finalize' }));
       };
 
@@ -878,11 +876,9 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
           return;
         }
         if (finalizationTimeout) clearTimeout(finalizationTimeout);
-        // Some providers omit session.finalized. Request closure after transcript inactivity.
+        // Lifecycle acknowledgments are optional and may precede trailing transcripts.
         finalizationTimeout = setTimeout(
-          () => {
-            if (ws) sendSessionClose(ws);
-          },
+          finishFinalization,
           finalTranscriptReceived ? TRANSCRIPT_INACTIVITY_TIMEOUT_MS : FIRST_TRANSCRIPT_TIMEOUT_MS,
         );
       };
@@ -1052,8 +1048,6 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
               case 'session.created':
                 break;
               case 'session.finalized':
-                pendingFinalizations = Math.max(0, pendingFinalizations - 1);
-                if (inputEnded && pendingFinalizations === 0 && ws) sendSessionClose(ws);
                 break;
               case 'session.closed':
                 if (!inputEnded && !sessionCloseSent) {

--- a/agents/src/inference/stt.ts
+++ b/agents/src/inference/stt.ts
@@ -820,12 +820,8 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       let inputEnded = false;
       let cleanedUp = false;
       let finalTranscriptReceived = false;
-      let finalTranscriptReceivedAfterInputEnd = false;
       let finalizationComplete = false;
-      let sessionClosedReceived = false;
       let sessionCloseSent = false;
-      // Acks have no IDs. Count them so a VAD-turn ack cannot close ended input early.
-      let pendingFinalizations = 0;
       let finalizationTimeout: ReturnType<typeof setTimeout> | undefined;
       let vadStream: VADStream | null = null;
 
@@ -838,7 +834,6 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       };
 
       const sendSessionFinalize = (socket: WebSocket) => {
-        pendingFinalizations += 1;
         socket.send(JSON.stringify({ type: 'session.finalize' }));
       };
 
@@ -868,7 +863,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
       const scheduleFinalizationTimeout = () => {
         if (!inputEnded || finalizationComplete || cleanedUp) return;
         if (finalizationTimeout) clearTimeout(finalizationTimeout);
-        // Some providers omit the ack. End the session after transcript inactivity.
+        // Lifecycle acknowledgements are not transcript barriers. End after transcript inactivity.
         finalizationTimeout = setTimeout(
           finishFinalization,
           finalTranscriptReceived ? TRANSCRIPT_INACTIVITY_TIMEOUT_MS : FIRST_TRANSCRIPT_TIMEOUT_MS,
@@ -889,7 +884,6 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
             if (json.type === 'final_transcript' && json.transcript) {
               finalTranscriptReceived = true;
             }
-            if (json.type === 'session.closed') sessionClosedReceived = true;
             if (
               json.type === 'interim_transcript' ||
               json.type === 'final_transcript' ||
@@ -910,10 +904,7 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
 
           ws.on('close', (code: number) => {
             const expectedClose =
-              signal.aborted ||
-              finalizationComplete ||
-              sessionCloseSent ||
-              (sessionClosedReceived && inputEnded);
+              signal.aborted || inputEnded || finalizationComplete || sessionCloseSent;
             resourceCleanup();
 
             if (expectedClose) return resolve();
@@ -1044,24 +1035,8 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
               case 'session.created':
                 break;
               case 'session.finalized':
-                pendingFinalizations = Math.max(0, pendingFinalizations - 1);
-                // xAI acknowledges finalize before endpointing emits its trailing transcript.
-                if (
-                  inputEnded &&
-                  pendingFinalizations === 0 &&
-                  finalTranscriptReceivedAfterInputEnd
-                ) {
-                  finishFinalization();
-                }
                 break;
               case 'session.closed':
-                if (!inputEnded && !sessionCloseSent) {
-                  throw new APIStatusError({
-                    message: 'LiveKit STT session closed before input ended',
-                    options: { statusCode: -1, retryable: true },
-                  });
-                }
-                finishFinalization();
                 break;
               case 'start_of_speech':
                 this.processStartOfSpeech();
@@ -1070,9 +1045,6 @@ export class SpeechStream<TModel extends STTModels> extends BaseSpeechStream {
                 this.processTranscript(event, SpeechEventType.INTERIM_TRANSCRIPT);
                 break;
               case 'final_transcript':
-                if (inputEnded && event.transcript) {
-                  finalTranscriptReceivedAfterInputEnd = true;
-                }
                 this.processTranscript(event, SpeechEventType.FINAL_TRANSCRIPT);
                 break;
               case 'preflight_transcript':

--- a/plugins/test/src/stt.ts
+++ b/plugins/test/src/stt.ts
@@ -25,6 +25,9 @@ const TRANSCRIPT =
   'With hands locked together, invisible among the press of bodies, ' +
   'they stared steadily in front of them, and instead of the eyes of the girl, the eyes of the aged prisoner gazed mournfully at Winston out of nests of hair.';
 
+const STREAM_CHUNK_DURATION_MS = 10;
+const TRAILING_SILENCE_DURATION_MS = 2_000;
+
 const validate = async (text: string, transcript: string, threshold: number) => {
   text = text.toLowerCase().replace(/\s/g, ' ').trim();
   transcript = transcript.toLowerCase().replace(/\s/g, ' ').trim();
@@ -52,9 +55,9 @@ export const stt = async (
     );
     it.each([24000, 44100])(
       'should properly stream transcribe speech at %i Hz',
-      { timeout: 60_000 },
+      { timeout: 120_000 },
       async (sampleRate) => {
-        const frames = makeTestSpeech(sampleRate, 10);
+        const frames = makeTestSpeech(sampleRate, STREAM_CHUNK_DURATION_MS);
         let stream: sttlib.SpeechStream;
         if (supports.streaming) {
           stream = stt.stream();
@@ -65,7 +68,22 @@ export const stt = async (
         const input = async () => {
           for (const frame of frames) {
             stream.pushFrame(frame);
-            await new Promise((resolve) => setTimeout(resolve, 5));
+            await new Promise((resolve) => setTimeout(resolve, STREAM_CHUNK_DURATION_MS));
+          }
+
+          const silence = new AudioFrame(
+            new Int16Array((sampleRate * STREAM_CHUNK_DURATION_MS) / 1_000),
+            sampleRate,
+            1,
+            (sampleRate * STREAM_CHUNK_DURATION_MS) / 1_000,
+          );
+          for (
+            let elapsed = 0;
+            elapsed < TRAILING_SILENCE_DURATION_MS;
+            elapsed += STREAM_CHUNK_DURATION_MS
+          ) {
+            stream.pushFrame(silence);
+            await new Promise((resolve) => setTimeout(resolve, STREAM_CHUNK_DURATION_MS));
           }
           stream.endInput();
         };

--- a/plugins/test/src/stt.ts
+++ b/plugins/test/src/stt.ts
@@ -64,6 +64,14 @@ export const stt = async (
         } else {
           stream = new sttlib.StreamAdapter(stt, vad).stream();
         }
+        let rejectStreamError!: (error: Error) => void;
+        const streamError = new Promise<never>((_, reject) => {
+          rejectStreamError = reject;
+        });
+        const onStreamError: sttlib.STTCallbacks['error'] = ({ error }) => {
+          rejectStreamError(error);
+        };
+        stt.on('error', onStreamError);
 
         const input = async () => {
           for (const frame of frames) {
@@ -114,8 +122,9 @@ export const stt = async (
         };
 
         try {
-          await Promise.all([input(), output()]);
+          await Promise.race([Promise.all([input(), output()]), streamError]);
         } finally {
+          stt.off('error', onStreamError);
           stream.close();
         }
       },


### PR DESCRIPTION
**Problem:** Inference STT requested session closure as soon as input ended. This could discard trailing transcripts. Waiting for lifecycle acknowledgments can also hang because providers do not always emit them.

**Behavior:** Treat ended input as closing. Send `session.finalize`, then keep receiving. Finish on `session.closed`, socket closure, or bounded inactivity: 30 seconds before a final transcript and 3 seconds after one. A final transcript is not required. Cleanup sends `session.close` as best effort and closes the client socket. Live tests stream real-time audio with trailing silence and retry once.

Addresses AJS-490 ([Linear](https://linear.app/livekit/issue/AJS-490/preserve-trailing-inference-stt-transcripts-during-shutdown)). Sources: [original failed CI](https://github.com/livekit/agents-js/actions/runs/34356083899/job/102480985201?pr=2400), [ack-wait failed CI](https://github.com/livekit/agents-js/actions/runs/34478478878/job/102875015237), [gateway lifecycle](https://github.com/livekit/agent-gateway/blob/802003d19fdfad0a691f27126783ef7dde198295/docs/STT_TTS_WEBSOCKET_API.md#L337-L347), [gateway E2E client](https://github.com/livekit/e2e/blob/357f781eb1b8945bd6409b26d9e684ae43cd1cc4/inference/stt/testcase.go#L225-L285).

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> PR tests are failing: https://github.com/livekit/agents-js/actions/runs/34356083899/job/102480985201?pr=2400
>
> okay, create a draft PR please
>
> there is a CI failure
>
> what does python do in this case?
>
> is post-finalize transcript expected?
>
> we should match Python then
>
> does python has a first transcript timeout or inactivity timeout?
>
> why do. we need this difference?
>
> why you keep talking about xai when we are changing inference stt?
>
> what is the downside of matching python parity?
>
> but logiocally speaking, we should close the stream once finalized event is received, right?
>
> wait, I guess no. we need to close it only after received closed event
>
> if the input stream is closed, then the session should be considered closing, right? then we wait for finalized and closed or socket clousure for the final close.
>
> can you investigate the exact protocol from the gateway repo?
>
> but we can't expect final from interim, right? they might not finalize at all
>
> why do we need a first transcript timeout?
>
> I don't know if we need this. $ponytail

</details>
