### PR TITLE
plugins/phonic: make allow_tool_chaining configurable per tool

### DIFF
--- a/.changeset/phonic-allow-tool-chaining.md
+++ b/.changeset/phonic-allow-tool-chaining.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-phonic': patch
+---
+
+Add `allow_tool_chaining` to the Phonic plugin's per-tool `configsForTools`. Defaults to `false`; set it per tool to allow another tool call immediately after that tool's output.

--- a/plugins/phonic/README.md
+++ b/plugins/phonic/README.md
@@ -136,10 +136,11 @@ new phonic.realtime.RealtimeModel({
 | `require_speech_before_tool_call` | `boolean` | `false` | Require the agent to speak before the tool can be called                                                                                                                |
 | `forbid_speech_after_tool_call`   | `boolean` | `false` | Suppress the auto-generated spoken reply after the tool. Use for tools that always hand off to another agent (a non-handoff tool set here would leave the agent silent) |
 | `forbid_tool_call_after_speech`   | `boolean` | `false` | Drop the tool call if the agent already spoke this turn                                                                                                                 |
+| `allow_tool_chaining`             | `boolean` | `false` | Allow another tool call immediately after this tool's output                                                                                                            |
 | `respond_after_sec`               | `number`  | —       | **`choose_not_to_respond` only.** Seconds to wait after the tool fires; if the user stays silent, the agent speaks a follow-up. Omit to keep the default (stay silent). |
 | `speech_before_tool_call`         | `string`  | —       | **`keypad_input` / `natural_conversation_ending` only.** `required` \| `optional` \| `suppressed`.                                                                      |
 
-The plugin always sends tool calls with `wait_for_speech_before_tool_call` on and `allow_tool_chaining` off; these are not configurable per tool.
+The plugin always sends tool calls with `wait_for_speech_before_tool_call` on; this is not configurable per tool.
 
 > **Deprecated:** the top-level `forbidSpeechAfterToolCall: string[]` option still works but is deprecated — it now folds each listed tool into `configsForTools` as `forbid_speech_after_tool_call: true` (an explicit `configsForTools` entry wins) and logs a warning. Prefer `configsForTools`.
 

--- a/plugins/phonic/src/realtime/realtime_model.ts
+++ b/plugins/phonic/src/realtime/realtime_model.ts
@@ -106,6 +106,7 @@ export interface PhonicToolConfig {
   require_speech_before_tool_call?: boolean;
   forbid_speech_after_tool_call?: boolean;
   forbid_tool_call_after_speech?: boolean;
+  allow_tool_chaining?: boolean;
   // Built-in tools only (set on the matching `phonicTools` entry):
   respond_after_sec?: number; // choose_not_to_respond: seconds to wait before a follow-up (or omit)
   speech_before_tool_call?: string; // keypad_input / natural_conversation_ending: required|optional|suppressed
@@ -635,11 +636,10 @@ export class RealtimeSession extends llm.RealtimeSession {
             },
           },
           tool_call_output_timeout_ms: TOOL_CALL_OUTPUT_TIMEOUT_MS,
-          // fixed, not configurable: the plugin does not support tool chaining or tool calls
-          // during agent speech within the RealtimeSession generations framework
+          // fixed, not configurable: the plugin does not support tool calls during agent speech
           wait_for_speech_before_tool_call: true,
-          allow_tool_chaining: false,
           require_speech_before_tool_call: cfg?.require_speech_before_tool_call ?? false,
+          allow_tool_chaining: cfg?.allow_tool_chaining ?? false,
           forbid_speech_after_tool_call: cfg?.forbid_speech_after_tool_call ?? false,
           forbid_tool_call_after_speech: cfg?.forbid_tool_call_after_speech ?? false,
         };
@@ -1119,7 +1119,8 @@ export class RealtimeSession extends llm.RealtimeSession {
         args: JSON.stringify(message.parameters),
       }),
     );
-    // At most 1 tool call is supported per turn due to `toolChaining: false`, allowing us to close the generation
+    // Close the generation after the tool call. With allow_tool_chaining enabled, any chained
+    // follow-up call arrives as a new generation.
     this.closeCurrentGeneration({ interrupted: false });
   }
 


### PR DESCRIPTION
Adds `allow_tool_chaining` to the Phonic plugin's per-tool `configsForTools`, alongside the existing `require_speech_before_tool_call` / `forbid_speech_after_tool_call` / `forbid_tool_call_after_speech` options.

Defaults to `false`, so existing behavior is unchanged. Set it per tool to allow another tool call immediately after that tool's output.