### PR TITLE
fix: serialize AgentConfigUpdate.instructions as a string in toJSON

### DIFF
--- a/.changeset/quiet-instructions-string.md
+++ b/.changeset/quiet-instructions-string.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Serialize `AgentConfigUpdate.instructions` as the rendered string in `toJSON`, matching the Python SDK and the proto encoder.

--- a/agents/src/llm/chat_context.test.ts
+++ b/agents/src/llm/chat_context.test.ts
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 import { initializeLogger } from '../log.js';
+import { encodeChatItem } from '../proto.js';
 import { INSTRUCTIONS_MESSAGE_ID, applyInstructionsModality } from '../voice/generation.js';
 import { FakeLLM } from '../voice/testing/fake_llm.js';
 import {
+  AgentConfigUpdate,
   type AudioContent,
   ChatContext,
   type ChatItem,
@@ -1628,5 +1630,33 @@ describe('ChatContext.copy with toolCtx filter', () => {
 
     const filtered = ctx.copy({ toolCtx: new ToolContext([provider]) });
     expect(filtered.items.map((i) => ('name' in i ? i.name : ''))).toEqual(['code_runner']);
+  });
+});
+
+describe('AgentConfigUpdate.toJSON', () => {
+  it('renders Instructions to the same string as the proto encoder', () => {
+    const instructions = new Instructions({ audio: 'keep it short', text: 'use markdown' });
+    const item = new AgentConfigUpdate({ id: 'item_acu', instructions, createdAt: 1 });
+
+    const json = item.toJSON() as { instructions: unknown };
+    expect(json.instructions).toBe('keep it short');
+
+    const encoded = encodeChatItem(item);
+    expect(encoded.item.case).toBe('agentConfigUpdate');
+    if (encoded.item.case === 'agentConfigUpdate') {
+      expect(encoded.item.value.instructions).toBe(json.instructions);
+    }
+  });
+
+  it('passes a plain string through and omits an unset field', () => {
+    const withString = new AgentConfigUpdate({ instructions: 'be nice' }).toJSON() as {
+      instructions?: unknown;
+    };
+    expect(withString.instructions).toBe('be nice');
+
+    const withoutInstructions = new AgentConfigUpdate({ toolsAdded: ['x'] }).toJSON() as {
+      instructions?: unknown;
+    };
+    expect(withoutInstructions).not.toHaveProperty('instructions');
   });
 });

--- a/agents/src/llm/chat_context.ts
+++ b/agents/src/llm/chat_context.ts
@@ -717,9 +717,7 @@ export class AgentConfigUpdate {
     };
 
     if (this.instructions !== undefined) {
-      result.instructions = isInstructions(this.instructions)
-        ? (this.instructions.toJSON() as JSONValue)
-        : this.instructions;
+      result.instructions = renderInstructions(this.instructions);
     }
     if (this.toolsAdded !== undefined) {
       result.toolsAdded = this.toolsAdded;


### PR DESCRIPTION
The Python SDK renders `Instructions` to a string before it builds an `AgentConfigUpdate`, and `encodeChatItem` already flattens with `renderInstructions`. Only `toJSON` emitted the `{type, audio, text}` object form. Consumers that share one chat-history schema across SDKs broke on it: the agents-private redaction recording path failed with `cannot unmarshal object into Go struct field rawChatItem.items.instructions of type string`.

`toJSON` now emits the same rendered string as the proto encoder.

Addresses AJS-491

<details>
<summary>Initial prompt and agent context</summary>

**Model:** Claude Fable 5.1

> I got an error message with redaction:
> build transcript logs: json: cannot unmarshal object into Go struct field rawChatItem.items.instructions of type string

> Yeah, js should follow python for this.

> okay can you open a draft PR for the js change?

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)