### PR TITLE
fix(agents): flush STT on manual commitUserTurn with detached input audio

### DIFF
--- a/.changeset/manual-commit-flush-detached-audio.md
+++ b/.changeset/manual-commit-flush-detached-audio.md
@@ -1,0 +1,5 @@
+---
+'@livekit/agents': patch
+---
+
+Flush the STT with silence when `commitUserTurn()` runs with input audio disabled, and track the STT sample rate from forwarded frames, so a manual (push-to-talk) commit holds the complete final transcript instead of a clipped interim one.

--- a/agents/src/voice/agent_session.ts
+++ b/agents/src/voice/agent_session.ts
@@ -1138,12 +1138,19 @@ export class AgentSession<
     }
   }
 
+  /**
+   * Commit the current user turn and generate a reply.
+   *
+   * With input audio disabled (`input.setAudioEnabled(false)`, the documented
+   * push-to-talk release), the recognizer pushes silence to flush the STT so the
+   * trailing words reach the final transcript instead of being clipped.
+   */
   commitUserTurn() {
     if (!this.activity) {
       throw new Error('AgentSession is not running');
     }
 
-    this.activity.commitUserTurn();
+    this.activity.commitUserTurn({ audioDetached: !this.input.audioEnabled });
   }
 
   clearUserTurn() {

--- a/agents/src/voice/agent_session_manual_commit_flush.test.ts
+++ b/agents/src/voice/agent_session_manual_commit_flush.test.ts
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 LiveKit, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { AudioFrame } from '@livekit/rtc-node';
+import { ReadableStream, type ReadableStreamDefaultController } from 'node:stream/web';
+import { describe, expect, it } from 'vitest';
+import { initializeLogger } from '../log.js';
+import { SpeechStream } from '../stt/stt.js';
+import { FakeRecognizeStream, FakeSTT } from '../stt/testing/fake_stt.js';
+import type { APIConnectOptions } from '../types.js';
+import { delay } from '../utils.js';
+import { Agent } from './agent.js';
+import { AgentSession } from './agent_session.js';
+import { AudioInput } from './io.js';
+import { FakeLLM } from './testing/fake_llm.js';
+
+const SPEECH_MS = 300;
+const TRAILING_AUDIO_MS = 200;
+const INTERIM_TRANSCRIPT = 'can you check';
+const FINAL_TRANSCRIPT = 'can you check the connection';
+const COMMIT_DEADLINE_MS = 3_000;
+
+/**
+ * Behaves like a streaming provider that only finalizes an utterance after it
+ * has received trailing audio: an interim result arrives mid-speech and the
+ * final result only once `SPEECH_MS + TRAILING_AUDIO_MS` of audio has been
+ * pushed. If the input is detached right after the speech, the final never
+ * arrives unless the recognizer flushes the stream with silence.
+ */
+class TrailingAudioStream extends FakeRecognizeStream {
+  protected override async run(): Promise<void> {
+    let receivedMs = 0;
+    let interimSent = false;
+    let finalSent = false;
+    for await (const data of this.input) {
+      if (data === SpeechStream.FLUSH_SENTINEL) continue;
+      receivedMs += (data.samplesPerChannel / data.sampleRate) * 1000;
+      if (!interimSent && receivedMs >= SPEECH_MS / 2) {
+        interimSent = true;
+        this.sendFakeTranscript(INTERIM_TRANSCRIPT, false);
+      }
+      if (!finalSent && receivedMs >= SPEECH_MS + TRAILING_AUDIO_MS) {
+        finalSent = true;
+        this.sendFakeTranscript(FINAL_TRANSCRIPT, true);
+      }
+    }
+  }
+}
+
+class TrailingAudioSTT extends FakeSTT {
+  override stream(options?: { connOptions?: APIConnectOptions }): FakeRecognizeStream {
+    return new TrailingAudioStream(this, options?.connOptions);
+  }
+}
+
+class FakeAudioInput extends AudioInput {
+  readonly #controller: ReadableStreamDefaultController<AudioFrame>;
+
+  constructor() {
+    super();
+    let controller!: ReadableStreamDefaultController<AudioFrame>;
+    this.multiStream.addInputStream(
+      new ReadableStream<AudioFrame>({
+        start(streamController) {
+          controller = streamController;
+        },
+      }),
+    );
+    this.#controller = controller;
+  }
+
+  push(durationMs: number, sampleRate = 16_000): void {
+    const samples = Math.floor((sampleRate * durationMs) / 1000);
+    this.#controller.enqueue(new AudioFrame(new Int16Array(samples), sampleRate, 1, samples));
+  }
+}
+
+const userMessages = (agent: Agent) =>
+  agent.chatCtx.items
+    .filter((item) => item.type === 'message' && item.role === 'user')
+    .map((item) => item.textContent);
+
+describe('AgentSession manual commit with detached audio', () => {
+  initializeLogger({ pretty: false, level: 'silent' });
+
+  it('flushes the STT with silence so the committed turn holds the final transcript', async () => {
+    const stt = new TrailingAudioSTT({ capabilities: { interimResults: true } });
+    const session = new AgentSession({
+      stt,
+      llm: new FakeLLM(),
+      vad: null,
+      turnHandling: { turnDetection: 'manual' },
+    });
+    const agent = new Agent({ instructions: 'You are a helpful assistant.' });
+    const audioInput = new FakeAudioInput();
+    session.input.audio = audioInput;
+    await session.start({ agent });
+
+    try {
+      audioInput.push(SPEECH_MS);
+      await delay(150);
+
+      // The documented push-to-talk release: stop the input, then commit.
+      session.input.setAudioEnabled(false);
+      session.commitUserTurn();
+
+      const deadline = performance.now() + COMMIT_DEADLINE_MS;
+      while (userMessages(agent).length === 0 && performance.now() < deadline) {
+        await delay(20);
+      }
+
+      expect(userMessages(agent)).toEqual([FINAL_TRANSCRIPT]);
+    } finally {
+      await session.close();
+    }
+  });
+});

--- a/agents/src/voice/audio_recognition.ts
+++ b/agents/src/voice/audio_recognition.ts
@@ -1977,6 +1977,10 @@ export class AudioRecognition {
 
   private async forwardInputAudioToStt(pipeline: STTPipeline, signal: AbortSignal) {
     for await (const frame of readStream(this.sttInputStream, signal)) {
+      // Track the STT input sample rate so a manual commit can flush with silence
+      // even when no VAD speech event has reported it (e.g. manual turn detection
+      // without a VAD). Mirrors Python's `_push_audio`.
+      this.sampleRate = frame.sampleRate;
       const frameDurationMs = (frame.samplesPerChannel / frame.sampleRate) * 1000;
       pipeline.inputStartedAt ??= Date.now() - frameDurationMs;
       await pipeline.audioChannel.write(frame);


### PR DESCRIPTION
## Description

With the documented push-to-talk flow (`session.input.setAudioEnabled(false)` followed by `session.commitUserTurn()`), the committed user turn is clipped. In a real room with LiveKit Inference STT, speaking "Can you check the connection?" and releasing right after the last word committed **"Can you check"**. The full final transcript only showed up later, during shutdown.

Two parity gaps with the Python framework cause this:

1. `AgentSession.commitUserTurn()` calls `activity.commitUserTurn()` with no options, so `audioDetached` defaults to `false` and `AudioRecognition.commitUserTurn` never pushes the silence frame that flushes the STT. The provider receives no trailing audio, the final never arrives inside the 500 ms commit wait, and the interim text is committed. Python passes `audio_detached=not self._session.input.audio_enabled` ([agent_activity.py](https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/agent_activity.py)). `closeImpl` already passes `audioDetached: true`, which is why the complete transcript appeared at shutdown.
2. The silence flush is skipped when `this.sampleRate` is `undefined`, and it was only recorded from VAD `START_OF_SPEECH` events. Python records it from every pushed frame in `_push_audio` ([audio_recognition.py](https://github.com/livekit/agents/blob/main/livekit-agents/livekit/agents/voice/audio_recognition.py)). Without that, fix 1 alone does nothing under manual turn detection with `vad: null`, or whenever the VAD has not fired for the turn.

## Changes Made

- `AgentSession.commitUserTurn()` passes `{ audioDetached: !this.input.audioEnabled }` to the activity, and documents the behavior.
- `AudioRecognition.forwardInputAudioToStt` records `this.sampleRate` from each forwarded frame.
- New `agent_session_manual_commit_flush.test.ts`: a fake streaming STT that emits an interim mid-speech and the final only after 200 ms of trailing audio. Under manual turn detection with `vad: null`, push 300 ms of speech, disable input, commit. On `main` the committed turn is `"can you check"`; with only the session change it is still `"can you check"`; with both changes it is `"can you check the connection"`.
- Changeset (`@livekit/agents` patch).

## Pre-Review Checklist
- [x] **Build passes**: `pnpm test agents/src/voice/agent_session agents/src/voice/audio_recognition agents/src/voice/agent_activity` passes (33 files, 277 tests); prettier and eslint clean on touched files
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title
- [ ] **Video demo**: Not applicable; covered by the automated regression test and a real-room manual-turn check in the reporting app

## Testing
- [x] Automated tests added/updated
- [x] All tests pass
- [ ] `restaurant_agent.ts` / `realtime_agent.ts`: not a major change; the default (non-manual) path is unaffected since `audioDetached` stays `false` while input audio is enabled

## Additional Notes

Found while building a push-to-talk agent on `@livekit/agents@1.8.1`. We are carrying the one-line session change as a pnpm patch; a six-turn real-room lifecycle check (press, release, cancel, empty turn, two segments with a pause, repeat) passes with it, committing about 600 ms after release. The sample-rate change is included here because the default `inference.VAD` happened to report it in our app, but any configuration without a VAD speech event for the turn would still clip.

This does not change the 500 ms commit wait or add a `transcript_timeout` / `stt_flush_duration` option as in Python; those could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHUXLhxd6NUoXwLzHKvjAv
