### PR TITLE
fix(agents): surface session transport send failures to the caller

### DIFF
--- a/.changeset/session-transport-send-failures.md
+++ b/.changeset/session-transport-send-failures.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Session transports now throw when a message cannot be sent because the transport is closed or the room is disconnected, instead of returning silently. A RemoteSession request over a dead transport fails at once rather than waiting out its timeout, and the session host logs a failed event send with one warning. Matches the Python SessionTransport contract.

--- a/agents/src/voice/console_io.ts
+++ b/agents/src/voice/console_io.ts
@@ -119,9 +119,17 @@ export class TcpAudioOutput extends AudioOutput {
     }
   }
 
+  // flush/clearBuffer are synchronous and nobody awaits a control message, so a
+  // send that fails on a closed transport is logged rather than left to reject
+  private sendControl(msg: pb.AgentSessionMessage): void {
+    this.transport.sendMessage(msg).catch((e) => {
+      log().debug({ error: e }, 'failed to send console control message');
+    });
+  }
+
   override flush(): void {
     super.flush();
-    void this.transport.sendMessage(
+    this.sendControl(
       new pb.AgentSessionMessage({
         message: {
           case: 'audioPlaybackFlush',
@@ -146,7 +154,7 @@ export class TcpAudioOutput extends AudioOutput {
   }
 
   override clearBuffer(): void {
-    void this.transport.sendMessage(
+    this.sendControl(
       new pb.AgentSessionMessage({
         message: {
           case: 'audioPlaybackClear',

--- a/agents/src/voice/remote_session.test.ts
+++ b/agents/src/voice/remote_session.test.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { AgentSession as pb } from '@livekit/protocol';
+import type { Room } from '@livekit/rtc-node';
 import * as net from 'node:net';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { InferenceExecutor } from '../ipc/inference_executor.js';
@@ -11,16 +12,18 @@ import {
   type RunningJobInfo,
   runWithJobContextAsync,
 } from '../job.js';
-import { initializeLogger } from '../log.js';
+import { initializeLogger, log } from '../log.js';
 import type { SimulationContext } from '../simulation.js';
 import type { AgentSession } from './agent_session.js';
 import { FinalizeSimulationError } from './index.js';
 import {
   RemoteSession,
+  RoomSessionTransport,
   SessionHost,
   SessionTransport,
   TcpSessionTransport,
 } from './remote_session.js';
+import type { RoomIO } from './room_io/room_io.js';
 
 beforeAll(() => {
   initializeLogger({ pretty: true, level: 'info' });
@@ -260,6 +263,66 @@ function createConnectedTransportPair(): [FakeTransport, FakeTransport] {
   host.connect(client);
   return [client, host];
 }
+
+// A message that cannot be sent is a request somebody waits out in full, so the
+// transport reports the failure and each caller decides what to do with it, as
+// the Python SessionTransport does. Events are the one caller nobody awaits.
+describe('SessionTransport failures surface to the caller', () => {
+  it('room transport rejects when the room is not connected', async () => {
+    const room = { isConnected: false, registerByteStreamHandler: () => {} };
+    const transport = new RoomSessionTransport(
+      room as unknown as Room,
+      { linkedParticipant: undefined } as unknown as RoomIO,
+    );
+    await expect(transport.sendMessage(pingMessage('r1'))).rejects.toThrow(
+      /room session transport is closed/,
+    );
+  });
+
+  it('tcp transport rejects once closed', async () => {
+    const server = net.createServer(() => {});
+    const port = await listen(server);
+    const t = new TcpSessionTransport('127.0.0.1', port);
+    try {
+      await t.start();
+      await t.close();
+      await expect(t.sendMessage(pingMessage('r2'))).rejects.toThrow(
+        /tcp session transport is closed/,
+      );
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('session host logs a failed event send instead of leaving it unhandled', async () => {
+    const warn = vi.spyOn(log(), 'warn').mockImplementation(() => log());
+    const transport = new (class extends SessionTransport {
+      async sendMessage(): Promise<void> {
+        throw new Error('room session transport is closed');
+      }
+      async close(): Promise<void> {}
+      [Symbol.asyncIterator](): AsyncIterator<pb.AgentSessionMessage> {
+        return { next: () => new Promise(() => {}) };
+      }
+    })();
+    const host = new SessionHost(transport, fakeSimJobContext());
+    const rejections: unknown[] = [];
+    const onRejection = (e: unknown) => rejections.push(e);
+    process.on('unhandledRejection', onRejection);
+    try {
+      (host as unknown as { emitEvent: (e: pb.AgentSessionEvent['event']) => void }).emitEvent({
+        case: 'debugMessage',
+        value: new pb.DebugMessage(),
+      });
+      await new Promise((r) => setTimeout(r, 20));
+    } finally {
+      process.off('unhandledRejection', onRejection);
+    }
+    expect(rejections).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.anything(), 'failed to send session event');
+    warn.mockRestore();
+  });
+});
 
 describe('SessionHost event forwarding', () => {
   it('registers every forwarded event', () => {

--- a/agents/src/voice/remote_session.test.ts
+++ b/agents/src/voice/remote_session.test.ts
@@ -324,6 +324,32 @@ describe('SessionTransport failures surface to the caller', () => {
   });
 });
 
+describe('RemoteSession request over a dead transport', () => {
+  it('rejects at once and leaves nothing pending', async () => {
+    const transport = new (class extends SessionTransport {
+      async sendMessage(): Promise<void> {
+        throw new Error('tcp session transport is closed');
+      }
+      async close(): Promise<void> {}
+      [Symbol.asyncIterator](): AsyncIterator<pb.AgentSessionMessage> {
+        return { next: () => new Promise(() => {}) };
+      }
+    })();
+    const session = new RemoteSession(transport);
+    await session.start();
+    try {
+      await expect(
+        session.finalizeSimulation({ provisionalSuccess: true, timeout: 60_000 }),
+      ).rejects.toThrow(/transport is closed/);
+      const pending = (session as unknown as { pendingRequests: Map<string, unknown> })
+        .pendingRequests;
+      expect(pending.size).toBe(0);
+    } finally {
+      await session.close();
+    }
+  });
+});
+
 describe('SessionHost event forwarding', () => {
   it('registers every forwarded event', () => {
     const on = vi.fn();

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -159,7 +159,12 @@ export class RoomSessionTransport extends SessionTransport {
   }
 
   override async sendMessage(msg: pb.AgentSessionMessage): Promise<void> {
-    if (this.closed || !this.room.isConnected) return;
+    // a dropped message is a request the caller waits out in full, so failures
+    // are thrown rather than logged: only the caller knows whether anyone is
+    // waiting on this one
+    if (this.closed || !this.room.isConnected) {
+      throw new Error('room session transport is closed');
+    }
 
     try {
       const data = msg.toBinary();
@@ -175,7 +180,7 @@ export class RoomSessionTransport extends SessionTransport {
       await writer.write(new Uint8Array(data));
       await writer.close();
     } catch (e) {
-      log().warn({ error: e }, 'failed to send binary stream message');
+      throw new Error(`failed to send binary stream message: ${e}`, { cause: e });
     }
   }
 
@@ -301,7 +306,9 @@ export class TcpSessionTransport extends SessionTransport {
 
   override async sendMessage(msg: pb.AgentSessionMessage): Promise<void> {
     const socket = this.socket;
-    if (this.closed || socket === null) return;
+    if (this.closed || socket === null) {
+      throw new Error('tcp session transport is closed');
+    }
 
     const data = msg.toBinary();
     const header = Buffer.allocUnsafe(TCP_HEADER_SIZE);
@@ -655,7 +662,16 @@ export class SessionHost {
     const msg = new pb.AgentSessionMessage({
       message: { case: 'event', value: event },
     });
-    this.trackTask(Task.from(async () => this.transport.sendMessage(msg)));
+    // nobody awaits an event, so a failed one is logged rather than thrown
+    this.trackTask(
+      Task.from(async () => {
+        try {
+          await this.transport.sendMessage(msg);
+        } catch (e) {
+          log().warn({ error: e }, 'failed to send session event');
+        }
+      }),
+    );
   }
 
   private emitEvent<Event extends pb.AgentSessionEvent['event']>(

--- a/agents/src/voice/remote_session.ts
+++ b/agents/src/voice/remote_session.ts
@@ -1265,19 +1265,18 @@ export class RemoteSession extends (EventEmitter as new () => TypedEventEmitter<
     const msg = new pb.AgentSessionMessage({
       message: { case: 'request', value: req },
     });
-    await this.transport.sendMessage(msg);
-
-    const timer = setTimeout(() => {
-      if (!future.done) {
-        this.pendingRequests.delete(requestId);
-        future.reject(new Error('RemoteSession request timed out'));
-      }
-    }, timeout);
-
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
+      await this.transport.sendMessage(msg);
+      timer = setTimeout(() => {
+        if (!future.done) {
+          future.reject(new Error('RemoteSession request timed out'));
+        }
+      }, timeout);
       return await future.await;
     } finally {
       clearTimeout(timer);
+      this.pendingRequests.delete(requestId);
     }
   }
 


### PR DESCRIPTION
## Problem

`RoomSessionTransport.sendMessage` returned silently when the transport was closed or the room had disconnected, and swallowed write errors behind a warning. `TcpSessionTransport.sendMessage` returned silently when closed. Two consequences:

- A `RemoteSession` request over a dead transport resolved as sent and then waited out its full timeout.
- A `SessionHost` response that could not be delivered disappeared with nothing to correlate to the request.

Python's `SessionTransport` raises in both cases. Its comment states the contract: a dropped message is a request the caller waits out in full, so failures are raised rather than logged, because only the caller knows whether anyone is waiting on this one. See `send_message` in https://github.com/livekit/agents/blob/bbfcbcebe9eeac16120ddffdc166d55f59295211/livekit-agents/livekit/agents/voice/remote_session.py#L148-L169 and the TCP variant just below it.

## Change

- `RoomSessionTransport.sendMessage` throws `room session transport is closed` when closed or the room is disconnected, and rethrows write failures as `failed to send binary stream message` with the cause attached.
- `TcpSessionTransport.sendMessage` throws `tcp session transport is closed` when closed or the socket is gone. A send already parked on backpressure still resolves when the transport closes, as before.
- `SessionHost.sendEvent` catches the rejection and logs one `failed to send session event` warning, mirroring Python's write loop. Request handling needed nothing: `handleRequestSafe` already logs and its error-response retry already has a catch.

## Tests

Three new tests in `remote_session.test.ts`: the room transport rejects on a disconnected room, the TCP transport rejects after close, and the host logs rather than leaving an unhandled rejection. All 23 tests in the file pass. The full `src/voice` directory passes except `amd_session_close.test.ts`, which needs a built `dist/` and fails identically on an untouched checkout.