### PR TITLE
plugins/deepgram: detect a silently dropped STT socket instead of hanging

### DIFF
--- a/.changeset/deepgram-stt-socket-liveness.md
+++ b/.changeset/deepgram-stt-socket-liveness.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents-plugin-deepgram': patch
+---
+
+Detect a silently dropped STT socket instead of hanging. Adds a ping/pong heartbeat to both STT streams, makes the v1 stream observe its connection monitor (`wsMonitor.result`, not `wsMonitor`, which left its retry path unreachable), lets the v2 stream reconnect from a mid-session close, and cancels an attempt's audio read on teardown so a torn-down sender cannot steal frames from the next one.

--- a/plugins/deepgram/src/_utils.test.ts
+++ b/plugins/deepgram/src/_utils.test.ts
@@ -83,3 +83,52 @@ describe('startWebSocketHeartbeat', () => {
     expect(ws.pings).toBe(0);
   });
 });
+
+describe('abandoned queue reads', () => {
+  // The send loops hand `input.next()` an AbortSignal and cancel it when an attempt
+  // ends. This pins why: an abandoned read stays parked inside the queue and shifts
+  // the next frame off it for a promise nobody awaits, so a sender left over from a
+  // previous attempt silently steals audio from the current one.
+  const tick = () => new Promise((r) => setImmediate(r));
+
+  it('steals the next item when the read is merely raced away', async () => {
+    const { AsyncIterableQueue } = await import('@livekit/agents');
+    const queue = new AsyncIterableQueue<string>();
+
+    void queue.next(); // the previous attempt's sender, abandoned by a Promise.race
+    await tick();
+
+    let received: string | undefined;
+    void queue.next().then((r) => {
+      received = r.value;
+    });
+    await tick();
+
+    queue.put('frame');
+    await tick();
+
+    expect(received).toBeUndefined(); // the abandoned read took it
+  });
+
+  it('leaves the next item alone when the read is cancelled', async () => {
+    const { AsyncIterableQueue } = await import('@livekit/agents');
+    const queue = new AsyncIterableQueue<string>();
+
+    const attempt = new AbortController();
+    void queue.next({ signal: attempt.signal }).catch(() => {});
+    await tick();
+    attempt.abort();
+    await tick();
+
+    let received: string | undefined;
+    void queue.next().then((r) => {
+      received = r.value;
+    });
+    await tick();
+
+    queue.put('frame');
+    await tick();
+
+    expect(received).toBe('frame');
+  });
+});

--- a/plugins/deepgram/src/_utils.test.ts
+++ b/plugins/deepgram/src/_utils.test.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2025 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WebSocket } from 'ws';
+import { HEARTBEAT_INTERVAL_MS, PONG_TIMEOUT_MS, startWebSocketHeartbeat } from './_utils.js';
+
+class FakeSocket extends EventEmitter {
+  readyState = 1; // WebSocket.OPEN
+  pings = 0;
+  terminated = 0;
+
+  ping() {
+    this.pings++;
+  }
+
+  terminate() {
+    this.terminated++;
+    this.readyState = 3; // WebSocket.CLOSED
+  }
+}
+
+const asWs = (socket: FakeSocket) => socket as unknown as WebSocket;
+
+describe('startWebSocketHeartbeat', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('terminates a socket that stops answering pings', () => {
+    const ws = new FakeSocket();
+    const onTimeout = vi.fn();
+    startWebSocketHeartbeat(asWs(ws), onTimeout);
+
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+    expect(ws.pings).toBe(1);
+    expect(ws.terminated).toBe(0); // still inside the pong window
+
+    vi.advanceTimersByTime(PONG_TIMEOUT_MS);
+    expect(onTimeout).toHaveBeenCalledOnce();
+    expect(ws.terminated).toBe(1);
+  });
+
+  it('leaves a socket alone while pongs keep coming back', () => {
+    const ws = new FakeSocket();
+    startWebSocketHeartbeat(asWs(ws));
+
+    // answer each ping before the next interval tick, so no deadline is ever
+    // left outstanding across a tick
+    for (let i = 0; i < 3; i++) {
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      ws.emit('pong');
+    }
+    // and nothing fires afterwards either, since the last deadline was cleared
+    vi.advanceTimersByTime(PONG_TIMEOUT_MS);
+
+    expect(ws.pings).toBe(3);
+    expect(ws.terminated).toBe(0);
+  });
+
+  it('stops cleanly, cancelling a deadline that is already pending', () => {
+    const ws = new FakeSocket();
+    const stop = startWebSocketHeartbeat(asWs(ws));
+
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+    expect(ws.pings).toBe(1); // a pong is now outstanding
+
+    stop();
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 5);
+
+    expect(ws.pings).toBe(1);
+    expect(ws.terminated).toBe(0);
+    expect(ws.listenerCount('pong')).toBe(0);
+  });
+
+  it('does not ping a socket that is not open', () => {
+    const ws = new FakeSocket();
+    ws.readyState = 3; // WebSocket.CLOSED
+    startWebSocketHeartbeat(asWs(ws));
+
+    vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 3);
+
+    expect(ws.pings).toBe(0);
+  });
+});

--- a/plugins/deepgram/src/_utils.ts
+++ b/plugins/deepgram/src/_utils.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 LiveKit, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+import { WebSocket } from 'ws';
 
 export class PeriodicCollector<T> {
   private duration: number;
@@ -47,4 +48,61 @@ export class PeriodicCollector<T> {
     }
     this.lastFlushTime = performance.now() / 1000;
   }
+}
+
+/** How often to ping an idle socket. Matches `heartbeat=30.0` in the Python plugin. */
+export const HEARTBEAT_INTERVAL_MS = 30_000;
+
+/** How long to wait for the pong before giving up, as aiohttp does, at half the interval. */
+export const PONG_TIMEOUT_MS = 15_000;
+
+/**
+ * Detect a socket that has gone away silently.
+ *
+ * Node's `ws` never pings on its own, so a half-open connection (no FIN, no RST) is
+ * invisible to the plugin: `send()` keeps buffering, no `close` or `error` is ever
+ * emitted, and a reconnect loop driven by those events never runs. Ping on an
+ * interval and terminate the socket when the pong does not come back, which emits
+ * `close` and lets the caller's existing reconnect path take over.
+ *
+ * Terminate rather than close: a close handshake needs a peer that is still
+ * listening, which by definition this one is not.
+ *
+ * @returns a function that stops the heartbeat. Call it when tearing the socket down.
+ */
+export function startWebSocketHeartbeat(ws: WebSocket, onTimeout?: () => void): () => void {
+  let pongDeadline: NodeJS.Timeout | undefined;
+
+  const clearDeadline = () => {
+    if (pongDeadline) {
+      clearTimeout(pongDeadline);
+      pongDeadline = undefined;
+    }
+  };
+
+  const onPong = () => clearDeadline();
+  ws.on('pong', onPong);
+
+  const interval = setInterval(() => {
+    if (ws.readyState !== WebSocket.OPEN) return;
+    if (pongDeadline) return; // a ping is already outstanding
+
+    try {
+      ws.ping();
+    } catch {
+      return; // the socket is already gone; `close` will have been emitted
+    }
+
+    pongDeadline = setTimeout(() => {
+      pongDeadline = undefined;
+      onTimeout?.();
+      ws.terminate();
+    }, PONG_TIMEOUT_MS);
+  }, HEARTBEAT_INTERVAL_MS);
+
+  return () => {
+    clearInterval(interval);
+    clearDeadline();
+    ws.off('pong', onPong);
+  };
 }

--- a/plugins/deepgram/src/stt.ts
+++ b/plugins/deepgram/src/stt.ts
@@ -385,6 +385,11 @@ export class SpeechStream extends stt.SpeechStream {
   async #runWS(ws: WebSocket) {
     this.#resetWS = new Future();
     let closing = false;
+    // Scoped to this connection. An abandoned `input.next()` stays parked inside the
+    // queue and shifts the next frame off it for a promise nobody awaits, so a sender
+    // left over from a previous attempt steals audio from the current one. The read
+    // has to be cancelled, not merely raced against.
+    const attempt = new AbortController();
 
     const keepalive = setInterval(() => {
       try {
@@ -439,7 +444,10 @@ export class SpeechStream extends stt.SpeechStream {
 
       try {
         while (!this.closed) {
-          const result = await Promise.race([this.input.next(), abortPromise]);
+          const result = await Promise.race([
+            this.input.next({ signal: attempt.signal }),
+            abortPromise,
+          ]);
 
           if (result === undefined) return; // aborted
           if (result.done) {
@@ -475,9 +483,14 @@ export class SpeechStream extends stt.SpeechStream {
             ws.send(JSON.stringify({ type: 'Finalize' }));
           }
         }
+      } catch (e) {
+        if (attempt.signal.aborted) return; // teardown, not a failure of this send
+        throw e;
       } finally {
         closing = true;
-        ws.send(JSON.stringify({ type: 'CloseStream' }));
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'CloseStream' }));
+        }
         wsMonitor.cancel();
       }
     };
@@ -595,19 +608,23 @@ export class SpeechStream extends stt.SpeechStream {
       await Promise.race([listenMessage, waitForAbort(controller.signal)]);
     }, this.abortController);
 
+    const sendPromise = sendTask();
     try {
       await Promise.race([
         this.#resetWS.await,
         // wsMonitor.result, not wsMonitor: Task is not thenable, so passing the
         // object made Promise.all resolve it instantly and the monitor's rejection
         // was never observed. A dropped socket could not reach the retry below.
-        Promise.all([sendTask(), listenTask.result, wsMonitor.result]),
+        Promise.all([sendPromise, listenTask.result, wsMonitor.result]),
       ]);
     } finally {
       closing = true;
       ws.close();
       clearInterval(keepalive);
       stopHeartbeat();
+      // settle this attempt's sender before the caller opens the next socket
+      attempt.abort();
+      await sendPromise.catch(() => {});
     }
   }
 

--- a/plugins/deepgram/src/stt.ts
+++ b/plugins/deepgram/src/stt.ts
@@ -21,7 +21,7 @@ import {
 } from '@livekit/agents';
 import type { AudioFrame } from '@livekit/rtc-node';
 import { WebSocket } from 'ws';
-import { PeriodicCollector } from './_utils.js';
+import { PeriodicCollector, startWebSocketHeartbeat } from './_utils.js';
 import type { STTLanguages, STTModels } from './models.js';
 
 export interface STTOptions {
@@ -395,6 +395,13 @@ export class SpeechStream extends stt.SpeechStream {
       }
     }, 5000);
 
+    // the KeepAlive above is an application-level message: it keeps Deepgram from
+    // timing the session out, but it cannot tell us whether the socket is still
+    // there. Only a ping that goes unanswered can.
+    const stopHeartbeat = startWebSocketHeartbeat(ws, () =>
+      this.#logger.warn('Deepgram did not answer a ping in time, terminating the socket'),
+    );
+
     // gets cancelled also when sendTask is complete
     const wsMonitor = Task.from(async (controller) => {
       const closed = new Promise<void>((_, reject) => {
@@ -588,13 +595,20 @@ export class SpeechStream extends stt.SpeechStream {
       await Promise.race([listenMessage, waitForAbort(controller.signal)]);
     }, this.abortController);
 
-    await Promise.race([
-      this.#resetWS.await,
-      Promise.all([sendTask(), listenTask.result, wsMonitor]),
-    ]);
-    closing = true;
-    ws.close();
-    clearInterval(keepalive);
+    try {
+      await Promise.race([
+        this.#resetWS.await,
+        // wsMonitor.result, not wsMonitor: Task is not thenable, so passing the
+        // object made Promise.all resolve it instantly and the monitor's rejection
+        // was never observed. A dropped socket could not reach the retry below.
+        Promise.all([sendTask(), listenTask.result, wsMonitor.result]),
+      ]);
+    } finally {
+      closing = true;
+      ws.close();
+      clearInterval(keepalive);
+      stopHeartbeat();
+    }
   }
 
   private onAudioDurationReport(duration: number) {

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -276,6 +276,10 @@ class SpeechStreamv2 extends stt.SpeechStream {
   #reconnectEvent = new Event();
   // set once we have sent CloseStream, so the close that follows is expected
   #closingWs = false;
+  // Scoped to the current connection. An abandoned `input.next()` stays parked inside
+  // the queue and shifts the next frame off it for a promise nobody awaits, so a
+  // sender left over from a previous attempt steals audio from the current one.
+  #attempt = new AbortController();
 
   // keyterms set while the user is speaking; applied at END_OF_SPEECH (latest wins)
   /** @internal */
@@ -333,9 +337,11 @@ class SpeechStreamv2 extends stt.SpeechStream {
     // Outer Loop: Handles reconnections (Configuration updates)
     while (!this.closed) {
       let stopHeartbeat: (() => void) | undefined;
+      let sendPromise: Promise<void> | undefined;
       try {
         this.#reconnectEvent.clear();
         this.#closingWs = false;
+        this.#attempt = new AbortController();
 
         const baseUrl = this.#opts.endpointUrl.replace(/^http/, 'ws');
         const url = `${baseUrl}?${queryString.stringify(this._liveConfig())}`;
@@ -381,7 +387,7 @@ class SpeechStreamv2 extends stt.SpeechStream {
         });
 
         // 2. Run Concurrent Tasks (Send & Receive)
-        const sendPromise = this.#sendTask();
+        sendPromise = this.#sendTask();
         const recvPromise = this.#recvTask();
         const reconnectWait = this.#reconnectEvent.wait();
 
@@ -405,6 +411,10 @@ class SpeechStreamv2 extends stt.SpeechStream {
         throw error; // Let Base Class handle retry logic
       } finally {
         stopHeartbeat?.();
+        // settle this attempt's sender before the loop opens the next socket, or its
+        // abandoned queue read will steal a frame from the next one
+        this.#attempt.abort();
+        await sendPromise?.catch(() => {});
         if (this.#ws?.readyState === WebSocket.OPEN) {
           this.#ws.close();
         }
@@ -420,14 +430,35 @@ class SpeechStreamv2 extends stt.SpeechStream {
     const samples50ms = Math.floor(this.#opts.sampleRate / 20);
     const audioBstream = new AudioByteStream(this.#opts.sampleRate, 1, samples50ms);
 
+    // Manual Iterator to allow racing against Reconnect Signal
+    const iterator = this.input[Symbol.asyncIterator]();
+    const attempt = this.#attempt;
+
+    try {
+      await this.#pumpAudio(iterator, attempt, audioBstream);
+    } catch (e) {
+      if (attempt.signal.aborted) return; // teardown cancelled the queue read
+      throw e;
+    }
+
+    // Only send CloseStream if we are exiting normally (not reconnecting)
+    if (!this.#reconnectEvent.isSet && this.#ws!.readyState === WebSocket.OPEN) {
+      this.#logger.debug('Sending CloseStream message to Deepgram');
+      this.#closingWs = true;
+      this.#ws!.send(_CLOSE_MSG);
+    }
+  }
+
+  async #pumpAudio(
+    iterator: AsyncIterator<AudioFrame | typeof stt.SpeechStream.FLUSH_SENTINEL>,
+    attempt: AbortController,
+    audioBstream: AudioByteStream,
+  ) {
     let hasEnded = false;
     let inputEnded = false;
 
-    // Manual Iterator to allow racing against Reconnect Signal
-    const iterator = this.input[Symbol.asyncIterator]();
-
     while (true) {
-      const nextPromise = iterator.next();
+      const nextPromise = iterator.next({ signal: attempt.signal });
       // If reconnect signal fires, abort the wait
       const abortPromise = this.#reconnectEvent.wait().then(() => ({ abort: true }) as const);
 
@@ -474,13 +505,6 @@ class SpeechStreamv2 extends stt.SpeechStream {
       }
 
       if (inputEnded) break;
-    }
-
-    // Only send CloseStream if we are exiting normally (not reconnecting)
-    if (!this.#reconnectEvent.isSet && this.#ws!.readyState === WebSocket.OPEN) {
-      this.#logger.debug('Sending CloseStream message to Deepgram');
-      this.#closingWs = true;
-      this.#ws!.send(_CLOSE_MSG);
     }
   }
 

--- a/plugins/deepgram/src/stt_v2.ts
+++ b/plugins/deepgram/src/stt_v2.ts
@@ -17,7 +17,7 @@ import {
 import type { AudioFrame } from '@livekit/rtc-node';
 import * as queryString from 'node:querystring';
 import { WebSocket } from 'ws';
-import { PeriodicCollector } from './_utils.js';
+import { PeriodicCollector, startWebSocketHeartbeat } from './_utils.js';
 import type { V2Models } from './models.js';
 
 const _CLOSE_MSG = JSON.stringify({ type: 'CloseStream' });
@@ -274,6 +274,8 @@ class SpeechStreamv2 extends stt.SpeechStream {
 
   // Parity: _reconnect_event - using existing Event class from @livekit/agents
   #reconnectEvent = new Event();
+  // set once we have sent CloseStream, so the close that follows is expected
+  #closingWs = false;
 
   // keyterms set while the user is speaking; applied at END_OF_SPEECH (latest wins)
   /** @internal */
@@ -330,8 +332,10 @@ class SpeechStreamv2 extends stt.SpeechStream {
   protected async run() {
     // Outer Loop: Handles reconnections (Configuration updates)
     while (!this.closed) {
+      let stopHeartbeat: (() => void) | undefined;
       try {
         this.#reconnectEvent.clear();
+        this.#closingWs = false;
 
         const baseUrl = this.#opts.endpointUrl.replace(/^http/, 'ws');
         const url = `${baseUrl}?${queryString.stringify(this._liveConfig())}`;
@@ -349,15 +353,43 @@ class SpeechStreamv2 extends stt.SpeechStream {
           });
         }
 
+        stopHeartbeat = startWebSocketHeartbeat(this.#ws, () =>
+          this.#logger.warn('Deepgram did not answer a ping in time, terminating the socket'),
+        );
+
+        // #recvTask resolves on close while #sendTask runs until its input ends, so
+        // Promise.all cannot settle when the socket goes away mid-session: the stream
+        // would sit there dropping audio. Surface the close as a rejection instead and
+        // let the base class retry, the way the v1 stream's wsMonitor does.
+        const socketFailed = new Promise<never>((_, reject) => {
+          this.#ws!.once('close', (code) => {
+            if (this.closed || this.#closingWs || this.#reconnectEvent.isSet) return;
+            reject(
+              new APIConnectionError({
+                message: `Deepgram WebSocket closed unexpectedly (${code})`,
+              }),
+            );
+          });
+          this.#ws!.once('error', (error) => {
+            if (this.closed || this.#closingWs || this.#reconnectEvent.isSet) return;
+            reject(
+              new APIConnectionError({
+                message: `Deepgram WebSocket failed (${errorName(error)})`,
+              }),
+            );
+          });
+        });
+
         // 2. Run Concurrent Tasks (Send & Receive)
         const sendPromise = this.#sendTask();
         const recvPromise = this.#recvTask();
         const reconnectWait = this.#reconnectEvent.wait();
 
-        // 3. Race: Normal Completion vs Reconnect Signal
+        // 3. Race: Normal Completion vs Reconnect Signal vs the socket dying
         const result = await Promise.race([
           Promise.all([sendPromise, recvPromise]),
           reconnectWait.then(() => 'RECONNECT'),
+          socketFailed,
         ]);
 
         if (result === 'RECONNECT') {
@@ -372,6 +404,7 @@ class SpeechStreamv2 extends stt.SpeechStream {
         this.#logger.error({ errorType: errorName(error) }, 'Deepgram stream error');
         throw error; // Let Base Class handle retry logic
       } finally {
+        stopHeartbeat?.();
         if (this.#ws?.readyState === WebSocket.OPEN) {
           this.#ws.close();
         }
@@ -446,6 +479,7 @@ class SpeechStreamv2 extends stt.SpeechStream {
     // Only send CloseStream if we are exiting normally (not reconnecting)
     if (!this.#reconnectEvent.isSet && this.#ws!.readyState === WebSocket.OPEN) {
       this.#logger.debug('Sending CloseStream message to Deepgram');
+      this.#closingWs = true;
       this.#ws!.send(_CLOSE_MSG);
     }
   }


### PR DESCRIPTION
A half-open connection (no FIN, no RST) left both Deepgram STT streams sitting on a dead socket: the session stayed open, no transcripts arrived, and no error was emitted.

Three independent faults each had to be fixed before a drop could recover. I found the second and third only by running it against a live socket; adding the heartbeat alone changed nothing.

## 1. Nothing noticed the socket was gone

Node's `ws` never pings on its own, so `send()` keeps buffering and no `close` or `error` is emitted. Adds `startWebSocketHeartbeat` in `_utils.js`: ping every 30s, terminate if no pong arrives within 15s. Terminate rather than close, because a close handshake needs a peer that is still listening. Interval and deadline mirror aiohttp's `heartbeat=30.0` in the Python plugin.

The `KeepAlive` v1 already sends is not a substitute. It is an application-level message that stops Deepgram timing the session out; it says nothing about whether the socket is still there.

## 2. `stt.ts` never observed its own monitor

```js
Promise.all([sendTask(), listenTask.result, wsMonitor])
```

`Task` is not thenable, so `Promise.all` resolved the bare object instantly and `wsMonitor`'s rejection was never seen. The retry in `run()` was unreachable for any socket failure, not just this one. With the heartbeat added but this line unchanged, the socket was correctly terminated and the stream still never reconnected.

`assemblyai`, `inworld` and `sarvam` all use `wsMonitor.result` here. `xai/src/stt.ts:364` has the same bare-object bug; I have left it alone rather than widen this PR, but you may want to pick it up.

## 3. `stt_v2.ts` could not reconnect from a mid-session close at all

`#recvTask` resolves on close while `#sendTask` runs until its input ends, so `Promise.all` never settled and the stream sat there dropping audio. This one needs no half-open case: any clean server close does it. An unexpected close or error now rejects the race, the way v1's `wsMonitor` does, with `#closingWs` keeping our own `CloseStream` from tripping it.

## Also

`stt.ts` cleared its keepalive interval only on the success path, leaking one interval per reconnect. Teardown now runs in a `finally`.

`tts.ts` is left alone: its recv already has an idle timeout.

## Verification

Run against `api.deepgram.com` through a proxy that holds both sockets open and stops delivering, so the client's writes keep succeeding and nothing comes back:

| | v1 before | v1 after | v2 before | v2 after |
|---|---|---|---|---|
| sockets opened | 1 | 2 | 1 | 2 |
| transcripts after the break | 0 | 1 | 0 | 1 |
| outcome | silent for the whole window | detected in 30s, recovered | silent for the whole window | detected in 30s, recovered |

Four unit tests cover the heartbeat helper and fail without it. The three existing `.test.ts` files in this plugin do not run in my environment, before or after this change, because they import other unbuilt workspace plugins.

This is the JS counterpart to the same fix on the Python side, livekit/agents#7206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
