### PR TITLE
Expose TTS fallback controls and activation events (LKINF-495)

### DIFF
--- a/.changeset/green-fallback-notices.md
+++ b/.changeset/green-fallback-notices.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': minor
+---
+
+Expose TTS system-default fallback opt-out and fallback activation events.

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -3661,6 +3661,22 @@ interface FakeUserSpeech {
     transcript: string;
 }
 
+// @public
+interface FallbackActivatedEvent {
+    // (undocumented)
+    cause: 'unknown' | 'timeout' | 'canceled' | 'provider_error' | 'quota_exceeded';
+    // (undocumented)
+    fallbackType: 'unknown' | 'fallback' | 'system_default';
+    // (undocumented)
+    model: string;
+    // (undocumented)
+    provider: string;
+    // (undocumented)
+    sessionId: string;
+    // (undocumented)
+    voice: string;
+}
+
 // Warning: (ae-missing-release-tag) "FallbackAdapter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
@@ -4368,6 +4384,7 @@ declare namespace inference {
         normalizeTTSFallback,
         parseTTSModelString,
         TTS_2 as TTS,
+        FallbackActivatedEvent,
         TTSFallbackModel,
         TTSFallbackModelType,
         TTSModels,
@@ -4480,6 +4497,8 @@ interface InferenceTTSOptions<TModel extends TTSModels> {
     baseURL: string;
     // (undocumented)
     connOptions?: APIConnectOptions;
+    // (undocumented)
+    disableSystemDefaultFallback?: boolean;
     // (undocumented)
     encoding: TTSEncoding;
     // (undocumented)
@@ -8619,6 +8638,7 @@ abstract class TTS extends TTS_base {
 declare namespace tts {
     export {
         SynthesizedAudio,
+        FallbackActivatedEvent,
         TTSCapabilities,
         TTSCallbacks,
         TTS,
@@ -8669,6 +8689,7 @@ class TTS_2<TModel extends TTSModels> extends TTS {
         apiSecret?: string;
         modelOptions?: TTSOptions<TModel>;
         fallback?: TTSFallbackModelType | TTSFallbackModelType[];
+        disableSystemDefaultFallback?: boolean;
         connOptions?: APIConnectOptions;
     });
     // (undocumented)
@@ -8710,6 +8731,7 @@ declare namespace tts_2 {
         parseTTSModelString,
         hasAlignedTranscript,
         normalizeTTSFallback,
+        FallbackActivatedEvent,
         CartesiaModels_2 as CartesiaModels,
         DeepgramTTSModels,
         InworldModels,
@@ -8744,6 +8766,7 @@ export const TTS_INSTRUCTIONS_PLACEHOLDER = "{tts.markup.llm_instructions}";
 type TTSCallbacks = {
     ['metrics_collected']: (metrics: TTSMetrics) => void;
     ['error']: (error: TTSError) => void;
+    ['fallback_activated']: (event: FallbackActivatedEvent) => void;
 };
 
 // Warning: (ae-missing-release-tag) "TTSCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9688,13 +9711,13 @@ export const zipFunctionCallsAndOutputs: (event: FunctionToolsExecutedEvent) => 
 //
 // src/_exceptions.ts:90:5 - (ae-forgotten-export) The symbol "APIStatusErrorOptions" needs to be exported by the entry point index.d.ts
 // src/_exceptions.ts:128:5 - (ae-forgotten-export) The symbol "APIErrorOptions" needs to be exported by the entry point index.d.ts
-// src/inference/tts.ts:282:5 - (ae-forgotten-export) The symbol "TTSEncoding" needs to be exported by the entry point index.d.ts
+// src/inference/tts.ts:285:5 - (ae-forgotten-export) The symbol "TTSEncoding" needs to be exported by the entry point index.d.ts
 // src/llm/chat_context.ts:76:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "audio"
 // src/llm/tool_context.ts:702:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "ToolFlag" has more than one declaration; you need to add a TSDoc member reference selector
 // src/llm/tool_context.ts:746:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "ToolFlag" has more than one declaration; you need to add a TSDoc member reference selector
 // src/metrics/base.ts:194:3 - (ae-forgotten-export) The symbol "RealtimeModelMetricsInputTokenDetails" needs to be exported by the entry point index.d.ts
 // src/metrics/base.ts:198:3 - (ae-forgotten-export) The symbol "RealtimeModelMetricsOutputTokenDetails" needs to be exported by the entry point index.d.ts
-// src/stt/stt.ts:361:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "STT"
+// src/stt/stt.ts:364:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "STT"
 // src/utils.ts:550:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "cancelled"
 // src/voice/agent_session.ts:380:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
 // src/voice/agent_session.ts:1010:5 - (ae-forgotten-export) The symbol "RecordingOptions" needs to be exported by the entry point index.d.ts

--- a/agents/src/inference/api_protos.test.ts
+++ b/agents/src/inference/api_protos.test.ts
@@ -45,6 +45,84 @@ describe('sttServerEventSchema', () => {
 });
 
 describe('ttsServerEventSchema', () => {
+  it.each(['fallback', 'system_default'] as const)(
+    'accepts %s fallback activation notices',
+    (fallbackType) => {
+      const notice = {
+        type: 'fallback_activated',
+        session_id: 's1',
+        fallback_type: fallbackType,
+        provider: 'deepgram',
+        model: 'deepgram/aura-2',
+        voice: 'asteria',
+        cause: 'timeout',
+      };
+
+      expect(ttsServerEventSchema.parse(notice)).toEqual(notice);
+    },
+  );
+
+  it.each(['unknown', 'timeout', 'canceled', 'provider_error', 'quota_exceeded'])(
+    'accepts the %s fallback cause',
+    (cause) => {
+      expect(
+        ttsServerEventSchema.safeParse({
+          type: 'fallback_activated',
+          session_id: 's1',
+          fallback_type: 'fallback',
+          provider: 'deepgram',
+          model: 'deepgram/aura-2',
+          voice: 'asteria',
+          cause,
+        }).success,
+      ).toBe(true);
+    },
+  );
+
+  it('normalizes unsupported fallback types', () => {
+    expect(
+      ttsServerEventSchema.parse({
+        type: 'fallback_activated',
+        session_id: 's1',
+        fallback_type: 'future_type',
+        provider: 'deepgram',
+        model: 'deepgram/aura-2',
+        voice: 'asteria',
+        cause: 'timeout',
+      }),
+    ).toEqual({
+      type: 'fallback_activated',
+      session_id: 's1',
+      fallback_type: 'unknown',
+      provider: 'deepgram',
+      model: 'deepgram/aura-2',
+      voice: 'asteria',
+      cause: 'timeout',
+    });
+  });
+
+  it('normalizes unsupported fallback causes', () => {
+    expect(
+      ttsServerEventSchema.parse({
+        type: 'fallback_activated',
+        session_id: 's1',
+        fallback_type: 'system_default',
+        provider: 'deepgram',
+        model: 'deepgram/aura-2',
+        voice: 'asteria',
+        cause: 'future_cause',
+      }),
+    ).toEqual({
+      type: 'fallback_activated',
+      session_id: 's1',
+      fallback_type: 'system_default',
+      provider: 'deepgram',
+      model: 'deepgram/aura-2',
+      voice: 'asteria',
+      cause: 'unknown',
+    });
+  });
+
   it('extracts output_alignment words payload', () => {
     const result = ttsServerEventSchema.safeParse({
       type: 'output_alignment',

--- a/agents/src/inference/api_protos.ts
+++ b/agents/src/inference/api_protos.ts
@@ -56,6 +56,18 @@ export const ttsSessionClosedEventSchema = z.object({
   session_id: z.string(),
 });
 
+export const ttsFallbackActivatedEventSchema = z.object({
+  type: z.literal('fallback_activated'),
+  session_id: z.string(),
+  fallback_type: z.enum(['unknown', 'fallback', 'system_default']).catch('unknown'),
+  provider: z.string(),
+  model: z.string(),
+  voice: z.string(),
+  cause: z
+    .enum(['unknown', 'timeout', 'canceled', 'provider_error', 'quota_exceeded'])
+    .catch('unknown'),
+});
+
 export const ttsErrorEventSchema = z.object({
   type: z.literal('error'),
   message: z.string().optional(),
@@ -94,6 +106,7 @@ export const ttsKnownServerEventSchema = z.discriminatedUnion('type', [
   ttsOutputAlignmentEventSchema,
   ttsDoneEventSchema,
   ttsSessionClosedEventSchema,
+  ttsFallbackActivatedEventSchema,
   ttsErrorEventSchema,
 ]);
 
@@ -103,6 +116,7 @@ const knownTtsServerEventTypes = new Set([
   'output_alignment',
   'done',
   'session.closed',
+  'fallback_activated',
   'error',
 ]);
 
@@ -129,6 +143,7 @@ export type TtsCharTimestamp = z.infer<typeof ttsCharTimestampSchema>;
 export type TtsOutputAlignmentEvent = z.infer<typeof ttsOutputAlignmentEventSchema>;
 export type TtsDoneEvent = z.infer<typeof ttsDoneEventSchema>;
 export type TtsSessionClosedEvent = z.infer<typeof ttsSessionClosedEventSchema>;
+export type TtsFallbackActivatedEvent = z.infer<typeof ttsFallbackActivatedEventSchema>;
 export type TtsErrorEvent = z.infer<typeof ttsErrorEventSchema>;
 export type TtsClientEvent = z.infer<typeof ttsClientEventSchema>;
 export type TtsServerEvent = z.infer<typeof ttsServerEventSchema>;

--- a/agents/src/inference/index.ts
+++ b/agents/src/inference/index.ts
@@ -66,6 +66,7 @@ export {
   normalizeTTSFallback,
   parseTTSModelString,
   TTS,
+  type FallbackActivatedEvent,
   type TTSFallbackModel,
   type TTSFallbackModelType,
   type TTSModels,

--- a/agents/src/inference/tts.test.ts
+++ b/agents/src/inference/tts.test.ts
@@ -12,6 +12,7 @@ import { type APIConnectOptions, DEFAULT_API_CONNECT_OPTIONS } from '../types.js
 import { STT } from './stt.js';
 import { describeLiveKitInference } from './test_utils.js';
 import {
+  type FallbackActivatedEvent,
   TTS,
   type TTSFallbackModel,
   hasAlignedTranscript,
@@ -32,6 +33,81 @@ function makeTts(overrides: Record<string, unknown> = {}) {
     baseURL: 'https://example.livekit.cloud',
   };
   return new TTS({ ...defaults, ...overrides });
+}
+
+async function captureSessionCreate(overrides: Record<string, unknown> = {}) {
+  const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  await once(server, 'listening');
+  const { port } = server.address() as AddressInfo;
+  let resolvePayload!: (payload: Record<string, unknown>) => void;
+  const payload = new Promise<Record<string, unknown>>((resolve) => {
+    resolvePayload = resolve;
+  });
+
+  server.on('connection', (socket) => {
+    socket.once('message', (raw) => {
+      resolvePayload(JSON.parse(raw.toString()) as Record<string, unknown>);
+    });
+  });
+
+  const tts = makeTts({ ...overrides, baseURL: `http://127.0.0.1:${port}` });
+  let socket: WebSocket | undefined;
+  try {
+    socket = await tts.connectWs(1_000);
+    return await payload;
+  } finally {
+    socket?.terminate();
+    await tts.close();
+    for (const client of server.clients) client.terminate();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+async function runGatewayEvents(events: Record<string, unknown>[]) {
+  const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  await once(server, 'listening');
+  const { port } = server.address() as AddressInfo;
+
+  server.on('connection', (socket) => {
+    socket.on('message', (raw) => {
+      const event = JSON.parse(raw.toString()) as { type: string };
+      if (event.type !== 'session.flush') return;
+      for (const serverEvent of events) {
+        socket.send(JSON.stringify(serverEvent));
+      }
+    });
+  });
+
+  const tts = makeTts({
+    baseURL: `http://127.0.0.1:${port}`,
+    connOptions: { maxRetry: 0, retryIntervalMs: 0, timeoutMs: 1_000 },
+  });
+  const fallbackEvents: FallbackActivatedEvent[] = [];
+  tts.on('fallback_activated', (event) => fallbackEvents.push(event));
+  const stream = tts.stream();
+
+  try {
+    stream.updateInputStream(
+      new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue('hello');
+          controller.close();
+        },
+      }),
+    );
+
+    const output = [];
+    for await (const event of stream) output.push(event);
+    return {
+      fallbackEvents,
+      audioEvents: output.filter((event) => typeof event !== 'symbol'),
+    };
+  } finally {
+    stream.close();
+    await tts.close();
+    for (const client of server.clients) client.terminate();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
 }
 
 describe('Inference TTS connection', () => {
@@ -66,6 +142,149 @@ describe('Inference TTS connection', () => {
       await tts.close();
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
+  });
+});
+
+describe('Inference TTS session.create fallback', () => {
+  const basePayload = {
+    type: 'session.create',
+    sample_rate: '16000',
+    encoding: 'pcm_s16le',
+    extra: {},
+    model: 'cartesia/sonic',
+    language: 'en',
+    connection: { timeout: 10, retries: 3 },
+  };
+
+  it.each([{}, { fallback: [] }])(
+    'omits fallback when no models and system fallback remains enabled',
+    async (overrides) => {
+      expect(await captureSessionCreate(overrides)).toEqual(basePayload);
+    },
+  );
+
+  it.each([
+    { disableSystemDefaultFallback: true },
+    { fallback: [], disableSystemDefaultFallback: true },
+  ])('can disable system fallback without customer fallback models', async (overrides) => {
+    expect(await captureSessionCreate(overrides)).toEqual({
+      ...basePayload,
+      fallback: {
+        models: [],
+        disable_system_default_fallback: true,
+      },
+    });
+  });
+
+  it.each([false, true])(
+    'maps customer fallback models exactly when opt-out is %s',
+    async (disableSystemDefaultFallback) => {
+      expect(
+        await captureSessionCreate({
+          fallback: [
+            'deepgram/aura-2:asteria',
+            {
+              model: 'rime/mistv3',
+              voice: 'speaker-1',
+              extraKwargs: { speed_alpha: 0.9 },
+            },
+          ],
+          disableSystemDefaultFallback,
+        }),
+      ).toEqual({
+        ...basePayload,
+        fallback: {
+          models: [
+            { model: 'deepgram/aura-2', voice: 'asteria', extra: {} },
+            {
+              model: 'rime/mistv3',
+              voice: 'speaker-1',
+              extra: { speed_alpha: 0.9 },
+            },
+          ],
+          ...(disableSystemDefaultFallback ? { disable_system_default_fallback: true } : {}),
+        },
+      });
+    },
+  );
+});
+
+describe('Inference TTS gateway notices', () => {
+  const audioEvent = {
+    type: 'output_audio',
+    session_id: 'session-1',
+    audio: Buffer.alloc(3200).toString('base64'),
+  };
+  const doneEvent = { type: 'done', session_id: 'session-1' };
+
+  it('emits fallback activation notices without interrupting audio', async () => {
+    const result = await runGatewayEvents([
+      { type: 'session.created', session_id: 'session-1' },
+      {
+        type: 'fallback_activated',
+        session_id: 'session-1',
+        fallback_type: 'fallback',
+        provider: 'deepgram',
+        model: 'deepgram/aura-2',
+        voice: 'asteria',
+        cause: 'quota_exceeded',
+      },
+      audioEvent,
+      doneEvent,
+    ]);
+
+    expect(result.fallbackEvents).toEqual([
+      {
+        sessionId: 'session-1',
+        fallbackType: 'fallback',
+        provider: 'deepgram',
+        model: 'deepgram/aura-2',
+        voice: 'asteria',
+        cause: 'quota_exceeded',
+      },
+    ]);
+    expect(result.audioEvents).toHaveLength(1);
+  });
+
+  it('ignores unrelated unknown gateway messages', async () => {
+    const result = await runGatewayEvents([
+      { type: 'session.created', session_id: 'session-1' },
+      { type: 'future_message', session_id: 'session-1', data: 'ignored' },
+      audioEvent,
+      doneEvent,
+    ]);
+
+    expect(result.fallbackEvents).toEqual([]);
+    expect(result.audioEvents).toHaveLength(1);
+  });
+
+  it('normalizes unsupported fallback causes without interrupting audio', async () => {
+    const result = await runGatewayEvents([
+      { type: 'session.created', session_id: 'session-1' },
+      {
+        type: 'fallback_activated',
+        session_id: 'session-1',
+        fallback_type: 'future_type',
+        provider: 'deepgram',
+        model: 'deepgram/aura-2',
+        voice: 'asteria',
+        cause: 'future_cause',
+      },
+      audioEvent,
+      doneEvent,
+    ]);
+
+    expect(result.fallbackEvents).toEqual([
+      {
+        sessionId: 'session-1',
+        fallbackType: 'unknown',
+        provider: 'deepgram',
+        model: 'deepgram/aura-2',
+        voice: 'asteria',
+        cause: 'unknown',
+      },
+    ]);
+    expect(result.audioEvents).toHaveLength(1);
   });
 });
 
@@ -227,6 +446,12 @@ describe('TTS constructor fallback and connOptions', () => {
   it('fallback not given defaults to undefined', () => {
     const tts = makeTts();
     expect(tts['opts'].fallback).toBeUndefined();
+    expect(tts['opts'].disableSystemDefaultFallback).toBe(false);
+  });
+
+  it('stores the system fallback opt-out', () => {
+    const tts = makeTts({ disableSystemDefaultFallback: true });
+    expect(tts['opts'].disableSystemDefaultFallback).toBe(true);
   });
 
   it('fallback single string is normalized', () => {

--- a/agents/src/inference/tts.ts
+++ b/agents/src/inference/tts.ts
@@ -33,6 +33,8 @@ import {
 } from './api_protos.js';
 import { type AnyString, connectWs, createAccessToken, getDefaultInferenceUrl } from './utils.js';
 
+export type { FallbackActivatedEvent } from '../tts/tts.js';
+
 export type CartesiaModels =
   | 'cartesia/sonic-3.5'
   | 'cartesia/sonic-3'
@@ -260,6 +262,7 @@ export interface InferenceTTSOptions<TModel extends TTSModels> {
   /** Flat provider-specific inference options forwarded as the `extra` payload field. */
   modelOptions: TTSOptions<TModel>;
   fallback?: TTSFallbackModel[];
+  disableSystemDefaultFallback?: boolean;
   connOptions?: APIConnectOptions;
 }
 
@@ -286,6 +289,7 @@ export class TTS<TModel extends TTSModels> extends BaseTTS {
     /** Flat provider-specific inference options forwarded as the `extra` payload field. */
     modelOptions?: TTSOptions<TModel>;
     fallback?: TTSFallbackModelType | TTSFallbackModelType[];
+    disableSystemDefaultFallback?: boolean;
     connOptions?: APIConnectOptions;
   }) {
     const sampleRate = opts?.sampleRate ?? DEFAULT_SAMPLE_RATE;
@@ -305,6 +309,7 @@ export class TTS<TModel extends TTSModels> extends BaseTTS {
       apiSecret,
       modelOptions = {} as TTSOptions<TModel>,
       fallback,
+      disableSystemDefaultFallback = false,
       connOptions,
     } = opts || {};
 
@@ -352,6 +357,7 @@ export class TTS<TModel extends TTSModels> extends BaseTTS {
       apiSecret: lkApiSecret,
       modelOptions,
       fallback: normalizedFallback,
+      disableSystemDefaultFallback,
       connOptions: connOptions ?? DEFAULT_API_CONNECT_OPTIONS,
     };
 
@@ -483,13 +489,16 @@ export class TTS<TModel extends TTSModels> extends BaseTTS {
     if (this.opts.model) (params as Record<string, unknown>).model = this.opts.model;
     if (this.opts.language) (params as Record<string, unknown>).language = this.opts.language;
 
-    if (this.opts.fallback?.length) {
+    if (this.opts.fallback?.length || this.opts.disableSystemDefaultFallback) {
       params.fallback = {
-        models: this.opts.fallback.map((m) => ({
+        models: (this.opts.fallback ?? []).map((m) => ({
           model: m.model,
           voice: m.voice,
           extra: m.extraKwargs ?? {},
         })),
+        ...(this.opts.disableSystemDefaultFallback
+          ? { disable_system_default_fallback: true }
+          : {}),
       };
     }
 
@@ -795,6 +804,16 @@ export class SynthesizeStream<TModel extends TTSModels> extends BaseSynthesizeSt
           switch (serverEvent.type) {
             case 'session.created':
               currentSessionId = serverEvent.session_id;
+              break;
+            case 'fallback_activated':
+              this.tts.emit('fallback_activated', {
+                sessionId: serverEvent.session_id,
+                fallbackType: serverEvent.fallback_type,
+                provider: serverEvent.provider,
+                model: serverEvent.model,
+                voice: serverEvent.voice,
+                cause: serverEvent.cause,
+              });
               break;
             case 'output_audio':
               const base64Data = new Int8Array(Buffer.from(serverEvent.audio, 'base64'));

--- a/agents/src/inference/tts.type.test.ts
+++ b/agents/src/inference/tts.type.test.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expectTypeOf, it } from 'vitest';
+import { type FallbackActivatedEvent, TTS } from './index.js';
+
+describe('Inference TTS event types', () => {
+  it('types fallback activation listeners', () => {
+    const tts = new TTS({
+      model: 'cartesia/sonic',
+      apiKey: 'test-key',
+      apiSecret: 'test-secret',
+      disableSystemDefaultFallback: true,
+    });
+
+    tts.on('fallback_activated', (event) => {
+      expectTypeOf(event).toEqualTypeOf<FallbackActivatedEvent>();
+      expectTypeOf(event.sessionId).toEqualTypeOf<string>();
+      expectTypeOf(event.fallbackType).toEqualTypeOf<'unknown' | 'fallback' | 'system_default'>();
+      expectTypeOf(event.cause).toEqualTypeOf<
+        'unknown' | 'timeout' | 'canceled' | 'provider_error' | 'quota_exceeded'
+      >();
+    });
+
+    // @ts-expect-error Unknown TTS events must not be accepted.
+    tts.on('future_gateway_event', () => {});
+
+    tts.updateOptions({
+      // @ts-expect-error The system fallback opt-out is constructor-only.
+      disableSystemDefaultFallback: false,
+    });
+  });
+});

--- a/agents/src/tts/fallback_adapter.test.ts
+++ b/agents/src/tts/fallback_adapter.test.ts
@@ -6,12 +6,22 @@ import { ReadableStream } from 'node:stream/web';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { APIError } from '../_exceptions.js';
 import { initializeLogger } from '../log.js';
+import { basic } from '../tokenize/index.js';
 import type { APIConnectOptions } from '../types.js';
 import { USERDATA_TTS_STARTED_TIME } from '../types.js';
 import { FallbackAdapter } from './fallback_adapter.js';
-import { ChunkedStream, SynthesizeStream, TTS } from './tts.js';
+import { StreamAdapter } from './stream_adapter.js';
+import { ChunkedStream, type FallbackActivatedEvent, SynthesizeStream, TTS } from './tts.js';
 
 const SAMPLE_RATE = 24000;
+const FALLBACK_ACTIVATED_EVENT: FallbackActivatedEvent = {
+  sessionId: 'session-1',
+  fallbackType: 'fallback',
+  provider: 'deepgram',
+  model: 'deepgram/aura-2',
+  voice: 'asteria',
+  cause: 'provider_error',
+};
 
 class MockSynthesizeStream extends SynthesizeStream {
   label = 'mock.SynthesizeStream';
@@ -124,6 +134,30 @@ describe('TTS FallbackAdapter', () => {
     initializeLogger({ pretty: false });
     // Suppress unhandled rejections from background tasks inside SynthesizeStream
     process.on('unhandledRejection', () => {});
+  });
+
+  it('forwards fallback activation events', async () => {
+    const source = new MockTTS('source');
+    const adapter = new FallbackAdapter({ ttsInstances: [source] });
+    const events: FallbackActivatedEvent[] = [];
+    adapter.on('fallback_activated', (event) => events.push(event));
+
+    source.emit('fallback_activated', FALLBACK_ACTIVATED_EVENT);
+
+    expect(events).toEqual([FALLBACK_ACTIVATED_EVENT]);
+    await adapter.close();
+  });
+
+  it('forwards fallback activation events through StreamAdapter', async () => {
+    const source = new MockTTS('source');
+    const adapter = new StreamAdapter(source, new basic.SentenceTokenizer());
+    const events: FallbackActivatedEvent[] = [];
+    adapter.on('fallback_activated', (event) => events.push(event));
+
+    source.emit('fallback_activated', FALLBACK_ACTIVATED_EVENT);
+
+    expect(events).toEqual([FALLBACK_ACTIVATED_EVENT]);
+    await adapter.close();
   });
 
   it('should fall back to the next TTS when the primary stream fails before any pushText', async () => {

--- a/agents/src/tts/fallback_adapter.ts
+++ b/agents/src/tts/fallback_adapter.ts
@@ -128,6 +128,9 @@ export class FallbackAdapter extends TTS {
       tts.on('error', (error) => {
         this.emit('error', error);
       });
+      tts.on('fallback_activated', (event) => {
+        this.emit('fallback_activated', event);
+      });
     });
   }
 
@@ -282,6 +285,7 @@ export class FallbackAdapter extends TTS {
     for (const tts of this.ttsInstances) {
       tts.removeAllListeners('metrics_collected');
       tts.removeAllListeners('error');
+      tts.removeAllListeners('fallback_activated');
     }
 
     // Close all TTS instances

--- a/agents/src/tts/index.ts
+++ b/agents/src/tts/index.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 export {
   type SynthesizedAudio,
+  type FallbackActivatedEvent,
   type TTSCapabilities,
   type TTSCallbacks,
   TTS,

--- a/agents/src/tts/stream_adapter.ts
+++ b/agents/src/tts/stream_adapter.ts
@@ -8,7 +8,7 @@ import type { APIConnectOptions } from '../types.js';
 import { USERDATA_TIMED_TRANSCRIPT } from '../types.js';
 import { Task } from '../utils.js';
 import { createTimedString } from '../voice/io.js';
-import type { ChunkedStream, TTSError } from './tts.js';
+import type { ChunkedStream, FallbackActivatedEvent, TTSError } from './tts.js';
 import { SynthesizeStream, TTS } from './tts.js';
 
 export class StreamAdapter extends TTS {
@@ -24,6 +24,10 @@ export class StreamAdapter extends TTS {
     this.emit('error', error);
   };
 
+  #forwardFallbackActivated = (event: FallbackActivatedEvent) => {
+    this.emit('fallback_activated', event);
+  };
+
   constructor(tts: TTS, sentenceTokenizer: SentenceTokenizer) {
     super(tts.sampleRate, tts.numChannels, { streaming: true, alignedTranscript: true });
     this.#tts = tts;
@@ -33,11 +37,13 @@ export class StreamAdapter extends TTS {
 
     this.#tts.on('metrics_collected', this.#forwardMetrics);
     this.#tts.on('error', this.#forwardError);
+    this.#tts.on('fallback_activated', this.#forwardFallbackActivated);
   }
 
   async close(): Promise<void> {
     this.#tts.off('metrics_collected', this.#forwardMetrics);
     this.#tts.off('error', this.#forwardError);
+    this.#tts.off('fallback_activated', this.#forwardFallbackActivated);
     await super.close();
   }
 

--- a/agents/src/tts/tts.ts
+++ b/agents/src/tts/tts.ts
@@ -136,9 +136,20 @@ export interface TTSError {
   recoverable: boolean;
 }
 
+/** An inference fallback produced content-bearing synthesis output. @public */
+export interface FallbackActivatedEvent {
+  sessionId: string;
+  fallbackType: 'unknown' | 'fallback' | 'system_default';
+  provider: string;
+  model: string;
+  voice: string;
+  cause: 'unknown' | 'timeout' | 'canceled' | 'provider_error' | 'quota_exceeded';
+}
+
 export type TTSCallbacks = {
   ['metrics_collected']: (metrics: TTSMetrics) => void;
   ['error']: (error: TTSError) => void;
+  ['fallback_activated']: (event: FallbackActivatedEvent) => void;
 };
 
 /**


### PR DESCRIPTION
## Summary
- add `disableSystemDefaultFallback` and exact opt-out-only session serialization without changing existing fallback payloads
- expose a typed `fallback_activated` event with idiomatic `sessionId` and `fallbackType`
- surface regular and system-default fallback activations with provider, model, voice, and sanitized cause
- forward fallback activation events through `FallbackAdapter` and `StreamAdapter`
- normalize future causes and fallback types to `unknown` without interrupting audio
- publish the additive public API as a minor changeset

`fallback_activated` is declared on the shared JS `TTSCallbacks` surface because the base TTS emitter is not generic. Scoping it to inference as Python does would require a broader emitter redesign; the adapters forward the event so wrapping an inference TTS does not create a dead listener.

## Testing
- `pnpm exec vitest run agents/src/inference/tts.test.ts agents/src/inference/api_protos.test.ts agents/src/inference/tts.type.test.ts agents/src/tts/fallback_adapter.test.ts`
- `pnpm --filter @livekit/agents typecheck`
- `pnpm --filter @livekit/agents build:types`
- `pnpm --filter @livekit/agents api:check`
- `pnpm --filter @livekit/agents lint`
- `pnpm exec prettier --check agents/src/inference/api_protos.ts agents/src/inference/api_protos.test.ts agents/src/inference/tts.test.ts agents/src/inference/tts.type.test.ts agents/src/tts/tts.ts agents/etc/agents.api.md`

## Coordinated PRs
- Gateway: https://github.com/livekit/agent-gateway/pull/1363
- Python: https://github.com/livekit/agents/pull/7185

[LKINF-495](https://linear.app/livekit/issue/LKINF-495/expose-tts-fallback-controls-and-notices)