### PR TITLE
fix(agents): refuse to start a DuplexModel under a text simulation

### DIFF
--- a/.changeset/duplex-text-simulation-error.md
+++ b/.changeset/duplex-text-simulation-error.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Fail fast with a clear error when a DuplexModel such as GPT-Live is started under a text simulation, which has no audio, instead of timing out on the first reply.

--- a/agents/src/llm/duplex_adapter.test.ts
+++ b/agents/src/llm/duplex_adapter.test.ts
@@ -817,6 +817,17 @@ describe('duplex requested replies', () => {
 });
 
 describe('duplex model integration', () => {
+  // a duplex model has no text modality: it hears and speaks only audio, and the adapter resolves
+  // a reply from the sound the model produces. under a text simulation there is no audio, so the
+  // session refuses to start rather than time out on the first turn
+  it('refuses to start under a text simulation', async () => {
+    vi.spyOn(AgentSession.prototype, '_textOnly', 'get').mockReturnValue(true);
+    const session = new AgentSession({ llm: new FakeDuplexModel(), vad: null });
+    await expect(session.start({ agent: new Agent({ instructions: '' }) })).rejects.toThrow(
+      /text simulation/,
+    );
+  });
+
   it('does not arm an away timer from a shutdown transcript and still handles restarts', async () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'], shouldAdvanceTime: true });
     const model = new FakeDuplexModel();

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -28,7 +28,7 @@ import {
   instructionsEqual,
   renderInstructions,
 } from '../llm/chat_context.js';
-import { DuplexRealtimeSession } from '../llm/duplex_adapter.js';
+import { DuplexRealtimeAdapter, DuplexRealtimeSession } from '../llm/duplex_adapter.js';
 import { AsyncToolset, type Toolset } from '../llm/index.js';
 import {
   type ChatItem,
@@ -452,6 +452,14 @@ export class AgentActivity implements RecognitionHooks {
       owningActivity: this,
       asyncToolOptions: this.agent._asyncToolOptions ?? this.agentSession._asyncToolOptions,
     });
+
+    // a duplex model has no text modality, and the adapter resolves each reply from the audio
+    // the model produces; without audio a text simulation would only time out on turn one
+    if (this.agentSession._textOnly && this.llm instanceof DuplexRealtimeAdapter) {
+      throw new Error(
+        'a DuplexModel speaks only through audio, so it cannot run under a text simulation; run `lk agent simulate audio` instead',
+      );
+    }
 
     if (
       this.llm instanceof RealtimeModel &&


### PR DESCRIPTION
## Problem

A duplex model such as `GPTLiveModel` hears and speaks only audio, and `DuplexRealtimeAdapter` resolves each reply from the audio the model produces. A text simulation (`lk agent simulate` without `audio`) disables audio I/O, so the first reply never opens and every scenario fails on turn one with "the model did not start speaking when asked" after a 10 second timeout, with nothing pointing at the cause.

## Fix

`AgentActivity` throws at construction when the session is a text simulation and the resolved llm is a `DuplexRealtimeAdapter`:

```
a DuplexModel speaks only through audio, so it cannot run under a text simulation; run `lk agent simulate audio` instead
```

No new capability flag: every duplex model is audio-only by definition, so the type is the signal.

## Tests

`duplex_adapter.test.ts` gains a test that `AgentSession.start` rejects with that message when `_textOnly` is true. Includes a patch changeset for `@livekit/agents`.

Python counterpart: https://github.com/livekit/agents/pull/7236.