### PR TITLE
fix: isolate llm fallback errors and prevent output replay

### DIFF
--- a/.changeset/fix-llm-fallback-stream-errors.md
+++ b/.changeset/fix-llm-fallback-stream-errors.md
@@ -4,4 +4,4 @@
 
 Fix LLM fallback errors crossing concurrent requests and outer retries replaying text or tool calls when `retryOnChunkSent` is false. Cancel active child streams when the fallback stream closes.
 
-After output, retryable provider errors are wrapped in a non-retryable `APIError` with the original error as `cause`. API error constructors now accept `cause`.
+Make `APIError.retryable` writable so fallback can mark failures after output as terminal while preserving the original error instance and metadata.

--- a/.changeset/fix-llm-fallback-stream-errors.md
+++ b/.changeset/fix-llm-fallback-stream-errors.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Fix LLM fallback errors crossing concurrent requests and outer retries replaying text or tool calls when `retryOnChunkSent` is false. Cancel active child streams when the fallback stream closes.

--- a/.changeset/fix-llm-fallback-stream-errors.md
+++ b/.changeset/fix-llm-fallback-stream-errors.md
@@ -3,3 +3,5 @@
 ---
 
 Fix LLM fallback errors crossing concurrent requests and outer retries replaying text or tool calls when `retryOnChunkSent` is false. Cancel active child streams when the fallback stream closes.
+
+After output, retryable provider errors are wrapped in a non-retryable `APIError` with the original error as `cause`. API error constructors now accept `cause`.

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -5386,6 +5386,8 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
     get connOptions(): APIConnectOptions;
     // (undocumented)
     protected _connOptions: APIConnectOptions;
+    // @internal
+    get _error(): Error | undefined;
     // (undocumented)
     protected logger: Logger;
     // (undocumented)

--- a/agents/etc/agents.api.md
+++ b/agents/etc/agents.api.md
@@ -954,7 +954,7 @@ export class APIError extends Error {
     // (undocumented)
     readonly body: object | null;
     // (undocumented)
-    readonly retryable: boolean;
+    retryable: boolean;
     // (undocumented)
     toString(): string;
 }

--- a/agents/src/_exceptions.test.ts
+++ b/agents/src/_exceptions.test.ts
@@ -2,7 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
-import { APIStatusError } from './_exceptions.js';
+import { APIConnectionError, APIError, APIStatusError, APITimeoutError } from './_exceptions.js';
+
+describe('API error causes', () => {
+  it.each([
+    ['APIError', (cause: Error) => new APIError('Failed', { cause })],
+    ['APIStatusError', (cause: Error) => new APIStatusError({ options: { cause } })],
+    ['APIConnectionError', (cause: Error) => new APIConnectionError({ options: { cause } })],
+    ['APITimeoutError', (cause: Error) => new APITimeoutError({ options: { cause } })],
+  ] as const)('preserves the cause through %s', (_, createError) => {
+    const cause = new Error('Original failure');
+    expect(createError(cause).cause).toBe(cause);
+  });
+});
 
 describe('APIStatusError retryability defaults', () => {
   it('treats 408 as retryable by default', () => {

--- a/agents/src/_exceptions.test.ts
+++ b/agents/src/_exceptions.test.ts
@@ -2,19 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
-import { APIConnectionError, APIError, APIStatusError, APITimeoutError } from './_exceptions.js';
-
-describe('API error causes', () => {
-  it.each([
-    ['APIError', (cause: Error) => new APIError('Failed', { cause })],
-    ['APIStatusError', (cause: Error) => new APIStatusError({ options: { cause } })],
-    ['APIConnectionError', (cause: Error) => new APIConnectionError({ options: { cause } })],
-    ['APITimeoutError', (cause: Error) => new APITimeoutError({ options: { cause } })],
-  ] as const)('preserves the cause through %s', (_, createError) => {
-    const cause = new Error('Original failure');
-    expect(createError(cause).cause).toBe(cause);
-  });
-});
+import { APIStatusError } from './_exceptions.js';
 
 describe('APIStatusError retryability defaults', () => {
   it('treats 408 as retryable by default', () => {

--- a/agents/src/_exceptions.ts
+++ b/agents/src/_exceptions.ts
@@ -32,7 +32,7 @@ export class AssignmentTimeoutError extends Error {
 /**
  * Interface for API error options
  */
-interface APIErrorOptions {
+interface APIErrorOptions extends ErrorOptions {
   body?: object | null;
   retryable?: boolean;
 }
@@ -47,8 +47,8 @@ export class APIError extends Error {
   readonly body: object | null;
   readonly retryable: boolean;
 
-  constructor(message: string, { body = null, retryable = true }: APIErrorOptions = {}) {
-    super(message);
+  constructor(message: string, { body = null, retryable = true, cause }: APIErrorOptions = {}) {
+    super(message, { cause });
     this.name = 'APIError';
 
     this.body = body;
@@ -97,7 +97,7 @@ export class APIStatusError extends APIError {
       isRetryable = false;
     }
 
-    super(message, { body: options.body, retryable: isRetryable });
+    super(message, { body: options.body, retryable: isRetryable, cause: options.cause });
     this.name = 'APIStatusError';
 
     this.statusCode = statusCode;
@@ -127,7 +127,7 @@ export class APIConnectionError extends APIError {
     message?: string;
     options?: APIErrorOptions;
   }) {
-    super(message, { body: null, retryable: options.retryable ?? true });
+    super(message, { body: null, retryable: options.retryable ?? true, cause: options.cause });
     this.name = 'APIConnectionError';
     Error.captureStackTrace(this, APIConnectionError);
   }
@@ -146,7 +146,7 @@ export class APITimeoutError extends APIConnectionError {
   }) {
     const retryable = options?.retryable ?? true;
 
-    super({ message, options: { retryable } });
+    super({ message, options: { retryable, cause: options.cause } });
     this.name = 'APITimeoutError';
     Error.captureStackTrace(this, APITimeoutError);
   }

--- a/agents/src/_exceptions.ts
+++ b/agents/src/_exceptions.ts
@@ -32,7 +32,7 @@ export class AssignmentTimeoutError extends Error {
 /**
  * Interface for API error options
  */
-interface APIErrorOptions extends ErrorOptions {
+interface APIErrorOptions {
   body?: object | null;
   retryable?: boolean;
 }
@@ -45,10 +45,10 @@ const API_ERROR_SYMBOL = Symbol('APIError');
  */
 export class APIError extends Error {
   readonly body: object | null;
-  readonly retryable: boolean;
+  retryable: boolean;
 
-  constructor(message: string, { body = null, retryable = true, cause }: APIErrorOptions = {}) {
-    super(message, { cause });
+  constructor(message: string, { body = null, retryable = true }: APIErrorOptions = {}) {
+    super(message);
     this.name = 'APIError';
 
     this.body = body;
@@ -97,7 +97,7 @@ export class APIStatusError extends APIError {
       isRetryable = false;
     }
 
-    super(message, { body: options.body, retryable: isRetryable, cause: options.cause });
+    super(message, { body: options.body, retryable: isRetryable });
     this.name = 'APIStatusError';
 
     this.statusCode = statusCode;
@@ -127,7 +127,7 @@ export class APIConnectionError extends APIError {
     message?: string;
     options?: APIErrorOptions;
   }) {
-    super(message, { body: null, retryable: options.retryable ?? true, cause: options.cause });
+    super(message, { body: null, retryable: options.retryable ?? true });
     this.name = 'APIConnectionError';
     Error.captureStackTrace(this, APIConnectionError);
   }
@@ -146,7 +146,7 @@ export class APITimeoutError extends APIConnectionError {
   }) {
     const retryable = options?.retryable ?? true;
 
-    super({ message, options: { retryable, cause: options.cause } });
+    super({ message, options: { retryable } });
     this.name = 'APITimeoutError';
     Error.captureStackTrace(this, APITimeoutError);
   }

--- a/agents/src/llm/fallback_adapter.ts
+++ b/agents/src/llm/fallback_adapter.ts
@@ -387,13 +387,7 @@ class FallbackLLMStream extends LLMStream {
                 { llm: llm.label(), ...extra },
                 'failed after sending chunk, skip retrying. Set `retryOnChunkSent` to `true` to enable.',
               );
-              if (error instanceof APIError && error.retryable) {
-                throw new APIError(error.message, {
-                  body: error.body,
-                  retryable: false,
-                  cause: error,
-                });
-              }
+              if (error instanceof APIError) error.retryable = false;
               throw error;
             }
 

--- a/agents/src/llm/fallback_adapter.ts
+++ b/agents/src/llm/fallback_adapter.ts
@@ -307,9 +307,9 @@ class FallbackLLMStream extends LLMStream {
 
   /**
    * Main run method - iterates through LLMs with fallback logic.
-   * @throws {APIConnectionError} When all LLM providers have been exhausted
+   * @throws {APIError} When generation fails or all LLM providers have been exhausted
    */
-  protected async run(): Promise<Throws<void, APIConnectionError>> {
+  protected async run(): Promise<Throws<void, APIError>> {
     const startTime = Date.now();
 
     // Check if all LLMs are unavailable
@@ -387,8 +387,13 @@ class FallbackLLMStream extends LLMStream {
                 { llm: llm.label(), ...extra },
                 'failed after sending chunk, skip retrying. Set `retryOnChunkSent` to `true` to enable.',
               );
-              // The outer LLMStream must not replay output already forwarded to the caller.
-              this._connOptions = { ...this._connOptions, maxRetry: 0 };
+              if (error instanceof APIError && error.retryable) {
+                throw new APIError(error.message, {
+                  body: error.body,
+                  retryable: false,
+                  cause: error,
+                });
+              }
               throw error;
             }
 

--- a/agents/src/llm/fallback_adapter.ts
+++ b/agents/src/llm/fallback_adapter.ts
@@ -7,7 +7,7 @@ import { log } from '../log.js';
 import { type APIConnectOptions, DEFAULT_API_CONNECT_OPTIONS } from '../types.js';
 import type { ChatContext } from './chat_context.js';
 import type { ChatChunk } from './llm.js';
-import { LLM, LLMStream } from './llm.js';
+import { LLM, LLMStream, hasResponse } from './llm.js';
 import type { ToolChoice, ToolContextLike } from './tool_context.js';
 
 /**
@@ -193,6 +193,9 @@ class FallbackLLMStream extends LLMStream {
     llm: LLM,
     checkRecovery: boolean = false,
   ): AsyncGenerator<Throws<ChatChunk, APIError>, void, unknown> {
+    const signal = this.abortController.signal;
+    if (!checkRecovery && signal.aborted) return;
+
     const connOptions: APIConnectOptions = {
       ...this.connOptions,
       maxRetry: this.adapter.maxRetryPerLLM,
@@ -209,16 +212,19 @@ class FallbackLLMStream extends LLMStream {
       extraKwargs: this.extraKwargs,
     });
 
-    // Listen for error events - child LLMs emit errors via their LLM instance, not the stream
-    let streamError: Error | undefined;
-    const errorHandler = (ev: { error: Error }) => {
-      streamError = ev.error;
-    };
+    // Keep EventEmitter's unhandled 'error' behavior from interrupting child retries.
+    const errorHandler = () => {};
     llm.on('error', errorHandler);
+    const closeStream = () => stream.close();
+    if (!checkRecovery) {
+      signal.addEventListener('abort', closeStream, { once: true });
+      if (signal.aborted) closeStream();
+    }
 
     try {
       let shouldSetCurrent = !checkRecovery;
       for await (const chunk of stream) {
+        if (!checkRecovery && signal.aborted) return;
         if (shouldSetCurrent) {
           shouldSetCurrent = false;
           this._currentStream = stream;
@@ -226,11 +232,12 @@ class FallbackLLMStream extends LLMStream {
         yield chunk;
       }
 
-      // If an error was emitted but not thrown through iteration, throw it now
-      if (streamError) {
-        throw streamError;
+      if (!checkRecovery && signal.aborted) return;
+      if (stream._error) {
+        throw stream._error;
       }
     } catch (error) {
+      if (!checkRecovery && signal.aborted) return;
       if (error instanceof APIError) {
         if (checkRecovery) {
           this._log.warn({ llm: llm.label(), error }, 'recovery failed');
@@ -258,6 +265,8 @@ class FallbackLLMStream extends LLMStream {
       }
       throw error;
     } finally {
+      signal.removeEventListener('abort', closeStream);
+      stream.close();
       llm.off('error', errorHandler);
     }
   }
@@ -310,6 +319,7 @@ class FallbackLLMStream extends LLMStream {
     }
 
     for (let i = 0; i < this.adapter.llms.length; i++) {
+      if (this.abortController.signal.aborted) return;
       const llm = this.adapter.llms[i]!;
       const status = this.adapter._status[i]!;
 
@@ -319,6 +329,7 @@ class FallbackLLMStream extends LLMStream {
       );
 
       if (status.available || allFailed) {
+        let responseSent = false;
         let textSent = '';
         const toolCallsSent: string[] = [];
 
@@ -328,6 +339,7 @@ class FallbackLLMStream extends LLMStream {
           let chunkCount = 0;
           for await (const chunk of this.tryGenerate(llm, false)) {
             chunkCount++;
+            responseSent ||= hasResponse(chunk);
             // Track what's been sent
             if (chunk.delta) {
               if (chunk.delta.content) {
@@ -354,6 +366,7 @@ class FallbackLLMStream extends LLMStream {
           );
           return;
         } catch (error) {
+          if (this.abortController.signal.aborted) return;
           // Mark as unavailable if it was available before
           if (status.available) {
             status.available = false;
@@ -363,7 +376,7 @@ class FallbackLLMStream extends LLMStream {
           this.tryRecovery(llm, i);
 
           // Check if we sent data before failing
-          if (textSent || toolCallsSent.length > 0) {
+          if (responseSent) {
             const extra = {
               'lk.pii.response.text': textSent,
               'lk.pii.response.function_calls': toolCallsSent,
@@ -374,6 +387,8 @@ class FallbackLLMStream extends LLMStream {
                 { llm: llm.label(), ...extra },
                 'failed after sending chunk, skip retrying. Set `retryOnChunkSent` to `true` to enable.',
               );
+              // The outer LLMStream must not replay output already forwarded to the caller.
+              this._connOptions = { ...this._connOptions, maxRetry: 0 };
               throw error;
             }
 

--- a/agents/src/llm/fallback_adapter_concurrency.test.ts
+++ b/agents/src/llm/fallback_adapter_concurrency.test.ts
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { APITimeoutError } from '../_exceptions.js';
+import { type APIConnectOptions, DEFAULT_API_CONNECT_OPTIONS } from '../types.js';
+import { Future } from '../utils.js';
+import { ChatContext, FunctionCall } from './chat_context.js';
+import { FallbackAdapter } from './fallback_adapter.js';
+import { type ChatChunk, LLM, type LLMError, LLMStream } from './llm.js';
+
+const noRetries: APIConnectOptions = { ...DEFAULT_API_CONNECT_OPTIONS, maxRetry: 0 };
+const textChunk: ChatChunk = {
+  id: 'response',
+  delta: { role: 'assistant', content: 'The answer.' },
+};
+const toolChunk: ChatChunk = {
+  id: 'response',
+  delta: {
+    role: 'assistant',
+    toolCalls: [new FunctionCall({ callId: 'transfer', name: 'transfer_call', args: '{}' })],
+  },
+};
+
+class ControlledLLM extends LLM {
+  readonly streams: ControlledStream[] = [];
+  readonly errors: LLMError[] = [];
+
+  constructor(readonly generate: (stream: ControlledStream, request: number) => Promise<void>) {
+    super();
+    this.on('error', (event) => this.errors.push(event));
+  }
+
+  label(): string {
+    return 'controlled';
+  }
+
+  chat(opts: Parameters<LLM['chat']>[0]): ControlledStream {
+    const stream = new ControlledStream(
+      this,
+      { ...opts, connOptions: opts.connOptions ?? noRetries },
+      this.streams.length + 1,
+    );
+    this.streams.push(stream);
+    return stream;
+  }
+}
+
+class ControlledStream extends LLMStream {
+  constructor(
+    private readonly provider: ControlledLLM,
+    opts: ConstructorParameters<typeof LLMStream>[1],
+    private readonly request: number,
+  ) {
+    super(provider, opts);
+  }
+
+  get signal(): AbortSignal {
+    return this.abortController.signal;
+  }
+
+  send(chunk: ChatChunk = textChunk): void {
+    this.queue.put(chunk);
+  }
+
+  protected run(): Promise<void> {
+    return this.provider.generate(this, this.request);
+  }
+}
+
+function observeErrors(adapter: FallbackAdapter): LLMError[] {
+  const errors: LLMError[] = [];
+  adapter.on('error', (event) => errors.push(event));
+  return errors;
+}
+
+async function collect(stream: LLMStream): Promise<ChatChunk[]> {
+  const chunks: ChatChunk[] = [];
+  try {
+    for await (const chunk of stream) chunks.push(chunk);
+  } finally {
+    stream.close();
+  }
+  return chunks;
+}
+
+async function waitForRecovery(adapter: FallbackAdapter): Promise<void> {
+  await Promise.all(adapter._status.map((status) => status.recoveringTask));
+}
+
+describe('FallbackAdapter stream isolation', () => {
+  it('does not attribute another stream error to a healthy foreground request', async () => {
+    const releaseEarlier = new Future();
+    const earlierError = new APITimeoutError({ message: 'Earlier request failed' });
+    const provider = new ControlledLLM(async (stream, request) => {
+      if (request === 1) {
+        await releaseEarlier.await;
+        throw earlierError;
+      }
+      stream.send();
+      releaseEarlier.resolve();
+      await earlierDone;
+    });
+    const earlierDone = collect(provider.chat({ chatCtx: new ChatContext() }));
+    const adapter = new FallbackAdapter({ llms: [provider] });
+    const errors = observeErrors(adapter);
+    const chunks = await collect(
+      adapter.chat({ chatCtx: new ChatContext(), connOptions: DEFAULT_API_CONNECT_OPTIONS }),
+    );
+    await earlierDone;
+    await waitForRecovery(adapter);
+
+    expect(chunks).toEqual([textChunk]);
+    expect(errors).toEqual([]);
+    expect(provider.errors.map((event) => event.error)).toEqual([earlierError]);
+    expect(provider.streams).toHaveLength(2);
+    expect(provider.listenerCount('error')).toBe(1);
+  });
+
+  it.each([true, false])(
+    'accepts a successful child retry (provider listener=%s)',
+    async (hasListener) => {
+      let attempts = 0;
+      const provider = new ControlledLLM(async (stream) => {
+        if (++attempts === 1) throw new APITimeoutError({});
+        stream.send();
+      });
+      if (!hasListener) provider.removeAllListeners('error');
+      const adapter = new FallbackAdapter({ llms: [provider], maxRetryPerLLM: 1 });
+      const errors = observeErrors(adapter);
+      const chunks = await collect(adapter.chat({ chatCtx: new ChatContext() }));
+      await waitForRecovery(adapter);
+
+      expect(chunks).toEqual([textChunk]);
+      expect(errors).toEqual([]);
+      expect(provider.errors).toEqual(
+        hasListener ? [expect.objectContaining({ recoverable: true })] : [],
+      );
+      expect(provider.streams).toHaveLength(1);
+      expect(attempts).toBe(2);
+    },
+  );
+
+  it('isolates errors from an overlapping background recovery request', async () => {
+    const recoveryStarted = new Future();
+    const releaseRecovery = new Future();
+    const provider = new ControlledLLM(async (stream, request) => {
+      if (request === 1) throw new APITimeoutError({ message: 'Initial failure' });
+      if (request === 2) {
+        recoveryStarted.resolve();
+        await releaseRecovery.await;
+        throw new APITimeoutError({ message: 'Recovery failure' });
+      }
+      stream.send();
+      if (request === 3) {
+        releaseRecovery.resolve();
+        await recoveryDone;
+      }
+    });
+    const adapter = new FallbackAdapter({ llms: [provider] });
+    const errors = observeErrors(adapter);
+    await collect(adapter.chat({ chatCtx: new ChatContext() }));
+    await recoveryStarted.await;
+    const recoveryDone = adapter._status[0]!.recoveringTask;
+    errors.length = 0;
+
+    const chunks = await collect(
+      adapter.chat({ chatCtx: new ChatContext(), connOptions: DEFAULT_API_CONNECT_OPTIONS }),
+    );
+    await waitForRecovery(adapter);
+
+    expect(chunks).toEqual([textChunk]);
+    expect(errors).toEqual([]);
+    expect(provider.streams).toHaveLength(3);
+  });
+});
+
+describe('FallbackAdapter retries after output', () => {
+  it.each<[string, ChatChunk]>([
+    ['text', textChunk],
+    ['tool calls', toolChunk],
+    [
+      'tool arguments without a name',
+      {
+        id: 'response',
+        delta: {
+          role: 'assistant',
+          toolCalls: [new FunctionCall({ callId: 'transfer', name: '', args: '{}' })],
+        },
+      },
+    ],
+  ])('does not replay %s through the outer retry loop', async (_, chunk) => {
+    const error = new APITimeoutError({ message: 'Failed after output' });
+    const provider = new ControlledLLM(async (stream, request) => {
+      stream.send(chunk);
+      if (request === 1) throw error;
+    });
+    const adapter = new FallbackAdapter({ llms: [provider], retryOnChunkSent: false });
+    const errors = observeErrors(adapter);
+    const connOptions = { ...DEFAULT_API_CONNECT_OPTIONS };
+    const chunks = await collect(adapter.chat({ chatCtx: new ChatContext(), connOptions }));
+    await waitForRecovery(adapter);
+
+    expect(chunks).toEqual([chunk]);
+    expect(errors).toEqual([expect.objectContaining({ error, recoverable: false })]);
+    expect(provider.streams).toHaveLength(2); // Foreground and background recovery.
+    expect(connOptions).toEqual(DEFAULT_API_CONNECT_OPTIONS);
+  });
+
+  it('still falls back after a metadata-only chunk', async () => {
+    const metadata: ChatChunk = {
+      id: 'metadata',
+      delta: { role: 'assistant', extra: { signature: 'test' } },
+    };
+    const primary = new ControlledLLM(async (stream) => {
+      stream.send(metadata);
+      throw new APITimeoutError({});
+    });
+    const secondary = new ControlledLLM(async (stream) => {
+      stream.send();
+    });
+    const adapter = new FallbackAdapter({ llms: [primary, secondary] });
+    const errors = observeErrors(adapter);
+    const chunks = await collect(
+      adapter.chat({ chatCtx: new ChatContext(), connOptions: DEFAULT_API_CONNECT_OPTIONS }),
+    );
+    await waitForRecovery(adapter);
+
+    expect(chunks).toEqual([metadata, textChunk]);
+    expect(errors).toEqual([]);
+  });
+
+  it('preserves explicit retryOnChunkSent=true', async () => {
+    const provider = new ControlledLLM(async (stream, request) => {
+      stream.send();
+      if (request === 1) throw new APITimeoutError({});
+    });
+    const adapter = new FallbackAdapter({ llms: [provider], retryOnChunkSent: true });
+    observeErrors(adapter);
+    const chunks = await collect(
+      adapter.chat({ chatCtx: new ChatContext(), connOptions: DEFAULT_API_CONNECT_OPTIONS }),
+    );
+    await waitForRecovery(adapter);
+
+    expect(chunks).toEqual([textChunk, textChunk]);
+  });
+});
+
+describe('FallbackAdapter cancellation', () => {
+  it('cancels a child waiting to retry without starting recovery', async () => {
+    const retrying = new Future();
+    let attempts = 0;
+    const provider = new ControlledLLM(async () => {
+      attempts++;
+      throw new APITimeoutError({});
+    });
+    provider.once('error', () => retrying.resolve());
+    const adapter = new FallbackAdapter({ llms: [provider], maxRetryPerLLM: 1 });
+    const errors = observeErrors(adapter);
+    const childFinished = new Future();
+    provider.once('metrics_collected', () => childFinished.resolve());
+    const stream = adapter.chat({
+      chatCtx: new ChatContext(),
+      connOptions: DEFAULT_API_CONNECT_OPTIONS,
+    });
+    const consumed = collect(stream);
+    await retrying.await;
+    stream.close();
+    await consumed;
+    await childFinished.await;
+    await waitForRecovery(adapter);
+
+    expect(attempts).toBe(1);
+    expect(provider.streams).toHaveLength(1);
+    expect(errors).toEqual([]);
+    expect(adapter._status[0]!.available).toBe(true);
+  });
+
+  it.each([false, true])('cancels the active child (output sent=%s)', async (sendOutput) => {
+    const started = new Future();
+    const release = new Future();
+    const provider = new ControlledLLM(async (stream, request) => {
+      if (request > 1) return;
+      if (sendOutput) stream.send();
+      started.resolve();
+      await release.await;
+      throw new APITimeoutError({});
+    });
+    const adapter = new FallbackAdapter({ llms: [provider] });
+    const errors = observeErrors(adapter);
+    const stream = adapter.chat({
+      chatCtx: new ChatContext(),
+      connOptions: DEFAULT_API_CONNECT_OPTIONS,
+    });
+    await started.await;
+    if (sendOutput) await stream.next();
+    stream.close();
+    const childCancelled = provider.streams[0]!.signal.aborted;
+    // Drain late provider completion before checking for erroneous recovery/retries.
+    const finished = new Future();
+    adapter.on('metrics_collected', (metrics) => {
+      if (metrics.label === adapter.label()) finished.resolve();
+    });
+    release.resolve();
+    await finished.await;
+    await waitForRecovery(adapter);
+
+    expect(childCancelled).toBe(true);
+    expect(errors).toEqual([]);
+    expect(provider.streams).toHaveLength(1);
+    expect(adapter._status[0]!.available).toBe(true);
+  });
+
+  it('does not start a provider when closed immediately', async () => {
+    const provider = new ControlledLLM(async () => {});
+    const adapter = new FallbackAdapter({ llms: [provider] });
+    const finished = new Future();
+    adapter.on('metrics_collected', (metrics) => {
+      if (metrics.label === adapter.label()) finished.resolve();
+    });
+    const stream = adapter.chat({ chatCtx: new ChatContext() });
+    stream.close();
+    await finished.await;
+
+    expect(provider.streams).toHaveLength(0);
+  });
+});

--- a/agents/src/llm/fallback_adapter_concurrency.test.ts
+++ b/agents/src/llm/fallback_adapter_concurrency.test.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
-import { APITimeoutError } from '../_exceptions.js';
+import { APIError, APIStatusError, APITimeoutError } from '../_exceptions.js';
 import { type APIConnectOptions, DEFAULT_API_CONNECT_OPTIONS } from '../types.js';
 import { Future } from '../utils.js';
 import { ChatContext, FunctionCall } from './chat_context.js';
@@ -198,13 +198,80 @@ describe('FallbackAdapter retries after output', () => {
     const adapter = new FallbackAdapter({ llms: [provider], retryOnChunkSent: false });
     const errors = observeErrors(adapter);
     const connOptions = { ...DEFAULT_API_CONNECT_OPTIONS };
-    const chunks = await collect(adapter.chat({ chatCtx: new ChatContext(), connOptions }));
+    const stream = adapter.chat({ chatCtx: new ChatContext(), connOptions });
+    const chunks = await collect(stream);
     await waitForRecovery(adapter);
 
     expect(chunks).toEqual([chunk]);
-    expect(errors).toEqual([expect.objectContaining({ error, recoverable: false })]);
+    expect(errors).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({ cause: error, retryable: false, message: error.message }),
+        recoverable: false,
+      }),
+    ]);
+    expect(errors[0]!.error).toBeInstanceOf(APIError);
+    expect(error.retryable).toBe(true);
     expect(provider.streams).toHaveLength(2); // Foreground and background recovery.
     expect(connOptions).toEqual(DEFAULT_API_CONNECT_OPTIONS);
+    expect(stream.connOptions).toBe(connOptions);
+  });
+
+  it('preserves provider error details when output fails on a later outer attempt', async () => {
+    const error = new APIStatusError({
+      message: 'Provider unavailable',
+      options: { statusCode: 503, requestId: 'request-1', body: { detail: 'overloaded' } },
+    });
+    const provider = new ControlledLLM(async (stream, request) => {
+      if (request === 1) throw new APITimeoutError({});
+      if (request === 2) return; // Recovery after the first failure.
+      stream.send();
+      if (request === 3) throw error;
+    });
+    const adapter = new FallbackAdapter({ llms: [provider] });
+    const errors = observeErrors(adapter);
+    const connOptions = { ...DEFAULT_API_CONNECT_OPTIONS, maxRetry: 1, retryIntervalMs: 0 };
+    const stream = adapter.chat({ chatCtx: new ChatContext(), connOptions });
+    const chunks = await collect(stream);
+    await waitForRecovery(adapter);
+
+    expect(chunks).toEqual([textChunk]);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]!.recoverable).toBe(true);
+    expect(errors[1]).toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          cause: error,
+          body: error.body,
+          message: error.message,
+          retryable: false,
+        }),
+        recoverable: false,
+      }),
+    );
+    expect(error.retryable).toBe(true);
+    expect(provider.streams).toHaveLength(4);
+    expect(stream.connOptions).toBe(connOptions);
+    expect(connOptions.maxRetry).toBe(1);
+  });
+
+  it.each([
+    new APITimeoutError({ options: { retryable: false } }),
+    new Error('Unexpected provider failure'),
+  ])('preserves an already terminal error: %s', async (error) => {
+    const provider = new ControlledLLM(async (stream, request) => {
+      stream.send();
+      if (request === 1) throw error;
+    });
+    const adapter = new FallbackAdapter({ llms: [provider] });
+    const errors = observeErrors(adapter);
+    const chunks = await collect(
+      adapter.chat({ chatCtx: new ChatContext(), connOptions: DEFAULT_API_CONNECT_OPTIONS }),
+    );
+    await waitForRecovery(adapter);
+
+    expect(chunks).toEqual([textChunk]);
+    expect(errors).toEqual([expect.objectContaining({ error, recoverable: false })]);
+    expect(provider.streams).toHaveLength(2);
   });
 
   it('still falls back after a metadata-only chunk', async () => {

--- a/agents/src/llm/fallback_adapter_concurrency.test.ts
+++ b/agents/src/llm/fallback_adapter_concurrency.test.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
-import { APIError, APIStatusError, APITimeoutError } from '../_exceptions.js';
+import { APIConnectionError, APIError, APIStatusError, APITimeoutError } from '../_exceptions.js';
 import { type APIConnectOptions, DEFAULT_API_CONNECT_OPTIONS } from '../types.js';
 import { Future } from '../utils.js';
 import { ChatContext, FunctionCall } from './chat_context.js';
@@ -203,14 +203,9 @@ describe('FallbackAdapter retries after output', () => {
     await waitForRecovery(adapter);
 
     expect(chunks).toEqual([chunk]);
-    expect(errors).toEqual([
-      expect.objectContaining({
-        error: expect.objectContaining({ cause: error, retryable: false, message: error.message }),
-        recoverable: false,
-      }),
-    ]);
-    expect(errors[0]!.error).toBeInstanceOf(APIError);
-    expect(error.retryable).toBe(true);
+    expect(errors).toEqual([expect.objectContaining({ error, recoverable: false })]);
+    expect(errors[0]!.error).toBe(error);
+    expect(error.retryable).toBe(false);
     expect(provider.streams).toHaveLength(2); // Foreground and background recovery.
     expect(connOptions).toEqual(DEFAULT_API_CONNECT_OPTIONS);
     expect(stream.connOptions).toBe(connOptions);
@@ -239,19 +234,41 @@ describe('FallbackAdapter retries after output', () => {
     expect(errors[0]!.recoverable).toBe(true);
     expect(errors[1]).toEqual(
       expect.objectContaining({
-        error: expect.objectContaining({
-          cause: error,
-          body: error.body,
-          message: error.message,
-          retryable: false,
-        }),
+        error,
         recoverable: false,
       }),
     );
-    expect(error.retryable).toBe(true);
+    expect(errors[1]!.error).toBe(error);
+    expect(error.retryable).toBe(false);
     expect(provider.streams).toHaveLength(4);
     expect(stream.connOptions).toBe(connOptions);
     expect(connOptions.maxRetry).toBe(1);
+  });
+
+  it.each([
+    ['APIError', () => new APIError('Failed after output')],
+    ['APIConnectionError', () => new APIConnectionError({})],
+    ['APITimeoutError', () => new APITimeoutError({})],
+    ['APIStatusError', () => new APIStatusError({ options: { statusCode: 503 } })],
+  ] as const)('preserves the original %s after output', async (_, createError) => {
+    const error = createError();
+    const provider = new ControlledLLM(async (stream, request) => {
+      stream.send();
+      if (request === 1) throw error;
+    });
+    const adapter = new FallbackAdapter({ llms: [provider] });
+    const errors = observeErrors(adapter);
+    const chunks = await collect(
+      adapter.chat({ chatCtx: new ChatContext(), connOptions: DEFAULT_API_CONNECT_OPTIONS }),
+    );
+    await waitForRecovery(adapter);
+
+    expect(chunks).toEqual([textChunk]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.error).toBe(error);
+    expect(errors[0]!.recoverable).toBe(false);
+    expect(error.retryable).toBe(false);
+    expect(provider.streams).toHaveLength(2);
   });
 
   it.each([

--- a/agents/src/llm/llm.ts
+++ b/agents/src/llm/llm.ts
@@ -190,6 +190,7 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
   #chatCtx: ChatContext;
   #toolCtx?: ToolContext;
   #llmRequestSpan?: Span;
+  #error?: Error;
   // Provider-known response ids collected from ChatChunks during the current
   // attempt; reset before each retry and written to the `llm_request_run` span.
   #providerRequestIds: string[] = [];
@@ -262,6 +263,7 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
     this.recordGenAIRequest(span);
 
     for (let i = 0; i < this._connOptions.maxRetry + 1; i++) {
+      if (this.abortController.signal.aborted) return;
       try {
         return await tracer.startActiveSpan(
           async (attemptSpan) => {
@@ -286,6 +288,7 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
           { name: 'llm_request_run' },
         );
       } catch (error) {
+        if (this.abortController.signal.aborted) return;
         if (error instanceof APIError) {
           const retryInterval = intervalForRetry(this._connOptions, i);
 
@@ -307,7 +310,7 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
           }
 
           if (retryInterval > 0) {
-            await delay(retryInterval);
+            await delay(retryInterval, { signal: this.abortController.signal });
           }
         } else {
           this.emitError({ error: toError(error), recoverable: false });
@@ -325,6 +328,7 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
   };
 
   private emitError({ error, recoverable }: { error: Error; recoverable: boolean }) {
+    if (!recoverable) this.#error = error;
     this.#llm.emit('error', {
       type: 'llm_error',
       timestamp: Date.now(),
@@ -451,6 +455,11 @@ export abstract class LLMStream implements AsyncIterableIterator<ChatChunk> {
   /** The connection options for this stream. */
   get connOptions(): APIConnectOptions {
     return this._connOptions;
+  }
+
+  /** The terminal error of this stream, if it failed. @internal */
+  get _error(): Error | undefined {
+    return this.#error;
   }
 
   next(): Promise<IteratorResult<ChatChunk>> {


### PR DESCRIPTION
Concurrent requests could inherit another stream's failure, and retries could replay text or tool calls. Isolate child failures, stop child and outer retries after output when `retryOnChunkSent` is false, and cancel active children when the parent closes.

Fixes [#2477](https://github.com/livekit/agents-js/issues/2477). Adopts @dtran26's diagnosis and reproduction, plus the retry guard from [Python #7233](https://github.com/livekit/agents/pull/7233). Addresses [AGT-3492](https://linear.app/livekit/issue/AGT-3492).

Validated with 31 regression cases and 2,641 passing core tests.

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-6

> can you investigate github 2477?

> can you check for python parity?

> okay, we need to fix both repos. Can you fix the node first? Then I will start another thread for the python issue

> run a subagent for code review, then if it looks good, open a draft PR.

</details>
