### PR TITLE
feat: support full-duplex speech models

### DIFF
--- a/.changeset/duplex-speech-model.md
+++ b/.changeset/duplex-speech-model.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Add DuplexModel and DuplexSession for full-duplex speech providers. Agent and AgentSession accept duplex models through an adapter that segments continuous audio and aligns transcripts. Preserve overlapping speech and collect usage reported during realtime session shutdown.

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -3322,6 +3322,8 @@ export abstract class DuplexSession<Events extends EventMap = Record<never, neve
     close(): Promise<void>;
     // (undocumented)
     protected abstract closeConnection(): Promise<void>;
+    // (undocumented)
+    protected _closing: boolean;
     protected readonly _configured: {
         readonly isSet: boolean;
         wait(): Promise<boolean>;

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -80,15 +80,13 @@ export type Aborted<T> = {
 // @public
 export class AdaptiveNoiseGate implements AudioGate {
     constructor(options?: AdaptiveNoiseGateOptions);
-    // (undocumented)
     deactivate(): void;
-    // (undocumented)
     update(frame: AudioFrame): boolean;
 }
 
 // Warning: (ae-missing-release-tag) "AdaptiveNoiseGateOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface AdaptiveNoiseGateOptions extends AudioGateOptions {
     window?: number;
 }
@@ -799,8 +797,12 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
     static create<ResultT = unknown, UserData = unknown>(options: AgentTaskCreateOptions<ResultT, UserData>): AgentTask<ResultT, UserData>;
     // (undocumented)
     get done(): boolean;
+    // @internal (undocumented)
+    _oldAgent?: Agent;
     // (undocumented)
     run(): Promise<ResultT>;
+    // @internal (undocumented)
+    _waitForInactive(): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "AgentTaskContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1771,17 +1773,14 @@ export function audioFramesFromFile(filePath: string, options?: AudioDecodeOptio
 // @public
 export interface AudioGate {
     deactivate(): void;
-    // (undocumented)
     update(frame: AudioFrame): boolean;
 }
 
 // Warning: (ae-missing-release-tag) "AudioGateOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface AudioGateOptions {
-    // (undocumented)
     activationRatio?: number;
-    // (undocumented)
     deactivationRatio?: number;
     minSilenceDuration?: number;
 }
@@ -3230,7 +3229,6 @@ type DtmfEvent = (typeof DTMF_EVENTS)[number];
 //
 // @public
 export interface DuplexAudioFrame {
-    // (undocumented)
     frame: AudioFrame;
     startMs?: number;
 }
@@ -3239,15 +3237,10 @@ export interface DuplexAudioFrame {
 //
 // @public
 export interface DuplexCapabilities {
-    // (undocumented)
     autoToolReplyGeneration: boolean;
-    // (undocumented)
     midSessionChatCtxUpdate?: boolean;
-    // (undocumented)
     midSessionInstructionsUpdate?: boolean;
-    // (undocumented)
     midSessionToolsUpdate?: boolean;
-    // (undocumented)
     userTranscription: boolean;
 }
 
@@ -3255,19 +3248,14 @@ export interface DuplexCapabilities {
 //
 // @public
 export abstract class DuplexModel {
-    constructor(capabilities: DuplexCapabilities);
+    constructor(
+    capabilities: DuplexCapabilities);
     audioGate(): AudioGate | undefined;
-    // (undocumented)
     readonly capabilities: DuplexCapabilities;
-    // (undocumented)
     abstract close(): Promise<void>;
-    // (undocumented)
     label(): string;
-    // (undocumented)
     get model(): string;
-    // (undocumented)
     get provider(): string;
-    // (undocumented)
     abstract session(): DuplexSession;
 }
 
@@ -3277,7 +3265,6 @@ export abstract class DuplexModel {
 export interface DuplexOutputTranscriptDelta {
     endMs?: number;
     startMs?: number;
-    // (undocumented)
     text: string;
 }
 
@@ -3285,22 +3272,18 @@ export interface DuplexOutputTranscriptDelta {
 //
 // @public
 export class DuplexRealtimeAdapter extends RealtimeModel {
-    constructor(duplexModel: DuplexModel, options?: DuplexRealtimeAdapterOptions);
-    // (undocumented)
+    constructor(
+    duplexModel: DuplexModel, options?: DuplexRealtimeAdapterOptions);
     close(): Promise<void>;
-    // (undocumented)
     readonly duplexModel: DuplexModel;
-    // (undocumented)
     get model(): string;
-    // (undocumented)
     get provider(): string;
-    // (undocumented)
     session(): RealtimeSession;
 }
 
 // Warning: (ae-missing-release-tag) "DuplexRealtimeAdapterOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface DuplexRealtimeAdapterOptions {
     audioTimeout?: number;
     gate?: () => AudioGate;
@@ -3311,52 +3294,39 @@ export interface DuplexRealtimeAdapterOptions {
 //
 // @public
 export abstract class DuplexSession<Events extends EventMap = Record<never, never>> extends DuplexSession_base<Events> {
-    constructor(duplexModel: DuplexModel);
-    // (undocumented)
+    constructor(
+    duplexModel: DuplexModel);
     abstract _appendItems(items: ChatItem[]): Promise<void>;
-    // (undocumented)
     abstract get audioStream(): ReadableStream_2<DuplexAudioFrame>;
-    // (undocumented)
     get capabilities(): DuplexCapabilities;
-    // (undocumented)
     close(): Promise<void>;
-    // (undocumented)
     protected abstract closeConnection(): Promise<void>;
-    // (undocumented)
     protected _closing: boolean;
     protected readonly _configured: {
         readonly isSet: boolean;
         wait(): Promise<boolean>;
         set(): void;
     };
-    // (undocumented)
     readonly duplexModel: DuplexModel;
     _generateReply(_instructions?: string, _options?: {
         toolChoice?: ToolChoice;
         tools?: ToolContext;
     }): void;
-    // (undocumented)
     abstract pushAudio(frame: AudioFrame): void;
-    // (undocumented)
     pushVideo(_frame: VideoFrame_2): void;
     protected _reportConnectionAcquired(acquireTimeMs: number): void;
-    // (undocumented)
     abstract get tools(): ToolContext;
-    // (undocumented)
     abstract _updateInstructions(instructions: string): Promise<void>;
-    // (undocumented)
     abstract _updateOptions(options: {
         toolChoice?: ToolChoice | null;
     }): void;
-    // (undocumented)
     _updateSession(instructions?: string, chatCtx?: ChatContext, tools?: ToolContext): Promise<void>;
-    // (undocumented)
     abstract _updateTools(tools: ToolContext): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "DuplexSessionCallbacks" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export type DuplexSessionCallbacks = {
     transcript_delta: (event: DuplexOutputTranscriptDelta) => void;
     function_call: (event: FunctionCall) => void;
@@ -4050,9 +4020,7 @@ interface FishAudioOptions {
 // @public
 export class FixedGate implements AudioGate {
     constructor(silence: number, options?: AudioGateOptions);
-    // (undocumented)
     deactivate(): void;
-    // (undocumented)
     update(frame: AudioFrame): boolean;
 }
 
@@ -9906,15 +9874,15 @@ export const zipFunctionCallsAndOutputs: (event: FunctionToolsExecutedEvent) => 
 // src/metrics/base.ts:202:3 - (ae-forgotten-export) The symbol "RealtimeModelMetricsOutputTokenDetails" needs to be exported by the entry point index.d.ts
 // src/stt/stt.ts:364:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "STT"
 // src/utils.ts:550:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "cancelled"
-// src/voice/agent_session.ts:380:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/voice/agent_session.ts:1012:5 - (ae-forgotten-export) The symbol "RecordingOptions" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1672:5 - (ae-forgotten-export) The symbol "STTError" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1672:5 - (ae-forgotten-export) The symbol "TTSError" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1672:5 - (ae-forgotten-export) The symbol "LLMError" needs to be exported by the entry point index.d.ts
-// src/voice/amd.ts:313:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "waitForTrackPublication" has more than one declaration; you need to add a TSDoc member reference selector
-// src/voice/amd.ts:313:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
-// src/voice/amd.ts:321:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "aclose"
-// src/voice/amd.ts:515:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
+// src/voice/agent_session.ts:386:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
+// src/voice/agent_session.ts:1021:5 - (ae-forgotten-export) The symbol "RecordingOptions" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1688:5 - (ae-forgotten-export) The symbol "STTError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1688:5 - (ae-forgotten-export) The symbol "TTSError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1688:5 - (ae-forgotten-export) The symbol "LLMError" needs to be exported by the entry point index.d.ts
+// src/voice/amd.ts:315:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "waitForTrackPublication" has more than one declaration; you need to add a TSDoc member reference selector
+// src/voice/amd.ts:315:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
+// src/voice/amd.ts:323:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "aclose"
+// src/voice/amd.ts:517:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
 // src/voice/events.ts:424:3 - (ae-forgotten-export) The symbol "InterruptionDetectionError" needs to be exported by the entry point index.d.ts
 // src/voice/room_io/_output.ts:178:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "segmentTags"
 // src/voice/testing/run_result.ts:93:5 - (ae-forgotten-export) The symbol "OutputSchema" needs to be exported by the entry point index.d.ts

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -13,6 +13,7 @@ import { Context } from '@opentelemetry/api';
 import type { E2EEOptions } from '@livekit/rtc-node';
 import { EventEmitter } from 'events';
 import { EventEmitter as EventEmitter_2 } from 'node:events';
+import type { EventMap } from '@livekit/typed-emitter';
 import { FrameProcessor } from '@livekit/rtc-node';
 import { JobType } from '@livekit/protocol';
 import { JsonObject } from '@bufbuild/protobuf';
@@ -3305,10 +3306,11 @@ export interface DuplexRealtimeAdapterOptions {
     gate?: () => AudioGate;
 }
 
+// Warning: (ae-forgotten-export) The symbol "DuplexSession_base" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "DuplexSession" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export abstract class DuplexSession extends EventEmitter_2 {
+export abstract class DuplexSession<Events extends EventMap = Record<never, never>> extends DuplexSession_base<Events> {
     constructor(duplexModel: DuplexModel);
     // (undocumented)
     abstract _appendItems(items: ChatItem[]): Promise<void>;
@@ -3316,7 +3318,10 @@ export abstract class DuplexSession extends EventEmitter_2 {
     abstract get audioStream(): ReadableStream_2<DuplexAudioFrame>;
     // (undocumented)
     get capabilities(): DuplexCapabilities;
-    abstract close(): Promise<void>;
+    // (undocumented)
+    close(): Promise<void>;
+    // (undocumented)
+    protected abstract closeConnection(): Promise<void>;
     protected readonly _configured: {
         readonly isSet: boolean;
         wait(): Promise<boolean>;
@@ -3346,6 +3351,20 @@ export abstract class DuplexSession extends EventEmitter_2 {
     // (undocumented)
     abstract _updateTools(tools: ToolContext): Promise<void>;
 }
+
+// Warning: (ae-missing-release-tag) "DuplexSessionCallbacks" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type DuplexSessionCallbacks = {
+    transcript_delta: (event: DuplexOutputTranscriptDelta) => void;
+    function_call: (event: FunctionCall) => void;
+    input_speech_started: (event: InputSpeechStartedEvent) => void;
+    input_speech_stopped: (event: InputSpeechStoppedEvent) => void;
+    input_audio_transcription_completed: (event: InputTranscriptionCompleted) => void;
+    session_reconnected: (event: RealtimeSessionReconnectedEvent) => void;
+    metrics_collected: (event: RealtimeModelMetrics) => void;
+    error: (event: RealtimeModelError) => void;
+};
 
 // Warning: (ae-missing-release-tag) "DuplicateMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -5183,6 +5202,7 @@ declare namespace llm {
         DuplexAudioFrame,
         DuplexCapabilities,
         DuplexOutputTranscriptDelta,
+        DuplexSessionCallbacks,
         AdaptiveNoiseGate,
         DuplexRealtimeAdapter,
         FixedGate,

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -74,6 +74,24 @@ export type Aborted<T> = {
     isAborted: true;
 };
 
+// Warning: (ae-missing-release-tag) "AdaptiveNoiseGate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export class AdaptiveNoiseGate implements AudioGate {
+    constructor(options?: AdaptiveNoiseGateOptions);
+    // (undocumented)
+    deactivate(): void;
+    // (undocumented)
+    update(frame: AudioFrame): boolean;
+}
+
+// Warning: (ae-missing-release-tag) "AdaptiveNoiseGateOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface AdaptiveNoiseGateOptions extends AudioGateOptions {
+    window?: number;
+}
+
 // Warning: (ae-missing-release-tag) "Agent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -101,6 +119,7 @@ export class Agent<UserData = any> {
         transcriptionNode(agent: Agent, text: ReadableStream_2<string | TimedString> | AsyncIterable<string | TimedString>, _modelSettings: ModelSettings): Promise<ReadableStream_2<string | TimedString> | null>;
         realtimeAudioOutputNode(_agent: Agent, audio: ReadableStream_2<AudioFrame> | AsyncIterable<AudioFrame>, _modelSettings: ModelSettings): Promise<ReadableStream_2<AudioFrame> | null>;
     };
+    get duplexSession(): DuplexSession;
     get expressive(): boolean | ExpressiveOptions | undefined;
     // @internal (undocumented)
     _expressive?: boolean | ExpressiveOptions;
@@ -387,7 +406,7 @@ export interface AgentOptions<UserData> {
     // (undocumented)
     instructions: string | Instructions;
     // (undocumented)
-    llm?: LLM | RealtimeModel | LLMModels | null;
+    llm?: LLM | RealtimeModel | DuplexModel | LLMModels | null;
     // (undocumented)
     minConsecutiveSpeechDelay?: number;
     // (undocumented)
@@ -710,7 +729,7 @@ export enum AgentSessionEventTypes {
 export type AgentSessionOptions<UserData = UnknownUserData> = {
     stt?: STT | ModelWithLanguage;
     vad?: VAD | null;
-    llm?: LLM | RealtimeModel | LLMModels;
+    llm?: LLM | RealtimeModel | DuplexModel | LLMModels;
     tts?: TTS | ModelWithVoice;
     userData?: UserData;
     connOptions?: SessionConnectOptions;
@@ -802,7 +821,7 @@ export interface AgentTaskCreateOptions<ResultT = unknown, UserData = any> exten
 // @public
 export interface AgentUpdateOptions {
     expressive?: boolean | ExpressiveOptions;
-    llm?: LLM | RealtimeModel | LLMModels | null;
+    llm?: LLM | RealtimeModel | DuplexModel | LLMModels | null;
     stt?: STT | ModelWithLanguage | null;
     tts?: TTS | ModelWithVoice | null;
     vad?: VAD | null;
@@ -1745,6 +1764,26 @@ export class AudioEnergyFilter {
 //
 // @public
 export function audioFramesFromFile(filePath: string, options?: AudioDecodeOptions): ReadableStream_2<AudioFrame>;
+
+// Warning: (ae-missing-release-tag) "AudioGate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface AudioGate {
+    deactivate(): void;
+    // (undocumented)
+    update(frame: AudioFrame): boolean;
+}
+
+// Warning: (ae-missing-release-tag) "AudioGateOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface AudioGateOptions {
+    // (undocumented)
+    activationRatio?: number;
+    // (undocumented)
+    deactivationRatio?: number;
+    minSilenceDuration?: number;
+}
 
 // Warning: (ae-missing-release-tag) "AudioInput" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3186,6 +3225,128 @@ function dropBracketCues(tokens: TimedString[], held: TimedString[], options?: {
 // @public (undocumented)
 type DtmfEvent = (typeof DTMF_EVENTS)[number];
 
+// Warning: (ae-missing-release-tag) "DuplexAudioFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface DuplexAudioFrame {
+    // (undocumented)
+    frame: AudioFrame;
+    startMs?: number;
+}
+
+// Warning: (ae-missing-release-tag) "DuplexCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface DuplexCapabilities {
+    // (undocumented)
+    autoToolReplyGeneration: boolean;
+    // (undocumented)
+    midSessionChatCtxUpdate?: boolean;
+    // (undocumented)
+    midSessionInstructionsUpdate?: boolean;
+    // (undocumented)
+    midSessionToolsUpdate?: boolean;
+    // (undocumented)
+    userTranscription: boolean;
+}
+
+// Warning: (ae-missing-release-tag) "DuplexModel" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export abstract class DuplexModel {
+    constructor(capabilities: DuplexCapabilities);
+    audioGate(): AudioGate | undefined;
+    // (undocumented)
+    readonly capabilities: DuplexCapabilities;
+    // (undocumented)
+    abstract close(): Promise<void>;
+    // (undocumented)
+    label(): string;
+    // (undocumented)
+    get model(): string;
+    // (undocumented)
+    get provider(): string;
+    // (undocumented)
+    abstract session(): DuplexSession;
+}
+
+// Warning: (ae-missing-release-tag) "DuplexOutputTranscriptDelta" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface DuplexOutputTranscriptDelta {
+    endMs?: number;
+    startMs?: number;
+    // (undocumented)
+    text: string;
+}
+
+// Warning: (ae-missing-release-tag) "DuplexRealtimeAdapter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export class DuplexRealtimeAdapter extends RealtimeModel {
+    constructor(duplexModel: DuplexModel, options?: DuplexRealtimeAdapterOptions);
+    // (undocumented)
+    close(): Promise<void>;
+    // (undocumented)
+    readonly duplexModel: DuplexModel;
+    // (undocumented)
+    get model(): string;
+    // (undocumented)
+    get provider(): string;
+    // (undocumented)
+    session(): RealtimeSession;
+}
+
+// Warning: (ae-missing-release-tag) "DuplexRealtimeAdapterOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface DuplexRealtimeAdapterOptions {
+    audioTimeout?: number;
+    gate?: () => AudioGate;
+}
+
+// Warning: (ae-missing-release-tag) "DuplexSession" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export abstract class DuplexSession extends EventEmitter_2 {
+    constructor(duplexModel: DuplexModel);
+    // (undocumented)
+    abstract _appendItems(items: ChatItem[]): Promise<void>;
+    // (undocumented)
+    abstract get audioStream(): ReadableStream_2<DuplexAudioFrame>;
+    // (undocumented)
+    get capabilities(): DuplexCapabilities;
+    abstract close(): Promise<void>;
+    protected readonly _configured: {
+        readonly isSet: boolean;
+        wait(): Promise<boolean>;
+        set(): void;
+    };
+    // (undocumented)
+    readonly duplexModel: DuplexModel;
+    _generateReply(_instructions?: string, _options?: {
+        toolChoice?: ToolChoice;
+        tools?: ToolContext;
+    }): void;
+    // (undocumented)
+    abstract pushAudio(frame: AudioFrame): void;
+    // (undocumented)
+    pushVideo(_frame: VideoFrame_2): void;
+    protected _reportConnectionAcquired(acquireTimeMs: number): void;
+    // (undocumented)
+    abstract get tools(): ToolContext;
+    // (undocumented)
+    abstract _updateInstructions(instructions: string): Promise<void>;
+    // (undocumented)
+    abstract _updateOptions(options: {
+        toolChoice?: ToolChoice | null;
+    }): void;
+    // (undocumented)
+    _updateSession(instructions?: string, chatCtx?: ChatContext, tools?: ToolContext): Promise<void>;
+    // (undocumented)
+    abstract _updateTools(tools: ToolContext): Promise<void>;
+}
+
 // Warning: (ae-missing-release-tag) "DuplicateMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -3863,6 +4024,17 @@ interface FishAudioOptions {
     volume?: number;
 }
 
+// Warning: (ae-missing-release-tag) "FixedGate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export class FixedGate implements AudioGate {
+    constructor(silence: number, options?: AudioGateOptions);
+    // (undocumented)
+    deactivate(): void;
+    // (undocumented)
+    update(frame: AudioFrame): boolean;
+}
+
 // @internal
 function flushOtelLogs(): Promise<void>;
 
@@ -4528,6 +4700,7 @@ export interface InputSpeechStoppedEvent {
 //
 // @public (undocumented)
 export interface InputTranscriptionCompleted {
+    confidence?: number;
     // (undocumented)
     isFinal: boolean;
     // (undocumented)
@@ -5005,6 +5178,18 @@ declare namespace llm {
         ToolType,
         AsyncToolset,
         AsyncToolsetCreateOptions,
+        DuplexModel,
+        DuplexSession,
+        DuplexAudioFrame,
+        DuplexCapabilities,
+        DuplexOutputTranscriptDelta,
+        AdaptiveNoiseGate,
+        DuplexRealtimeAdapter,
+        FixedGate,
+        AdaptiveNoiseGateOptions,
+        AudioGate,
+        AudioGateOptions,
+        DuplexRealtimeAdapterOptions,
         AsyncToolOptions,
         DuplicatePromptArgs,
         ReplyPromptArgs,
@@ -5992,6 +6177,7 @@ export interface RealtimeCapabilities {
     // @deprecated
     nativeTranscriptSync?: boolean;
     perResponseToolChoice?: boolean;
+    supportsOverlappingSpeech?: boolean;
     turnDetection: boolean;
     userTranscription: boolean;
 }
@@ -6047,6 +6233,8 @@ export type RealtimeModelMetrics = {
     timestamp: number;
     durationMs: number;
     sessionDurationMs?: number;
+    acquireTimeMs?: number;
+    connectionReused?: boolean;
     ttftMs: number;
     cancelled: boolean;
     inputTokens: number;
@@ -9692,15 +9880,15 @@ export const zipFunctionCallsAndOutputs: (event: FunctionToolsExecutedEvent) => 
 // src/llm/chat_context.ts:76:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "audio"
 // src/llm/tool_context.ts:702:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "ToolFlag" has more than one declaration; you need to add a TSDoc member reference selector
 // src/llm/tool_context.ts:746:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "ToolFlag" has more than one declaration; you need to add a TSDoc member reference selector
-// src/metrics/base.ts:194:3 - (ae-forgotten-export) The symbol "RealtimeModelMetricsInputTokenDetails" needs to be exported by the entry point index.d.ts
-// src/metrics/base.ts:198:3 - (ae-forgotten-export) The symbol "RealtimeModelMetricsOutputTokenDetails" needs to be exported by the entry point index.d.ts
-// src/stt/stt.ts:361:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "STT"
+// src/metrics/base.ts:198:3 - (ae-forgotten-export) The symbol "RealtimeModelMetricsInputTokenDetails" needs to be exported by the entry point index.d.ts
+// src/metrics/base.ts:202:3 - (ae-forgotten-export) The symbol "RealtimeModelMetricsOutputTokenDetails" needs to be exported by the entry point index.d.ts
+// src/stt/stt.ts:364:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "STT"
 // src/utils.ts:550:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "cancelled"
 // src/voice/agent_session.ts:380:3 - (ae-unresolved-link) The @link reference could not be resolved: This type of declaration is not supported yet by the resolver
-// src/voice/agent_session.ts:1010:5 - (ae-forgotten-export) The symbol "RecordingOptions" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1670:5 - (ae-forgotten-export) The symbol "STTError" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1670:5 - (ae-forgotten-export) The symbol "TTSError" needs to be exported by the entry point index.d.ts
-// src/voice/agent_session.ts:1670:5 - (ae-forgotten-export) The symbol "LLMError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1012:5 - (ae-forgotten-export) The symbol "RecordingOptions" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1672:5 - (ae-forgotten-export) The symbol "STTError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1672:5 - (ae-forgotten-export) The symbol "TTSError" needs to be exported by the entry point index.d.ts
+// src/voice/agent_session.ts:1672:5 - (ae-forgotten-export) The symbol "LLMError" needs to be exported by the entry point index.d.ts
 // src/voice/amd.ts:313:3 - (ae-unresolved-link) The @link reference could not be resolved: The reference is ambiguous because "waitForTrackPublication" has more than one declaration; you need to add a TSDoc member reference selector
 // src/voice/amd.ts:313:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "gateListening"
 // src/voice/amd.ts:321:3 - (ae-unresolved-link) The @link reference could not be resolved: The package "@livekit/agents" does not have an export "aclose"

--- a/agents/src/llm/duplex.ts
+++ b/agents/src/llm/duplex.ts
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { AudioFrame, VideoFrame } from '@livekit/rtc-node';
+import { EventEmitter } from 'node:events';
+import type { ReadableStream } from 'node:stream/web';
+import type { RealtimeModelMetrics } from '../metrics/base.js';
+import { Event } from '../utils.js';
+import type { ChatContext, ChatItem } from './chat_context.js';
+import type { AudioGate } from './duplex_adapter.js';
+import { RealtimeError } from './realtime.js';
+import type { ToolChoice, ToolContext } from './tool_context.js';
+
+/** One frame of the model's continuous output, including its silence. */
+export interface DuplexAudioFrame {
+  frame: AudioFrame;
+  /** Position on the model's timeline, in milliseconds. */
+  startMs?: number;
+}
+
+/** A fragment of the model's transcript of its own speech. */
+export interface DuplexOutputTranscriptDelta {
+  text: string;
+  /** Start of the fragment on the model's timeline, in milliseconds. */
+  startMs?: number;
+  /** End of the fragment on the model's timeline, in milliseconds. */
+  endMs?: number;
+}
+
+/** Capabilities that vary between duplex providers. */
+export interface DuplexCapabilities {
+  userTranscription: boolean;
+  autoToolReplyGeneration: boolean;
+  midSessionChatCtxUpdate?: boolean;
+  midSessionInstructionsUpdate?: boolean;
+  midSessionToolsUpdate?: boolean;
+}
+
+/** A speech model that listens and speaks at once and handles its own interruptions. */
+export abstract class DuplexModel {
+  constructor(readonly capabilities: DuplexCapabilities) {}
+
+  get model(): string {
+    return 'unknown';
+  }
+
+  get provider(): string {
+    return 'unknown';
+  }
+
+  label(): string {
+    return this.constructor.name;
+  }
+
+  /** Return a new gate for this model's output, or let the adapter infer one. */
+  audioGate(): AudioGate | undefined {
+    return undefined;
+  }
+
+  abstract session(): DuplexSession;
+
+  abstract close(): Promise<void>;
+}
+
+/**
+ * A provider session with continuous audio output.
+ *
+ * Emits `transcript_delta`, `function_call`, `input_speech_started`, `input_speech_stopped`,
+ * `input_audio_transcription_completed`, `session_reconnected`, `metrics_collected`, and `error`.
+ * Provider-specific APIs are accessible through `Agent.duplexSession`.
+ */
+export abstract class DuplexSession extends EventEmitter {
+  /** Wait for complete startup configuration before connecting an immutable model. */
+  protected readonly _configured: {
+    readonly isSet: boolean;
+    wait(): Promise<boolean>;
+    set(): void;
+  } = new Event();
+
+  constructor(readonly duplexModel: DuplexModel) {
+    super();
+  }
+
+  get capabilities(): DuplexCapabilities {
+    return this.duplexModel.capabilities;
+  }
+
+  abstract get audioStream(): ReadableStream<DuplexAudioFrame>;
+  abstract get tools(): ToolContext;
+  abstract pushAudio(frame: AudioFrame): void;
+
+  pushVideo(_frame: VideoFrame): void {}
+
+  /** Release `_configured` before waiting for a connection task during close. */
+  abstract close(): Promise<void>;
+
+  abstract _updateInstructions(instructions: string): Promise<void>;
+  abstract _appendItems(items: ChatItem[]): Promise<void>;
+  abstract _updateTools(tools: ToolContext): Promise<void>;
+  abstract _updateOptions(options: { toolChoice?: ToolChoice | null }): void;
+
+  /** Ask the model to speak; its next speech is the reply. Providers may override this. */
+  _generateReply(
+    _instructions?: string,
+    _options?: { toolChoice?: ToolChoice; tools?: ToolContext },
+  ): void {
+    throw new RealtimeError(`${this.constructor.name} decides for itself when to speak`);
+  }
+
+  async _updateSession(
+    instructions?: string,
+    chatCtx?: ChatContext,
+    tools?: ToolContext,
+  ): Promise<void> {
+    if (instructions !== undefined) await this._updateInstructions(instructions);
+    if (chatCtx !== undefined) await this._appendItems(chatCtx.items);
+    if (tools !== undefined) await this._updateTools(tools);
+    this._configured.set();
+  }
+
+  /** Report connection acquisition time in milliseconds, with zero token usage. */
+  protected _reportConnectionAcquired(acquireTimeMs: number): void {
+    const metrics: RealtimeModelMetrics = {
+      type: 'realtime_model_metrics',
+      label: this.duplexModel.label(),
+      requestId: '',
+      timestamp: Date.now(),
+      durationMs: 0,
+      ttftMs: -1,
+      cancelled: false,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      tokensPerSecond: 0,
+      acquireTimeMs,
+      connectionReused: false,
+      inputTokenDetails: { audioTokens: 0, textTokens: 0, imageTokens: 0, cachedTokens: 0 },
+      outputTokenDetails: { audioTokens: 0, textTokens: 0, imageTokens: 0 },
+      metadata: { modelName: this.duplexModel.model, modelProvider: this.duplexModel.provider },
+    };
+    this.emit('metrics_collected', metrics);
+  }
+}

--- a/agents/src/llm/duplex.ts
+++ b/agents/src/llm/duplex.ts
@@ -93,7 +93,9 @@ export abstract class DuplexSession<
   Omit<Events, keyof DuplexSessionCallbacks>
 > &
   TypedEmitter<DuplexSessionCallbacks>)<Events> {
-  /** Wait for complete startup configuration before connecting an immutable model. */
+  protected _closing = false;
+
+  /** Wait for startup configuration, then check `_closing` before connecting. */
   protected readonly _configured: {
     readonly isSet: boolean;
     wait(): Promise<boolean>;
@@ -115,6 +117,7 @@ export abstract class DuplexSession<
   pushVideo(_frame: VideoFrame): void {}
 
   async close(): Promise<void> {
+    this._closing = true;
     this._configured.set();
     await this.closeConnection();
   }

--- a/agents/src/llm/duplex.ts
+++ b/agents/src/llm/duplex.ts
@@ -2,13 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { AudioFrame, VideoFrame } from '@livekit/rtc-node';
+import type { EventMap, TypedEventEmitter as TypedEmitter } from '@livekit/typed-emitter';
 import { EventEmitter } from 'node:events';
 import type { ReadableStream } from 'node:stream/web';
 import type { RealtimeModelMetrics } from '../metrics/base.js';
 import { Event } from '../utils.js';
-import type { ChatContext, ChatItem } from './chat_context.js';
+import type { ChatContext, ChatItem, FunctionCall } from './chat_context.js';
 import type { AudioGate } from './duplex_adapter.js';
-import { RealtimeError } from './realtime.js';
+import {
+  type InputSpeechStartedEvent,
+  type InputSpeechStoppedEvent,
+  type InputTranscriptionCompleted,
+  RealtimeError,
+  type RealtimeModelError,
+  type RealtimeSessionReconnectedEvent,
+} from './realtime.js';
 import type { ToolChoice, ToolContext } from './tool_context.js';
 
 /** One frame of the model's continuous output, including its silence. */
@@ -62,14 +70,29 @@ export abstract class DuplexModel {
   abstract close(): Promise<void>;
 }
 
+export type DuplexSessionCallbacks = {
+  transcript_delta: (event: DuplexOutputTranscriptDelta) => void;
+  function_call: (event: FunctionCall) => void;
+  input_speech_started: (event: InputSpeechStartedEvent) => void;
+  input_speech_stopped: (event: InputSpeechStoppedEvent) => void;
+  input_audio_transcription_completed: (event: InputTranscriptionCompleted) => void;
+  session_reconnected: (event: RealtimeSessionReconnectedEvent) => void;
+  metrics_collected: (event: RealtimeModelMetrics) => void;
+  error: (event: RealtimeModelError) => void;
+};
+
 /**
  * A provider session with continuous audio output.
  *
- * Emits `transcript_delta`, `function_call`, `input_speech_started`, `input_speech_stopped`,
- * `input_audio_transcription_completed`, `session_reconnected`, `metrics_collected`, and `error`.
+ * `Events` adds provider-specific callbacks to {@link DuplexSessionCallbacks}.
  * Provider-specific APIs are accessible through `Agent.duplexSession`.
  */
-export abstract class DuplexSession extends EventEmitter {
+export abstract class DuplexSession<
+  Events extends EventMap = Record<never, never>,
+> extends (EventEmitter as new <Events extends EventMap>() => TypedEmitter<
+  Omit<Events, keyof DuplexSessionCallbacks>
+> &
+  TypedEmitter<DuplexSessionCallbacks>)<Events> {
   /** Wait for complete startup configuration before connecting an immutable model. */
   protected readonly _configured: {
     readonly isSet: boolean;
@@ -91,8 +114,12 @@ export abstract class DuplexSession extends EventEmitter {
 
   pushVideo(_frame: VideoFrame): void {}
 
-  /** Release `_configured` before waiting for a connection task during close. */
-  abstract close(): Promise<void>;
+  async close(): Promise<void> {
+    this._configured.set();
+    await this.closeConnection();
+  }
+
+  protected abstract closeConnection(): Promise<void>;
 
   abstract _updateInstructions(instructions: string): Promise<void>;
   abstract _appendItems(items: ChatItem[]): Promise<void>;

--- a/agents/src/llm/duplex.ts
+++ b/agents/src/llm/duplex.ts
@@ -21,6 +21,7 @@ import type { ToolChoice, ToolContext } from './tool_context.js';
 
 /** One frame of the model's continuous output, including its silence. */
 export interface DuplexAudioFrame {
+  /** PCM audio to play or use to detect a silence boundary. */
   frame: AudioFrame;
   /** Position on the model's timeline, in milliseconds. */
   startMs?: number;
@@ -28,6 +29,7 @@ export interface DuplexAudioFrame {
 
 /** A fragment of the model's transcript of its own speech. */
 export interface DuplexOutputTranscriptDelta {
+  /** Text to append to the model's output transcript. */
   text: string;
   /** Start of the fragment on the model's timeline, in milliseconds. */
   startMs?: number;
@@ -37,25 +39,37 @@ export interface DuplexOutputTranscriptDelta {
 
 /** Capabilities that vary between duplex providers. */
 export interface DuplexCapabilities {
+  /** The provider emits transcripts of the user's audio. */
   userTranscription: boolean;
+  /** The provider starts its next reply after receiving tool results. */
   autoToolReplyGeneration: boolean;
+  /** The provider accepts appended chat items after startup. Defaults to false. */
   midSessionChatCtxUpdate?: boolean;
+  /** The provider accepts instruction changes after startup. Defaults to false. */
   midSessionInstructionsUpdate?: boolean;
+  /** The provider accepts tool changes after startup. Defaults to false. */
   midSessionToolsUpdate?: boolean;
 }
 
 /** A speech model that listens and speaks at once and handles its own interruptions. */
 export abstract class DuplexModel {
-  constructor(readonly capabilities: DuplexCapabilities) {}
+  /** Declare the provider features available to the framework. */
+  constructor(
+    /** Provider features used to configure the realtime adapter. */
+    readonly capabilities: DuplexCapabilities,
+  ) {}
 
+  /** Model identifier reported in metrics. */
   get model(): string {
     return 'unknown';
   }
 
+  /** Provider identifier reported in metrics. */
   get provider(): string {
     return 'unknown';
   }
 
+  /** Display label used in logs and metrics. */
   label(): string {
     return this.constructor.name;
   }
@@ -65,19 +79,30 @@ export abstract class DuplexModel {
     return undefined;
   }
 
+  /** Create a session. The framework applies its startup configuration after this returns. */
   abstract session(): DuplexSession;
 
+  /** Release resources shared by this model's sessions. */
   abstract close(): Promise<void>;
 }
 
+/** Events emitted by every duplex provider session. */
 export type DuplexSessionCallbacks = {
+  /** A fragment of the model's output transcript became available. */
   transcript_delta: (event: DuplexOutputTranscriptDelta) => void;
+  /** The model requested a tool call. */
   function_call: (event: FunctionCall) => void;
+  /** The provider detected the start of user speech. */
   input_speech_started: (event: InputSpeechStartedEvent) => void;
+  /** The provider detected the end of user speech. */
   input_speech_stopped: (event: InputSpeechStoppedEvent) => void;
+  /** A partial or final user transcript became available. */
   input_audio_transcription_completed: (event: InputTranscriptionCompleted) => void;
+  /** The provider reconnected; output from its previous connection is abandoned. */
   session_reconnected: (event: RealtimeSessionReconnectedEvent) => void;
+  /** The provider reported connection timing or model usage. */
   metrics_collected: (event: RealtimeModelMetrics) => void;
+  /** The provider reported an error and whether the session can recover. */
   error: (event: RealtimeModelError) => void;
 };
 
@@ -93,6 +118,7 @@ export abstract class DuplexSession<
   Omit<Events, keyof DuplexSessionCallbacks>
 > &
   TypedEmitter<DuplexSessionCallbacks>)<Events> {
+  /** Closing has started; a released configuration wait must not start a new connection. */
   protected _closing = false;
 
   /** Wait for startup configuration, then check `_closing` before connecting. */
@@ -102,31 +128,46 @@ export abstract class DuplexSession<
     set(): void;
   } = new Event();
 
-  constructor(readonly duplexModel: DuplexModel) {
+  /** Create a provider session owned by the given model. */
+  constructor(
+    /** Model that created this session. */
+    readonly duplexModel: DuplexModel,
+  ) {
     super();
   }
 
+  /** Provider features declared by the owning model. */
   get capabilities(): DuplexCapabilities {
     return this.duplexModel.capabilities;
   }
 
+  /** Continuous output audio, including silence, delivered at playback pace. */
   abstract get audioStream(): ReadableStream<DuplexAudioFrame>;
+  /** Tools currently available to the provider. */
   abstract get tools(): ToolContext;
+  /** Feed an input audio frame to the provider. */
   abstract pushAudio(frame: AudioFrame): void;
 
+  /** Feed an input video frame. Providers without video input can ignore it. */
   pushVideo(_frame: VideoFrame): void {}
 
+  /** Mark the session closing, release configuration waits, and close provider resources. */
   async close(): Promise<void> {
     this._closing = true;
     this._configured.set();
     await this.closeConnection();
   }
 
+  /** Close provider tasks, streams, and connections after the configuration wait is released. */
   protected abstract closeConnection(): Promise<void>;
 
+  /** Apply instructions, or reject changes the provider cannot accept. */
   abstract _updateInstructions(instructions: string): Promise<void>;
+  /** Append chat items to the provider's context. */
   abstract _appendItems(items: ChatItem[]): Promise<void>;
+  /** Replace the tools available to the provider. */
   abstract _updateTools(tools: ToolContext): Promise<void>;
+  /** Apply provider options used for subsequent replies. */
   abstract _updateOptions(options: { toolChoice?: ToolChoice | null }): void;
 
   /** Ask the model to speak; its next speech is the reply. Providers may override this. */
@@ -137,6 +178,7 @@ export abstract class DuplexSession<
     throw new RealtimeError(`${this.constructor.name} decides for itself when to speak`);
   }
 
+  /** Apply the complete startup configuration before releasing a waiting provider connection. */
   async _updateSession(
     instructions?: string,
     chatCtx?: ChatContext,
@@ -148,7 +190,10 @@ export abstract class DuplexSession<
     this._configured.set();
   }
 
-  /** Report connection acquisition time in milliseconds, with zero token usage. */
+  /**
+   * Report connection acquisition time in milliseconds, with zero token usage.
+   * This connection event has no response to correlate, so its `requestId` is empty.
+   */
   protected _reportConnectionAcquired(acquireTimeMs: number): void {
     const metrics: RealtimeModelMetrics = {
       type: 'realtime_model_metrics',

--- a/agents/src/llm/duplex.ts
+++ b/agents/src/llm/duplex.ts
@@ -51,7 +51,12 @@ export interface DuplexCapabilities {
   midSessionToolsUpdate?: boolean;
 }
 
-/** A speech model that listens and speaks at once and handles its own interruptions. */
+/**
+ * A speech model that listens and speaks at once and handles its own interruptions.
+ *
+ * Chat context updates append new items. Edits and removals change the framework's local
+ * history; the provider retains the content it has already received.
+ */
 export abstract class DuplexModel {
   /** Declare the provider features available to the framework. */
   constructor(

--- a/agents/src/llm/duplex.type.test.ts
+++ b/agents/src/llm/duplex.type.test.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expectTypeOf, it } from 'vitest';
+import type { DuplexOutputTranscriptDelta } from './duplex.js';
+import { DuplexSession, type DuplexSessionCallbacks } from './index.js';
+import type { InputTranscriptionCompleted } from './realtime.js';
+
+type ProviderCallbacks = {
+  provider_state: (state: 'listening' | 'speaking') => void;
+};
+
+abstract class ProviderSession extends DuplexSession<ProviderCallbacks> {
+  checkEventTypes(): void {
+    this.emit('transcript_delta', { text: 'hello' });
+    this.on('transcript_delta', (event) => {
+      expectTypeOf(event).toEqualTypeOf<DuplexOutputTranscriptDelta>();
+    });
+    this.on('input_audio_transcription_completed', (event) => {
+      expectTypeOf(event).toEqualTypeOf<InputTranscriptionCompleted>();
+    });
+    this.emit('provider_state', 'listening');
+    this.on('provider_state', (state) => {
+      expectTypeOf(state).toEqualTypeOf<'listening' | 'speaking'>();
+    });
+
+    // @ts-expect-error Event names must match the callback map.
+    this.emit('transcript_dleta', { text: 'hello' });
+    // @ts-expect-error Function calls require the FunctionCall payload.
+    this.emit('function_call', { text: 'hello' });
+    // @ts-expect-error The event name selects the listener's payload type.
+    this.on('input_audio_transcription_completed', (event: number) => event.toFixed());
+    // @ts-expect-error Provider-specific payloads are also checked.
+    this.emit('provider_state', 42);
+    // @ts-expect-error Metrics require the RealtimeModelMetrics payload.
+    this.emit('metrics_collected', { wrong: true });
+  }
+}
+
+describe('DuplexSession events', () => {
+  it('limits base sessions to the standard callbacks', () => {
+    expectTypeOf<DuplexSession['on']>().parameter(0).toEqualTypeOf<keyof DuplexSessionCallbacks>();
+  });
+
+  it('accepts provider sessions with additional typed callbacks', () => {
+    expectTypeOf<ProviderSession>().toExtend<DuplexSession>();
+  });
+});

--- a/agents/src/llm/duplex_adapter.test.ts
+++ b/agents/src/llm/duplex_adapter.test.ts
@@ -49,6 +49,7 @@ class FakeDuplexModel extends DuplexModel {
 }
 
 class FakeDuplexSession extends DuplexSession {
+  private readonly connectionTask = this._configured.wait();
   controller!: ReadableStreamDefaultController<DuplexAudioFrame>;
   readonly audioStream = new ReadableStream<DuplexAudioFrame>({
     start: (controller) => {
@@ -78,8 +79,8 @@ class FakeDuplexSession extends DuplexSession {
   }
   _updateOptions(_options: { toolChoice?: ToolChoice | null }): void {}
   pushAudio(_frame: AudioFrame): void {}
-  async close(): Promise<void> {
-    this._configured.set();
+  protected async closeConnection(): Promise<void> {
+    await this.connectionTask;
     if (!this.closed) this.controller.close();
     this.closed = true;
   }
@@ -665,11 +666,17 @@ describe('duplex events and context', () => {
   it('releases the blocked reader and event listeners when closing before configuration', async () => {
     const { fake, session } = setup();
     const close = vi.spyOn(fake, 'close');
-    await Promise.all([session.close(), session.close()]);
-    expect(close).toHaveBeenCalledOnce();
-    expect(fake.configured).toBe(true);
-    expect(fake.audioStream.locked).toBe(false);
-    expect(fake.eventNames()).toEqual([]);
+    const closing = Promise.all([session.close(), session.close()]);
+    try {
+      await vi.waitFor(() => expect(fake.closed).toBe(true));
+      expect(close).toHaveBeenCalledOnce();
+      expect(fake.configured).toBe(true);
+      expect(fake.audioStream.locked).toBe(false);
+      expect(fake.eventNames()).toEqual([]);
+    } finally {
+      await fake._updateSession();
+      await closing;
+    }
   });
 });
 
@@ -744,6 +751,30 @@ describe('duplex requested replies', () => {
 });
 
 describe('duplex model integration', () => {
+  it('closes the provider after startup configuration fails', async () => {
+    vi.spyOn(FakeDuplexSession.prototype, '_updateInstructions').mockRejectedValueOnce(
+      new RealtimeError('configuration failed'),
+    );
+    const model = new FakeDuplexModel();
+    const agent = new Agent({ instructions: 'be brief' });
+    const session = new AgentSession({ llm: model, vad: null, aecWarmupDuration: null });
+    await session.start({ agent });
+    const provider = model.activeSession;
+    expect(provider.configured).toBe(false);
+
+    const closing = session.close();
+    try {
+      await vi.waitFor(() => expect(provider.closed).toBe(true));
+      await closing;
+      expect(provider.audioStream.locked).toBe(false);
+      expect(provider.eventNames()).toEqual([]);
+      expect(() => agent.getActivityOrThrow()).toThrow('Agent activity not found');
+    } finally {
+      await provider._updateSession();
+      await closing;
+    }
+  });
+
   it.each(['none', 'listening', 'throwing'] as const)(
     'closes on an unrecoverable audio error with a %s application error listener',
     async (listener) => {

--- a/agents/src/llm/duplex_adapter.test.ts
+++ b/agents/src/llm/duplex_adapter.test.ts
@@ -673,20 +673,27 @@ describe('duplex events and context', () => {
     ]);
   });
 
-  it('reports a failed audio consumer as unrecoverable and closes the open generation', async () => {
-    const { fake, session, generations } = setup({ gate: () => new FixedGate(0.002) });
-    const errors: RealtimeModelError[] = [];
-    session.on('error', (error) => errors.push(error));
-    fake.push(0.3);
-    await setImmediate();
-    fake.controller.error(new Error('stream failed'));
-    fake.closed = true;
-    await setImmediate();
-    expect(errors).toMatchObject([
-      { recoverable: false, label: fake.duplexModel.label(), error: new Error('stream failed') },
-    ]);
-    expect((await readGeneration(generations[0]!)).frames).toHaveLength(1);
-  });
+  it.each([new Error('stream failed'), 'secret provider payload', { payload: 'secret' }])(
+    'reports an unrecoverable audio failure and closes the generation (reason: %s)',
+    async (reason) => {
+      const { fake, session, generations } = setup({ gate: () => new FixedGate(0.002) });
+      const errors: RealtimeModelError[] = [];
+      const logged = vi.spyOn(log(), 'error');
+      session.on('error', (error) => errors.push(error));
+      fake.push(0.3);
+      await setImmediate();
+      fake.controller.error(reason);
+      fake.closed = true;
+      await setImmediate();
+      const expectedError =
+        reason instanceof Error ? reason : new RealtimeError('duplex audio stream failed');
+      expect(errors).toMatchObject([
+        { recoverable: false, label: fake.duplexModel.label(), error: expectedError },
+      ]);
+      expect(logged).toHaveBeenCalledWith({ error: expectedError }, 'duplex audio stream failed');
+      expect((await readGeneration(generations[0]!)).frames).toHaveLength(1);
+    },
+  );
 
   it('releases the blocked reader and event listeners when closing before configuration', async () => {
     const { fake, session } = setup();

--- a/agents/src/llm/duplex_adapter.test.ts
+++ b/agents/src/llm/duplex_adapter.test.ts
@@ -21,7 +21,7 @@ import {
 } from './duplex_adapter.js';
 import type { DuplexRealtimeAdapterOptions } from './duplex_adapter.js';
 import { type GenerationCreatedEvent, RealtimeError, type RealtimeModelError } from './realtime.js';
-import { type ToolChoice, ToolContext } from './tool_context.js';
+import { type ToolChoice, ToolContext, Toolset } from './tool_context.js';
 
 function frame(level: number, duration = 100): AudioFrame {
   const samples = new Int16Array((24_000 * duration) / 1000);
@@ -756,36 +756,50 @@ describe('duplex requested replies', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it('cancels pending requests with AbortSignal without claiming later spontaneous speech', async () => {
-    const { model, fake, session, generations } = setup({ gate: () => new FixedGate(0.002) });
-    model.askable = true;
-    const controller = new AbortController();
-    const reply = expect(
-      session.generateReply(undefined, { signal: controller.signal }),
-    ).rejects.toThrow('aborted');
-    controller.abort();
-    await reply;
-    fake.push(0.3);
-    await setImmediate();
-    expect(generations[0]!.userInitiated).toBe(false);
-    const count = fake.repliesRequested.length;
-    await expect(session.generateReply(undefined, { signal: controller.signal })).rejects.toThrow(
-      'aborted',
-    );
-    expect(fake.repliesRequested).toHaveLength(count);
-  });
+  it.each([undefined, 'user disconnected', { source: 'client' }, new Error('aborted')])(
+    'cancels pending requests without claiming later speech (abort reason: %s)',
+    async (reason) => {
+      const { model, fake, session, generations } = setup({ gate: () => new FixedGate(0.002) });
+      model.askable = true;
+      const controller = new AbortController();
+      const reply = expect(
+        session.generateReply(undefined, { signal: controller.signal }),
+      ).rejects.toThrow('aborted');
+      controller.abort(reason);
+      await reply;
+      fake.push(0.3);
+      await setImmediate();
+      expect(generations[0]!.userInitiated).toBe(false);
+      const count = fake.repliesRequested.length;
+      await expect(session.generateReply(undefined, { signal: controller.signal })).rejects.toThrow(
+        'aborted',
+      );
+      expect(fake.repliesRequested).toHaveLength(count);
+    },
+  );
 });
 
 describe('duplex model integration', () => {
-  it('closes the provider immediately when startup configuration fails', async () => {
-    vi.spyOn(FakeDuplexSession.prototype, '_updateInstructions').mockRejectedValueOnce(
-      new RealtimeError('configuration failed'),
-    );
+  it('rejects failed startup, cleans up, and allows a fresh start', async () => {
+    const error = new RealtimeError('configuration failed');
+    vi.spyOn(FakeDuplexSession.prototype, '_updateInstructions').mockRejectedValueOnce(error);
     const model = new FakeDuplexModel();
-    const agent = new Agent({ instructions: 'be brief' });
-    const session = new AgentSession({ llm: model, vad: null, aecWarmupDuration: null });
+    const agentTools = Toolset.create({ id: 'agent', tools: [] });
+    const sessionTools = Toolset.create({ id: 'session', tools: [] });
+    const setupAgentTools = vi.spyOn(agentTools, 'setup');
+    const setupSessionTools = vi.spyOn(sessionTools, 'setup');
+    const closeAgentTools = vi.spyOn(agentTools, 'aclose');
+    const closeSessionTools = vi.spyOn(sessionTools, 'aclose');
+    const agent = new Agent({ instructions: 'be brief', tools: [agentTools] });
+    const session = new AgentSession({
+      llm: model,
+      tools: [sessionTools],
+      vad: null,
+      aecWarmupDuration: null,
+    });
     const closeProvider = vi.spyOn(FakeDuplexSession.prototype, 'close');
-    await session.start({ agent });
+    const onEnter = vi.spyOn(agent, 'onEnter');
+    await expect(session.start({ agent })).rejects.toBe(error);
     const provider = model.activeSession;
     try {
       expect(provider.closed).toBe(true);
@@ -793,12 +807,72 @@ describe('duplex model integration', () => {
       expect(provider.connected).toBe(false);
       expect(provider.audioStream.locked).toBe(false);
       expect(provider.eventNames()).toEqual([]);
+      expect(session._started).toBe(false);
+      expect(session.rootSpanContext).toBeUndefined();
+      expect(onEnter).not.toHaveBeenCalled();
+      expect(() => agent.getActivityOrThrow()).toThrow('Agent activity not found');
+      expect(setupAgentTools).toHaveBeenCalledOnce();
+      expect(setupSessionTools).toHaveBeenCalledOnce();
+      expect(closeAgentTools).toHaveBeenCalledOnce();
+      expect(closeSessionTools).toHaveBeenCalledOnce();
     } finally {
       await session.close();
     }
     expect(closeProvider).toHaveBeenCalledOnce();
     expect(() => agent.getActivityOrThrow()).toThrow('Agent activity not found');
+
+    await session.start({ agent });
+    try {
+      expect(session._started).toBe(true);
+      expect(model.activeSession.connected).toBe(true);
+      expect(model.activeSession.closed).toBe(false);
+      expect(setupAgentTools).toHaveBeenCalledTimes(2);
+      expect(setupSessionTools).toHaveBeenCalledTimes(2);
+    } finally {
+      await session.close();
+    }
   });
+
+  it.each(['none', 'listening', 'throwing'] as const)(
+    'closes after failed handoff configuration with a %s application error listener',
+    async (listener) => {
+      const model = new FakeDuplexModel();
+      const agent = new Agent({ instructions: 'first' });
+      const nextAgent = new Agent({ instructions: 'second' });
+      const session = new AgentSession({ llm: model, vad: null, aecWarmupDuration: null });
+      const closed = vi.fn();
+      session.on(AgentSessionEventTypes.Close, closed);
+      const errors = vi.fn(() => {
+        if (listener === 'throwing') throw new Error('application error listener failed');
+      });
+      if (listener !== 'none') session.on(AgentSessionEventTypes.Error, errors);
+      await session.start({ agent });
+      const firstProvider = model.activeSession;
+      const onEnter = vi.spyOn(nextAgent, 'onEnter');
+      vi.spyOn(FakeDuplexSession.prototype, '_updateInstructions').mockRejectedValueOnce(
+        new RealtimeError('configuration failed'),
+      );
+      session.updateAgent(nextAgent);
+
+      try {
+        await vi.waitFor(() => {
+          expect(closed).toHaveBeenCalledWith(
+            expect.objectContaining({ reason: CloseReason.ERROR }),
+          );
+        });
+        expect(firstProvider.closed).toBe(true);
+        expect(model.activeSession.closed).toBe(true);
+        expect(model.activeSession.audioStream.locked).toBe(false);
+        expect(model.activeSession.eventNames()).toEqual([]);
+        expect(onEnter).not.toHaveBeenCalled();
+        expect(errors).toHaveBeenCalledTimes(listener === 'none' ? 0 : 1);
+        expect(() => agent.getActivityOrThrow()).toThrow('Agent activity not found');
+        expect(() => nextAgent.getActivityOrThrow()).toThrow('Agent activity not found');
+      } finally {
+        await session.close();
+      }
+    },
+  );
 
   it.each(['none', 'listening', 'throwing'] as const)(
     'closes on an unrecoverable audio error with a %s application error listener',

--- a/agents/src/llm/duplex_adapter.test.ts
+++ b/agents/src/llm/duplex_adapter.test.ts
@@ -1,0 +1,849 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream, type ReadableStreamDefaultController } from 'node:stream/web';
+import { setImmediate } from 'node:timers/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { log } from '../log.js';
+import type { RealtimeModelMetrics } from '../metrics/base.js';
+import { Agent } from '../voice/agent.js';
+import { AgentSession } from '../voice/agent_session.js';
+import { AgentSessionEventTypes, CloseReason } from '../voice/events.js';
+import { type TimedString, isTimedString } from '../voice/io.js';
+import { ChatContext, type ChatItem, FunctionCall, FunctionCallOutput } from './chat_context.js';
+import { type DuplexAudioFrame, DuplexModel, DuplexSession } from './duplex.js';
+import {
+  AdaptiveNoiseGate,
+  DuplexRealtimeAdapter,
+  DuplexRealtimeSession,
+  FixedGate,
+} from './duplex_adapter.js';
+import type { DuplexRealtimeAdapterOptions } from './duplex_adapter.js';
+import { type GenerationCreatedEvent, RealtimeError, type RealtimeModelError } from './realtime.js';
+import { type ToolChoice, ToolContext } from './tool_context.js';
+
+function frame(level: number, duration = 100): AudioFrame {
+  const samples = new Int16Array((24_000 * duration) / 1000);
+  const amplitude = Math.trunc(level * 32767);
+  for (let i = 0; i < samples.length; i++) samples[i] = i % 2 ? -amplitude : amplitude;
+  return new AudioFrame(samples, 24_000, 1, samples.length);
+}
+
+class FakeDuplexModel extends DuplexModel {
+  activeSession!: FakeDuplexSession;
+  askable = false;
+  constructor() {
+    super({ userTranscription: true, autoToolReplyGeneration: true });
+  }
+  get model() {
+    return 'fake-duplex';
+  }
+  get provider() {
+    return 'fake';
+  }
+  session(): FakeDuplexSession {
+    return (this.activeSession = new FakeDuplexSession(this));
+  }
+  async close(): Promise<void> {}
+}
+
+class FakeDuplexSession extends DuplexSession {
+  controller!: ReadableStreamDefaultController<DuplexAudioFrame>;
+  readonly audioStream = new ReadableStream<DuplexAudioFrame>({
+    start: (controller) => {
+      this.controller = controller;
+    },
+  });
+  tools = ToolContext.empty();
+  appended: ChatItem[] = [];
+  configBatches: unknown[][] = [];
+  repliesRequested: Array<string | undefined> = [];
+  failInstructions = false;
+  closed = false;
+  constructor(readonly fakeModel: FakeDuplexModel) {
+    super(fakeModel);
+  }
+  get configured(): boolean {
+    return this._configured.isSet;
+  }
+  async _updateInstructions(_instructions: string): Promise<void> {
+    if (this.failInstructions) throw new RealtimeError('configuration failed');
+  }
+  async _appendItems(items: ChatItem[]): Promise<void> {
+    this.appended.push(...items);
+  }
+  async _updateTools(tools: ToolContext): Promise<void> {
+    this.tools = tools;
+  }
+  _updateOptions(_options: { toolChoice?: ToolChoice | null }): void {}
+  pushAudio(_frame: AudioFrame): void {}
+  async close(): Promise<void> {
+    this._configured.set();
+    if (!this.closed) this.controller.close();
+    this.closed = true;
+  }
+  _generateReply(instructions?: string): void {
+    if (!this.fakeModel.askable) super._generateReply(instructions);
+    this.repliesRequested.push(instructions);
+  }
+  async _updateSession(
+    instructions?: string,
+    chatCtx?: ChatContext,
+    tools?: ToolContext,
+  ): Promise<void> {
+    this.configBatches.push([instructions, chatCtx, tools]);
+    await super._updateSession(instructions, chatCtx, tools);
+  }
+  reportConnectionAcquired(duration: number): void {
+    this._reportConnectionAcquired(duration);
+  }
+  push(level: number, count = 1, startMs?: number): void {
+    for (let i = 0; i < count; i++) {
+      this.controller.enqueue({
+        frame: frame(level),
+        startMs: startMs === undefined ? undefined : startMs + i * 100,
+      });
+    }
+  }
+  say(text: string, startMs?: number, endMs?: number): void {
+    this.emit('transcript_delta', { text, startMs, endMs });
+  }
+  heard(itemId: string, transcript: string): void {
+    this.emit('input_speech_started', {});
+    this.emit('input_audio_transcription_completed', { itemId, transcript, isFinal: true });
+    this.emit('input_speech_stopped', { userTranscriptionEnabled: false });
+  }
+}
+
+const sessions: DuplexRealtimeSession[] = [];
+afterEach(async () => {
+  await Promise.all(sessions.splice(0).map((session) => session.close()));
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function setup(options: DuplexRealtimeAdapterOptions = {}, model = new FakeDuplexModel()) {
+  const adapter = new DuplexRealtimeAdapter(model, options);
+  const session = adapter.session();
+  if (!(session instanceof DuplexRealtimeSession)) throw new Error('expected duplex session');
+  sessions.push(session);
+  const generations: GenerationCreatedEvent[] = [];
+  session.on('generation_created', (ev) => generations.push(ev));
+  return { model, adapter, fake: model.activeSession, session, generations };
+}
+
+async function readGeneration(ev: GenerationCreatedEvent) {
+  const chunks: Array<string | TimedString> = [];
+  const frames: AudioFrame[] = [];
+  const messages = [];
+  for await (const message of ev.messageStream) {
+    messages.push(message);
+    for await (const f of message.audioStream) frames.push(f);
+    for await (const chunk of message.textStream) chunks.push(chunk);
+  }
+  const functions = [];
+  for await (const call of ev.functionStream) functions.push(call);
+  return {
+    frames,
+    chunks,
+    messages,
+    functions,
+    text: chunks.map((chunk) => (isTimedString(chunk) ? chunk.text : chunk)).join(''),
+  };
+}
+
+describe('duplex audio gates', () => {
+  it.each([0, 0.02])('stays closed on a steady floor of %s', (level) => {
+    const gate = new AdaptiveNoiseGate();
+    for (let i = 0; i < 40; i++) expect(gate.update(frame(level))).toBe(false);
+  });
+
+  it('opens above room tone and holds through short quiet gaps', () => {
+    const gate = new AdaptiveNoiseGate({ minSilenceDuration: 250 });
+    for (let i = 0; i < 30; i++) gate.update(frame(0.001));
+    expect(gate.update(frame(0.3))).toBe(true);
+    expect(gate.update(frame(0.001))).toBe(true);
+    expect(gate.update(frame(0.001))).toBe(true);
+    expect(gate.update(frame(0.001))).toBe(false);
+  });
+
+  it.each([false, true])('does not learn sustained speech as silence (gaps: %s)', (gaps) => {
+    const gate = new AdaptiveNoiseGate({ window: 1000 });
+    for (let i = 0; i < 30; i++) gate.update(frame(0.002));
+    for (let i = 0; i < 400; i++) {
+      expect(gate.update(frame(gaps && i % 10 === 9 ? 0.003 : 0.3))).toBe(true);
+    }
+    expect(gate.update(frame(0.3))).toBe(true);
+    for (let i = 0; i < 4; i++) expect(gate.update(frame(0.002))).toBe(true);
+    expect(gate.update(frame(0.002))).toBe(false);
+    expect(gate.update(frame(0.3))).toBe(true);
+  });
+
+  it('does not learn its floor from one dropped frame', () => {
+    const gate = new AdaptiveNoiseGate();
+    for (let i = 0; i < 30; i++) gate.update(frame(0.002));
+    gate.update(frame(0));
+    for (let i = 0; i < 300; i++) expect(gate.update(frame(0.002))).toBe(false);
+  });
+
+  it('recovers when a session starts mid-speech', () => {
+    const gate = new AdaptiveNoiseGate();
+    for (let i = 0; i < 30; i++) expect(gate.update(frame(0.2))).toBe(false);
+    for (let i = 0; i < 20; i++) gate.update(frame(0.002));
+    expect(gate.update(frame(0.2))).toBe(true);
+  });
+
+  it('uses a declared silence without learning and ignores room tone', () => {
+    const gate = new FixedGate(0.02);
+    for (let i = 0; i < 40; i++) expect(gate.update(frame(0.02))).toBe(false);
+    for (let i = 0; i < 600; i++) expect(gate.update(frame(0.3))).toBe(true);
+    for (let i = 0; i < 5; i++) gate.update(frame(0.02));
+    expect(gate.update(frame(0.02))).toBe(false);
+    expect(new FixedGate(0.002).update(frame(0.2))).toBe(true);
+  });
+
+  it('uses audio duration rather than frame count', () => {
+    const levels = [
+      ...Array<number>(12).fill(0.001),
+      ...Array<number>(6).fill(0.3),
+      ...Array<number>(12).fill(0.001),
+    ];
+    const decisions = [20, 100].map((duration) => {
+      const gate = new AdaptiveNoiseGate({ window: 1000, minSilenceDuration: 450 });
+      return levels.map((level) => {
+        let open = false;
+        for (let i = 0; i < 100 / duration; i++) open = gate.update(frame(level, duration));
+        return open;
+      });
+    });
+    expect(decisions[0]).toEqual(decisions[1]);
+    expect(decisions[0]![12]).toBe(true);
+    expect(decisions[0]!.at(-1)).toBe(false);
+  });
+
+  it.each([FixedGate, AdaptiveNoiseGate])(
+    'deactivates without forgetting the floor: %s',
+    (Gate) => {
+      const gate = Gate === FixedGate ? new FixedGate(0.002) : new AdaptiveNoiseGate();
+      for (let i = 0; i < 20; i++) gate.update(frame(0.002));
+      expect(gate.update(frame(0.3))).toBe(true);
+      gate.deactivate();
+      expect(gate.update(frame(0.002))).toBe(false);
+      expect(gate.update(frame(0.3))).toBe(true);
+    },
+  );
+});
+
+describe('duplex segmentation', () => {
+  it('prefers an explicit gate, then the model gate, then an adaptive gate', async () => {
+    const model = new FakeDuplexModel();
+    const inferred = setup({}, model);
+    inferred.fake.push(0.3);
+    await setImmediate();
+    expect(inferred.generations).toHaveLength(0);
+    vi.spyOn(model, 'audioGate').mockImplementation(() => new FixedGate(0.002));
+    const declared = setup({}, model);
+    declared.fake.push(0.3);
+    await setImmediate();
+    expect(declared.generations).toHaveLength(1);
+    const explicit = setup({ gate: () => new AdaptiveNoiseGate() }, model);
+    explicit.fake.push(0.3);
+    await setImmediate();
+    expect(explicit.generations).toHaveLength(0);
+  });
+
+  it('closes a burst when frames stop arriving, including the last frame duration', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const { fake, generations } = setup({ audioTimeout: 50 });
+    fake.push(0.001, 20);
+    fake.push(0.3, 3);
+    await setImmediate();
+    const read = readGeneration(generations[0]!);
+    let finished = false;
+    void read.then(() => {
+      finished = true;
+    });
+    await vi.advanceTimersByTimeAsync(149);
+    expect(finished).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect((await read).frames).toHaveLength(3);
+    fake.push(0.3, 3);
+    await setImmediate();
+    expect(generations).toHaveLength(2);
+  });
+
+  it('does not produce a generation from silence', async () => {
+    const { fake, generations } = setup();
+    fake.push(0, 20);
+    await setImmediate();
+    expect(generations).toEqual([]);
+  });
+
+  it('plays untranscribed backchannels without creating a chat item', async () => {
+    const { fake, session, generations } = setup();
+    fake.push(0.001, 20);
+    fake.push(0.3, 3);
+    fake.push(0.001, 8);
+    await setImmediate();
+    expect(generations).toHaveLength(1);
+    const result = await readGeneration(generations[0]!);
+    expect(result.frames).toHaveLength(7);
+    expect(result.text).toBe('');
+    expect(session.chatCtx.items).toEqual([]);
+  });
+
+  it('creates two generations for two stretches of speech', async () => {
+    const { fake, generations } = setup();
+    fake.push(0.001, 20);
+    for (let i = 0; i < 2; i++) {
+      fake.push(0.3, 3);
+      fake.push(0.001, 8);
+    }
+    await setImmediate();
+    expect(generations).toHaveLength(2);
+    expect(generations[0]!.responseId).not.toBe(generations[1]!.responseId);
+  });
+
+  it('preserves pauses inside an utterance', async () => {
+    const { fake, generations } = setup();
+    fake.push(0.001, 20);
+    fake.push(0.3, 3);
+    fake.push(0.001, 3);
+    fake.push(0.3, 3);
+    fake.push(0.001, 8);
+    await setImmediate();
+    expect(generations).toHaveLength(1);
+    expect((await readGeneration(generations[0]!)).frames).toHaveLength(13);
+  });
+
+  it('joins transcript fragments to the open burst', async () => {
+    const { fake, generations } = setup();
+    fake.push(0.001, 20);
+    fake.push(0.3, 2);
+    await setImmediate();
+    fake.say('Sure,', 2000, 2200);
+    fake.push(0.3, 2);
+    fake.say(' I can.', 2200, 2400);
+    fake.push(0.001, 8);
+    await setImmediate();
+    expect((await readGeneration(generations[0]!)).text).toBe('Sure, I can.');
+  });
+
+  it.each([false, true])(
+    'anchors timed text to the burst onset (stamped audio: %s)',
+    async (stamped) => {
+      const { fake, generations } = setup();
+      fake.push(0.001, 20, stamped ? 5000 : undefined);
+      fake.push(0.3, 2, stamped ? 7000 : undefined);
+      await setImmediate();
+      fake.say('hello', 7000, 7200);
+      fake.say(' there', 7200, 7400);
+      fake.push(0.3, 3, stamped ? 7200 : undefined);
+      await fake.close();
+      await setImmediate();
+      const { chunks } = await readGeneration(generations[0]!);
+      expect(chunks).toMatchObject([
+        { text: 'hello', startTime: 0, endTime: 0.2 },
+        { text: ' there', startTime: 0.2, endTime: 0.4 },
+      ]);
+    },
+  );
+
+  it('waits for sound when its transcript arrives first', async () => {
+    const { fake, generations } = setup();
+    fake.push(0.001, 20);
+    await setImmediate();
+    fake.say(' Sure.', 2000, 2200);
+    fake.push(0.001, 5);
+    await setImmediate();
+    expect(generations).toHaveLength(0);
+    fake.push(0.3, 3);
+    fake.push(0.001, 8);
+    await setImmediate();
+    expect((await readGeneration(generations[0]!)).text).toBe(' Sure.');
+  });
+
+  it('carries fragments beyond a burst into the next burst', async () => {
+    const { fake, generations } = setup();
+    fake.push(0.001, 20);
+    fake.push(0.3, 3);
+    await setImmediate();
+    fake.say(' Checking the current conditions.', 2000, 2800);
+    fake.say(" It's", 4200, 4400);
+    fake.push(0.001, 8);
+    await setImmediate();
+    expect((await readGeneration(generations[0]!)).text).toBe(' Checking the current conditions.');
+    fake.push(0.3, 3);
+    await setImmediate();
+    fake.say(' 62 degrees.', 4400, 5000);
+    fake.push(0.3, 3);
+    fake.push(0.001, 8);
+    await setImmediate();
+    expect((await readGeneration(generations[1]!)).text).toBe(" It's 62 degrees.");
+  });
+
+  it('anchors late fragments at the onset and keeps annotations monotonic', async () => {
+    const { fake, generations } = setup();
+    fake.push(0.001, 20);
+    fake.push(0.3, 5);
+    await setImmediate();
+    fake.say('Hello there.', 9000, 9400);
+    fake.say(' Again.', 9200, 9300);
+    fake.push(0.3);
+    await fake.close();
+    await setImmediate();
+    expect((await readGeneration(generations[0]!)).chunks).toMatchObject([
+      { startTime: 0, endTime: 0.4 },
+      { startTime: 0.4, endTime: 0.4 },
+    ]);
+  });
+
+  it('attaches an ahead-of-audio fragment only when the audio reaches it', async () => {
+    const { fake, generations } = setup();
+    fake.push(0.001, 20);
+    fake.push(0.3, 3);
+    await setImmediate();
+    fake.say(" Yep, I've got order A1042", 5000, 5600);
+    fake.say(' on file.', 6500, 6900);
+    fake.push(0.3);
+    await setImmediate();
+    const messageReader = generations[0]!.messageStream.getReader();
+    const message = (await messageReader.read()).value!;
+    const reader = message.textStream.getReader();
+    expect((await reader.read()).value).toMatchObject({ text: " Yep, I've got order A1042" });
+    let nextArrived = false;
+    const next = reader.read().then((value) => {
+      nextArrived = true;
+      return value;
+    });
+    await setImmediate();
+    expect(nextArrived).toBe(false);
+    fake.push(0.3, 2);
+    fake.push(0.001, 4);
+    fake.push(0.3, 3);
+    await setImmediate();
+    expect((await next).value).toMatchObject({ text: ' on file.' });
+    fake.push(0.001, 8);
+    await setImmediate();
+    expect(generations).toHaveLength(1);
+    reader.releaseLock();
+    messageReader.releaseLock();
+  });
+
+  it('emits an unclaimed transcript after three seconds of silent audio', async () => {
+    const { fake, generations } = setup();
+    const error = vi.spyOn(log(), 'error');
+    fake.push(0.001, 20);
+    await setImmediate();
+    fake.say('lost audio');
+    fake.push(0.001, 29);
+    await setImmediate();
+    expect(generations).toHaveLength(0);
+    fake.push(0.001);
+    await setImmediate();
+    const result = await readGeneration(generations[0]!);
+    expect(result.text).toBe('lost audio');
+    expect(result.frames).toHaveLength(0);
+    expect(error).toHaveBeenCalledWith(
+      expect.anything(),
+      'duplex transcript outlived the audio it describes',
+    );
+  });
+});
+
+describe('duplex events and context', () => {
+  it.each([false, true])(
+    'delivers tool calls with or without speech (speaking: %s)',
+    async (speaking) => {
+      const { fake, session, generations } = setup();
+      if (speaking) {
+        fake.push(0.001, 20);
+        fake.push(0.3, 3);
+        await setImmediate();
+      }
+      const call = FunctionCall.create({ callId: 'c1', name: 'lookup', args: '{}' });
+      fake.emit('function_call', call);
+      if (speaking) {
+        fake.say('Let me check.');
+        fake.push(0.001, 8);
+        await setImmediate();
+      }
+      expect(generations).toHaveLength(1);
+      const result = await readGeneration(generations[0]!);
+      expect(result.functions).toEqual([call]);
+      expect(result.messages).toHaveLength(speaking ? 1 : 0);
+      expect(result.text).toBe(speaking ? 'Let me check.' : '');
+      expect(session.chatCtx.getById(call.id)).toBe(call);
+    },
+  );
+
+  it('reconnects without carrying abandoned fragments into new speech', async () => {
+    const { fake, session, generations } = setup();
+    const reconnected = vi.fn();
+    session.on('session_reconnected', reconnected);
+    fake.push(0.001, 20);
+    fake.push(0.3, 3);
+    await setImmediate();
+    fake.say('lost words');
+    fake.emit('session_reconnected', {});
+    expect((await readGeneration(generations[0]!)).text).toBe('');
+    fake.push(0.3, 3);
+    fake.push(0.001, 8);
+    await setImmediate();
+    expect((await readGeneration(generations[1]!)).text).toBe('');
+    expect(reconnected).toHaveBeenCalledOnce();
+  });
+
+  it('forwards user events without cutting the current burst', async () => {
+    const { fake, session, generations } = setup();
+    const events: unknown[] = [];
+    for (const name of [
+      'input_speech_started',
+      'input_audio_transcription_completed',
+      'input_speech_stopped',
+    ]) {
+      session.on(name, (ev) => events.push(ev));
+    }
+    fake.push(0.001, 20);
+    fake.push(0.3, 3);
+    await setImmediate();
+    fake.heard('u1', 'Hello');
+    fake.say('Still speaking');
+    fake.push(0.3, 2);
+    fake.push(0.001, 8);
+    await setImmediate();
+    expect(generations).toHaveLength(1);
+    expect(events).toHaveLength(3);
+    expect((await readGeneration(generations[0]!)).text).toBe('Still speaking');
+    expect(session.chatCtx.getById('u1')).toMatchObject({ transcriptConfidence: 1 });
+  });
+
+  it('records the same message IDs and preserves a delayed user transcript time and confidence', async () => {
+    const { fake, session, generations } = setup();
+    fake.push(0.001, 20);
+    fake.push(0.3, 3);
+    await setImmediate();
+    fake.say('Hi');
+    fake.push(0.001, 8);
+    await setImmediate();
+    fake.emit('input_audio_transcription_completed', {
+      itemId: 'u1',
+      transcript: 'Hello',
+      isFinal: true,
+      turnStartedAt: 1000,
+      confidence: 0,
+    });
+    const items = session.chatCtx.items;
+    expect(items[0]).toMatchObject({ id: 'u1', createdAt: 1000, transcriptConfidence: 0 });
+    expect(items[1]).toMatchObject({
+      id: generations[0]!.responseId,
+      role: 'assistant',
+      content: ['Hi'],
+    });
+    await session.updateChatCtx(session.chatCtx);
+    expect(fake.appended).toEqual([]);
+  });
+
+  it('forwards only new chat items and warns for edits to append-only history', async () => {
+    const { fake, session } = setup();
+    fake.heard('u1', 'Hello');
+    const context = session.chatCtx;
+    context.addMessage({ id: 'typed', role: 'user', content: 'typed input' });
+    const output = FunctionCallOutput.create({
+      callId: 'c1',
+      name: 'lookup',
+      output: 'rainy',
+      isError: false,
+    });
+    context.insert(output);
+    await session.updateChatCtx(context);
+    expect(fake.appended.map((item) => item.id)).toEqual(['typed', output.id]);
+    const warn = vi.spyOn(log(), 'warn');
+    const edited = session.chatCtx;
+    edited.remove('u1');
+    await session.updateChatCtx(edited);
+    expect(warn).toHaveBeenCalledWith(
+      { item_ids: ['u1'] },
+      'duplex context is append-only; the model keeps what it has been told',
+    );
+    expect(fake.appended).toHaveLength(2);
+  });
+
+  it('allows the framework to shorten assistant transcripts without warning or resending them', async () => {
+    const { fake, session } = setup();
+    const context = ChatContext.empty();
+    context.addMessage({ id: 'assistant', role: 'assistant', content: 'Hello there' });
+    await session._updateSession(undefined, context);
+    const edited = ChatContext.empty();
+    edited.addMessage({ id: 'assistant', role: 'assistant', content: 'Hello' });
+    const warn = vi.spyOn(log(), 'warn');
+    await session.updateChatCtx(edited);
+    expect(warn).not.toHaveBeenCalled();
+    expect(fake.appended).toHaveLength(1);
+  });
+
+  it('hands over complete configuration and seeds both histories', async () => {
+    const { fake, session } = setup();
+    expect(fake.configured).toBe(false);
+    const context = ChatContext.empty();
+    context.addMessage({ id: 'm1', role: 'user', content: 'a prior turn' });
+    const tools = ToolContext.empty();
+    await session._updateSession('be brief', context, tools);
+    expect(fake.configured).toBe(true);
+    expect(fake.configBatches).toEqual([['be brief', expect.any(ChatContext), tools]]);
+    expect(fake.appended.map((item) => item.id)).toEqual(['m1']);
+    expect(session.chatCtx.items.map((item) => item.id)).toEqual(['m1']);
+  });
+
+  it('does not release configuration when an update fails', async () => {
+    const { fake, session } = setup();
+    fake.failInstructions = true;
+    await expect(
+      session._updateSession('be brief', undefined, ToolContext.empty()),
+    ).rejects.toThrow(RealtimeError);
+    expect(fake.configured).toBe(false);
+  });
+
+  it('forwards input, configuration, metrics, and provider errors', async () => {
+    const { fake, adapter, session } = setup();
+    const push = vi.spyOn(fake, 'pushAudio');
+    const instructions = vi.spyOn(fake, '_updateInstructions');
+    const tools = vi.spyOn(fake, '_updateTools');
+    const options = vi.spyOn(fake, '_updateOptions');
+    const metrics: RealtimeModelMetrics[] = [];
+    const errors: RealtimeModelError[] = [];
+    session.on('metrics_collected', (ev) => metrics.push(ev));
+    session.on('error', (ev) => errors.push(ev));
+    const input = frame(0.3);
+    session.pushAudio(input);
+    await session.updateInstructions('new instructions');
+    const context = ToolContext.empty();
+    await session.updateTools(context);
+    session.updateOptions({ toolChoice: 'none' });
+    fake.reportConnectionAcquired(125);
+    const error: RealtimeModelError = {
+      type: 'realtime_model_error',
+      error: new Error('provider'),
+      timestamp: Date.now(),
+      label: 'fake',
+      recoverable: true,
+    };
+    fake.emit('error', error);
+    expect(push).toHaveBeenCalledWith(input);
+    expect(instructions).toHaveBeenCalledWith('new instructions');
+    expect(tools).toHaveBeenCalledWith(context);
+    expect(session.tools).toBe(context);
+    expect(options).toHaveBeenCalledWith({ toolChoice: 'none' });
+    expect(errors).toEqual([error]);
+    expect(metrics).toMatchObject([
+      {
+        acquireTimeMs: 125,
+        connectionReused: false,
+        inputTokens: 0,
+        outputTokens: 0,
+        metadata: { modelName: adapter.model, modelProvider: adapter.provider },
+      },
+    ]);
+  });
+
+  it('reports a failed audio consumer as unrecoverable and closes the open generation', async () => {
+    const { fake, session, generations } = setup({ gate: () => new FixedGate(0.002) });
+    const errors: RealtimeModelError[] = [];
+    session.on('error', (error) => errors.push(error));
+    fake.push(0.3);
+    await setImmediate();
+    fake.controller.error(new Error('stream failed'));
+    fake.closed = true;
+    await setImmediate();
+    expect(errors).toMatchObject([
+      { recoverable: false, label: fake.duplexModel.label(), error: new Error('stream failed') },
+    ]);
+    expect((await readGeneration(generations[0]!)).frames).toHaveLength(1);
+  });
+
+  it('releases the blocked reader and event listeners when closing before configuration', async () => {
+    const { fake, session } = setup();
+    const close = vi.spyOn(fake, 'close');
+    await Promise.all([session.close(), session.close()]);
+    expect(close).toHaveBeenCalledOnce();
+    expect(fake.configured).toBe(true);
+    expect(fake.audioStream.locked).toBe(false);
+    expect(fake.eventNames()).toEqual([]);
+  });
+});
+
+describe('duplex requested replies', () => {
+  it('rejects requests if the model decides when to speak', async () => {
+    const { session } = setup();
+    await expect(session.generateReply()).rejects.toThrow('decides for itself');
+  });
+
+  it('resolves a requested reply on speech, not an earlier standalone tool call', async () => {
+    const { fake, model, session, generations } = setup();
+    model.askable = true;
+    const reply = session.generateReply('say hi');
+    let replied = false;
+    void reply.then(() => {
+      replied = true;
+    });
+    expect(fake.repliesRequested).toEqual(['say hi']);
+    fake.emit('function_call', FunctionCall.create({ callId: 'c1', name: 'lookup', args: '{}' }));
+    await setImmediate();
+    expect(replied).toBe(false);
+    expect(generations[0]!.userInitiated).toBe(false);
+    fake.push(0.001, 20);
+    fake.push(0.3, 3);
+    await setImmediate();
+    expect(await reply).toBe(generations[1]);
+    expect(generations[1]!.userInitiated).toBe(true);
+  });
+
+  it('rejects superseded, reconnected, and closed requests', async () => {
+    const { model, fake, session } = setup();
+    model.askable = true;
+    const first = expect(session.generateReply()).rejects.toThrow('superseded');
+    const second = expect(session.generateReply()).rejects.toThrow('reconnected');
+    await first;
+    fake.emit('session_reconnected', {});
+    await second;
+    const third = expect(session.generateReply()).rejects.toThrow('closed');
+    await session.close();
+    await third;
+    await expect(session.generateReply()).rejects.toThrow('closed');
+  });
+
+  it('times out a declined request', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const { model, session } = setup();
+    model.askable = true;
+    const reply = expect(session.generateReply()).rejects.toThrow('did not start speaking');
+    await vi.advanceTimersByTimeAsync(10_000);
+    await reply;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cancels pending requests with AbortSignal without claiming later spontaneous speech', async () => {
+    const { model, fake, session, generations } = setup({ gate: () => new FixedGate(0.002) });
+    model.askable = true;
+    const controller = new AbortController();
+    const reply = expect(
+      session.generateReply(undefined, { signal: controller.signal }),
+    ).rejects.toThrow('aborted');
+    controller.abort();
+    await reply;
+    fake.push(0.3);
+    await setImmediate();
+    expect(generations[0]!.userInitiated).toBe(false);
+    const count = fake.repliesRequested.length;
+    await expect(session.generateReply(undefined, { signal: controller.signal })).rejects.toThrow(
+      'aborted',
+    );
+    expect(fake.repliesRequested).toHaveLength(count);
+  });
+});
+
+describe('duplex model integration', () => {
+  it.each(['none', 'listening', 'throwing'] as const)(
+    'closes on an unrecoverable audio error with a %s application error listener',
+    async (listener) => {
+      const model = new FakeDuplexModel();
+      const agent = new Agent({ instructions: '' });
+      const session = new AgentSession({ llm: model, vad: null, aecWarmupDuration: null });
+      const closed = vi.fn();
+      session.on(AgentSessionEventTypes.Close, closed);
+      const errors = vi.fn(() => {
+        if (listener === 'throwing') throw new Error('application error listener failed');
+      });
+      if (listener !== 'none') session.on(AgentSessionEventTypes.Error, errors);
+      await session.start({ agent });
+      const provider = model.activeSession;
+      const closeProvider = vi.spyOn(provider, 'close');
+      provider.controller.error(new Error('audio stream failed'));
+      provider.closed = true;
+
+      try {
+        await vi.waitFor(() => {
+          expect(closed).toHaveBeenCalledWith(
+            expect.objectContaining({ reason: CloseReason.ERROR }),
+          );
+        });
+        expect(closeProvider).toHaveBeenCalledOnce();
+        expect(provider.eventNames()).toEqual([]);
+        expect(errors).toHaveBeenCalledTimes(listener === 'none' ? 0 : 1);
+        expect(() => agent.getActivityOrThrow()).toThrow('Agent activity not found');
+      } finally {
+        await session.close();
+      }
+    },
+  );
+
+  it.each([false, true])(
+    'closes after an audio error during shutdown (error listener: %s)',
+    async (listenForErrors) => {
+      const model = new FakeDuplexModel();
+      const agent = new Agent({ instructions: '' });
+      const session = new AgentSession({ llm: model, vad: null, aecWarmupDuration: null });
+      const errors = vi.fn();
+      if (listenForErrors) session.on(AgentSessionEventTypes.Error, errors);
+      await session.start({ agent });
+      const provider = model.activeSession;
+      const realtime = agent.getActivityOrThrow().realtimeLLMSession!;
+      const closeProvider = vi.spyOn(provider, 'close');
+      const closeKeyterms = session._keytermDetector.aclose.bind(session._keytermDetector);
+      vi.spyOn(session._keytermDetector, 'aclose').mockImplementationOnce(async () => {
+        provider.controller.error(new Error('audio failed during shutdown'));
+        provider.closed = true;
+        await setImmediate();
+        await closeKeyterms();
+      });
+
+      await session.close();
+
+      expect(closeProvider).toHaveBeenCalledOnce();
+      expect(provider.audioStream.locked).toBe(false);
+      expect(provider.eventNames()).toEqual([]);
+      expect(realtime.listenerCount('error')).toBe(0);
+      expect(realtime.listenerCount('metrics_collected')).toBe(0);
+      expect(errors).toHaveBeenCalledTimes(listenForErrors ? 1 : 0);
+      expect(() => agent.getActivityOrThrow()).toThrow('Agent activity not found');
+    },
+  );
+
+  it('wraps models passed to Agent, AgentSession, and updateOptions', async () => {
+    const model = new FakeDuplexModel();
+    const session = new AgentSession({ llm: model, vad: null });
+    const agent = new Agent({ instructions: '', llm: model });
+    expect(session.llm).toBeInstanceOf(DuplexRealtimeAdapter);
+    expect(agent.llm).toBeInstanceOf(DuplexRealtimeAdapter);
+    const replacement = new FakeDuplexModel();
+    await agent.updateOptions({ llm: replacement });
+    expect((agent.llm as DuplexRealtimeAdapter).duplexModel).toBe(replacement);
+    expect(() => agent.duplexSession).toThrow('Agent activity not found');
+  });
+
+  it('exposes the running provider session and rejects a model swap while running', async () => {
+    const model = new FakeDuplexModel();
+    const agent = new Agent({ instructions: '' });
+    const session = new AgentSession({ llm: model, vad: null, aecWarmupDuration: null });
+    await session.start({ agent });
+    try {
+      expect(agent.duplexSession).toBe(model.activeSession);
+      expect(model.activeSession.configured).toBe(true);
+      await expect(agent.updateOptions({ llm: new FakeDuplexModel() })).rejects.toThrow();
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('rejects duplexSession when the running agent has no duplex model', async () => {
+    const agent = new Agent({ instructions: '' });
+    const session = new AgentSession({ vad: null, turnHandling: { turnDetection: null } });
+    await session.start({ agent });
+    try {
+      expect(() => agent.duplexSession).toThrow('not running a DuplexModel');
+    } finally {
+      await session.close();
+    }
+  });
+});

--- a/agents/src/llm/duplex_adapter.test.ts
+++ b/agents/src/llm/duplex_adapter.test.ts
@@ -817,6 +817,37 @@ describe('duplex requested replies', () => {
 });
 
 describe('duplex model integration', () => {
+  it('does not arm an away timer from a shutdown transcript and still handles restarts', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'], shouldAdvanceTime: true });
+    const model = new FakeDuplexModel();
+    const agent = new Agent({ instructions: '' });
+    const session = new AgentSession({
+      llm: model,
+      vad: null,
+      aecWarmupDuration: null,
+      userAwayTimeout: 1,
+    });
+    await session.start({ agent });
+    vi.spyOn(agent, 'onExit').mockImplementationOnce(async () => {
+      session.emit(
+        AgentSessionEventTypes.UserInputTranscribed,
+        createUserInputTranscribedEvent({ transcript: 'goodbye', isFinal: true }),
+      );
+    });
+    await session.close();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(session.userState).toBe('listening');
+    await session.start({ agent });
+    try {
+      await vi.advanceTimersByTimeAsync(500);
+      expect(session.userState).toBe('listening');
+      await vi.advanceTimersByTimeAsync(500);
+      expect(session.userState).toBe('away');
+    } finally {
+      await session.close();
+    }
+  });
+
   it.each([false, true])(
     'awaits provider chat updates through Agent.updateChatCtx (failure: %s)',
     async (fail) => {

--- a/agents/src/llm/duplex_adapter.test.ts
+++ b/agents/src/llm/duplex_adapter.test.ts
@@ -7,9 +7,14 @@ import { setImmediate } from 'node:timers/promises';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { log } from '../log.js';
 import type { RealtimeModelMetrics } from '../metrics/base.js';
+import { Future } from '../utils.js';
 import { Agent } from '../voice/agent.js';
 import { AgentSession } from '../voice/agent_session.js';
-import { AgentSessionEventTypes, CloseReason } from '../voice/events.js';
+import {
+  AgentSessionEventTypes,
+  CloseReason,
+  createUserInputTranscribedEvent,
+} from '../voice/events.js';
 import { type TimedString, isTimedString } from '../voice/io.js';
 import { ChatContext, type ChatItem, FunctionCall, FunctionCallOutput } from './chat_context.js';
 import { type DuplexAudioFrame, DuplexModel, DuplexSession } from './duplex.js';
@@ -673,7 +678,11 @@ describe('duplex events and context', () => {
     ]);
   });
 
-  it.each([new Error('stream failed'), 'secret provider payload', { payload: 'secret' }])(
+  it.each([
+    new Error('secret provider payload', { cause: new Error('secret nested cause') }),
+    'secret provider payload',
+    { payload: 'secret' },
+  ])(
     'reports an unrecoverable audio failure and closes the generation (reason: %s)',
     async (reason) => {
       const { fake, session, generations } = setup({ gate: () => new FixedGate(0.002) });
@@ -690,7 +699,8 @@ describe('duplex events and context', () => {
       expect(errors).toMatchObject([
         { recoverable: false, label: fake.duplexModel.label(), error: expectedError },
       ]);
-      expect(logged).toHaveBeenCalledWith({ error: expectedError }, 'duplex audio stream failed');
+      if (reason instanceof Error) expect(errors[0]!.error).toBe(reason);
+      expect(logged).toHaveBeenCalledWith('duplex audio stream failed');
       expect((await readGeneration(generations[0]!)).frames).toHaveLength(1);
     },
   );
@@ -714,6 +724,26 @@ describe('duplex events and context', () => {
 });
 
 describe('duplex requested replies', () => {
+  it.each([false, true])(
+    'claims audio enqueued inside the provider reply hook (previous request: %s)',
+    async (previousRequest) => {
+      const { model, fake, session, generations } = setup({ gate: () => new FixedGate(0.002) });
+      model.askable = true;
+      const previous = previousRequest
+        ? expect(session.generateReply()).rejects.toThrow('superseded')
+        : undefined;
+      vi.spyOn(fake, '_generateReply').mockImplementationOnce(() => fake.push(0.3));
+
+      const reply = session.generateReply();
+      await setImmediate();
+
+      expect(generations).toHaveLength(1);
+      expect(generations[0]!.userInitiated).toBe(true);
+      await expect(reply).resolves.toBe(generations[0]);
+      await previous;
+    },
+  );
+
   it('rejects requests if the model decides when to speak', async () => {
     const { session } = setup();
     await expect(session.generateReply()).rejects.toThrow('decides for itself');
@@ -787,6 +817,53 @@ describe('duplex requested replies', () => {
 });
 
 describe('duplex model integration', () => {
+  it.each([false, true])(
+    'awaits provider chat updates through Agent.updateChatCtx (failure: %s)',
+    async (fail) => {
+      const model = new FakeDuplexModel();
+      const agent = new Agent({ instructions: '' });
+      const session = new AgentSession({ llm: model, vad: null, aecWarmupDuration: null });
+      await session.start({ agent });
+      const provider = model.activeSession;
+      const appended = new Future<void>();
+      const entered = new Future<void>();
+      const appendItems = provider._appendItems.bind(provider);
+      vi.spyOn(provider, '_appendItems').mockImplementationOnce(async (items) => {
+        entered.resolve();
+        await appended.await;
+        await appendItems(items);
+      });
+      const error = new RealtimeError('append failed');
+      const context = agent.chatCtx.copy();
+      context.addMessage({ id: 'new-item', role: 'user', content: 'hello' });
+      let settled = false;
+      const result = agent.updateChatCtx(context).then(
+        () => {
+          settled = true;
+          return undefined;
+        },
+        (error: unknown) => {
+          settled = true;
+          return error;
+        },
+      );
+
+      try {
+        await entered.await;
+        await setImmediate();
+        expect(settled).toBe(false);
+        if (fail) appended.reject(error);
+        else appended.resolve();
+        expect(await result).toBe(fail ? error : undefined);
+        expect(provider.appended.some((item) => item.id === 'new-item')).toBe(!fail);
+      } finally {
+        if (!appended.done) appended.resolve();
+        await result;
+        await session.close();
+      }
+    },
+  );
+
   it('rejects failed startup, cleans up, and allows a fresh start', async () => {
     const error = new RealtimeError('configuration failed');
     vi.spyOn(FakeDuplexSession.prototype, '_updateInstructions').mockRejectedValueOnce(error);
@@ -835,6 +912,12 @@ describe('duplex model integration', () => {
       expect(model.activeSession.closed).toBe(false);
       expect(setupAgentTools).toHaveBeenCalledTimes(2);
       expect(setupSessionTools).toHaveBeenCalledTimes(2);
+      session._updateUserState('away');
+      session.emit(
+        AgentSessionEventTypes.UserInputTranscribed,
+        createUserInputTranscribedEvent({ transcript: 'hello', isFinal: true }),
+      );
+      expect(session.userState).toBe('listening');
     } finally {
       await session.close();
     }

--- a/agents/src/llm/duplex_adapter.test.ts
+++ b/agents/src/llm/duplex_adapter.test.ts
@@ -49,7 +49,9 @@ class FakeDuplexModel extends DuplexModel {
 }
 
 class FakeDuplexSession extends DuplexSession {
-  private readonly connectionTask = this._configured.wait();
+  private readonly connectionTask = this._configured.wait().then(() => {
+    if (!this._closing) this.connected = true;
+  });
   controller!: ReadableStreamDefaultController<DuplexAudioFrame>;
   readonly audioStream = new ReadableStream<DuplexAudioFrame>({
     start: (controller) => {
@@ -60,7 +62,7 @@ class FakeDuplexSession extends DuplexSession {
   appended: ChatItem[] = [];
   configBatches: unknown[][] = [];
   repliesRequested: Array<string | undefined> = [];
-  failInstructions = false;
+  connected = false;
   closed = false;
   constructor(readonly fakeModel: FakeDuplexModel) {
     super(fakeModel);
@@ -68,9 +70,7 @@ class FakeDuplexSession extends DuplexSession {
   get configured(): boolean {
     return this._configured.isSet;
   }
-  async _updateInstructions(_instructions: string): Promise<void> {
-    if (this.failInstructions) throw new RealtimeError('configuration failed');
-  }
+  async _updateInstructions(_instructions: string): Promise<void> {}
   async _appendItems(items: ChatItem[]): Promise<void> {
     this.appended.push(...items);
   }
@@ -480,7 +480,7 @@ describe('duplex events and context', () => {
   );
 
   it('reconnects without carrying abandoned fragments into new speech', async () => {
-    const { fake, session, generations } = setup();
+    const { model, fake, session, generations } = setup();
     const reconnected = vi.fn();
     session.on('session_reconnected', reconnected);
     fake.push(0.001, 20);
@@ -489,9 +489,18 @@ describe('duplex events and context', () => {
     fake.say('lost words');
     fake.emit('session_reconnected', {});
     expect((await readGeneration(generations[0]!)).text).toBe('');
+    model.askable = true;
+    const reply = session.generateReply();
+    const replied = vi.fn();
+    void reply.then(replied, replied);
+    fake.push(0.001, 3);
+    await setImmediate();
+    expect(generations).toHaveLength(1);
+    expect(replied).not.toHaveBeenCalled();
     fake.push(0.3, 3);
     fake.push(0.001, 8);
     await setImmediate();
+    await expect(reply).resolves.toBe(generations[1]);
     expect((await readGeneration(generations[1]!)).text).toBe('');
     expect(reconnected).toHaveBeenCalledOnce();
   });
@@ -592,18 +601,34 @@ describe('duplex events and context', () => {
     const tools = ToolContext.empty();
     await session._updateSession('be brief', context, tools);
     expect(fake.configured).toBe(true);
+    expect(fake.connected).toBe(true);
     expect(fake.configBatches).toEqual([['be brief', expect.any(ChatContext), tools]]);
     expect(fake.appended.map((item) => item.id)).toEqual(['m1']);
     expect(session.chatCtx.items.map((item) => item.id)).toEqual(['m1']);
   });
 
-  it('does not release configuration when an update fails', async () => {
+  it.each([
+    new RealtimeError('configuration failed'),
+    new Error('configuration failed'),
+    new DOMException('configuration aborted', 'AbortError'),
+  ])('closes a session whose startup configuration fails with %s', async (error) => {
     const { fake, session } = setup();
-    fake.failInstructions = true;
-    await expect(
-      session._updateSession('be brief', undefined, ToolContext.empty()),
-    ).rejects.toThrow(RealtimeError);
-    expect(fake.configured).toBe(false);
+    vi.spyOn(fake, '_updateInstructions').mockRejectedValueOnce(error);
+    const updateTools = vi.spyOn(fake, '_updateTools');
+    const context = ChatContext.empty();
+    context.addMessage({ id: 'm1', role: 'user', content: 'a prior turn' });
+
+    await expect(session._updateSession('be brief', context, ToolContext.empty())).rejects.toBe(
+      error,
+    );
+
+    expect(fake.appended).toEqual([]);
+    expect(updateTools).not.toHaveBeenCalled();
+    expect(fake.closed).toBe(true);
+    expect(fake.connected).toBe(false);
+    expect(fake.configured).toBe(true);
+    expect(fake.audioStream.locked).toBe(false);
+    expect(fake.eventNames()).toEqual([]);
   });
 
   it('forwards input, configuration, metrics, and provider errors', async () => {
@@ -671,6 +696,7 @@ describe('duplex events and context', () => {
       await vi.waitFor(() => expect(fake.closed).toBe(true));
       expect(close).toHaveBeenCalledOnce();
       expect(fake.configured).toBe(true);
+      expect(fake.connected).toBe(false);
       expect(fake.audioStream.locked).toBe(false);
       expect(fake.eventNames()).toEqual([]);
     } finally {
@@ -751,28 +777,27 @@ describe('duplex requested replies', () => {
 });
 
 describe('duplex model integration', () => {
-  it('closes the provider after startup configuration fails', async () => {
+  it('closes the provider immediately when startup configuration fails', async () => {
     vi.spyOn(FakeDuplexSession.prototype, '_updateInstructions').mockRejectedValueOnce(
       new RealtimeError('configuration failed'),
     );
     const model = new FakeDuplexModel();
     const agent = new Agent({ instructions: 'be brief' });
     const session = new AgentSession({ llm: model, vad: null, aecWarmupDuration: null });
+    const closeProvider = vi.spyOn(FakeDuplexSession.prototype, 'close');
     await session.start({ agent });
     const provider = model.activeSession;
-    expect(provider.configured).toBe(false);
-
-    const closing = session.close();
     try {
-      await vi.waitFor(() => expect(provider.closed).toBe(true));
-      await closing;
+      expect(provider.closed).toBe(true);
+      expect(provider.configured).toBe(true);
+      expect(provider.connected).toBe(false);
       expect(provider.audioStream.locked).toBe(false);
       expect(provider.eventNames()).toEqual([]);
-      expect(() => agent.getActivityOrThrow()).toThrow('Agent activity not found');
     } finally {
-      await provider._updateSession();
-      await closing;
+      await session.close();
     }
+    expect(closeProvider).toHaveBeenCalledOnce();
+    expect(() => agent.getActivityOrThrow()).toThrow('Agent activity not found');
   });
 
   it.each(['none', 'listening', 'throwing'] as const)(

--- a/agents/src/llm/duplex_adapter.ts
+++ b/agents/src/llm/duplex_adapter.ts
@@ -311,10 +311,7 @@ export class DuplexRealtimeSession extends RealtimeSession {
         this.onAudioFrame(value);
         if (this.burst) {
           idleTimeout = setTimeout(
-            () => {
-              this.gate.deactivate();
-              this.closeBurst();
-            },
+            () => this.closeBurst(),
             this.audioTimeout + calculateAudioDurationSeconds(value.frame) * 1000,
           );
         }
@@ -400,6 +397,7 @@ export class DuplexRealtimeSession extends RealtimeSession {
   private closeBurst(): void {
     const burst = this.burst;
     this.burst = undefined;
+    this.gate.deactivate();
     if (burst) {
       burst.close();
       if (burst.transcript) {
@@ -458,7 +456,12 @@ export class DuplexRealtimeSession extends RealtimeSession {
       chatCtx = chatCtx.copy({ excludeHandoff: true, excludeConfigUpdate: true });
       this._chatCtx = chatCtx.copy();
     }
-    await this.duplexSession._updateSession(instructions, chatCtx, tools);
+    try {
+      await this.duplexSession._updateSession(instructions, chatCtx, tools);
+    } catch (error) {
+      await this.close();
+      throw error;
+    }
   }
 
   async updateInstructions(instructions: string): Promise<void> {

--- a/agents/src/llm/duplex_adapter.ts
+++ b/agents/src/llm/duplex_adapter.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AudioFrame, VideoFrame } from '@livekit/rtc-node';
 import type { ReadableStreamDefaultReader } from 'node:stream/web';
+import { calculateAudioDurationSeconds } from '../audio.js';
 import { AsyncIterableQueue, Future, shortuuid, toError, toStream } from '../utils.js';
 import { type TimedString, createTimedString } from '../voice/io.js';
 import { ChatContext, ChatMessage, type FunctionCall } from './chat_context.js';
@@ -44,10 +45,6 @@ export interface AudioGateOptions {
   minSilenceDuration?: number;
 }
 
-function durationMs(frame: AudioFrame): number {
-  return (frame.samplesPerChannel / frame.sampleRate) * 1000;
-}
-
 function rms(frame: AudioFrame): number {
   let sum = 0;
   for (const sample of frame.data) sum += sample * sample;
@@ -83,7 +80,7 @@ export class FixedGate implements AudioGate {
         this.quiet = 0;
       }
     } else if (level < this.floor * this.deactivationRatio) {
-      this.quiet += durationMs(frame);
+      this.quiet += calculateAudioDurationSeconds(frame) * 1000;
       if (this.quiet >= this.minSilenceDuration) this.open = false;
     } else {
       this.quiet = 0;
@@ -124,7 +121,7 @@ export class AdaptiveNoiseGate implements AudioGate {
 
   update(frame: AudioFrame): boolean {
     const level = rms(frame);
-    const duration = durationMs(frame);
+    const duration = calculateAudioDurationSeconds(frame) * 1000;
     if (!this.open) {
       this.stretchSum += level * duration;
       this.stretchDuration += duration;
@@ -320,7 +317,7 @@ export class DuplexRealtimeSession extends RealtimeSession {
               this.gate.deactivate();
               this.closeBurst();
             },
-            this.audioTimeout + durationMs(value.frame),
+            this.audioTimeout + calculateAudioDurationSeconds(value.frame) * 1000,
           );
         }
       }
@@ -349,7 +346,7 @@ export class DuplexRealtimeSession extends RealtimeSession {
     if (this.gate.update(output.frame)) {
       const burst = this.burst ?? this.openBurst();
       if (!burst.audio.closed) burst.audio.put(output.frame);
-      this.audioMs += Math.round(durationMs(output.frame));
+      this.audioMs += Math.round(calculateAudioDurationSeconds(output.frame) * 1000);
       while (this.fragments.length) {
         const fragment = this.fragments[0]!;
         if (fragment.startMs !== undefined) {
@@ -361,7 +358,7 @@ export class DuplexRealtimeSession extends RealtimeSession {
       return;
     }
 
-    this.audioMs += Math.round(durationMs(output.frame));
+    this.audioMs += Math.round(calculateAudioDurationSeconds(output.frame) * 1000);
     if (this.burst) {
       this.closeBurst();
     } else if (

--- a/agents/src/llm/duplex_adapter.ts
+++ b/agents/src/llm/duplex_adapter.ts
@@ -34,13 +34,17 @@ const ATTACH_LEAD_MS = 300;
 
 /** Decides which output frames carry speech worth playing. */
 export interface AudioGate {
+  /** Return whether this frame belongs to an active speech burst. */
   update(frame: AudioFrame): boolean;
   /** End the current burst while retaining the learned noise floor. */
   deactivate(): void;
 }
 
+/** Thresholds and timing used to distinguish speech from silence. */
 export interface AudioGateOptions {
+  /** RMS level relative to the silence floor that opens the gate. Defaults to 3. */
   activationRatio?: number;
+  /** RMS level relative to the silence floor that starts the quiet timer. Defaults to 1.8. */
   deactivationRatio?: number;
   /** Duration of quiet audio that ends a burst, in milliseconds. Defaults to 500. */
   minSilenceDuration?: number;
@@ -61,6 +65,7 @@ export class FixedGate implements AudioGate {
   private open = false;
   private quiet = 0;
 
+  /** Create a gate with a normalized PCM RMS silence level and optional thresholds. */
   constructor(silence: number, options: AudioGateOptions = {}) {
     this.floor = Math.max(silence, SILENCE_FLOOR);
     this.activationRatio = options.activationRatio ?? 3;
@@ -68,11 +73,13 @@ export class FixedGate implements AudioGate {
     this.minSilenceDuration = options.minSilenceDuration ?? 500;
   }
 
+  /** End the active burst while preserving the configured silence floor. */
   deactivate(): void {
     this.open = false;
     this.quiet = 0;
   }
 
+  /** Update the gate from this frame's RMS level and audio duration. */
   update(frame: AudioFrame): boolean {
     const level = rms(frame);
     if (!this.open) {
@@ -90,6 +97,7 @@ export class FixedGate implements AudioGate {
   }
 }
 
+/** Options for learning a silence floor from the provider's continuous audio. */
 export interface AdaptiveNoiseGateOptions extends AudioGateOptions {
   /** Duration of quiet history used to learn the floor, in milliseconds. Defaults to 10000. */
   window?: number;
@@ -108,6 +116,7 @@ export class AdaptiveNoiseGate implements AudioGate {
   private open = false;
   private quiet = 0;
 
+  /** Create a gate that learns its silence floor from quiet audio. */
   constructor(options: AdaptiveNoiseGateOptions = {}) {
     this.activationRatio = options.activationRatio ?? 3;
     this.deactivationRatio = options.deactivationRatio ?? 1.8;
@@ -115,11 +124,13 @@ export class AdaptiveNoiseGate implements AudioGate {
     this.window = options.window ?? 10_000;
   }
 
+  /** End the active burst while preserving the learned silence floor. */
   deactivate(): void {
     this.open = false;
     this.quiet = 0;
   }
 
+  /** Update the learned floor and determine whether this frame belongs to a speech burst. */
   update(frame: AudioFrame): boolean {
     const level = rms(frame);
     const duration = calculateAudioDurationSeconds(frame) * 1000;
@@ -198,6 +209,7 @@ class Burst {
   }
 }
 
+/** Options for converting continuous duplex audio into realtime generations. */
 export interface DuplexRealtimeAdapterOptions {
   /** Creates a separate gate for each session. Defaults to the model's gate or an adaptive gate. */
   gate?: () => AudioGate;
@@ -207,7 +219,9 @@ export interface DuplexRealtimeAdapterOptions {
 
 /** Segments a duplex model's continuous output into ordinary realtime generations. */
 export class DuplexRealtimeAdapter extends RealtimeModel {
+  /** Adapt a duplex model for the framework's realtime generation interface. */
   constructor(
+    /** Continuous audio model wrapped by this adapter. */
     readonly duplexModel: DuplexModel,
     private readonly options: DuplexRealtimeAdapterOptions = {},
   ) {
@@ -227,14 +241,17 @@ export class DuplexRealtimeAdapter extends RealtimeModel {
     });
   }
 
+  /** Model identifier reported by the wrapped provider. */
   get model(): string {
     return this.duplexModel.model;
   }
 
+  /** Provider identifier reported by the wrapped model. */
   get provider(): string {
     return this.duplexModel.provider;
   }
 
+  /** Create a provider session with its own audio gate and burst state. */
   session(): RealtimeSession {
     const gate = this.options.gate?.() ?? this.duplexModel.audioGate() ?? new AdaptiveNoiseGate();
     return new DuplexRealtimeSession(
@@ -245,6 +262,7 @@ export class DuplexRealtimeAdapter extends RealtimeModel {
     );
   }
 
+  /** Release the wrapped model's shared resources. */
   async close(): Promise<void> {
     await this.duplexModel.close();
   }
@@ -510,7 +528,9 @@ export class DuplexRealtimeSession extends RealtimeSession {
   ): Promise<GenerationCreatedEvent> {
     if (this.closed) throw new RealtimeError('the session is closed');
     const signal = options?.signal;
-    signal?.throwIfAborted();
+    const abortError = () =>
+      signal?.reason instanceof Error ? signal.reason : new RealtimeError('the reply was aborted');
+    if (signal?.aborted) throw abortError();
     this.duplexSession._generateReply(instructions);
     this.failPendingReply('a newer ask superseded this one');
     const reply = (this.pendingReply = new Future<GenerationCreatedEvent>());
@@ -519,7 +539,7 @@ export class DuplexRealtimeSession extends RealtimeSession {
         reply.reject(new RealtimeError('the model did not start speaking when asked'));
     }, REPLY_TIMEOUT);
     const onAbort = () => {
-      if (!reply.done) reply.reject(toError(signal!.reason));
+      if (!reply.done) reply.reject(abortError());
     };
     signal?.addEventListener('abort', onAbort, { once: true });
     try {

--- a/agents/src/llm/duplex_adapter.ts
+++ b/agents/src/llm/duplex_adapter.ts
@@ -1,0 +1,567 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { AudioFrame, VideoFrame } from '@livekit/rtc-node';
+import type { ReadableStreamDefaultReader } from 'node:stream/web';
+import { AsyncIterableQueue, Future, shortuuid, toError, toStream } from '../utils.js';
+import { type TimedString, createTimedString } from '../voice/io.js';
+import { ChatContext, ChatMessage, type FunctionCall } from './chat_context.js';
+import type {
+  DuplexAudioFrame,
+  DuplexModel,
+  DuplexOutputTranscriptDelta,
+  DuplexSession,
+} from './duplex.js';
+import {
+  type GenerationCreatedEvent,
+  type InputTranscriptionCompleted,
+  type MessageGeneration,
+  RealtimeError,
+  RealtimeModel,
+  type RealtimeModelError,
+  RealtimeSession,
+} from './realtime.js';
+import type { ToolChoice, ToolContext } from './tool_context.js';
+import { computeChatCtxDiff } from './utils.js';
+
+const SILENCE_FLOOR = 1e-4;
+const UNCLAIMED_TRANSCRIPT_MS = 3000;
+const REPLY_TIMEOUT = 10_000;
+const AUDIO_TIMEOUT = 800;
+const ATTACH_LEAD_MS = 300;
+
+/** Decides which output frames carry speech worth playing. */
+export interface AudioGate {
+  update(frame: AudioFrame): boolean;
+  /** End the current burst while retaining the learned noise floor. */
+  deactivate(): void;
+}
+
+export interface AudioGateOptions {
+  activationRatio?: number;
+  deactivationRatio?: number;
+  /** Duration of quiet audio that ends a burst, in milliseconds. Defaults to 500. */
+  minSilenceDuration?: number;
+}
+
+function durationMs(frame: AudioFrame): number {
+  return (frame.samplesPerChannel / frame.sampleRate) * 1000;
+}
+
+function rms(frame: AudioFrame): number {
+  let sum = 0;
+  for (const sample of frame.data) sum += sample * sample;
+  return frame.data.length ? Math.sqrt(sum / frame.data.length) / 32768 : 0;
+}
+
+/** An audio gate for a provider whose silence level is known. */
+export class FixedGate implements AudioGate {
+  private readonly floor: number;
+  private readonly activationRatio: number;
+  private readonly deactivationRatio: number;
+  private readonly minSilenceDuration: number;
+  private open = false;
+  private quiet = 0;
+
+  constructor(silence: number, options: AudioGateOptions = {}) {
+    this.floor = Math.max(silence, SILENCE_FLOOR);
+    this.activationRatio = options.activationRatio ?? 3;
+    this.deactivationRatio = options.deactivationRatio ?? 1.8;
+    this.minSilenceDuration = options.minSilenceDuration ?? 500;
+  }
+
+  deactivate(): void {
+    this.open = false;
+    this.quiet = 0;
+  }
+
+  update(frame: AudioFrame): boolean {
+    const level = rms(frame);
+    if (!this.open) {
+      if (level > this.floor * this.activationRatio) {
+        this.open = true;
+        this.quiet = 0;
+      }
+    } else if (level < this.floor * this.deactivationRatio) {
+      this.quiet += durationMs(frame);
+      if (this.quiet >= this.minSilenceDuration) this.open = false;
+    } else {
+      this.quiet = 0;
+    }
+    return this.open;
+  }
+}
+
+export interface AdaptiveNoiseGateOptions extends AudioGateOptions {
+  /** Duration of quiet history used to learn the floor, in milliseconds. Defaults to 10000. */
+  window?: number;
+}
+
+/** Learns the noise floor from quiet stretches, so sustained speech cannot raise it. */
+export class AdaptiveNoiseGate implements AudioGate {
+  private readonly activationRatio: number;
+  private readonly deactivationRatio: number;
+  private readonly minSilenceDuration: number;
+  private readonly window: number;
+  private history: Array<{ level: number; duration: number }> = [];
+  private historyDuration = 0;
+  private stretchSum = 0;
+  private stretchDuration = 0;
+  private open = false;
+  private quiet = 0;
+
+  constructor(options: AdaptiveNoiseGateOptions = {}) {
+    this.activationRatio = options.activationRatio ?? 3;
+    this.deactivationRatio = options.deactivationRatio ?? 1.8;
+    this.minSilenceDuration = options.minSilenceDuration ?? 500;
+    this.window = options.window ?? 10_000;
+  }
+
+  deactivate(): void {
+    this.open = false;
+    this.quiet = 0;
+  }
+
+  update(frame: AudioFrame): boolean {
+    const level = rms(frame);
+    const duration = durationMs(frame);
+    if (!this.open) {
+      this.stretchSum += level * duration;
+      this.stretchDuration += duration;
+      if (this.stretchDuration >= this.minSilenceDuration) {
+        this.history.push({
+          level: this.stretchSum / this.stretchDuration,
+          duration: this.stretchDuration,
+        });
+        this.historyDuration += this.stretchDuration;
+        this.stretchSum = this.stretchDuration = 0;
+        while (this.historyDuration > this.window && this.history.length > 1) {
+          this.historyDuration -= this.history.shift()!.duration;
+        }
+      }
+    }
+
+    let floor = this.stretchDuration ? this.stretchSum / this.stretchDuration : level;
+    if (this.history.length) {
+      floor = this.history.reduce((min, entry) => Math.min(min, entry.level), Infinity);
+    }
+    floor = Math.max(floor, SILENCE_FLOOR);
+
+    if (!this.open) {
+      if (level > floor * this.activationRatio) {
+        this.open = true;
+        this.quiet = 0;
+      }
+    } else if (level < floor * this.deactivationRatio) {
+      this.quiet += duration;
+      if (this.quiet >= this.minSilenceDuration) this.open = false;
+    } else {
+      this.quiet = 0;
+    }
+    return this.open;
+  }
+}
+
+class Burst {
+  readonly id = shortuuid('item_');
+  readonly messages = new AsyncIterableQueue<MessageGeneration>();
+  readonly functions = new AsyncIterableQueue<FunctionCall>();
+  readonly text = new AsyncIterableQueue<string | TimedString>();
+  readonly audio = new AsyncIterableQueue<AudioFrame>();
+  readonly openedAt = Date.now();
+  anchorMs?: number;
+  transcript = '';
+  private lastAnnotationInS = 0;
+
+  constructor(readonly audioStartMs: number) {}
+
+  attach(fragment: DuplexOutputTranscriptDelta): void {
+    this.transcript += fragment.text;
+    let text: string | TimedString = fragment.text;
+    if (fragment.startMs !== undefined && this.anchorMs !== undefined) {
+      const offset = this.anchorMs + this.audioStartMs;
+      const startTime = Math.max(this.lastAnnotationInS, (fragment.startMs - offset) / 1000);
+      const endTime =
+        fragment.endMs === undefined
+          ? undefined
+          : Math.max(startTime, (fragment.endMs - offset) / 1000);
+      this.lastAnnotationInS = endTime ?? startTime;
+      // TimedString uses seconds, unlike the model's millisecond timeline.
+      text = createTimedString({ text: fragment.text, startTime, endTime });
+    }
+    if (!this.text.closed) this.text.put(text);
+  }
+
+  close(): void {
+    this.text.close();
+    this.audio.close();
+    this.functions.close();
+    this.messages.close();
+  }
+}
+
+export interface DuplexRealtimeAdapterOptions {
+  /** Creates a separate gate for each session. Defaults to the model's gate or an adaptive gate. */
+  gate?: () => AudioGate;
+  /** Wait after the last frame's duration before ending a burst, in milliseconds. Defaults to 800. */
+  audioTimeout?: number;
+}
+
+/** Segments a duplex model's continuous output into ordinary realtime generations. */
+export class DuplexRealtimeAdapter extends RealtimeModel {
+  constructor(
+    readonly duplexModel: DuplexModel,
+    private readonly options: DuplexRealtimeAdapterOptions = {},
+  ) {
+    const caps = duplexModel.capabilities;
+    super({
+      messageTruncation: false,
+      turnDetection: true,
+      supportsOverlappingSpeech: true,
+      userTranscription: caps.userTranscription,
+      autoToolReplyGeneration: caps.autoToolReplyGeneration,
+      audioOutput: true,
+      manualFunctionCalls: false,
+      midSessionChatCtxUpdate: caps.midSessionChatCtxUpdate ?? false,
+      midSessionInstructionsUpdate: caps.midSessionInstructionsUpdate ?? false,
+      midSessionToolsUpdate: caps.midSessionToolsUpdate ?? false,
+      perResponseToolChoice: false,
+    });
+  }
+
+  get model(): string {
+    return this.duplexModel.model;
+  }
+
+  get provider(): string {
+    return this.duplexModel.provider;
+  }
+
+  session(): RealtimeSession {
+    const gate = this.options.gate?.() ?? this.duplexModel.audioGate() ?? new AdaptiveNoiseGate();
+    return new DuplexRealtimeSession(
+      this,
+      this.duplexModel.session(),
+      gate,
+      this.options.audioTimeout ?? AUDIO_TIMEOUT,
+    );
+  }
+
+  async close(): Promise<void> {
+    await this.duplexModel.close();
+  }
+}
+
+/** @internal */
+export class DuplexRealtimeSession extends RealtimeSession {
+  private burst?: Burst;
+  private audioMs = 0;
+  private fragments: DuplexOutputTranscriptDelta[] = [];
+  private waitingSinceMs = 0;
+  private pendingReply?: Future<GenerationCreatedEvent>;
+  private _chatCtx = ChatContext.empty();
+  private audioReader?: ReadableStreamDefaultReader<DuplexAudioFrame>;
+  private readonly segmentTask: Promise<void>;
+  private readonly unsubscribe: Array<() => void> = [];
+  private closed = false;
+  private closeTask?: Promise<void>;
+
+  constructor(
+    adapter: DuplexRealtimeAdapter,
+    readonly duplexSession: DuplexSession,
+    private readonly gate: AudioGate,
+    private readonly audioTimeout: number,
+  ) {
+    super(adapter);
+    this.listen('transcript_delta', (ev: DuplexOutputTranscriptDelta) => {
+      if (!this.fragments.length) this.waitingSinceMs = this.audioMs;
+      this.fragments.push(ev);
+    });
+    this.listen('function_call', (ev: FunctionCall) => this.onFunctionCall(ev));
+    this.listen('input_audio_transcription_completed', (ev: InputTranscriptionCompleted) =>
+      this.onInputTranscription(ev),
+    );
+    this.listen('session_reconnected', (ev: object) => {
+      this.fragments = [];
+      this.closeBurst();
+      this.failPendingReply('the session reconnected before the model replied');
+      this.emit('session_reconnected', ev);
+    });
+    for (const event of [
+      'input_speech_started',
+      'input_speech_stopped',
+      'metrics_collected',
+      'error',
+    ]) {
+      this.listen(event, (ev: unknown) => this.emit(event, ev));
+    }
+    this.segmentTask = this.segment().catch((error: unknown) => {
+      this.logger.error({ error }, 'duplex audio consumer failed');
+    });
+  }
+
+  private listen<T>(event: string, handler: (ev: T) => void): void {
+    this.duplexSession.on(event, handler);
+    this.unsubscribe.push(() => this.duplexSession.off(event, handler));
+  }
+
+  private async segment(): Promise<void> {
+    let idleTimeout: NodeJS.Timeout | undefined;
+    try {
+      this.audioReader = this.duplexSession.audioStream.getReader();
+      while (!this.closed) {
+        const { value, done } = await this.audioReader.read();
+        if (done || this.closed) break;
+        clearTimeout(idleTimeout);
+        this.onAudioFrame(value);
+        if (this.burst) {
+          idleTimeout = setTimeout(
+            () => {
+              this.gate.deactivate();
+              this.closeBurst();
+            },
+            this.audioTimeout + durationMs(value.frame),
+          );
+        }
+      }
+    } catch (error) {
+      if (!this.closed) {
+        this.logger.error({ error }, 'duplex audio stream failed');
+        const ev: RealtimeModelError = {
+          type: 'realtime_model_error',
+          timestamp: Date.now(),
+          label: this.duplexSession.duplexModel.label(),
+          error: toError(error),
+          recoverable: false,
+        };
+        this.emit('error', ev);
+      }
+    } finally {
+      clearTimeout(idleTimeout);
+      this.audioReader?.releaseLock();
+      this.audioReader = undefined;
+      this.closeBurst();
+    }
+  }
+
+  private onAudioFrame(output: DuplexAudioFrame): void {
+    if (output.startMs !== undefined) this.audioMs = output.startMs;
+    if (this.gate.update(output.frame)) {
+      const burst = this.burst ?? this.openBurst();
+      if (!burst.audio.closed) burst.audio.put(output.frame);
+      this.audioMs += Math.round(durationMs(output.frame));
+      while (this.fragments.length) {
+        const fragment = this.fragments[0]!;
+        if (fragment.startMs !== undefined) {
+          burst.anchorMs ??= fragment.startMs - burst.audioStartMs;
+          if (fragment.startMs - burst.anchorMs > this.audioMs + ATTACH_LEAD_MS) break;
+        }
+        burst.attach(this.fragments.shift()!);
+      }
+      return;
+    }
+
+    this.audioMs += Math.round(durationMs(output.frame));
+    if (this.burst) {
+      this.closeBurst();
+    } else if (
+      this.fragments.length &&
+      this.audioMs - this.waitingSinceMs >= UNCLAIMED_TRANSCRIPT_MS
+    ) {
+      this.logger.error(
+        { 'lk.pii.transcript': this.fragments.map((fragment) => fragment.text).join('') },
+        'duplex transcript outlived the audio it describes',
+      );
+      const burst = this.openBurst();
+      while (this.fragments.length) burst.attach(this.fragments.shift()!);
+      this.closeBurst();
+    }
+  }
+
+  private openBurst(message = true): Burst {
+    const burst = (this.burst = new Burst(this.audioMs));
+    const ev: GenerationCreatedEvent = {
+      messageStream: toStream(burst.messages),
+      functionStream: toStream(burst.functions),
+      userInitiated: false,
+      responseId: burst.id,
+    };
+    if (message && this.pendingReply && !this.pendingReply.done) {
+      ev.userInitiated = true;
+      this.pendingReply.resolve(ev);
+    }
+    this.emit('generation_created', ev);
+    if (message) {
+      burst.messages.put({
+        messageId: burst.id,
+        textStream: toStream(burst.text),
+        audioStream: toStream(burst.audio),
+        modalities: Promise.resolve(['audio', 'text']),
+      });
+    }
+    return burst;
+  }
+
+  private closeBurst(): void {
+    const burst = this.burst;
+    this.burst = undefined;
+    if (burst) {
+      burst.close();
+      if (burst.transcript) {
+        this._chatCtx.insert(
+          ChatMessage.create({
+            id: burst.id,
+            role: 'assistant',
+            content: burst.transcript,
+            createdAt: burst.openedAt,
+          }),
+        );
+      }
+    }
+    this.waitingSinceMs = this.audioMs;
+  }
+
+  private onInputTranscription(ev: InputTranscriptionCompleted): void {
+    if (ev.isFinal) {
+      this._chatCtx.insert(
+        ChatMessage.create({
+          id: ev.itemId,
+          role: 'user',
+          content: ev.transcript,
+          transcriptConfidence: ev.confidence ?? 1,
+          createdAt: ev.turnStartedAt,
+        }),
+      );
+    }
+    this.emit('input_audio_transcription_completed', ev);
+  }
+
+  private onFunctionCall(call: FunctionCall): void {
+    this._chatCtx.insert(call);
+    if (this.burst) {
+      this.burst.functions.put(call);
+      return;
+    }
+    this.openBurst(false).functions.put(call);
+    this.closeBurst();
+  }
+
+  get chatCtx(): ChatContext {
+    return this._chatCtx.copy();
+  }
+
+  get tools(): ToolContext {
+    return this.duplexSession.tools;
+  }
+
+  async _updateSession(
+    instructions?: string,
+    chatCtx?: ChatContext,
+    tools?: ToolContext,
+  ): Promise<void> {
+    if (chatCtx !== undefined) {
+      chatCtx = chatCtx.copy({ excludeHandoff: true, excludeConfigUpdate: true });
+      this._chatCtx = chatCtx.copy();
+    }
+    await this.duplexSession._updateSession(instructions, chatCtx, tools);
+  }
+
+  async updateInstructions(instructions: string): Promise<void> {
+    await this.duplexSession._updateInstructions(instructions);
+  }
+
+  async updateChatCtx(chatCtx: ChatContext): Promise<void> {
+    const { removeInstructions } = await import('../voice/generation.js');
+    chatCtx = chatCtx.copy({ excludeHandoff: true, excludeConfigUpdate: true });
+    removeInstructions(chatCtx);
+    const diff = computeChatCtxDiff(this._chatCtx, chatCtx);
+    const edited = [...diff.toRemove, ...diff.toUpdate.map(([, id]) => id)].filter((id) => {
+      const item = this._chatCtx.getById(id);
+      return item?.type !== 'message' || item.role !== 'assistant';
+    });
+    if (edited.length) {
+      this.logger.warn(
+        { item_ids: edited },
+        'duplex context is append-only; the model keeps what it has been told',
+      );
+    }
+    const newItems = diff.toCreate.map(([, id]) => chatCtx.getById(id)!);
+    if (newItems.length) await this.duplexSession._appendItems(newItems);
+    this._chatCtx = chatCtx;
+  }
+
+  async updateTools(tools: ToolContext): Promise<void> {
+    await this.duplexSession._updateTools(tools);
+  }
+
+  updateOptions(options: { toolChoice?: ToolChoice | null }): void {
+    this.duplexSession._updateOptions(options);
+  }
+
+  pushAudio(frame: AudioFrame): void {
+    this.duplexSession.pushAudio(frame);
+  }
+
+  pushVideo(frame: VideoFrame): void {
+    this.duplexSession.pushVideo(frame);
+  }
+
+  async generateReply(
+    instructions?: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<GenerationCreatedEvent> {
+    if (this.closed) throw new RealtimeError('the session is closed');
+    const signal = options?.signal;
+    signal?.throwIfAborted();
+    this.duplexSession._generateReply(instructions);
+    this.failPendingReply('a newer ask superseded this one');
+    const reply = (this.pendingReply = new Future<GenerationCreatedEvent>());
+    const timeout = setTimeout(() => {
+      if (!reply.done)
+        reply.reject(new RealtimeError('the model did not start speaking when asked'));
+    }, REPLY_TIMEOUT);
+    const onAbort = () => {
+      if (!reply.done) reply.reject(toError(signal!.reason));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+    try {
+      return await reply.await;
+    } finally {
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+      if (this.pendingReply === reply) this.pendingReply = undefined;
+    }
+  }
+
+  async commitAudio(): Promise<void> {}
+  async clearAudio(): Promise<void> {}
+  async interrupt(): Promise<void> {}
+  async truncate(): Promise<void> {}
+
+  private failPendingReply(reason: string): void {
+    if (this.pendingReply && !this.pendingReply.done) {
+      this.pendingReply.reject(new RealtimeError(reason));
+    }
+  }
+
+  close(): Promise<void> {
+    return (this.closeTask ??= this.closeImpl());
+  }
+
+  private async closeImpl(): Promise<void> {
+    this.closed = true;
+    // Release a blocked read before asking the provider to close its stream.
+    this.audioReader?.releaseLock();
+    await this.segmentTask;
+    this.closeBurst();
+    this.failPendingReply('the session closed before the model replied');
+    try {
+      await this.duplexSession.close();
+    } catch (error) {
+      this.logger.debug({ error }, 'duplex session close failed');
+    } finally {
+      for (const unsubscribe of this.unsubscribe) unsubscribe();
+      await super.close();
+    }
+  }
+}

--- a/agents/src/llm/duplex_adapter.ts
+++ b/agents/src/llm/duplex_adapter.ts
@@ -12,6 +12,7 @@ import type {
   DuplexModel,
   DuplexOutputTranscriptDelta,
   DuplexSession,
+  DuplexSessionCallbacks,
 } from './duplex.js';
 import {
   type GenerationCreatedEvent,
@@ -270,34 +271,31 @@ export class DuplexRealtimeSession extends RealtimeSession {
     private readonly audioTimeout: number,
   ) {
     super(adapter);
-    this.listen('transcript_delta', (ev: DuplexOutputTranscriptDelta) => {
+    this.listen('transcript_delta', (ev) => {
       if (!this.fragments.length) this.waitingSinceMs = this.audioMs;
       this.fragments.push(ev);
     });
-    this.listen('function_call', (ev: FunctionCall) => this.onFunctionCall(ev));
-    this.listen('input_audio_transcription_completed', (ev: InputTranscriptionCompleted) =>
-      this.onInputTranscription(ev),
-    );
-    this.listen('session_reconnected', (ev: object) => {
+    this.listen('function_call', (ev) => this.onFunctionCall(ev));
+    this.listen('input_audio_transcription_completed', (ev) => this.onInputTranscription(ev));
+    this.listen('session_reconnected', (ev) => {
       this.fragments = [];
       this.closeBurst();
       this.failPendingReply('the session reconnected before the model replied');
       this.emit('session_reconnected', ev);
     });
-    for (const event of [
-      'input_speech_started',
-      'input_speech_stopped',
-      'metrics_collected',
-      'error',
-    ]) {
-      this.listen(event, (ev: unknown) => this.emit(event, ev));
-    }
+    this.listen('input_speech_started', (ev) => this.emit('input_speech_started', ev));
+    this.listen('input_speech_stopped', (ev) => this.emit('input_speech_stopped', ev));
+    this.listen('metrics_collected', (ev) => this.emit('metrics_collected', ev));
+    this.listen('error', (ev) => this.emit('error', ev));
     this.segmentTask = this.segment().catch((error: unknown) => {
       this.logger.error({ error }, 'duplex audio consumer failed');
     });
   }
 
-  private listen<T>(event: string, handler: (ev: T) => void): void {
+  private listen<E extends keyof DuplexSessionCallbacks>(
+    event: E,
+    handler: DuplexSessionCallbacks[E],
+  ): void {
     this.duplexSession.on(event, handler);
     this.unsubscribe.push(() => this.duplexSession.off(event, handler));
   }

--- a/agents/src/llm/duplex_adapter.ts
+++ b/agents/src/llm/duplex_adapter.ts
@@ -344,8 +344,8 @@ export class DuplexRealtimeSession extends RealtimeSession {
   private onAudioFrame(output: DuplexAudioFrame): void {
     if (output.startMs !== undefined) this.audioMs = output.startMs;
     if (this.gate.update(output.frame)) {
-      const burst = this.burst ?? this.openBurst();
-      if (!burst.audio.closed) burst.audio.put(output.frame);
+      const burst = !this.burst || this.burst.audio.closed ? this.openBurst() : this.burst;
+      burst.audio.put(output.frame);
       this.audioMs += Math.round(calculateAudioDurationSeconds(output.frame) * 1000);
       while (this.fragments.length) {
         const fragment = this.fragments[0]!;

--- a/agents/src/llm/duplex_adapter.ts
+++ b/agents/src/llm/duplex_adapter.ts
@@ -305,8 +305,8 @@ export class DuplexRealtimeSession extends RealtimeSession {
     this.listen('input_speech_stopped', (ev) => this.emit('input_speech_stopped', ev));
     this.listen('metrics_collected', (ev) => this.emit('metrics_collected', ev));
     this.listen('error', (ev) => this.emit('error', ev));
-    this.segmentTask = this.segment().catch((error: unknown) => {
-      this.logger.error({ error }, 'duplex audio consumer failed');
+    this.segmentTask = this.segment().catch(() => {
+      this.logger.error('duplex audio consumer failed');
     });
   }
 
@@ -338,7 +338,7 @@ export class DuplexRealtimeSession extends RealtimeSession {
       if (!this.closed) {
         const streamError =
           error instanceof Error ? error : new RealtimeError('duplex audio stream failed');
-        this.logger.error({ error: streamError }, 'duplex audio stream failed');
+        this.logger.error('duplex audio stream failed');
         const ev: RealtimeModelError = {
           type: 'realtime_model_error',
           timestamp: Date.now(),
@@ -577,8 +577,8 @@ export class DuplexRealtimeSession extends RealtimeSession {
     this.failPendingReply('the session closed before the model replied');
     try {
       await this.duplexSession.close();
-    } catch (error) {
-      this.logger.debug({ error }, 'duplex session close failed');
+    } catch {
+      this.logger.debug('duplex session close failed');
     } finally {
       for (const unsubscribe of this.unsubscribe) unsubscribe();
       await super.close();

--- a/agents/src/llm/duplex_adapter.ts
+++ b/agents/src/llm/duplex_adapter.ts
@@ -4,7 +4,7 @@
 import type { AudioFrame, VideoFrame } from '@livekit/rtc-node';
 import type { ReadableStreamDefaultReader } from 'node:stream/web';
 import { calculateAudioDurationSeconds } from '../audio.js';
-import { AsyncIterableQueue, Future, shortuuid, toError, toStream } from '../utils.js';
+import { AsyncIterableQueue, Future, shortuuid, toStream } from '../utils.js';
 import { type TimedString, createTimedString } from '../voice/io.js';
 import { ChatContext, ChatMessage, type FunctionCall } from './chat_context.js';
 import type {
@@ -336,12 +336,14 @@ export class DuplexRealtimeSession extends RealtimeSession {
       }
     } catch (error) {
       if (!this.closed) {
-        this.logger.error({ error }, 'duplex audio stream failed');
+        const streamError =
+          error instanceof Error ? error : new RealtimeError('duplex audio stream failed');
+        this.logger.error({ error: streamError }, 'duplex audio stream failed');
         const ev: RealtimeModelError = {
           type: 'realtime_model_error',
           timestamp: Date.now(),
           label: this.duplexSession.duplexModel.label(),
-          error: toError(error),
+          error: streamError,
           recoverable: false,
         };
         this.emit('error', ev);

--- a/agents/src/llm/index.ts
+++ b/agents/src/llm/index.ts
@@ -34,6 +34,23 @@ export {
 } from './tool_context.js';
 
 export { AsyncToolset, type AsyncToolsetCreateOptions } from './async_toolset.js';
+
+export {
+  DuplexModel,
+  DuplexSession,
+  type DuplexAudioFrame,
+  type DuplexCapabilities,
+  type DuplexOutputTranscriptDelta,
+} from './duplex.js';
+export {
+  AdaptiveNoiseGate,
+  DuplexRealtimeAdapter,
+  FixedGate,
+  type AdaptiveNoiseGateOptions,
+  type AudioGate,
+  type AudioGateOptions,
+  type DuplexRealtimeAdapterOptions,
+} from './duplex_adapter.js';
 export type {
   AsyncToolOptions,
   DuplicatePromptArgs,

--- a/agents/src/llm/index.ts
+++ b/agents/src/llm/index.ts
@@ -41,6 +41,7 @@ export {
   type DuplexAudioFrame,
   type DuplexCapabilities,
   type DuplexOutputTranscriptDelta,
+  type DuplexSessionCallbacks,
 } from './duplex.js';
 export {
   AdaptiveNoiseGate,

--- a/agents/src/llm/realtime.ts
+++ b/agents/src/llm/realtime.ts
@@ -48,6 +48,8 @@ export interface RealtimeCapabilities {
   messageTruncation: boolean;
   /** Whether the model emits server-side speech start and stop events for turn taking. */
   turnDetection: boolean;
+  /** Whether the model may speak over the caller and decides when to yield. Defaults to false. */
+  supportsOverlappingSpeech?: boolean;
   /** Whether the model emits user audio transcription events. */
   userTranscription: boolean;
   /** Whether the model automatically generates a reply after receiving tool results. */
@@ -87,6 +89,8 @@ export interface InputTranscriptionCompleted {
   itemId: string;
   transcript: string;
   isFinal: boolean;
+  /** Confidence in the user transcript, when the provider supplies it. */
+  confidence?: number;
   /**
    * When the turn this transcript belongs to began, in milliseconds since epoch.
    *

--- a/agents/src/metrics/base.ts
+++ b/agents/src/metrics/base.ts
@@ -164,6 +164,10 @@ export type RealtimeModelMetrics = {
    * The duration of the session connection in milliseconds (for session-based billing like xAI).
    */
   sessionDurationMs?: number;
+  /** Time to acquire the realtime connection, in milliseconds. */
+  acquireTimeMs?: number;
+  /** Whether an existing realtime connection was reused. */
+  connectionReused?: boolean;
   /**
    * Time to first audio token in milliseconds. -1 if no audio token was sent.
    */

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -13,6 +13,8 @@ import {
   type TTSModelString,
 } from '../inference/index.js';
 import { type Instructions, ReadonlyChatContext } from '../llm/chat_context.js';
+import { DuplexModel, type DuplexSession } from '../llm/duplex.js';
+import { DuplexRealtimeAdapter, DuplexRealtimeSession } from '../llm/duplex_adapter.js';
 import type { ChatMessage, FunctionCall } from '../llm/index.js';
 import {
   type ChatChunk,
@@ -149,11 +151,11 @@ export interface AgentUpdateOptions {
   /**
    * New LLM model. Pass `null` to disable the agent LLM and override any session LLM.
    *
-   * A {@link RealtimeModel} can only be set while the agent is not running: swapping to or
-   * from one on a running agent throws, because it replaces the whole pipeline rather than
-   * one model. Use `AgentSession.updateAgent()` for that.
+   * A {@link RealtimeModel} or {@link DuplexModel} can only be set while the agent is stopped.
+   * Swapping to or from one while running throws because it replaces the whole pipeline.
+   * Use `AgentSession.updateAgent()` for that.
    */
-  llm?: LLM | RealtimeModel | LLMModels | null;
+  llm?: LLM | RealtimeModel | DuplexModel | LLMModels | null;
   /** New TTS model. Pass `null` to disable the agent TTS and override any session TTS. */
   tts?: TTS | TTSModelString | null;
   /** Expressive TTS delivery. Pass `false` to override and disable the session setting. */
@@ -167,7 +169,7 @@ export interface AgentOptions<UserData> {
   tools?: ToolContextLike<UserData>;
   stt?: STT | STTModelString | null;
   vad?: VAD | null;
-  llm?: LLM | RealtimeModel | LLMModels | null;
+  llm?: LLM | RealtimeModel | DuplexModel | LLMModels | null;
   tts?: TTS | TTSModelString | null;
   /** Expressive TTS delivery. When set, overrides the session value for this agent. */
   expressive?: boolean | ExpressiveOptions;
@@ -275,6 +277,8 @@ export class Agent<UserData = any> {
 
     if (typeof llm === 'string') {
       this._llm = InferenceLLM.fromModelString(llm);
+    } else if (llm instanceof DuplexModel) {
+      this._llm = new DuplexRealtimeAdapter(llm);
     } else {
       this._llm = llm;
     }
@@ -302,6 +306,15 @@ export class Agent<UserData = any> {
 
   get llm(): LLM | RealtimeModel | undefined {
     return this._llm ?? undefined;
+  }
+
+  /** The running duplex provider session, for provider-specific APIs. */
+  get duplexSession(): DuplexSession {
+    const session = this.getActivityOrThrow().realtimeLLMSession;
+    if (!(session instanceof DuplexRealtimeSession)) {
+      throw new Error('no duplex session, this agent is not running a DuplexModel');
+    }
+    return session.duplexSession;
   }
 
   get tts(): TTS | undefined {
@@ -433,6 +446,8 @@ export class Agent<UserData = any> {
     }
     if (typeof resolved.llm === 'string') {
       resolved.llm = InferenceLLM.fromModelString(resolved.llm);
+    } else if (resolved.llm instanceof DuplexModel) {
+      resolved.llm = new DuplexRealtimeAdapter(resolved.llm);
     }
     if (typeof resolved.tts === 'string') {
       resolved.tts = InferenceTTS.fromModelString(resolved.tts);

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -427,7 +427,7 @@ export class Agent<UserData = any> {
       return;
     }
 
-    this._agentActivity.updateChatCtx(chatCtx);
+    await this._agentActivity.updateChatCtx(chatCtx);
   }
 
   async updateInstructions(instructions: string | Instructions): Promise<void> {

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -329,6 +329,7 @@ export class AgentActivity implements RecognitionHooks {
   private realtimeSession?: RealtimeSession;
   private realtimeSpans?: Map<string, Span>; // Maps response_id to OTEL span for metrics recording
   private turnDetectionMode?: TurnDetectionMode;
+  private rtOverlappingSpeechEnabled = false;
   private logger = log();
   private _schedulingPaused = true;
   private newTurnsBlocked = false;
@@ -464,6 +465,10 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     this._resolvedTurnDetection = this._resolveTurnDetection(this.turnDetection);
+    this.rtOverlappingSpeechEnabled =
+      this.llm instanceof RealtimeModel &&
+      this.llm.capabilities.turnDetection &&
+      this.llm.capabilities.supportsOverlappingSpeech === true;
     this.turnDetectionMode =
       typeof this._resolvedTurnDetection === 'string' ? this._resolvedTurnDetection : undefined;
 
@@ -1637,21 +1642,23 @@ export class AgentActivity implements RecognitionHooks {
   };
 
   private onError(ev: RealtimeModelError | STTError | TTSError | LLMError): void {
-    if (ev.type === 'realtime_model_error') {
-      const errorEvent = createErrorEvent(ev, this.llm);
-      this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
-    } else if (ev.type === 'stt_error') {
-      const errorEvent = createErrorEvent(ev, this.stt);
-      this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
-    } else if (ev.type === 'tts_error') {
-      const errorEvent = createErrorEvent(ev, this.tts);
-      this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
-    } else if (ev.type === 'llm_error') {
-      const errorEvent = createErrorEvent(ev, this.llm);
-      this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
+    try {
+      if (ev.type === 'realtime_model_error') {
+        const errorEvent = createErrorEvent(ev, this.llm);
+        this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
+      } else if (ev.type === 'stt_error') {
+        const errorEvent = createErrorEvent(ev, this.stt);
+        this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
+      } else if (ev.type === 'tts_error') {
+        const errorEvent = createErrorEvent(ev, this.tts);
+        this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
+      } else if (ev.type === 'llm_error') {
+        const errorEvent = createErrorEvent(ev, this.llm);
+        this.agentSession.emit(AgentSessionEventTypes.Error, errorEvent);
+      }
+    } finally {
+      this.agentSession._onError(ev);
     }
-
-    this.agentSession._onError(ev);
   }
 
   // -- Realtime Session events --
@@ -1673,6 +1680,8 @@ export class AgentActivity implements RecognitionHooks {
         );
       }
     }
+
+    if (this.rtOverlappingSpeechEnabled) return;
 
     // this.interrupt() is going to raise when allow_interruptions is False,
     // llm.InputSpeechStartedEvent is only fired by the server when the turn_detection is enabled.
@@ -1734,6 +1743,7 @@ export class AgentActivity implements RecognitionHooks {
         content: ev.transcript,
         id: ev.itemId,
         createdAt: turnStartedAt,
+        transcriptConfidence: ev.confidence ?? 1,
         metrics: userMetrics,
       });
       // insert rather than append: this transcript can arrive after the reply that
@@ -4095,7 +4105,7 @@ export class AgentActivity implements RecognitionHooks {
     const toolCtx = realtimeSession.tools;
 
     const authorizationTasks: Promise<unknown>[] = [speechHandle._waitForAuthorization()];
-    if (speechHandle.allowInterruptions) {
+    if (speechHandle.allowInterruptions && !this.rtOverlappingSpeechEnabled) {
       authorizationTasks.push(this.userSilenceEvent.wait());
     }
     await speechHandle.waitIfNotInterrupted(authorizationTasks);
@@ -4811,7 +4821,7 @@ export class AgentActivity implements RecognitionHooks {
     }
 
     const authorizationTasks: Promise<unknown>[] = [speechHandle._waitForAuthorization()];
-    if (speechHandle.allowInterruptions) {
+    if (speechHandle.allowInterruptions && !this.rtOverlappingSpeechEnabled) {
       authorizationTasks.push(this.userSilenceEvent.wait());
     }
     await speechHandle.waitIfNotInterrupted(authorizationTasks);
@@ -5289,6 +5299,7 @@ export class AgentActivity implements RecognitionHooks {
   }
 
   private pauseEnabled(): boolean {
+    if (this.rtOverlappingSpeechEnabled) return false;
     const interruptionOptions = this.agentSession.sessionOptions.turnHandling.interruption;
     return !!(
       interruptionOptions.resumeFalseInterruption &&
@@ -5546,8 +5557,6 @@ export class AgentActivity implements RecognitionHooks {
         'input_audio_transcription_completed',
         this.onRealtimeInputAudioTranscriptionCompleted,
       );
-      this.realtimeSession.off('metrics_collected', this.onMetricsCollected);
-      this.realtimeSession.off('error', this.onModelError);
     }
 
     if (this.stt instanceof STT) {
@@ -5577,8 +5586,14 @@ export class AgentActivity implements RecognitionHooks {
     await this.agentSession._keytermDetector.aclose();
 
     this.detachAudioInput();
-    this.realtimeSpans?.clear();
-    await this.realtimeSession?.close();
+    try {
+      await this.realtimeSession?.close();
+    } finally {
+      // Providers can report final usage while closing the connection.
+      this.realtimeSession?.off('metrics_collected', this.onMetricsCollected);
+      this.realtimeSession?.off('error', this.onModelError);
+      this.realtimeSpans?.clear();
+    }
     await this.audioRecognition?.close();
     await this.closeToolsets();
     this.realtimeSession = undefined;

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -1059,7 +1059,7 @@ export class AgentActivity implements RecognitionHooks {
 
     if (this.realtimeSession) {
       removeInstructions(chatCtx);
-      this.realtimeSession.updateChatCtx(chatCtx);
+      await this.realtimeSession.updateChatCtx(chatCtx);
     } else {
       updateInstructions({
         chatCtx,

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -28,6 +28,7 @@ import {
   instructionsEqual,
   renderInstructions,
 } from '../llm/chat_context.js';
+import { DuplexRealtimeSession } from '../llm/duplex_adapter.js';
 import { AsyncToolset, type Toolset } from '../llm/index.js';
 import {
   type ChatItem,
@@ -657,6 +658,20 @@ export class AgentActivity implements RecognitionHooks {
           !rtReused || capabilities.midSessionToolsUpdate ? this.tools : undefined,
         );
       } catch (error) {
+        if (this.realtimeSession instanceof DuplexRealtimeSession) {
+          startSpan.end();
+          if (this.agentSession._started) {
+            this.onError({
+              type: 'realtime_model_error',
+              timestamp: Date.now(),
+              label: this.llm.label(),
+              error:
+                error instanceof Error ? error : new RealtimeError('duplex configuration failed'),
+              recoverable: false,
+            });
+          }
+          throw error;
+        }
         this.logger.error(error, 'failed to update realtime session');
       }
 

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -1924,6 +1924,7 @@ export class AgentSession<
   }
 
   private _onUserInputTranscribed(ev: UserInputTranscribedEvent): void {
+    if (this.closing) return;
     if (ev.isFinal && this._userState !== 'speaking') {
       if (this._userState === 'away') {
         this.logger.debug('User returned from away state due to speech input');

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -47,7 +47,13 @@ import type {
   ToolContextEntry,
   ToolContextLike,
 } from '../llm/index.js';
-import { ToolContext, ToolError, toToolContext } from '../llm/index.js';
+import {
+  DuplexModel,
+  DuplexRealtimeAdapter,
+  ToolContext,
+  ToolError,
+  toToolContext,
+} from '../llm/index.js';
 import { LLM as BaseLLM } from '../llm/llm.js';
 import type { LLMError } from '../llm/llm.js';
 import { log } from '../log.js';
@@ -284,7 +290,7 @@ export type AgentSessionOptions<UserData = UnknownUserData> = {
    * one as absent). Pass `null` to opt out entirely.
    */
   vad?: VAD | null;
-  llm?: LLM | RealtimeModel | LLMModels;
+  llm?: LLM | RealtimeModel | DuplexModel | LLMModels;
   tts?: TTS | TTSModelString;
   userData?: UserData;
   connOptions?: SessionConnectOptions;
@@ -723,6 +729,8 @@ export class AgentSession<
 
     if (typeof llm === 'string') {
       this.llm = InferenceLLM.fromModelString(llm);
+    } else if (llm instanceof DuplexModel) {
+      this.llm = new DuplexRealtimeAdapter(llm);
     } else {
       this.llm = llm;
     }

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -1964,7 +1964,6 @@ export class AgentSession<
     this.closingController.abort();
     this._cancelUserAwayTimer();
     this._onAecWarmupExpired();
-    this.off(AgentSessionEventTypes.UserInputTranscribed, this._onUserInputTranscribed);
 
     let activity = this.activity;
     // Let inline tasks finish their handoffs before closing the resumed parent.

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -971,7 +971,10 @@ export class AgentSession<
     // Initial start does not wait on onEnter
     tasks.push(this._updateActivity(this.agent, { waitOnEnter: false }));
 
-    await ThrowsPromise.allSettled(tasks);
+    const startupResults = await ThrowsPromise.allSettled(tasks);
+    for (const result of startupResults) {
+      if (result.status === 'rejected') throw result.reason;
+    }
 
     if (this.sessionHost) {
       await this.sessionHost.start();
@@ -1074,13 +1077,19 @@ export class AgentSession<
 
     this.rootSpanContext = trace.setSpan(otelContext.active(), this.sessionSpan);
 
-    await this._startImpl({
-      agent,
-      room,
-      inputOptions,
-      outputOptions,
-      span: this.sessionSpan,
-    });
+    try {
+      await this._startImpl({
+        agent,
+        room,
+        inputOptions,
+        outputOptions,
+        span: this.sessionSpan,
+      });
+    } catch (error) {
+      this._closeSoon({ reason: CloseReason.ERROR });
+      await this.closingTask;
+      throw error;
+    }
   }
 
   updateAgent(agent: Agent): void {
@@ -1944,7 +1953,8 @@ export class AgentSession<
     error: RealtimeModelError | LLMError | TTSError | STTError | null = null,
     drain: boolean = false,
   ): Promise<void> {
-    if (!this.started) {
+    const wasStarted = this.started;
+    if (!wasStarted && !this.activity && !this.sessionSpan) {
       return;
     }
 
@@ -1958,7 +1968,7 @@ export class AgentSession<
 
     let activity = this.activity;
     // Let inline tasks finish their handoffs before closing the resumed parent.
-    while (activity?.agent instanceof AgentTask) {
+    while (wasStarted && activity?.agent instanceof AgentTask) {
       const task = activity.agent;
       activity.interrupt({ force: true });
       if (!task.done) {
@@ -1975,7 +1985,7 @@ export class AgentSession<
       activity = task._oldAgent._agentActivity;
     }
 
-    if (activity) {
+    if (wasStarted && activity) {
       if (!drain) {
         try {
           await activity.interrupt({ force: true }).await;
@@ -2014,6 +2024,7 @@ export class AgentSession<
 
     const sessionToolsets = this._toolCtx.toolsets;
     await Promise.allSettled(sessionToolsets.map((toolset) => toolset.aclose()));
+    this._sessionToolsetsSetup = false;
 
     if (this.sessionSpan) {
       this.sessionSpan.end();
@@ -2032,7 +2043,7 @@ export class AgentSession<
 
     this.started = false;
 
-    this.emit(AgentSessionEventTypes.Close, createCloseEvent(reason, error));
+    if (wasStarted) this.emit(AgentSessionEventTypes.Close, createCloseEvent(reason, error));
 
     this._userState = 'listening';
     this._agentState = 'initializing';

--- a/agents/src/voice/realtime_message_metrics.test.ts
+++ b/agents/src/voice/realtime_message_metrics.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../llm/realtime.js';
 import { type ToolChoice, ToolContext } from '../llm/tool_context.js';
 import { initializeLogger, log } from '../log.js';
+import type { RealtimeModelMetrics } from '../metrics/base.js';
 import { FakeSTT } from '../stt/testing/fake_stt.js';
 import { Agent } from './agent.js';
 import { AgentSession } from './agent_session.js';
@@ -40,6 +41,7 @@ function oneItemStream<T>(item: T): ReadableStream<T> {
 }
 
 class FakeRealtimeSession extends RealtimeSession {
+  closingMetrics?: RealtimeModelMetrics;
   private _chatCtx = ChatContext.empty();
   private _tools = ToolContext.empty();
 
@@ -88,6 +90,11 @@ class FakeRealtimeSession extends RealtimeSession {
   async interrupt(): Promise<void> {}
 
   async truncate(): Promise<void> {}
+
+  async close(): Promise<void> {
+    if (this.closingMetrics) this.emit('metrics_collected', this.closingMetrics);
+    await super.close();
+  }
 }
 
 class FakeRealtimeModel extends RealtimeModel {
@@ -162,6 +169,45 @@ async function runRealtimeSession({
 }
 
 describe('Realtime message metrics', () => {
+  it('collects usage reported while the provider session closes', async () => {
+    const model = new FakeRealtimeModel();
+    const session = new AgentSession({
+      llm: model,
+      vad: null,
+      turnHandling: { turnDetection: null },
+    });
+    await session.start({ agent: new Agent({ instructions: 'test' }) });
+    model.activeSession.closingMetrics = {
+      type: 'realtime_model_metrics',
+      label: 'fake',
+      requestId: 'sess_1',
+      timestamp: Date.now(),
+      durationMs: 0,
+      ttftMs: -1,
+      cancelled: false,
+      tokensPerSecond: 0,
+      sessionDurationMs: 12_500,
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      inputTokenDetails: { audioTokens: 90, textTokens: 10, imageTokens: 0, cachedTokens: 0 },
+      outputTokenDetails: { audioTokens: 40, textTokens: 10, imageTokens: 0 },
+      metadata: { modelName: 'fake-live', modelProvider: 'fake.provider' },
+    };
+    await session.close();
+    expect(session.usage.modelUsage).toContainEqual(
+      expect.objectContaining({
+        provider: 'fake.provider',
+        inputTokens: 100,
+        inputAudioTokens: 90,
+        outputTokens: 50,
+        outputAudioTokens: 40,
+        sessionDurationMs: 12_500,
+      }),
+    );
+    expect(model.activeSession.listenerCount('metrics_collected')).toBe(0);
+  });
+
   it('makes realtime response IDs available on assistant messages', async () => {
     const llm = new FakeRealtimeModel();
     const session = new AgentSession({ llm, vad: null, turnHandling: { turnDetection: null } });

--- a/agents/src/voice/realtime_overlapping_speech.test.ts
+++ b/agents/src/voice/realtime_overlapping_speech.test.ts
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream, type ReadableStreamDefaultController } from 'node:stream/web';
+import { setImmediate } from 'node:timers/promises';
+import { describe, expect, it, vi } from 'vitest';
+import { ChatContext, type FunctionCall } from '../llm/chat_context.js';
+import { type GenerationCreatedEvent, RealtimeModel, RealtimeSession } from '../llm/realtime.js';
+import { ToolContext } from '../llm/tool_context.js';
+import { log } from '../log.js';
+import { type VADEvent, VADEventType } from '../vad.js';
+import { Agent } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AudioOutput } from './io.js';
+
+class TracingAudioOutput extends AudioOutput {
+  frames = 0;
+  clears = 0;
+  pauses = 0;
+  constructor() {
+    super(24_000, undefined, { pause: true });
+  }
+  async captureFrame(frame: AudioFrame): Promise<void> {
+    await super.captureFrame(frame);
+    this.frames++;
+    this.onPlaybackStarted(Date.now());
+  }
+  flush(): void {
+    super.flush();
+    this.onPlaybackFinished({ playbackPosition: this.frames * 0.1, interrupted: false });
+  }
+  clearBuffer(): void {
+    this.clears++;
+    this.onPlaybackFinished({ playbackPosition: this.frames * 0.1, interrupted: true });
+  }
+  pause(): void {
+    this.pauses++;
+  }
+  resume(): void {}
+}
+
+function empty<T>(): ReadableStream<T> {
+  return new ReadableStream<T>({
+    start(controller) {
+      controller.close();
+    },
+  });
+}
+
+class FakeRealtimeSession extends RealtimeSession {
+  chatCtx = ChatContext.empty();
+  tools = ToolContext.empty();
+  asks = 0;
+  audio?: ReadableStreamDefaultController<AudioFrame>;
+  text?: ReadableStreamDefaultController<string>;
+  async updateInstructions(): Promise<void> {}
+  async updateChatCtx(context: ChatContext): Promise<void> {
+    this.chatCtx = context;
+  }
+  async updateTools(tools: ToolContext): Promise<void> {
+    this.tools = tools;
+  }
+  updateOptions(): void {}
+  pushAudio(): void {}
+  async generateReply(): Promise<GenerationCreatedEvent> {
+    this.asks++;
+    return this.generation(true);
+  }
+  generation(userInitiated: boolean): GenerationCreatedEvent {
+    const audioStream = new ReadableStream<AudioFrame>({
+      start: (controller) => {
+        this.audio = controller;
+      },
+      cancel: () => {
+        this.audio = undefined;
+      },
+    });
+    const textStream = new ReadableStream<string>({
+      start: (controller) => {
+        this.text = controller;
+      },
+      cancel: () => {
+        this.text = undefined;
+      },
+    });
+    this.audio!.enqueue(new AudioFrame(new Int16Array(2400), 24_000, 1, 2400));
+    this.text!.enqueue('The weather today is');
+    return {
+      userInitiated,
+      messageStream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            messageId: 'msg-1',
+            audioStream,
+            textStream,
+            modalities: Promise.resolve(['audio', 'text'] as ('audio' | 'text')[]),
+          });
+          controller.close();
+        },
+      }),
+      functionStream: empty<FunctionCall>(),
+    };
+  }
+  endSpeech(): void {
+    this.audio?.close();
+    this.text?.close();
+  }
+  async commitAudio(): Promise<void> {}
+  async clearAudio(): Promise<void> {}
+  async interrupt(): Promise<void> {}
+  async truncate(): Promise<void> {}
+}
+
+class FakeRealtimeModel extends RealtimeModel {
+  activeSession!: FakeRealtimeSession;
+  constructor(overlap: boolean, turnDetection = true) {
+    super({
+      messageTruncation: true,
+      turnDetection,
+      supportsOverlappingSpeech: overlap,
+      userTranscription: true,
+      autoToolReplyGeneration: true,
+      audioOutput: true,
+      manualFunctionCalls: true,
+    });
+  }
+  get model(): string {
+    return 'fake';
+  }
+  session(): FakeRealtimeSession {
+    return (this.activeSession = new FakeRealtimeSession(this));
+  }
+  async close(): Promise<void> {}
+}
+
+const speechStart: VADEvent = {
+  type: VADEventType.START_OF_SPEECH,
+  samplesIndex: 0,
+  timestamp: 0,
+  speechDuration: 0,
+  silenceDuration: 0,
+  frames: [],
+  probability: 1,
+  inferenceDuration: 0,
+  speaking: true,
+  rawAccumulatedSilence: 0,
+  rawAccumulatedSpeech: 0,
+};
+
+async function start(overlap: boolean, turnDetection = true) {
+  const model = new FakeRealtimeModel(overlap, turnDetection);
+  const session = new AgentSession({
+    llm: model,
+    vad: null,
+    aecWarmupDuration: null,
+    turnHandling: { turnDetection: turnDetection ? 'realtime_llm' : 'manual' },
+  });
+  const output = new TracingAudioOutput();
+  session.output.audio = output;
+  const agent = new Agent({ instructions: 'be concise' });
+  await session.start({ agent });
+  return { model, session, output, activity: agent.getActivityOrThrow() };
+}
+
+describe('realtime overlapping speech', () => {
+  it.each([false, true])('handles server speech start with overlap=%s', async (overlap) => {
+    const { model, session, output } = await start(overlap);
+    try {
+      const speech = session.generateReply();
+      await setImmediate();
+      expect(output.frames).toBeGreaterThan(0);
+      model.activeSession.emit('input_speech_started', {});
+      await setImmediate();
+      expect(speech.interrupted).toBe(!overlap);
+      expect(output.clears).toBe(overlap ? 0 : 1);
+      expect(session.userState).toBe('speaking');
+    } finally {
+      model.activeSession.endSpeech();
+      await session.close();
+    }
+  });
+
+  it.each([false, true])(
+    'does not wait for caller silence or pause output (requested: %s)',
+    async (requested) => {
+      const { model, session, output, activity } = await start(true);
+      try {
+        activity.onStartOfSpeech(speechStart);
+        if (requested) session.generateReply();
+        else model.activeSession.emit('generation_created', model.activeSession.generation(false));
+        await setImmediate();
+        expect(output.frames).toBeGreaterThan(0);
+        expect(session.agentState).toBe('speaking');
+        expect(output.pauses).toBe(0);
+        expect(output.clears).toBe(0);
+      } finally {
+        model.activeSession.endSpeech();
+        await session.close();
+      }
+    },
+  );
+
+  it.each([
+    { overlap: false, turnDetection: true },
+    { overlap: true, turnDetection: false },
+  ])(
+    'keeps the silence gate for $overlap overlap and $turnDetection server turn detection',
+    async ({ overlap, turnDetection }) => {
+      const { model, session, output, activity } = await start(overlap, turnDetection);
+      try {
+        activity.onStartOfSpeech(speechStart);
+        session.generateReply();
+        await setImmediate();
+        expect(model.activeSession.asks).toBe(0);
+        expect(output.frames).toBe(0);
+        activity.onEndOfSpeech();
+        await setImmediate();
+        expect(model.activeSession.asks).toBe(1);
+        expect(output.frames).toBeGreaterThan(0);
+      } finally {
+        model.activeSession.endSpeech();
+        await session.close();
+      }
+    },
+  );
+
+  it.each([false, true])(
+    'warns when interruptions are disabled with server turn detection (overlap: %s)',
+    async (overlap) => {
+      const session = new AgentSession({
+        llm: new FakeRealtimeModel(overlap),
+        vad: null,
+        turnHandling: { interruption: { enabled: false } },
+      });
+      const warn = vi.spyOn(log(), 'warn');
+      try {
+        await session.start({ agent: new Agent({ instructions: 'test' }) });
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining('allowInterruptions cannot be false'),
+        );
+      } finally {
+        await session.close();
+        warn.mockRestore();
+      }
+    },
+  );
+});

--- a/agents/src/voice/transcription/synchronizer.test.ts
+++ b/agents/src/voice/transcription/synchronizer.test.ts
@@ -4,7 +4,13 @@
 import { AudioFrame } from '@livekit/rtc-node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as logModule from '../../log.js';
-import { AudioOutput, TextOutput } from '../io.js';
+import {
+  AudioOutput,
+  TextOutput,
+  type TimedString,
+  createTimedString,
+  isTimedString,
+} from '../io.js';
 import {
   SpeakingRateData,
   TranscriptionSynchronizer,
@@ -227,14 +233,40 @@ class MockAudioOutput extends AudioOutput {
 class MockTextOutput extends TextOutput {
   captured: string[] = [];
 
-  async captureText(text: string): Promise<void> {
-    this.captured.push(text);
+  async captureText(text: string | TimedString): Promise<void> {
+    this.captured.push(isTimedString(text) ? text.text : text);
   }
 
   flush(): void {}
 }
 
 describe('TranscriptionSynchronizer enabled behavior', () => {
+  it.each([
+    ['It is', ' sunny'],
+    ['It is curren', 'tly sunny'],
+  ])(
+    'releases trailing words of timed spans before text input ends: %s + %s',
+    async (first, second) => {
+      const downstream = new MockTextOutput();
+      const synchronizer = new TranscriptionSynchronizer(new MockAudioOutput(), downstream);
+      await synchronizer.barrier();
+      const impl = synchronizer._impl;
+      try {
+        impl.pushAudio(new AudioFrame(new Int16Array(6400), 16_000, 1, 6400));
+        impl.endAudioInput();
+        impl.onPlaybackStarted(Date.now());
+        impl.pushText(createTimedString({ text: first, startTime: 0, endTime: 0.2 }));
+        impl.pushText(createTimedString({ text: second, startTime: 0.2, endTime: 0.4 }));
+        await vi.waitFor(() => expect(downstream.captured.join('')).toBe(first + second), {
+          timeout: 2000,
+        });
+        expect(impl.textInputEnded).toBe(false);
+      } finally {
+        await synchronizer.close();
+      }
+    },
+  );
+
   it('directly forwards text when synchronization is disabled', async () => {
     const downstream = new MockTextOutput();
     const synchronizer = new TranscriptionSynchronizer(new MockAudioOutput(), downstream, {

--- a/agents/src/voice/transcription/synchronizer.ts
+++ b/agents/src/voice/transcription/synchronizer.ts
@@ -314,6 +314,10 @@ class SegmentSynchronizerImpl {
 
     this.textData.wordStream.pushText(textStr);
     this.textData.pushedText += textStr;
+    if (endTime !== undefined) {
+      // A closed span releases its trailing word while the turn is still open.
+      this.textData.wordStream.flush();
+    }
   }
 
   endTextInput() {


### PR DESCRIPTION
Adds full-duplex speech to `Agent` and `AgentSession`, with a patch changeset.

Ports @longcw’s [Python implementation](https://github.com/livekit/agents/pull/6677) through [`53e68945`](https://github.com/livekit/agents/commit/53e689456bd7933072408412f3af685e93712fcb). Includes reconnect gate reset and cleanup after failed configuration.

**Validation:** 2,577 core tests, build, typecheck, core API, and scripted Python/Node voice parity pass. Full-workspace lint/API checks have existing OpenAI/Phonic failures.

Addresses [AGT-3487](https://linear.app/livekit/issue/AGT-3487/port-duplexmodel-and-full-duplex-speech-support-to-agents-js).

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-6

> I need to port over https://github.com/livekit/agents/pull/6677 to node.js

> This is a patch level change.

> can you open a draft PR? Before doing that, run a subagent for code review?

</details>

