### PR TITLE
openai: keep GPT-Live's input clock running when no audio is pushed

### DIFF
--- a/.changeset/gpt-live-input-clock.md
+++ b/.changeset/gpt-live-input-clock.md
@@ -1,0 +1,6 @@
+---
+'@livekit/agents-plugin-openai': patch
+'@livekit/agents': patch
+---
+
+GPT-Live sessions keep the model's input clock running with silence when no microphone audio is pushed, so text simulations, text-mode consoles and muted input get replies instead of timing out. The text-simulation refusal for duplex models is removed.

--- a/agents/src/llm/duplex_adapter.test.ts
+++ b/agents/src/llm/duplex_adapter.test.ts
@@ -817,17 +817,6 @@ describe('duplex requested replies', () => {
 });
 
 describe('duplex model integration', () => {
-  // a duplex model has no text modality: it hears and speaks only audio, and the adapter resolves
-  // a reply from the sound the model produces. under a text simulation there is no audio, so the
-  // session refuses to start rather than time out on the first turn
-  it('refuses to start under a text simulation', async () => {
-    vi.spyOn(AgentSession.prototype, '_textOnly', 'get').mockReturnValue(true);
-    const session = new AgentSession({ llm: new FakeDuplexModel(), vad: null });
-    await expect(session.start({ agent: new Agent({ instructions: '' }) })).rejects.toThrow(
-      /text simulation/,
-    );
-  });
-
   it('does not arm an away timer from a shutdown transcript and still handles restarts', async () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'], shouldAdvanceTime: true });
     const model = new FakeDuplexModel();

--- a/agents/src/voice/agent_activity.ts
+++ b/agents/src/voice/agent_activity.ts
@@ -28,7 +28,7 @@ import {
   instructionsEqual,
   renderInstructions,
 } from '../llm/chat_context.js';
-import { DuplexRealtimeAdapter, DuplexRealtimeSession } from '../llm/duplex_adapter.js';
+import { DuplexRealtimeSession } from '../llm/duplex_adapter.js';
 import { AsyncToolset, type Toolset } from '../llm/index.js';
 import {
   type ChatItem,
@@ -452,14 +452,6 @@ export class AgentActivity implements RecognitionHooks {
       owningActivity: this,
       asyncToolOptions: this.agent._asyncToolOptions ?? this.agentSession._asyncToolOptions,
     });
-
-    // a duplex model has no text modality, and the adapter resolves each reply from the audio
-    // the model produces; without audio a text simulation would only time out on turn one
-    if (this.agentSession._textOnly && this.llm instanceof DuplexRealtimeAdapter) {
-      throw new Error(
-        'a DuplexModel speaks only through audio, so it cannot run under a text simulation; run `lk agent simulate audio` instead',
-      );
-    }
 
     if (
       this.llm instanceof RealtimeModel &&

--- a/plugins/openai/src/realtime/gpt_live_model.test.ts
+++ b/plugins/openai/src/realtime/gpt_live_model.test.ts
@@ -69,6 +69,9 @@ const completed = (): GPTLive.ResponsesEvent => ({
 const output = (callId: string) =>
   new llm.FunctionCallOutput({ callId, name: 'getWeather', output: 'rainy', isError: false });
 
+const isSilence = (event: GPTLive.ClientEvent) =>
+  event.type === 'session.input_audio.append' &&
+  Buffer.from(event.audio, 'base64').every((byte) => byte === 0);
 class Server {
   readonly server = new WebSocketServer({ port: 0, host: '127.0.0.1' });
   readonly sockets: WebSocket[] = [];
@@ -105,8 +108,9 @@ class Server {
   get url(): string {
     return `http://127.0.0.1:${(this.server.address() as AddressInfo).port}/v1`;
   }
-  events(index = 0): GPTLive.ClientEvent[] {
-    return this.sent[index] ?? [];
+  /** The session pads an idle microphone with silence; sequence assertions ignore that padding. */
+  events(index = 0, silence = false): GPTLive.ClientEvent[] {
+    return (this.sent[index] ?? []).filter((event) => silence || !isSilence(event));
   }
   async send(
     session: GPTLiveSession,
@@ -348,7 +352,7 @@ describe('GPTLiveModel', () => {
     await session._updateSession();
     await waitCount(1);
     session._generateReply('Greet the caller.');
-    session.pushAudio(pcm());
+    session.pushAudio(pcm(100, 0.2));
     await server.send(session, { type: 'session.updated' });
     expect(server.events().map((event) => event.type)).toEqual(['session.start']);
     expect(session.sessionId).toBeUndefined();
@@ -516,7 +520,7 @@ describe('GPTLiveModel', () => {
       session.appendInstructions('Be concise.');
       session.appendThinking('The caller is returning a chair.');
       session.appendCommentary('Ask for the order number.');
-      session.pushAudio(pcm());
+      session.pushAudio(pcm(100, 0.2));
       await waitCount(5);
       vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
       await vi.advanceTimersByTimeAsync(model._opts.connOptions.timeoutMs * 2);
@@ -644,10 +648,10 @@ describe('GPTLiveModel', () => {
     const session = create();
     await ready(session);
     session.pushAudio(pcm(200, 0, 48000, 2));
-    await vi.waitFor(() => expect(server.events().length).toBeGreaterThan(1));
+    await vi.waitFor(() => expect(server.events(0, true).length).toBeGreaterThan(1));
     session.pushAudio(pcm(200));
-    await vi.waitFor(() => expect(server.events().length).toBeGreaterThan(2));
-    for (const event of server.events().slice(1)) {
+    await vi.waitFor(() => expect(server.events(0, true).length).toBeGreaterThan(2));
+    for (const event of server.events(0, true).slice(1)) {
       expect(event.type).toBe('session.input_audio.append');
       if (event.type === 'session.input_audio.append') {
         const bytes = Buffer.from(event.audio, 'base64');
@@ -1194,10 +1198,10 @@ describe('GPTLiveModel', () => {
       if (rate !== 24000) expect(closeResampler).toHaveBeenCalledOnce();
       session.pushAudio(pcm(40, 0, rate));
       await delay(20);
-      expect(server.events(1).map((event) => event.type)).toEqual(['session.start']);
+      expect(server.events(1, true).map((event) => event.type)).toEqual(['session.start']);
       session.pushAudio(pcm(200, 0, rate));
-      await vi.waitFor(() => expect(server.events(1).length).toBeGreaterThan(1));
-      for (const event of server.events(1)) {
+      await vi.waitFor(() => expect(server.events(1, true).length).toBeGreaterThan(1));
+      for (const event of server.events(1, true)) {
         if (event.type !== 'session.input_audio.append') continue;
         const audio = Buffer.from(event.audio, 'base64');
         expect(audio.length).toBe(4800);
@@ -1454,5 +1458,40 @@ describe('GPT-Live AgentSession integration', () => {
     } finally {
       await session.close();
     }
+  });
+});
+
+// GPT-Live speaks only while its input clock is running, and that clock is the audio the client
+// appends. A session with no microphone (text simulation, muted input, text console) would
+// otherwise never hear a reply to anything it asks.
+describe('GPTLiveSession input clock', () => {
+  it('appends silence while no microphone audio is pushed', async () => {
+    const session = create();
+    await ready(session);
+    await vi.waitFor(
+      () =>
+        expect(
+          server.events(0, true).filter((event) => event.type === 'session.input_audio.append')
+            .length,
+        ).toBeGreaterThanOrEqual(3),
+      { timeout: 2000 },
+    );
+    for (const event of server.events(0, true).slice(1)) {
+      expect(event.type).toBe('session.input_audio.append');
+      if (event.type === 'session.input_audio.append')
+        expect(Buffer.from(event.audio, 'base64')).toHaveLength(4800);
+    }
+  });
+
+  it('does not pad a live microphone', async () => {
+    const session = create();
+    await ready(session);
+    for (let i = 0; i < 6; i++) {
+      session.pushAudio(pcm(100, 0.2));
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(
+      server.events(0, true).filter((event) => event.type === 'session.input_audio.append'),
+    ).toHaveLength(6);
   });
 });

--- a/plugins/openai/src/realtime/gpt_live_model.ts
+++ b/plugins/openai/src/realtime/gpt_live_model.ts
@@ -33,6 +33,15 @@ import type {
 
 const SAMPLE_RATE = 24000;
 const MIN_SILENCE_DURATION = 800;
+// the model speaks only while its input clock runs, and that clock is the audio the client
+// appends: a session with no microphone keeps it running with silence
+const INPUT_IDLE_MS = 200;
+const SILENCE_100MS = new AudioFrame(
+  new Int16Array(SAMPLE_RATE / 10),
+  SAMPLE_RATE,
+  1,
+  SAMPLE_RATE / 10,
+);
 const DEFAULT_MODEL = 'gpt-live-1';
 const DEFAULT_BACKEND_MODEL = 'gpt-5.6-luna';
 const SPEAK_NOW = 'Do not wait for the caller to speak first. After that, pause and listen.';
@@ -220,6 +229,12 @@ export class GPTLiveSession extends llm.DuplexSession<{
   private requestConnectionClose?: () => void;
   private readonly shutdown = new AbortController();
   private readonly mainTask: Promise<void>;
+  private lastAudioAt = -Infinity;
+  private readonly silenceTimer = setInterval(() => {
+    if (!this.sessionStarted || this.closing) return;
+    if (Date.now() - this.lastAudioAt < INPUT_IDLE_MS) return;
+    this.appendAudio(SILENCE_100MS);
+  }, INPUT_IDLE_MS / 2);
   private audioController!: ReadableStreamDefaultController<llm.DuplexAudioFrame>;
   private readonly output = new ReadableStream<llm.DuplexAudioFrame>({
     start: (controller) => {
@@ -817,6 +832,7 @@ export class GPTLiveSession extends llm.DuplexSession<{
 
   /** Buffer microphone audio, mixing to mono and resampling to 24 kHz as needed. */
   pushAudio(frame: AudioFrame): void {
+    this.lastAudioAt = Date.now();
     this.appendAudio(frame);
   }
 
@@ -919,6 +935,7 @@ export class GPTLiveSession extends llm.DuplexSession<{
 
   /** Drain final provider usage, then close the transport and output stream. */
   protected async closeConnection(): Promise<void> {
+    clearInterval(this.silenceTimer);
     if (!this.closing) {
       this.closing = true;
       this.shutdown.abort();

--- a/plugins/openai/src/realtime/gpt_live_model.ts
+++ b/plugins/openai/src/realtime/gpt_live_model.ts
@@ -817,6 +817,10 @@ export class GPTLiveSession extends llm.DuplexSession<{
 
   /** Buffer microphone audio, mixing to mono and resampling to 24 kHz as needed. */
   pushAudio(frame: AudioFrame): void {
+    this.appendAudio(frame);
+  }
+
+  private appendAudio(frame: AudioFrame): void {
     if (this.closing) return;
     const speech = this.speech.get('user');
     if (speech) {


### PR DESCRIPTION
## Problem

GPT-Live speaks only while its input clock runs, and that clock is the audio the client appends. A session with no microphone never appends anything, so every ask times out after 10 seconds with "the model did not start speaking when asked". That is what happens under a text simulation, in `lk agent console --text`, and whenever input audio is disabled. #2481 refused to start in the first case; the other two still hang.

Measured against the live service through the Python plugin: with nothing pushed the ask times out; with 100 ms silence frames pushed at 10 Hz the reply opens in 1.6 s with transcript and audio. `session.input_audio.mute` alone does not do it.

## Change

- `GPTLiveSession` appends 100 ms of silence whenever nothing has been pushed for 200 ms, once the session has started. A live microphone is never padded: the timer only fills gaps.
- The #2481 guard is removed. A duplex model now runs under a text simulation like any other model.
- Pure refactor first: `pushAudio` split into the timestamp and a shared `appendAudio`.

## Tests

`gpt_live_model.test.ts`: an idle session appends silence; a live microphone is not padded. The test server's `events()` ignores silent appends by default so the existing sequence assertions stay exact; the two tests that assert on silent input opt back in. The #2481 test is removed with the guard. 148 tests pass across the GPT-Live and duplex adapter files. The idle test fails when the timer is disabled.

## What text mode still cannot do well

GPT-Live has no typed user-input channel; the plugin delivers typed turns as `session.commentary.append` with an instruction to reply. In the Python end-to-end run the voice model delegated to the backend, and so reached the tools, in one of three text-mode scenarios versus three of three in audio mode. Text mode is now usable for exercising conversation flow, not for asserting tool behavior. That limit is the protocol's, not this change's.

Python counterpart: https://github.com/livekit/agents/pull/7239