### PR TITLE
fix: wait for agent task handoffs before closing sessions

### DIFF
--- a/.changeset/agent-task-shutdown.md
+++ b/.changeset/agent-task-shutdown.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Wait for agent task handoffs during session shutdown, including concurrent agent updates, without leaking activities or waiting on the task's own tool. Preserve transfer errors, suppress tool replies during shutdown, and make warm-transfer room-disconnect failures explicit.

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -870,7 +870,9 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
                 `${this.constructor.name} completed, but the agent has changed in the meantime. ` +
                   `Ignoring handoff to the previous agent, likely due to AgentSession.updateAgent being invoked.`,
               );
-              await oldActivity.close();
+              // Shutdown closes the parent after this task returns. Closing it here
+              // would wait for the tool that is currently awaiting this task.
+              if (!session._closing) await oldActivity.close();
             } else {
               const mergedChatCtx = oldAgent._chatCtx.merge(this._chatCtx, {
                 excludeFunctionCall: !this._preserveFunctionCallHistory,

--- a/agents/src/voice/agent.ts
+++ b/agents/src/voice/agent.ts
@@ -32,7 +32,7 @@ import { SentenceTokenizer as BasicSentenceTokenizer } from '../tokenize/basic/i
 import type { TTS } from '../tts/index.js';
 import { SynthesizeStream, StreamAdapter as TTSStreamAdapter } from '../tts/index.js';
 import { type FlushSentinel, USERDATA_TIMED_TRANSCRIPT } from '../types.js';
-import { Future, Task, toStream } from '../utils.js';
+import { Event, Future, Task, toStream } from '../utils.js';
 import type { VAD } from '../vad.js';
 import { type AgentActivity, agentActivityStorage } from './agent_activity.js';
 import type { AgentSession, ExpressiveOptions, TurnDetectionMode } from './agent_session.js';
@@ -676,7 +676,11 @@ export interface AgentTaskOptions<UserData = any> extends AgentOptions<UserData>
 export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData> {
   private started = false;
   private future = new Future<ResultT>();
+  private readonly inactive = new Event();
   private _preserveFunctionCallHistory: boolean;
+
+  /** @internal */
+  _oldAgent?: Agent;
 
   #logger = log();
 
@@ -690,10 +694,16 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
     const { preserveFunctionCallHistory = false, ...rest } = options;
     super(rest);
     this._preserveFunctionCallHistory = preserveFunctionCallHistory;
+    this.inactive.set();
   }
 
   get done(): boolean {
     return this.future.done;
+  }
+
+  /** @internal */
+  async _waitForInactive(): Promise<void> {
+    await this.inactive.wait();
   }
 
   complete(result: ResultT | Error): void {
@@ -747,6 +757,7 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
     const ownerIsNonBlocking =
       taskInfo.functionCall?.extra.__livekit_agents_tool_non_blocking === true;
     const oldAgent = oldActivity.agent;
+    this._oldAgent = oldAgent;
     const session = oldActivity.agentSession;
 
     const blockedTasks: Task<any>[] = [currentTask];
@@ -756,6 +767,7 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
       blockedTasks.push(onEnterTask);
     }
 
+    this.inactive.clear();
     try {
       return await oldActivity._withInlineTaskSlot({
         speechHandle,
@@ -875,8 +887,8 @@ export class AgentTask<ResultT = unknown, UserData = any> extends Agent<UserData
           }
         },
       });
-    } catch (error) {
-      throw error;
+    } finally {
+      this.inactive.set();
     }
   }
 }

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -3915,7 +3915,7 @@ export class AgentActivity implements RecognitionHooks {
       this.agentSession._toolItemsAdded(toolCallOutputs);
     }
 
-    if (shouldGenerateToolReply) {
+    if (shouldGenerateToolReply && !this.agentSession._closing) {
       _stripRunningToolCalls(chatCtx);
       chatCtx.insert(toolMessages);
 

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -1957,6 +1957,12 @@ export class AgentSession<
         task.complete(new ToolError(`AgentTask ${task.id} is cancelled`));
       }
       await task._waitForInactive();
+      // A concurrent updateAgent can prevent the task from resuming its parent.
+      // In that case its activity still needs the normal exit and close sequence.
+      if (task._agentActivity === activity) {
+        await activity.drain();
+        await activity.close();
+      }
       if (!task._oldAgent) break;
       activity = task._oldAgent._agentActivity;
     }

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -47,7 +47,7 @@ import type {
   ToolContextEntry,
   ToolContextLike,
 } from '../llm/index.js';
-import { ToolContext, toToolContext } from '../llm/index.js';
+import { ToolContext, ToolError, toToolContext } from '../llm/index.js';
 import { LLM as BaseLLM } from '../llm/llm.js';
 import type { LLMError } from '../llm/llm.js';
 import { log } from '../log.js';
@@ -71,7 +71,7 @@ import {
 } from '../types.js';
 import { Event, Task, asError } from '../utils.js';
 import type { VAD } from '../vad.js';
-import type { Agent } from './agent.js';
+import { type Agent, AgentTask } from './agent.js';
 import {
   AgentActivity,
   type ReusableResources,
@@ -1530,17 +1530,18 @@ export class AgentSession<
           'Agent handoff inserted into chat context',
         );
 
+        const activity = this.activity!;
         if (newActivity === 'start') {
-          await this.activity!.start({ reuseResources: reusableResources });
+          await activity.start({ reuseResources: reusableResources });
         } else {
-          await this.activity!.resume({ reuseResources: reusableResources });
+          await activity.resume({ reuseResources: reusableResources });
         }
         reusableResources = undefined;
 
-        onEnterTask = this.activity!._onEnterTask;
+        onEnterTask = activity._onEnterTask;
 
         if (this._input.audio) {
-          this.activity!.attachAudioInput(this._input.audio.stream);
+          activity.attachAudioInput(this._input.audio.stream);
         }
       } catch (error) {
         // JS safeguard: session cleanup owns the detached resources until the next activity
@@ -1947,25 +1948,38 @@ export class AgentSession<
     this._onAecWarmupExpired();
     this.off(AgentSessionEventTypes.UserInputTranscribed, this._onUserInputTranscribed);
 
-    if (this.activity) {
+    let activity = this.activity;
+    // Let inline tasks finish their handoffs before closing the resumed parent.
+    while (activity?.agent instanceof AgentTask) {
+      const task = activity.agent;
+      activity.interrupt({ force: true });
+      if (!task.done) {
+        task.complete(new ToolError(`AgentTask ${task.id} is cancelled`));
+      }
+      await task._waitForInactive();
+      if (!task._oldAgent) break;
+      activity = task._oldAgent._agentActivity;
+    }
+
+    if (activity) {
       if (!drain) {
         try {
-          await this.activity.interrupt({ force: true }).await;
+          await activity.interrupt({ force: true }).await;
         } catch (error) {
           this.logger.warn({ error }, 'Error interrupting activity');
         }
       }
 
-      await this.activity.drain();
+      await activity.drain();
       // wait any uninterruptible speech to finish
-      await this.activity.currentSpeech?.waitForPlayout();
+      await activity.currentSpeech?.waitForPlayout();
 
       if (reason !== CloseReason.ERROR) {
-        this.activity.commitUserTurn({ audioDetached: true, throwIfNotReady: false });
+        activity.commitUserTurn({ audioDetached: true, throwIfNotReady: false });
       }
 
       try {
-        this.activity.detachAudioInput();
+        activity.detachAudioInput();
       } catch (error) {
         // Ignore detach errors during cleanup - source may not have been set
       }
@@ -1981,7 +1995,7 @@ export class AgentSession<
     this.output.audio = null;
     this.output.transcription = null;
 
-    await this.activity?.close();
+    await activity?.close();
     this.activity = undefined;
 
     const sessionToolsets = this._toolCtx.toolsets;

--- a/agents/src/voice/agent_task_close.test.ts
+++ b/agents/src/voice/agent_task_close.test.ts
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { expect, it, vi } from 'vitest';
+import { ToolError, tool } from '../llm/tool_context.js';
+import { Future } from '../utils.js';
+import { Agent, AgentTask } from './agent.js';
+import { AgentActivity } from './agent_activity.js';
+import { AgentSession } from './agent_session.js';
+import { FakeLLM } from './testing/fake_llm.js';
+
+it.each(['before completion', 'during onExit', 'during resume'] as const)(
+  'preserves the task error when the session closes %s',
+  async (timing) => {
+    const entered = new Future<void>();
+    const exiting = new Future<void>();
+    const notificationDone = new Future<void>();
+    const result = new Future<unknown>();
+    const failure = new ToolError('caller hung up before the transfer completed');
+    const transfer = AgentTask.create<void>({
+      instructions: 'transfer',
+      onEnter: async () => {
+        entered.resolve();
+      },
+      onExit: async () => {
+        exiting.resolve();
+        await notificationDone.await;
+      },
+    });
+    const agent = new Agent({
+      instructions: 'support',
+      tools: [
+        tool({
+          name: 'transfer',
+          description: 'Transfer the caller.',
+          execute: async () => {
+            try {
+              await transfer.run();
+            } catch (error) {
+              result.resolve(error);
+              throw error;
+            }
+          },
+        }),
+      ],
+    });
+    const llm = new FakeLLM([{ input: 'transfer', toolCalls: [{ name: 'transfer', args: {} }] }]);
+    const chat = vi.spyOn(llm, 'chat');
+    const session = new AgentSession({ llm });
+    let closing: Promise<void> | undefined;
+    const originalResume = AgentActivity.prototype.resume;
+    const resume = vi.spyOn(AgentActivity.prototype, 'resume').mockImplementation(function (
+      this: AgentActivity,
+      options,
+    ) {
+      if (timing === 'during resume') closing = session.close();
+      return originalResume.call(this, options);
+    });
+    try {
+      await session.start({ agent });
+      const originalActivity = agent._agentActivity!;
+      session.generateReply({ userInput: 'transfer' });
+      await entered.await;
+      if (timing === 'before completion') closing = session.close();
+      transfer.complete(failure);
+      await exiting.await;
+      if (timing === 'during onExit') closing = session.close();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(result.done).toBe(false);
+      notificationDone.resolve();
+      await result.await;
+      await closing;
+
+      expect(await result.await).toBe(failure);
+      expect(resume).toHaveBeenCalledOnce();
+      expect(chat).toHaveBeenCalledOnce();
+      expect(agent._agentActivity).toBeUndefined();
+      expect(transfer._agentActivity).toBeUndefined();
+      expect(originalActivity.schedulingPaused).toBe(true);
+    } finally {
+      notificationDone.resolve();
+      await session.close();
+      resume.mockRestore();
+      chat.mockRestore();
+    }
+  },
+  10_000,
+);
+
+it.each([1, 2])('cancels and unwinds %i pending tasks before closing the parent', async (depth) => {
+  const entered = new Future<void>();
+  const result = new Future<unknown>();
+  const tasks: AgentTask<void>[] = [];
+  const createTask = (remaining: number): AgentTask<void> => {
+    const task = AgentTask.create<void>({
+      instructions: 'transfer',
+      onEnter: async () => {
+        if (remaining === 1) {
+          entered.resolve();
+        } else {
+          try {
+            await createTask(remaining - 1).run();
+          } catch (error) {
+            expect(error).toBeInstanceOf(ToolError);
+          }
+        }
+      },
+    });
+    tasks.push(task);
+    return task;
+  };
+  const agent = new Agent({
+    instructions: 'support',
+    tools: [
+      tool({
+        name: 'transfer',
+        description: 'Transfer the caller.',
+        execute: async () => {
+          try {
+            await createTask(depth).run();
+          } catch (error) {
+            result.resolve(error);
+            throw error;
+          }
+        },
+      }),
+    ],
+  });
+  const llm = new FakeLLM([{ input: 'transfer', toolCalls: [{ name: 'transfer', args: {} }] }]);
+  const chat = vi.spyOn(llm, 'chat');
+  const session = new AgentSession({ llm });
+  const resume = vi.spyOn(AgentActivity.prototype, 'resume');
+  try {
+    await session.start({ agent });
+    session.generateReply({ userInput: 'transfer' });
+    await entered.await;
+    await session.close();
+
+    expect(await result.await).toBeInstanceOf(ToolError);
+    expect(resume).toHaveBeenCalledTimes(depth);
+    expect(chat).toHaveBeenCalledOnce();
+    expect(agent._agentActivity).toBeUndefined();
+    for (const task of tasks) {
+      expect(task.done).toBe(true);
+      expect(task._agentActivity).toBeUndefined();
+    }
+  } finally {
+    await session.close();
+    resume.mockRestore();
+    chat.mockRestore();
+  }
+});

--- a/agents/src/voice/agent_task_close.test.ts
+++ b/agents/src/voice/agent_task_close.test.ts
@@ -150,3 +150,72 @@ it.each([1, 2])('cancels and unwinds %i pending tasks before closing the parent'
     chat.mockRestore();
   }
 });
+
+it.each([
+  { owner: 'onEnter', timing: 'queued' },
+  { owner: 'tool', timing: 'queued' },
+  { owner: 'onEnter', timing: 'draining' },
+  { owner: 'tool', timing: 'draining' },
+])(
+  'closes the task and parent when updateAgent is $timing and the task owner is $owner',
+  async ({ owner, timing }) => {
+    const entered = new Future<void>();
+    const exiting = new Future<void>();
+    const finishExit = new Future<void>();
+    const transfer = AgentTask.create<void>({
+      instructions: 'transfer',
+      onEnter: async () => {
+        entered.resolve();
+      },
+      onExit: async () => {
+        exiting.resolve();
+        await finishExit.await;
+      },
+    });
+    const result = new Future<unknown>();
+    const runTransfer = async () => {
+      try {
+        await transfer.run();
+      } catch (error) {
+        result.resolve(error);
+      }
+    };
+    class SupportAgent extends Agent {
+      constructor() {
+        super({
+          instructions: 'support',
+          tools: [
+            tool({ name: 'transfer', description: 'Transfer the caller.', execute: runTransfer }),
+          ],
+        });
+      }
+      async onEnter() {
+        if (owner === 'onEnter') await runTransfer();
+      }
+    }
+    const agent = new SupportAgent();
+    const fallback = new Agent({ instructions: 'fallback' });
+    const session = new AgentSession({
+      llm: new FakeLLM([{ input: 'transfer', toolCalls: [{ name: 'transfer', args: {} }] }]),
+    });
+    await session.start({ agent });
+    if (owner === 'tool') session.generateReply({ userInput: 'transfer' });
+    await entered.await;
+    const taskActivity = transfer._agentActivity!;
+    const closeTask = vi.spyOn(taskActivity, 'close');
+    session.updateAgent(fallback);
+    if (timing === 'draining') await exiting.await;
+    const closing = session.close();
+    finishExit.resolve();
+    await closing;
+    await (session as unknown as { updateActivityTask: { result: Promise<void> } })
+      .updateActivityTask.result;
+
+    expect(await result.await).toBeInstanceOf(ToolError);
+    expect(closeTask).toHaveBeenCalled();
+    expect(transfer._agentActivity).toBeUndefined();
+    expect(agent._agentActivity).toBeUndefined();
+    expect(fallback._agentActivity).toBeUndefined();
+  },
+  5_000,
+);

--- a/agents/src/workflows/warm_transfer.test.ts
+++ b/agents/src/workflows/warm_transfer.test.ts
@@ -545,7 +545,7 @@ describe('createWarmTransferTask', () => {
       );
       expect(complete).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: `room closed: ${expectedReason}`,
+          message: `Transfer failed: the human agent room disconnected before the transfer completed (reason: ${expectedReason}). The caller has not been connected to a human agent.`,
         }),
       );
     },

--- a/agents/src/workflows/warm_transfer.ts
+++ b/agents/src/workflows/warm_transfer.ts
@@ -283,7 +283,11 @@ export function createWarmTransferTask({
       logger.warn({ reason }, 'human agent room disconnected before transfer completed');
     }
     humanAgentFailedFut.resolve();
-    setResult(new ToolError(`room closed: ${reason}`));
+    setResult(
+      new ToolError(
+        `Transfer failed: the human agent room disconnected before the transfer completed (reason: ${reason}). The caller has not been connected to a human agent.`,
+      ),
+    );
   };
 
   const hasCallerParticipant = (): boolean => {

--- a/examples/src/warm_transfer.ts
+++ b/examples/src/warm_transfer.ts
@@ -62,6 +62,7 @@ Examples on when the tool should be called:
                 // `ringingTimeout: 25000`.
                 instructions: { extra: SUMMARY_INSTRUCTIONS },
                 greetingSpeech: (session) => session.generateReply({ toolChoice: 'none' }),
+                callerHangupSpeech: 'The caller has disconnected. I am ending this call now.',
               }).run();
 
               logger.info(
@@ -146,6 +147,8 @@ You are a customer support agent for LiveKit.
 
 In some cases, the user may ask to speak to a human agent. This could happen when you are unable to answer their question.
 When such is requested, you would always confirm with the user before initiating the transfer.
+If the transfer fails, tell the user that they could not be connected and offer further help.
+Only announce a successful connection after the transfer succeeds.
 `;
 
 const SUMMARY_INSTRUCTIONS = `


### PR DESCRIPTION
Session shutdown can race with an `AgentTask` resuming its parent and throw an `_onEnterTask` TypeError. Port @longcw’s shutdown coordination from [livekit/agents#4730](https://github.com/livekit/agents/pull/4730): unwind tasks, resume parents, then close them.

Also preserve activity references across awaits, suppress shutdown replies, clarify transfer failures, and use a fixed hangup notice.

92 targeted tests pass; live SIP verification remains pending.

Addresses [AJS-492](https://linear.app/livekit/issue/AJS-492/fix-warm-transfer-failures-and-caller-hangup-shutdown-race)

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-6

**Initial prompt (verbatim):**

```text
warm transfer doesn't recognize the tool failure: [15:43:47.409] ERROR (50600): failed to transfer to human agent with tool error
    example: "warm-transfer"
    error: {
      "type": "ToolError",
      "message": "room closed: 5",
      "stack":
          Error: room closed: 5
              at Room.onHumanAgentRoomClose (file:///Users/chenghao/Developer/agents-js/agents/dist/workflows/warm_transfer.js:99:15)
              at Room.emit (node:events:514:20)
              at Room.cleanupOnDisconnect (/Users/chenghao/Developer/agents-js/node_modules/.pnpm/@livekit+rtc-node@0.13.34/node_modules/@livekit/rtc-node/dist/room.cjs:720:10)
              at Room.processFfiEvent (/Users/chenghao/Developer/agents-js/node_modules/.pnpm/@livekit+rtc-node@0.13.34/node_modules/@livekit/rtc-node/dist/room.cjs:383:14)
              at Room.onFfiEvent (/Users/chenghao/Developer/agents-js/node_modules/.pnpm/@livekit+rtc-node@0.13.34/node_modules/@livekit/rtc-node/dist/room.cjs:103:20)
    }
[15:43:47.412] ERROR (50600): exception occurred while executing tool
    function: "transfer_to_human"
    speech_id: "speech_ca4f5d60-b67"
    error: "room closed: 5"
[15:43:47.413] DEBUG (50600): Task.runTask: task performToolExecution:transfer_to_human done
[15:43:47.413] DEBUG (50600): tools execution completed
    speech_id: "speech_ca4f5d60-b67"
[15:43:47.414] DEBUG (transfer_to_human/50600): Tool call execution finished
    speechId: "speech_ca4f5d60-b67"
    lk.pii.arguments: "{}"
    lk.pii.output: "room closed: 5"
    isError: true
[15:43:47.415] DEBUG (50600): Task.runTask: task AgentActivity.pipelineReply started
[15:43:47.415] DEBUG (50600): Task.runTask: task performLLMInference started
[15:43:47.416] DEBUG (50600): Task.runTask: task AgentActivity.pipelineReply.produceSegments started
[15:43:47.416] DEBUG (50600): Task.runTask: task AgentActivity.pipelineReply done
[15:43:47.416] DEBUG (50600): Task.runTask: task performToolExecutions started
[15:43:47.669] DEBUG (50600): adaptive interruption session created
    defaultThreshold: 0.656
    effectiveThreshold: 0.656
    userOverride: false
[15:43:47.724] INFO (50600): room deleted
    jobId: "AJ_3ReJmHZ2cJfN"
    lk.pii.room_name: "console-87660842-human-agent"
[15:43:47.724] INFO (50600): AgentSession closed
    reason: "participant_disconnected"
    error: null
[15:43:47.869] DEBUG (50600): Task.runTask: task performTTSInference started
[15:43:47.870] DEBUG (50600): Task.runTask: task performTextForwarding started
[15:43:47.870] DEBUG (50600): Task.runTask: task performAudioForwarding started
[15:43:47.871] DEBUG (50600): Task.runTask: task inference-tts-input started
[15:43:47.871] DEBUG (50600): Task.runTask: task inference-tts-sentence started
[15:43:47.871] DEBUG (50600): Task.runTask: task inference-tts-ws-listener started
[15:43:47.871] DEBUG (50600): Task.runTask: task inference-tts-recv started
[15:43:48.153] DEBUG (50600): agent speech started
[15:43:48.163] DEBUG (50600): Task.runTask: task performTextForwarding done
[15:43:48.163] DEBUG (50600): Task.runTask: task performToolExecutions done
[15:43:48.163] DEBUG (50600): Task.runTask: task AgentActivity.pipelineReply.produceSegments done
[15:43:48.163] DEBUG (50600): Task.runTask: task performLLMInference done
[15:43:48.163] DEBUG (50600): Task.runTask: task inference-tts-input done
[15:43:48.164] DEBUG (50600): Task.runTask: task inference-tts-sentence done
[15:43:49.740] DEBUG (50600): Task.runTask: task inference-tts-recv done
[15:43:49.741] DEBUG (50600): Task.runTask: task inference-tts-ws-listener done
[15:43:49.741] DEBUG (50600): Task.runTask: task performTTSInference done
[15:43:54.885] DEBUG (50600): Task.runTask: task performAudioForwarding done
[15:43:55.108] INFO (50600): playout completed without interruption
    speech_id: "speech_ca4f5d60-b67"
    lk.pii.message: "Thank you for confirming. I'm connecting you to a human agent now... If you have any other questions before then, feel free to let me know."
[15:43:55.108] DEBUG (50600): agent speech ended
[15:43:55.109] DEBUG (50600): Task.runTask: task AgentActivity.pipelineReply done, why?
```

**Additional report (excerpts):**

> I also hit this issue: when the caller hangup during the transfering briefing:

```text
[15:48:39.488] WARN (61093): caller hangup notification timed out
    timeoutMs: 30000
[15:48:40.079] ERROR (61093): failed to transfer to human agent
    example: "warm-transfer"
    error: {
      "type": "TypeError",
      "message": "Cannot read properties of undefined (reading '_onEnterTask')",
      "stack":
          TypeError: Cannot read properties of undefined (reading '_onEnterTask')
              at runWithContext (file:///Users/chenghao/Developer/agents-js/agents/dist/voice/agent_session.js:902:37)
              at async fn (file:///Users/chenghao/Developer/agents-js/agents/dist/voice/agent.js:580:15)
              at async AgentActivity._withInlineTaskSlot (file:///Users/chenghao/Developer/agents-js/agents/dist/voice/agent_activity.js:3634:16)
              at async AgentTaskV2.run (file:///Users/chenghao/Developer/agents-js/agents/dist/voice/agent.js:491:14)
              at async Object.execute (file:///Users/chenghao/Developer/agents-js/examples/src/warm_transfer.ts:56:30)
    }
```

**Scope clarification:**

> I don't know if we should skip resuming. At least that's a bigger change because Python also needs it, right?

> so this is a parity port?

The shutdown fix preserves parent resume and adopts Python's task cancellation and handoff coordination. The remaining changes address the reported failure message and hangup notice.

</details>

